### PR TITLE
fix: allow html in tooltip

### DIFF
--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -13,6 +13,11 @@
             {{ text }}
           </div>
         </div>
+        <div
+          v-else-if="html"
+          class="rounded bg-gray-900 px-2 py-1 text-xs text-white shadow-xl"
+          v-html="html"
+        />
       </slot>
     </template>
   </Popover>
@@ -30,6 +35,10 @@ export default {
       default: 'top',
     },
     text: {
+      type: String,
+      default: null,
+    },
+    html: {
       type: String,
       default: null,
     },


### PR DESCRIPTION
<img width="787" alt="image" src="https://github.com/frappe/frappe-ui/assets/30859809/41a2fac4-75da-46c1-bb66-fe2a1d104ec1">
