### PR TITLE
fix: default loading state for dialog actions

### DIFF
--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -196,7 +196,7 @@ export default {
         this.dialogActions = actions.map((action) => {
           let _action = {
             ...action,
-            loading: false,
+            loading: action.loading || false,
             _onClick: action.onClick,
             onClick: () => this.handleAction(_action),
           }


### PR DESCRIPTION
As of now, this is always set to false and overrides the action.loading even if it exists (...action). Only happens when `actions` are passed as `options`.

Works fine for slot actions.