### PR TITLE
fix: add onClick with route in breadcrumb

### DIFF
--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -60,11 +60,10 @@
 </template>
 <script setup lang="ts">
 import { useWindowSize } from '@vueuse/core'
-import { computed } from 'vue'
+import { computed, h } from 'vue'
 import { RouterLinkProps, useRouter } from 'vue-router'
 import Dropdown from '../components/Dropdown.vue'
 import { Button } from './Button'
-import { h } from 'vue'
 
 interface BreadcrumbItem {
   label: string

--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -39,7 +39,14 @@
               ? 'text-ink-gray-9'
               : 'text-ink-gray-5 hover:text-ink-gray-7',
           ]"
-          v-bind="item.route ? { to: item.route } : { onClick: item.onClick }"
+          v-bind="
+            item.route
+              ? {
+                  to: item.route,
+                  onClick: item.hasOwnProperty('onClick') && item.onClick,
+                }
+              : { onClick: item.onClick }
+          "
         >
           <slot name="prefix" :item="item" />
           <span>

--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -39,13 +39,7 @@
               ? 'text-ink-gray-9'
               : 'text-ink-gray-5 hover:text-ink-gray-7',
           ]"
-          v-bind="
-            item.route
-              ? {
-                  to: item.route,
-                }
-              : { onClick: item.onClick }
-          "
+          v-bind="item.route ? { to: item.route } : { onClick: item.onClick }"
         >
           <slot name="prefix" :item="item" />
           <span>

--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -32,7 +32,7 @@
     >
       <template v-for="(item, i) in crumbs" :key="item.label">
         <component
-          :is="item.route ? 'router-link' : 'button'"
+          :is="item.route ? 'router-link' : button"
           class="flex items-center rounded px-0.5 py-1 text-lg font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
           :class="[
             i == crumbs.length - 1
@@ -43,7 +43,6 @@
             item.route
               ? {
                   to: item.route,
-                  onClick: item.hasOwnProperty('onClick') && item.onClick,
                 }
               : { onClick: item.onClick }
           "
@@ -71,6 +70,7 @@ import { computed } from 'vue'
 import { RouterLinkProps, useRouter } from 'vue-router'
 import Dropdown from '../components/Dropdown.vue'
 import { Button } from './Button'
+import { h } from 'vue'
 
 interface BreadcrumbItem {
   label: string
@@ -118,5 +118,10 @@ const crumbs = computed(() => {
 
   let lastTwo = items.value.slice(-2)
   return lastTwo
+})
+
+const button = h(Button, {
+  variant: 'ghost',
+  class: 'hover:bg-inherit active:bg-inherit',
 })
 </script>


### PR DESCRIPTION
**Issue:**
<img width="406" alt="image" src="https://github.com/user-attachments/assets/ae232269-b746-4f4e-b2e4-e9cc2f799d85">

Currently when the we add a route along with onClick property to a "breadcrumb", the route takes the precedence, as shown below.
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/52b822c0-76e9-41ff-84fb-c74aab332b2a">
This results in a problem where we want to trigger a function while clicking on a breadcrumb.

But if we just add onClick and remove the "route" property like this
<img width="359" alt="image" src="https://github.com/user-attachments/assets/b4b878f0-581c-40ee-9024-cbc5e916296a">

Then the breadcrumb results in a button
<img width="540" alt="image" src="https://github.com/user-attachments/assets/3b858930-4330-42ac-971e-57dc636b5049">

which is a bad UI.



**Result**
1.  API
<img width="685" alt="image" src="https://github.com/user-attachments/assets/d5e829ac-bba8-4f1c-9eb4-b12aeeaa8efe">

2.  Both focus and hover classes has been made inherit
![image](https://github.com/user-attachments/assets/5894ba54-115f-4539-99fe-da05ca535ab9)




