### PR TITLE
fix(toast): render html correctly

### DIFF
--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -12,11 +12,10 @@
             v-if="title"
             class="text-base font-medium text-gray-900"
             :class="{ 'mb-1': text }"
+            v-html="title"
           >
-            {{ title }}
           </p>
-          <p v-if="text" class="text-base text-gray-600">
-            {{ text }}
+          <p v-if="text" class="text-base text-gray-600" v-html="text">
           </p>
         </slot>
       </div>

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -12,11 +12,10 @@
             v-if="title"
             class="text-base font-medium text-gray-900"
             :class="{ 'mb-1': text }"
-            v-html="title"
           >
+            {{ title }}
           </p>
-          <p v-if="text" class="text-base text-gray-600" v-html="text">
-          </p>
+          <p v-if="text" class="text-base text-gray-600" v-html="text"></p>
         </slot>
       </div>
       <div class="ml-auto pl-2">


### PR DESCRIPTION
when html string is used in the toast problem appears

![WhatsApp Image 2024-09-09 at 21 43 32_7a488e5b](https://github.com/user-attachments/assets/a7f9ab61-ddbf-457d-b9da-8f47edd86af2)

in the toast.vue component the title and text are using text interpolation so instead of using text interpolation using v-html directive we can avoid the issue 

![image](https://github.com/user-attachments/assets/021c1c79-fcfb-4d65-ba9a-d8020d6f5fd3)
