### PR TITLE
fix: show video controls when the editor is in edit mode

### DIFF
--- a/src/components/TextEditor/InsertVideo.vue
+++ b/src/components/TextEditor/InsertVideo.vue
@@ -44,10 +44,12 @@
       />
     </template>
     <template #actions>
-      <Button variant="solid" @click="addVideo(addVideoDialog.url)">
-        Insert Video
-      </Button>
-      <Button @click="reset">Cancel</Button>
+      <div class="flex gap-2">
+        <Button variant="solid" @click="addVideo(addVideoDialog.url)">
+          Insert Video
+        </Button>
+        <Button @click="reset">Cancel</Button>
+      </div>
     </template>
   </Dialog>
 </template>

--- a/src/components/TextEditor/video-extension.js
+++ b/src/components/TextEditor/video-extension.js
@@ -38,6 +38,7 @@ const Video = Node.create({
       const video = document.createElement('video')
       if (editor.isEditable) {
         video.className = 'pointer-events-none'
+        video.controls = true
       }
       video.src = node.attrs.src
       if (!editor.isEditable) {


### PR DESCRIPTION
While the editor is in edit mode, the video controls are not shown in the editor.

The video controls should be shown in the edit mode.