### PR TITLE
fix: form control import

### DIFF
--- a/src/components/TextEditor/InsertLink.vue
+++ b/src/components/TextEditor/InsertLink.vue
@@ -28,7 +28,7 @@ import FormControl from '../FormControl.vue'
 export default {
   name: 'InsertLink',
   props: ['editor'],
-  components: { Button, Input, Dialog },
+  components: { Button, FormControl, Dialog },
   data() {
     return {
       setLinkDialog: { url: '', show: false },

--- a/src/components/TextEditor/InsertLink.vue
+++ b/src/components/TextEditor/InsertLink.vue
@@ -23,7 +23,7 @@
 <script>
 import Dialog from '../Dialog.vue'
 import Button from '../Button.vue'
-import Input from '../Input.vue'
+import FormControl from '../FormControl.vue'
 
 export default {
   name: 'InsertLink',


### PR DESCRIPTION
FormControl was not imported for InsertLink Dialog.

<img width="1440" alt="Screenshot 2024-05-09 at 1 07 29 PM" src="https://github.com/frappe/frappe-ui/assets/31363128/9ab7d567-098c-4113-96dc-95aa481f14f7">
