### PR TITLE
fix: (Tabs Component) Apply transition after mount

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -27,7 +27,8 @@
       </Tab>
       <div
         ref="indicator"
-        class="absolute -bottom-px h-px bg-gray-900 transition-all duration-300 ease-in-out"
+        class="absolute -bottom-px h-px bg-gray-900"
+        :class="transitionClass"
         :style="{ left: `${indicatorLeft}px` }"
       />
     </TabList>
@@ -76,6 +77,7 @@ const indicator = ref(null)
 const tabsLength = ref(props.tabs?.length)
 
 const indicatorLeft = ref(props.options?.indicatorLeft)
+const transitionClass = ref('')
 
 function moveIndicator(index) {
   if (index >= tabsLength.value) {
@@ -93,5 +95,10 @@ watch(changedIndex, (index) => {
   nextTick(() => moveIndicator(index))
 })
 
-onMounted(() => moveIndicator(changedIndex.value))
+onMounted(() => {
+  moveIndicator(changedIndex.value)
+  nextTick(() => {
+    transitionClass.value = 'transition-all duration-300 ease-in-out'
+  })
+})
 </script>


### PR DESCRIPTION
Apply transition after mount to avoid start animation if default tab is other than the first tab
Before:

https://github.com/frappe/frappe-ui/assets/30859809/45c86eaf-d909-40c7-8224-f4a24493b1e5

After:

https://github.com/frappe/frappe-ui/assets/30859809/fdd98ca1-a8b5-4163-b952-1e3858c706a9


