### PR TITLE
fix: correct endpoint methods with /api/method

### DIFF
--- a/src/resources/documentResource.js
+++ b/src/resources/documentResource.js
@@ -55,7 +55,7 @@ export function createDocumentResource(options, vm) {
     auto: options.auto || true,
     get: createResource(
       {
-        url: 'frappe.client.get',
+        url: '/api/method/frappe.client.get',
         makeParams() {
           return {
             doctype: out.doctype,

--- a/src/resources/documentResource.js
+++ b/src/resources/documentResource.js
@@ -22,7 +22,7 @@ export function createDocumentResource(options, vm) {
   }
 
   let setValueOptions = {
-    url: 'frappe.client.set_value',
+    url: '/api/method/frappe.client.set_value',
     makeParams(values) {
       return {
         doctype: out.doctype,

--- a/src/resources/documentResource.js
+++ b/src/resources/documentResource.js
@@ -81,7 +81,7 @@ export function createDocumentResource(options, vm) {
     ),
     delete: createResource(
       {
-        url: 'frappe.client.delete',
+        url: '/api/method/frappe.client.delete',
         makeParams() {
           return {
             doctype: out.doctype,
@@ -112,7 +112,7 @@ export function createDocumentResource(options, vm) {
     let { method, onSuccess, ...otherOptions } = methodOptions
     out[methodKey] = createResource(
       {
-        url: 'run_doc_method',
+        url: '/api/method/run_doc_method',
         makeParams(values) {
           return {
             dt: out.doctype,

--- a/src/resources/listResource.js
+++ b/src/resources/listResource.js
@@ -38,7 +38,7 @@ export function createListResource(options, vm) {
     auto: options.auto,
     list: createResource(
       {
-        url: options.url || 'frappe.client.get_list',
+        url: options.url || '/api/method/frappe.client.get_list',
         makeParams() {
           return {
             doctype: out.doctype,
@@ -74,7 +74,7 @@ export function createListResource(options, vm) {
     ),
     fetchOne: createResource(
       {
-        url: 'frappe.client.get_list',
+        url: '/api/method/frappe.client.get_list',
         makeParams(name) {
           return {
             doctype: out.doctype,
@@ -96,7 +96,7 @@ export function createListResource(options, vm) {
     ),
     insert: createResource(
       {
-        url: 'frappe.client.insert',
+        url: '/api/method/frappe.client.insert',
         makeParams(values) {
           return {
             doc: {
@@ -115,7 +115,7 @@ export function createListResource(options, vm) {
     ),
     setValue: createResource(
       {
-        url: 'frappe.client.set_value',
+        url: '/api/method/frappe.client.set_value',
         makeParams(options) {
           let { name, ...values } = options
           return {
@@ -134,7 +134,7 @@ export function createListResource(options, vm) {
     ),
     delete: createResource(
       {
-        url: 'frappe.client.delete',
+        url: '/api/method/frappe.client.delete',
         makeParams(name) {
           return {
             doctype: out.doctype,
@@ -151,7 +151,7 @@ export function createListResource(options, vm) {
     ),
     runDocMethod: createResource(
       {
-        url: 'run_doc_method',
+        url: '/api/method/run_doc_method',
         makeParams({ method, name, ...values }) {
           return {
             dt: out.doctype,


### PR DESCRIPTION
The requests are made to 
http://localhost:8000/frappe.client.get_list

This will always result it 404. 

Fixed by prefixing all requests with /api/method