### PR TITLE
feat: `ListEmptyState` and configurable `ListRowItem` prefix

### DIFF
--- a/src/components/ListView.story.vue
+++ b/src/components/ListView.story.vue
@@ -1,21 +1,30 @@
 <script setup>
-import ListView from './ListView/ListView.vue'
-import ListHeader from './ListView/ListHeader.vue'
-import ListHeaderItem from './ListView/ListHeaderItem.vue'
-import ListRows from './ListView/ListRows.vue'
-import ListRow from './ListView/ListRow.vue'
-import ListRowItem from './ListView/ListRowItem.vue'
-import ListSelectBanner from './ListView/ListSelectBanner.vue'
-import FeatherIcon from './FeatherIcon.vue'
+import { reactive, h } from 'vue'
+import Avatar from './Avatar.vue'
 import Badge from './Badge.vue'
 import Button from './Button.vue'
-import Avatar from './Avatar.vue'
-import { reactive } from 'vue'
+import FeatherIcon from './FeatherIcon.vue'
+import ListHeader from './ListView/ListHeader.vue'
+import ListHeaderItem from './ListView/ListHeaderItem.vue'
+import ListRow from './ListView/ListRow.vue'
+import ListRowItem from './ListView/ListRowItem.vue'
+import ListRows from './ListView/ListRows.vue'
+import ListSelectBanner from './ListView/ListSelectBanner.vue'
+import ListView from './ListView/ListView.vue'
 
 const state = reactive({
   selectable: true,
   showTooltip: true,
   resizeColumn: true,
+  emptyState: {
+    title: 'No records found',
+    description: 'Create a new record to get started',
+    button: {
+      label: 'New Record',
+      variant: 'solid',
+      onClick: () => console.log('New Record'),
+    },
+  },
 })
 
 const simple_columns = reactive([
@@ -23,6 +32,14 @@ const simple_columns = reactive([
     label: 'Name',
     key: 'name',
     width: 3,
+    getLabel: ({ row }) => row.name,
+    prefix: ({ row }) => {
+      return h(Avatar, {
+        shape: 'circle',
+        image: row.user_image,
+        size: 'sm',
+      })
+    },
   },
   {
     label: 'Email',
@@ -46,6 +63,7 @@ const simple_rows = [
     email: 'john@doe.com',
     status: 'Active',
     role: 'Developer',
+    user_image: 'https://avatars.githubusercontent.com/u/499550',
   },
   {
     id: 2,
@@ -53,6 +71,7 @@ const simple_rows = [
     email: 'jane@doe.com',
     status: 'Inactive',
     role: 'HR',
+    user_image: 'https://avatars.githubusercontent.com/u/499120',
   },
 ]
 
@@ -119,6 +138,21 @@ const custom_rows = [
 
 <template>
   <Story :layout="{ type: 'grid', width: '95%' }">
+    <Variant title="Empty List">
+      <div class="h-[250px]">
+        <ListView
+          :columns="simple_columns"
+          :rows="[]"
+          :options="{
+            selectable: state.selectable,
+            showTooltip: state.showTooltip,
+            resizeColumn: state.resizeColumn,
+            emptyState: state.emptyState,
+          }"
+          row-key="id"
+        />
+      </div>
+    </Variant>
     <Variant title="Simple List">
       <ListView
         class="h-[250px]"
@@ -207,6 +241,17 @@ const custom_rows = [
       <HstCheckbox v-model="state.selectable" title="Selectable" />
       <HstCheckbox v-model="state.showTooltip" title="Show tooltip" />
       <HstCheckbox v-model="state.resizeColumn" title="Resize Column" />
+      <!-- empty state config -->
+      <HstText
+        v-model="state.emptyState.title"
+        title="Empty Title"
+        placeholder="No records found"
+      />
+      <HstText
+        v-model="state.emptyState.description"
+        title="Empty Description"
+        placeholder="Create a new record to get started"
+      />
     </template>
   </Story>
 </template>

--- a/src/components/ListView/ListEmptyState.vue
+++ b/src/components/ListView/ListEmptyState.vue
@@ -1,0 +1,21 @@
+<template>
+  <div
+    class="flex h-full w-full flex-col items-center justify-center text-base"
+  >
+    <div class="text-xl font-medium">{{ list.options.emptyState.title }}</div>
+    <div class="mt-1 text-base text-gray-600">
+      {{ list.options.emptyState.description }}
+    </div>
+    <Button
+      v-if="list.options.emptyState.button"
+      v-bind="list.options.emptyState.button"
+      class="mt-4"
+    ></Button>
+  </div>
+</template>
+
+<script setup>
+import { inject } from 'vue'
+
+const list = inject('list')
+</script>

--- a/src/components/ListView/ListEmptyState.vue
+++ b/src/components/ListView/ListEmptyState.vue
@@ -2,15 +2,17 @@
   <div
     class="flex h-full w-full flex-col items-center justify-center text-base"
   >
-    <div class="text-xl font-medium">{{ list.options.emptyState.title }}</div>
-    <div class="mt-1 text-base text-gray-600">
-      {{ list.options.emptyState.description }}
-    </div>
-    <Button
-      v-if="list.options.emptyState.button"
-      v-bind="list.options.emptyState.button"
-      class="mt-4"
-    ></Button>
+    <slot>
+      <div class="text-xl font-medium">{{ list.options.emptyState.title }}</div>
+      <div class="mt-1 text-base text-gray-600">
+        {{ list.options.emptyState.description }}
+      </div>
+      <Button
+        v-if="list.options.emptyState.button"
+        v-bind="list.options.emptyState.button"
+        class="mt-4"
+      ></Button>
+    </slot>
   </div>
 </template>
 

--- a/src/components/ListView/ListEmptyState.vue
+++ b/src/components/ListView/ListEmptyState.vue
@@ -16,6 +16,7 @@
 
 <script setup>
 import { inject } from 'vue'
+import Button from '../Button.vue'
 
 const list = inject('list')
 </script>

--- a/src/components/ListView/ListRow.vue
+++ b/src/components/ListView/ListRow.vue
@@ -14,7 +14,7 @@
       class="[all:unset] hover:[all:unset]"
     >
       <div
-        class="grid items-center space-x-4 rounded px-2 py-2.5"
+        class="grid h-[40px] items-center space-x-4 rounded px-2"
         :class="
           list.selections.has(row[list.rowKey])
             ? 'bg-gray-100 hover:bg-gray-200'
@@ -42,7 +42,12 @@
           ]"
         >
           <slot v-bind="{ idx: i, column, item: row[column.key] }">
-            <ListRowItem :item="row[column.key]" :align="column.align" />
+            <ListRowItem
+              :column="column"
+              :row="row"
+              :item="row[column.key]"
+              :align="column.align"
+            />
           </slot>
         </div>
       </div>

--- a/src/components/ListView/ListRow.vue
+++ b/src/components/ListView/ListRow.vue
@@ -14,13 +14,14 @@
       class="[all:unset] hover:[all:unset]"
     >
       <div
-        class="grid h-[40px] items-center space-x-4 rounded px-2"
+        class="grid items-center space-x-4 rounded px-2"
         :class="
           list.selections.has(row[list.rowKey])
             ? 'bg-gray-100 hover:bg-gray-200'
             : 'hover:bg-gray-50'
         "
         :style="{
+          height: rowHeight,
           gridTemplateColumns: getGridTemplateColumns(
             list.columns,
             list.options.selectable
@@ -77,5 +78,12 @@ const isLastRow = computed(() => {
     list.value.rows[list.value.rows.length - 1][list.value.rowKey] ===
     props.row[list.value.rowKey]
   )
+})
+
+const rowHeight = computed(() => {
+  if (typeof list.value.options.rowHeight === 'number') {
+    return `${list.value.options.rowHeight}px`
+  }
+  return list.value.options.rowHeight
 })
 </script>

--- a/src/components/ListView/ListRowItem.vue
+++ b/src/components/ListView/ListRowItem.vue
@@ -17,7 +17,7 @@
     </slot>
     <slot v-bind="{ label }">
       <div class="truncate text-base">
-        {{ column.getLabel ? column.getLabel({ row }) : label }}
+        {{ column?.getLabel ? column.getLabel({ row }) : label }}
       </div>
     </slot>
     <slot name="suffix" />
@@ -31,11 +31,11 @@ import { alignmentMap } from './utils'
 const props = defineProps({
   column: {
     type: Object,
-    required: true,
+    default: {},
   },
   row: {
     type: Object,
-    required: true,
+    default: {},
   },
   item: {
     type: [String, Number, Object],

--- a/src/components/ListView/ListRowItem.vue
+++ b/src/components/ListView/ListRowItem.vue
@@ -5,21 +5,38 @@
     class="flex items-center space-x-2"
     :class="alignmentMap[align]"
   >
-    <slot name="prefix" />
+    <slot name="prefix">
+      <component
+        v-if="column.prefix"
+        :is="
+          typeof column.prefix === 'function'
+            ? column.prefix({ row })
+            : column.prefix
+        "
+      />
+    </slot>
     <slot v-bind="{ label }">
       <div class="truncate text-base">
-        {{ label }}
+        {{ column.getLabel ? column.getLabel({ row }) : label }}
       </div>
     </slot>
     <slot name="suffix" />
   </component>
 </template>
 <script setup>
-import { alignmentMap } from './utils'
-import Tooltip from '../Tooltip.vue'
 import { computed, inject } from 'vue'
+import Tooltip from '../Tooltip.vue'
+import { alignmentMap } from './utils'
 
 const props = defineProps({
+  column: {
+    type: Object,
+    required: true,
+  },
+  row: {
+    type: Object,
+    required: true,
+  },
   item: {
     type: [String, Number, Object],
     default: '',

--- a/src/components/ListView/ListRows.vue
+++ b/src/components/ListView/ListRows.vue
@@ -2,12 +2,14 @@
   <div class="h-full overflow-y-auto">
     <slot>
       <ListRow v-for="row in list.rows" :key="row[list.rowKey]" :row="row" />
+      <ListEmptyState v-if="!list.rows.length" />
     </slot>
   </div>
 </template>
 
 <script setup>
 import ListRow from './ListRow.vue'
+import ListEmptyState from './ListEmptyState.vue'
 import { inject } from 'vue'
 
 const list = inject('list')

--- a/src/components/ListView/ListRows.vue
+++ b/src/components/ListView/ListRows.vue
@@ -2,16 +2,12 @@
   <div class="h-full overflow-y-auto">
     <slot>
       <ListRow v-for="row in list.rows" :key="row[list.rowKey]" :row="row" />
-      <slot name="empty-state" v-if="!list.rows.length">
-        <ListEmptyState />
-      </slot>
     </slot>
   </div>
 </template>
 
 <script setup>
 import ListRow from './ListRow.vue'
-import ListEmptyState from './ListEmptyState.vue'
 import { inject } from 'vue'
 
 const list = inject('list')

--- a/src/components/ListView/ListRows.vue
+++ b/src/components/ListView/ListRows.vue
@@ -2,7 +2,9 @@
   <div class="h-full overflow-y-auto">
     <slot>
       <ListRow v-for="row in list.rows" :key="row[list.rowKey]" :row="row" />
-      <ListEmptyState v-if="!list.rows.length" />
+      <slot name="empty-state" v-if="!list.rows.length">
+        <ListEmptyState />
+      </slot>
     </slot>
   </div>
 </template>

--- a/src/components/ListView/ListView.vue
+++ b/src/components/ListView/ListView.vue
@@ -6,13 +6,15 @@
     >
       <slot>
         <ListHeader />
-        <ListRows />
+        <ListRows v-if="props.rows.length" />
+        <ListEmptyState v-else />
         <ListSelectBanner v-if="_options.selectable" />
       </slot>
     </div>
   </div>
 </template>
 <script setup>
+import ListEmptyState from './ListEmptyState.vue'
 import ListHeader from './ListHeader.vue'
 import ListRows from './ListRows.vue'
 import ListSelectBanner from './ListSelectBanner.vue'

--- a/src/components/ListView/ListView.vue
+++ b/src/components/ListView/ListView.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="relative flex w-full flex-1 flex-col overflow-x-auto">
+  <div class="relative flex h-full w-full flex-1 flex-col overflow-x-auto">
     <div
-      class="flex w-max min-w-full flex-col overflow-y-hidden"
+      class="flex w-max min-w-full flex-1 flex-col overflow-y-hidden"
       :class="$attrs.class"
     >
       <slot>
@@ -43,6 +43,10 @@ const props = defineProps({
       showTooltip: true,
       selectable: true,
       resizeColumn: false,
+      emptyState: {
+        title: 'No Data',
+        description: 'No data available',
+      },
     },
   },
 })
@@ -70,6 +74,7 @@ let _options = computed(() => {
     showTooltip: defaultTrue(props.options.showTooltip),
     selectable: defaultTrue(props.options.selectable),
     resizeColumn: defaultFalse(props.options.resizeColumn),
+    emptyState: props.options.emptyState,
   }
 })
 

--- a/src/components/ListView/ListView.vue
+++ b/src/components/ListView/ListView.vue
@@ -43,6 +43,7 @@ const props = defineProps({
       showTooltip: true,
       selectable: true,
       resizeColumn: false,
+      rowHeight: 40,
       emptyState: {
         title: 'No Data',
         description: 'No data available',
@@ -74,6 +75,7 @@ let _options = computed(() => {
     showTooltip: defaultTrue(props.options.showTooltip),
     selectable: defaultTrue(props.options.selectable),
     resizeColumn: defaultFalse(props.options.resizeColumn),
+    rowHeight: props.options.rowHeight || 40,
     emptyState: props.options.emptyState,
   }
 })

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -17,8 +17,8 @@
     <teleport to="#frappeui-popper-root">
       <div
         ref="popover"
-        :class="popoverClass"
-        class="popover-container relative z-[100]"
+        class="relative z-[100]"
+        :class="[popoverContainerClass, popoverClass]"
         :style="{ minWidth: targetWidth ? targetWidth + 'px' : null }"
         @mouseover="pointerOverTargetOrPopup = true"
         @mouseleave="onMouseleave"
@@ -87,6 +87,7 @@ export default {
   expose: ['open', 'close'],
   data() {
     return {
+      popoverContainerClass: 'body-container',
       showPopup: false,
       targetWidth: null,
       pointerOverTargetOrPopup: false,
@@ -111,14 +112,35 @@ export default {
   },
   mounted() {
     this.listener = (e) => {
-      let $els = [this.$refs.reference, this.$refs.popover]
-      let insideClick = $els.some(
-        ($el) => $el && (e.target === $el || $el.contains(e.target))
-      )
+      const clickedElement = e.target
+      const reference = this.$refs.reference
+      const popoverBody = this.$refs.popover
+      const insideClick =
+        clickedElement === reference ||
+        clickedElement === popoverBody ||
+        reference?.contains(clickedElement) ||
+        popoverBody?.contains(clickedElement)
       if (insideClick) {
         return
       }
-      this.close()
+
+      const root = document.getElementById('frappeui-popper-root')
+      const insidePopoverRoot = root.contains(clickedElement)
+      if (!insidePopoverRoot) {
+        return this.close()
+      }
+
+      const bodyClass = `.${this.popoverContainerClass}`
+      const clickedElementBody = clickedElement?.closest(bodyClass)
+      const currentPopoverBody = reference?.closest(bodyClass)
+      const isSiblingClicked =
+        clickedElementBody &&
+        currentPopoverBody &&
+        clickedElementBody === currentPopoverBody
+
+      if (isSiblingClicked) {
+        this.close()
+      }
     }
     if (this.hideOnBlur) {
       document.addEventListener('click', this.listener)

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ export {
 export { default as ListView } from './components/ListView/ListView.vue'
 export { default as ListHeader } from './components/ListView/ListHeader.vue'
 export { default as ListHeaderItem } from './components/ListView/ListHeaderItem.vue'
+export { default as ListEmptyState } from './components/ListView/ListEmptyState.vue'
 export { default as ListRows } from './components/ListView/ListRows.vue'
 export { default as ListRow } from './components/ListView/ListRow.vue'
 export { default as ListRowItem } from './components/ListView/ListRowItem.vue'


### PR DESCRIPTION
### Added empty state for list component.

```js
emptyState: {
	title: 'No Query Created.',
	description: 'Create a new query to get started.',
	button: {
		label: 'New Query',
		variant: 'solid',
		onClick: () => (),
	},
},
```

Also configurable by `slots`

```vue
<ListView>
	<ListHeader />
	<ListRows />
	<ListEmptyState>
		<p>No pages to display.</p>
		<Button label="New Page" variant="solid" @click="() => {}" />
	</ListEmptyState>
</ListView>
```


![image](https://github.com/frappe/frappe-ui/assets/25369014/27d60508-45e7-4431-b763-80faf88848fe)

### Set default row height to 40px. 
This ensures that the row height does not change if a row item prefix (like `Avatar`, or `Indicator`) is added to the list row item. It can be modified using `options.rowHeight`


### Added configuration to define prefix/suffix and custom label for each column

```jsx
{
	label: 'Label',
	key: 'label',
	width: 1,
	getLabel: ({ row }) => row.label,
	prefix: ({ row }) => <IndicatorIcon />,
}
```
