### PR TITLE
fix: Remove start animation from tabs component

### DIFF
--- a/src/components/Tabs.story.md
+++ b/src/components/Tabs.story.md
@@ -1,0 +1,21 @@
+## Props
+
+### Tabs
+
+It is an array of objects which contains the following attributes:
+
+1. `label` is the name of the tab, it is required.
+2. `icon` is the icon to be shown in the tab, it accept component and it is
+   optional.
+3. You can add more attributes which can be used for custom rendering in the tab
+   header or content.
+
+### Options
+
+Currently, it has only one option `indicatorLeft` which is used to set the left
+position of the indicator in case of custom rendering. It is optional and
+default value is `20`.
+
+## v-model
+
+It is used to set the active tab or change the active tab. It is required.

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -27,8 +27,8 @@
       </Tab>
       <div
         ref="indicator"
-        class="absolute -bottom-px h-px bg-gray-900"
-        :style="{ left: `${indicatorLeftValue}px` }"
+        class="absolute -bottom-px h-px bg-gray-900 transition-all duration-300 ease-in-out"
+        :style="{ left: `${indicatorLeft}px` }"
       />
     </TabList>
     <TabPanels class="flex flex-1 overflow-hidden">
@@ -45,7 +45,6 @@
 
 <script setup>
 import { TabGroup, TabList, Tab, TabPanels, TabPanel } from '@headlessui/vue'
-import { TransitionPresets, useTransition } from '@vueuse/core'
 import { ref, watch, computed, onMounted, nextTick } from 'vue'
 
 const props = defineProps({
@@ -70,12 +69,7 @@ const tabRef = ref([])
 const indicator = ref(null)
 const tabsLength = ref(props.tabs?.length)
 
-let indicatorLeft = ref(0)
-
-const indicatorLeftValue = useTransition(indicatorLeft, {
-  duration: 250,
-  ease: TransitionPresets.easeOutCubic,
-})
+const indicatorLeft = ref(0)
 
 function moveIndicator(index) {
   if (index >= tabsLength.value) {

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -56,6 +56,12 @@ const props = defineProps({
     type: Number,
     default: 0,
   },
+  options: {
+    type: Object,
+    default: () => ({
+      indicatorLeft: 20,
+    }),
+  },
 })
 
 const emit = defineEmits(['update:modelValue'])
@@ -69,7 +75,7 @@ const tabRef = ref([])
 const indicator = ref(null)
 const tabsLength = ref(props.tabs?.length)
 
-const indicatorLeft = ref(0)
+const indicatorLeft = ref(props.options?.indicatorLeft)
 
 function moveIndicator(index) {
   if (index >= tabsLength.value) {


### PR DESCRIPTION
1. Remove start animation
	Before:

	https://github.com/frappe/frappe-ui/assets/30859809/6a274d0f-3bf0-4edb-95ca-c5595fad6e0e

	After:

	https://github.com/frappe/frappe-ui/assets/30859809/5596912e-0eeb-482f-b3f6-dc301253e3b7


3. Made `indicatorLeft` customizable to handle custom tab header with custom left padding
4. Added docs