### PR TITLE
chore: define component prop types & expose Autocomplete's root element

### DIFF
--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -179,14 +179,29 @@ import FeatherIcon from './FeatherIcon.vue'
 
 export default {
   name: 'Autocomplete',
-  props: [
-    'modelValue',
-    'options',
-    'placeholder',
-    'bodyClasses',
-    'multiple',
-    'hideSearch',
-  ],
+  props: {
+    options: {
+      type: Array,
+      default: () => [],
+    },
+    modelValue: {
+      type: [Object, Array],
+    },
+    placeholder: {
+      type: String,
+    },
+    bodyClasses: {
+      type: [String, Array, Object],
+    },
+    multiple: {
+      type: Boolean,
+      default: false,
+    },
+    hideSearch: {
+      type: Boolean,
+      default: false,
+    },
+  },
   emits: ['update:modelValue', 'update:query', 'change'],
   components: {
     Popover,

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -5,7 +5,7 @@
     nullable
     v-slot="{ open: isComboboxOpen }"
   >
-    <Popover class="w-full" v-model:show="showOptions">
+    <Popover class="w-full" v-model:show="showOptions" ref="rootRef">
       <template #target="{ open: openPopover, togglePopover }">
         <slot name="target" v-bind="{ open: openPopover, togglePopover }">
           <div class="w-full">
@@ -198,7 +198,7 @@ export default {
     ComboboxOption,
     ComboboxButton,
   },
-  expose: ['togglePopover'],
+  expose: ['togglePopover', 'rootRef'],
   data() {
     return {
       query: '',
@@ -262,6 +262,9 @@ export default {
     },
   },
   methods: {
+    rootRef() {
+      return this.$refs['rootRef']
+    },
     togglePopover(val) {
       this.showOptions = val ?? !this.showOptions
     },

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -29,7 +29,17 @@
 import LoadingText from './LoadingText.vue'
 export default {
   name: 'Card',
-  props: ['title', 'subtitle', 'loading'],
+  props: {
+    title: {
+      type: String,
+    },
+    subtitle: {
+      type: String,
+    },
+    loading: {
+      type: Boolean,
+    },
+  },
   components: {
     LoadingText,
   },

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -118,14 +118,27 @@ import FeatherIcon from './FeatherIcon.vue'
 import TextInput from './TextInput.vue'
 export default {
   name: 'DatePicker',
-  props: [
-    'value',
-    'modelValue',
-    'placeholder',
-    'formatter',
-    'readonly',
-    'inputClass',
-  ],
+  props: {
+    value: {
+      type: String,
+    },
+    modelValue: {
+      type: String,
+    },
+    placeholder: {
+      type: String,
+    },
+    formatter: {
+      type: Function,
+      default: null,
+    },
+    readonly: {
+      type: Boolean,
+    },
+    inputClass: {
+      type: [String, Array, Object],
+    },
+  },
   emits: ['update:modelValue', 'change'],
   components: {
     Popover,

--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -107,14 +107,27 @@ import FeatherIcon from './FeatherIcon.vue'
 import TextInput from './TextInput.vue'
 export default {
   name: 'DateRangePicker',
-  props: [
-    'value',
-    'modelValue',
-    'placeholder',
-    'formatter',
-    'readonly',
-    'inputClass',
-  ],
+  props: {
+    value: {
+      type: String,
+    },
+    modelValue: {
+      type: String,
+    },
+    placeholder: {
+      type: String,
+    },
+    formatter: {
+      type: Function,
+      default: null,
+    },
+    readonly: {
+      type: Boolean,
+    },
+    inputClass: {
+      type: [String, Array, Object],
+    },
+  },
   emits: ['update:modelValue', 'change'],
   components: {
     Popover,

--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -157,14 +157,27 @@ import FeatherIcon from './FeatherIcon.vue'
 import TextInput from './TextInput.vue'
 export default {
   name: 'DateTimePicker',
-  props: [
-    'value',
-    'modelValue',
-    'placeholder',
-    'formatter',
-    'readonly',
-    'inputClass',
-  ],
+  props: {
+    value: {
+      type: String,
+    },
+    modelValue: {
+      type: String,
+    },
+    placeholder: {
+      type: String,
+    },
+    formatter: {
+      type: Function,
+      default: null,
+    },
+    readonly: {
+      type: Boolean,
+    },
+    inputClass: {
+      type: [String, Array, Object],
+    },
+  },
   emits: ['update:modelValue', 'change'],
   components: {
     Popover,

--- a/src/components/FileUploader.vue
+++ b/src/components/FileUploader.vue
@@ -28,7 +28,18 @@ import FileUploadHandler from '../utils/fileUploadHandler'
 
 export default {
   name: 'FileUploader',
-  props: ['fileTypes', 'uploadArgs', 'validateFile'],
+  props: {
+    fileTypes: {
+      type: [String, Array],
+    },
+    uploadArgs: {
+      type: Object,
+    },
+    validateFile: {
+      type: Function,
+      default: null,
+    },
+  },
   data() {
     return {
       uploader: null,


### PR DESCRIPTION
Basic prop type info was missing for components (not typescript at the moment). Added it for:
- Autcomplete
- Date components (DatePicker, DateTimePicker, DateRangePicker)
- FileUploader
- Card

Also, exposing the root element of Autocomplete for controlling it from the parent component. I need access to template refs (for, you know what...). Accessing $el in this case references a TEXT_NODE (https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#node.text_node)`, so exposing it explicitly.