### PR TITLE
fix: move typescript from devDependencies to dependencies + enforce vue 3.3+ for peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,10 +53,11 @@
     "radix-vue": "^1.5.3",
     "showdown": "^2.1.0",
     "socket.io-client": "^4.5.1",
-    "tippy.js": "^6.3.7"
+    "tippy.js": "^6.3.7",
+    "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "vue": "^3.2.45",
+    "vue": "^3.3.0",
     "vue-router": "^4.1.6"
   },
   "devDependencies": {
@@ -69,9 +70,8 @@
     "postcss": "^8.4.21",
     "prettier-plugin-tailwindcss": "^0.1.13",
     "tailwindcss": "^3.2.7",
-    "typescript": "^5.0.2",
     "vite": "^4.1.0",
-    "vue": "^3.2.45",
+    "vue": "^3.3.0",
     "vue-router": "^4.1.6"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "vue": "^3.3.0",
+    "vue": ">=3.3.0",
     "vue-router": "^4.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Alternate solution to this: https://github.com/frappe/frappe-ui/pull/220
- All frappe apps are already at vue 3.3+
- frappe-ui's yarn.lock is also at 3.5.12 - https://github.com/frappe/frappe-ui/blob/050467de060e546bea6c9fdb6c89f0997713020a/yarn.lock#L4570
- Moved typescript from dev dependency to prod dependency because importing types and using it for prop definitions requires typescript as a dependency. Ref: [https://vuejs.org/guide/typescript/composition-api.html\#syntax-limitations](https://vuejs.org/guide/typescript/composition-api.html/#syntax-limitations)


### From the vue docs:

This also works if Props is imported from an external source. This feature requires TypeScript to be a peer dependency of Vue.

```vue
<script setup lang="ts">
import type { Props } from './foo'

const props = defineProps<Props>()
</script>
```

