### PR TITLE
fix: increase mention result display count to 10

### DIFF
--- a/src/components/TextEditor/mention.js
+++ b/src/components/TextEditor/mention.js
@@ -19,7 +19,7 @@ function getSuggestionOptions(options) {
         .filter((item) =>
           item.label.toLowerCase().startsWith(query.toLowerCase())
         )
-        .slice(0, 5)
+        .slice(0, 10)
     },
 
     render: () => {


### PR DESCRIPTION
Previously only 5 names were shown when mentioning a user in a comment. This number is too small for a large user base. I am increasing it to 10.

<img width="1089" alt="Screenshot 2024-05-24 at 10 08 40 AM" src="https://github.com/frappe/frappe-ui/assets/31363128/51b91934-84b8-418f-91e0-acde1e6f3774">
