### PR TITLE
fix: Semantic color for border

### DIFF
--- a/src/tailwind/plugin.js
+++ b/src/tailwind/plugin.js
@@ -210,9 +210,6 @@ module.exports = plugin(
         textColor: {
           ink: semanticColors.ink,
         },
-        borderColor: {
-          outline: semanticColors.outline,
-        },
         backgroundColor: {
           surface: semanticColors.surface,
         },
@@ -255,6 +252,7 @@ module.exports = plugin(
         },
         borderColor: (theme) => ({
           DEFAULT: theme('colors.gray.200'),
+          outline: semanticColors.outline,
         }),
         typography: (theme) => ({
           DEFAULT: {


### PR DESCRIPTION
- It was not working because borderColor key was defined twice and the second one was overriding the first one

**Before:**
<img width="357" alt="Screenshot 2024-11-22 at 3 45 36 PM" src="https://github.com/user-attachments/assets/b50050b0-69e2-4170-bbc4-99103e26688a">

**After:**
<img width="812" alt="Screenshot 2024-11-22 at 3 44 48 PM" src="https://github.com/user-attachments/assets/a33f3623-076e-44ca-9d16-112f59e40597">
