### PR TITLE
Fileuploader fixes

### DIFF
--- a/src/components/FileUploader.vue
+++ b/src/components/FileUploader.vue
@@ -51,11 +51,7 @@ export default {
     },
   },
   methods: {
-    openFileSelector(type) {
-      if (type) {
-        // change inputs filetype to accept the type of file you want to upload
-        this.$refs['input'].accept = type
-      }
+    openFileSelector() {
       this.$refs['input'].click()
     },
     async onFileAdd(e) {

--- a/src/components/FileUploader.vue
+++ b/src/components/FileUploader.vue
@@ -51,6 +51,9 @@ export default {
     },
   },
   methods: {
+    inputRef() {
+      return this.$refs['input']
+    },
     openFileSelector() {
       this.$refs['input'].click()
     },
@@ -114,5 +117,6 @@ export default {
         })
     },
   },
+  expose: ['inputRef'],
 }
 </script>


### PR DESCRIPTION
Reverts commit https://github.com/frappe/frappe-ui/commit/54caea6b7090dbed2cb0a0333c21dc0e6d9db3a0.

Fixes mime type selection regression introduced by it.

`inputRef` is exposed to handle changing accepted mime types outside the component. 