### PR TITLE
perf: Delete `_previousData` before stringifying

### DIFF
--- a/src/resources/listResource.js
+++ b/src/resources/listResource.js
@@ -289,6 +289,7 @@ export function updateRowInListResource(doctype, doc) {
     if (resource.originalData) {
       for (let row of resource.originalData) {
         if (row.name && row.name == doc.name) {
+          delete row._previousData
           let previousRowData = JSON.stringify(row)
           for (let key in row) {
             if (key in doc) {


### PR DESCRIPTION
Delete `_previousData` before stringifying

- Without this, object size used to grow exponentially on every update and if the original object is already big with JSON data in it, it use to cause heavy performance issues as it fills up memory in no time.

**Example with a small obj and with JSON string data:**
```JS
	// original object
	{
		name: 'Frappe', 
		data: '{"type":"company","location":"India"}'
	}
	
	// first update
	{
	    "name": "Frappe 1",
	    "data": "{\"type\":\"company\",\"location\":\"India\"}",
	    "_previousData": "{\"name\":\"Frappe\",
		\"data\":\"{\\\"type\\\":\\\"company\\\",\\\"location\\\":\\\"India\\\"}\"}"
	}
	
	// second update
	{
	    "name": "Frappe 2",
	    "data": "{\"type\":\"company\",\"location\":\"India\"}",
	    "_previousData": "{\"name\":\"Frappe 1\",\"data\":\"
		{\\\"type\\\":\\\"company\\\",\\\"location\\\":\\\"India\\\"}\",\"_previousData\":
		\"{\\\"name\\\":\\\"Frappe\\\",\\\"data\\\":\\\"{\\\\\\\"type\\\\\\\":\\\\\\\
		"company\\\\\\\",\\\\\\\"location\\\\\\\":\\\\\\\"India\\\\\\\"}\\\"}\"}"
	}
	
	and so on...
	```
