### PR TITLE
fix: alt attribute for avatar image

### DIFF
--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -6,6 +6,7 @@
     <img
       v-if="image"
       :src="image"
+      :alt="label"
       :class="[shapeClasses, 'h-full w-full object-cover']"
     />
     <div


### PR DESCRIPTION
Added label as `alt` attribute for Avatar image. SEO engines check for alt tags in images.