### PR TITLE
fix: text editor default right padding issue

### DIFF
--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -224,7 +224,7 @@ export default {
       return {
         attributes: {
           class: normalizeClass([
-            'prose prose-sm prose-p:my-1',
+            'prose prose-p:my-1',
             this.editorClass,
           ]),
         },


### PR DESCRIPTION
Removes this padding on the right

![telegram-cloud-photo-size-5-6275923332834636723-y](https://user-images.githubusercontent.com/22856401/181518753-f4fe2d22-544a-4d9c-861f-c98f04b912ac.jpg)
