### PR TITLE
ci: Move histoire pages from netlify to GH pages 

### DIFF
--- a/.github/workflows/story-publish.yml
+++ b/.github/workflows/story-publish.yml
@@ -1,13 +1,14 @@
 name: Build and Deploy Storybook
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types:
+      - closed
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
 
     steps:
       - name: Checkout code
@@ -16,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/story-publish.yml
+++ b/.github/workflows/story-publish.yml
@@ -1,0 +1,36 @@
+name: Build and Deploy Storybook
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build package
+        run: yarn run build
+
+      - name: Build Histoire
+        run: yarn run story:build
+
+      - name: Deploy Histoire to
+
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./.histoire/dist
+          publish_branch: gh-pages

--- a/.github/workflows/story-publish.yml
+++ b/.github/workflows/story-publish.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build Histoire
         run: yarn run story:build
 
+      - name: Create CNAME file
+        run: echo 'ui.frappe.io' > ./.histoire/dist/CNAME
+
       - name: Deploy Histoire to
 
         uses: peaceiris/actions-gh-pages@v3

--- a/src/utils/espressoVariables.js
+++ b/src/utils/espressoVariables.js
@@ -80,4 +80,4 @@ const espressoColors = {
   },
 }
 
-export default espressoColors
+module.exports = espressoColors

--- a/src/utils/tailwind.config.js
+++ b/src/utils/tailwind.config.js
@@ -1,5 +1,5 @@
 const plugin = require('tailwindcss/plugin')
-import espressoVariables from './espressoVariables'
+const espressoVariables = require('./espressoVariables.js')
 
 module.exports = {
   darkMode: ['selector', '[data-theme="dark"]'],


### PR DESCRIPTION
Added a new GH action that
1. Checks if a PR was merged 
2. Builds Histoire
3. Adds CNAME (ui.frappe.io) file to build
4. Moves built dist to `gh-pages` branch

espressoVariables changed to `module.exports`
 