### PR TITLE
Added URL Argument to Call method

### DIFF
--- a/src/utils/call.js
+++ b/src/utils/call.js
@@ -20,7 +20,7 @@ export default async function call(method, args, options = {}) {
   
   // Allow custom path override using the url args
   if (args.url) {
-    path = url;
+    path = url + path;
   }
   const res = await fetch(path, {
     method: 'POST',

--- a/src/utils/call.js
+++ b/src/utils/call.js
@@ -17,6 +17,11 @@ export default async function call(method, args, options = {}) {
   }
 
   let path = method.startsWith('/') ? method : `/api/method/${method}`
+  
+  // Allow custom path override using the url args
+  if (args.url) {
+    path = url;
+  }
   const res = await fetch(path, {
     method: 'POST',
     headers,


### PR DESCRIPTION


**Problem:**
The current `call` method is limited to using a fixed base URL. It does not support sending requests to a different hostname or port, which restricts its flexibility in multi-environment or distributed system setups.


**Solution:**
This update introduces the `url` key as an optional parameter in the `call` method. When provided, the process constructs the request URL using the specified hostname and port. If the `URL` key is omitted, the method defaults to the existing base URL.


**Usage Example:**
```javascript
call('example.method', {
  url: 'http://localhost:3001'
});
```
This resolves the request to:
```
http://localhost:3001/api/method/example.method
```
