### PR TITLE
Increase the Dialog z-index

### DIFF
--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -4,7 +4,7 @@
     :show="open"
     @after-leave="$emit('after-leave')"
   >
-    <HDialog as="div" class="fixed inset-0 z-10 overflow-y-auto" @close="close">
+    <HDialog as="div" class="fixed inset-0 z-50 overflow-y-auto" @close="close">
       <div
         class="flex min-h-screen flex-col items-center px-4 py-4 text-center"
         :class="dialogPositionClasses"


### PR DESCRIPTION
I have increased the Dialog z-index to `z-50` so that it appears on top always also allowing other elements to be given the lower z-index, making it `z-10` affects other elements on a page.