### PR TITLE
fix: Update `vite-dev-server.js` Node IP resolution fix

### DIFF
--- a/src/utils/vite-dev-server.js
+++ b/src/utils/vite-dev-server.js
@@ -2,7 +2,7 @@ module.exports = {
   getProxyOptions({ port }) {
     return {
       '^/(app|login|api|assets|files)': {
-        target: `http://localhost:${port}`,
+        target: `http://127.0.0.1:${port}`,
         ws: true,
         router: function (req) {
           const site_name = req.headers.host.split(':')[0]


### PR DESCRIPTION
Node more correctly follows OS native [`dns.lookup()`](https://github.com/nodejs/node/pull/39987) resulting in this breakage