### PR TITLE
fix(TabButtons): register FeatherIcon

### DIFF
--- a/src/components/TabButtons.vue
+++ b/src/components/TabButtons.vue
@@ -50,6 +50,7 @@ export default {
   },
   emits: ['update:modelValue'],
   components: {
+    FeatherIcon,
     RadioGroup,
     RadioGroupOption,
     RadioGroupLabel,


### PR DESCRIPTION
got `[Vue warn]: Failed to resolve component: FeatherIcon` originating from TabButtons component.