### PR TITLE
fix(ux)!: white-listed method `onSuccess` argument must be `message`

### DIFF
--- a/src/resources/documentResource.js
+++ b/src/resources/documentResource.js
@@ -135,7 +135,7 @@ export function createDocumentResource(options, vm) {
               }
             }
           }
-          onSuccess?.call(vm, out.doc)
+          onSuccess?.call(vm, data.message)
         },
         ...otherOptions,
       },


### PR DESCRIPTION
Example:
```typescript
whitelistedMethods:  {
  lastCommunication: {
    method: "last_communication",
    onSuccess: (arg) => {},
  },
}
````

Currently, `arg` is the parent doc, which we already have. It does make sense to return `data.message` instead, which is the return value of the white-listed method