### PR TITLE
fix: align right not making header item right & set resize column default value as false

### DIFF
--- a/src/components/ListView.story.md
+++ b/src/components/ListView.story.md
@@ -78,7 +78,7 @@ required to be passed in the `row` object.
 4. showTooltip (Boolean) - if true, tooltip will be shown on hover of row -
    default is true
 5. resizeColumn (Boolean) - if true, column can be resized by dragging the
-   resizer on the right side of the column header - default is true
+   resizer on the right side of the column header - default is false
 
 ---
 

--- a/src/components/ListView/ListHeaderItem.vue
+++ b/src/components/ListView/ListHeaderItem.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     ref="columnRef"
-    class="group flex items-center justify-between"
-    :class="alignmentMap[item.align]"
+    class="group flex items-center"
+    :class="item.align ? alignmentMap[item.align] : 'justify-between'"
   >
     <div
       class="flex items-center space-x-2 truncate text-sm text-gray-600"

--- a/src/components/ListView/ListView.vue
+++ b/src/components/ListView/ListView.vue
@@ -42,7 +42,7 @@ const props = defineProps({
       onRowClick: null,
       showTooltip: true,
       selectable: true,
-      resizeColumn: true,
+      resizeColumn: false,
     },
   },
 })
@@ -60,12 +60,16 @@ let _options = computed(() => {
     return value === undefined ? true : value
   }
 
+  function defaultFalse(value) {
+    return value === undefined ? false : value
+  }
+
   return {
     getRowRoute: props.options.getRowRoute || null,
     onRowClick: props.options.onRowClick || null,
     showTooltip: defaultTrue(props.options.showTooltip),
     selectable: defaultTrue(props.options.selectable),
-    resizeColumn: defaultTrue(props.options.resizeColumn),
+    resizeColumn: defaultFalse(props.options.resizeColumn),
   }
 })
 


### PR DESCRIPTION
Before:
<img width="1204" alt="image" src="https://github.com/frappe/frappe-ui/assets/30859809/571e2dd8-341e-403b-93a2-f735b2de904f">

After:
<img width="1204" alt="image" src="https://github.com/frappe/frappe-ui/assets/30859809/c48e05e8-ddbe-493d-bfd6-6d3b9c13d47f">
