### PR TITLE
fix: increase Tooltip's z-index to avoid overlap

### DIFF
--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -47,7 +47,7 @@ const delayDuration = computed(() => props.hoverDelay * 1000)
           v-if="props.text || $slots.body"
           :side="props.placement"
           :side-offset="4"
-          class="z-10"
+          class="z-[100]"
         >
           <slot name="body">
             <div


### PR DESCRIPTION
Currently, the tooltip z-index is 10. Gets hidden by other layers having z-index. Popover has a z-index of 100: https://github.com/frappe/frappe-ui/blob/96ecd6adf3669bd231e59ee442ac9fb3711a840d/src/components/Popover.vue#L20
Bumping it up for Tooltip too

<img width="339" alt="image" src="https://github.com/user-attachments/assets/e65acf48-b707-4b21-8809-4db1bb3d48ec">

**After**

<img width="339" alt="image" src="https://github.com/user-attachments/assets/0f15504d-69cc-4a45-8a0a-5cdd384fa6bf">
