### PR TITLE
fix: file uploader: consider `doctype` & `docname` separately

### DIFF
--- a/src/utils/fileUploadHandler.ts
+++ b/src/utils/fileUploadHandler.ts
@@ -109,12 +109,16 @@ class FileUploadHandler {
         form_data.append('file_url', options.file_url)
       }
 
-      if (options.doctype && options.docname) {
+      if (options.doctype) {
         form_data.append('doctype', options.doctype)
+      }
+
+      if (options.docname) {
         form_data.append('docname', options.docname)
-        if (options.fieldname) {
-          form_data.append('fieldname', options.fieldname)
-        }
+      }
+
+      if (options.fieldname) {
+        form_data.append('fieldname', options.fieldname)
       }
 
       if (options.method) {


### PR DESCRIPTION
In `FileUploader`, `doctype` is ignored if `docname` is not present. This PR change the behaviour to consider `doctype`, `docname` and `fieldname` as separate, unrelated properties. Please let me know if there is a reason to couple `doctype` and `docname` together.