### PR TITLE
fix: video and image controls should not have empty url

### DIFF
--- a/src/components/TextEditor/InsertImage.vue
+++ b/src/components/TextEditor/InsertImage.vue
@@ -65,9 +65,7 @@ export default {
       })
     },
     addImage(src) {
-      if (!src) {
-        return
-      }
+      if (!src) return
       this.editor.chain().focus().setImage({ src }).run()
       this.reset()
     },

--- a/src/components/TextEditor/InsertImage.vue
+++ b/src/components/TextEditor/InsertImage.vue
@@ -26,10 +26,12 @@
       />
     </template>
     <template #actions>
-      <Button variant="solid" @click="addImage(addImageDialog.url)">
-        Insert Image
-      </Button>
-      <Button @click="reset"> Cancel </Button>
+      <div class="flex gap-2">
+        <Button variant="solid" @click="addImage(addImageDialog.url)">
+          Insert Image
+        </Button>
+        <Button @click="reset"> Cancel </Button>
+      </div>
     </template>
   </Dialog>
 </template>
@@ -63,6 +65,9 @@ export default {
       })
     },
     addImage(src) {
+      if (!src) {
+        return
+      }
       this.editor.chain().focus().setImage({ src }).run()
       this.reset()
     },

--- a/src/components/TextEditor/InsertVideo.vue
+++ b/src/components/TextEditor/InsertVideo.vue
@@ -81,6 +81,9 @@ export default {
     },
 
     addVideo(src) {
+      if (!src) {
+        return
+      }
       this.editor
         .chain()
         .focus()

--- a/src/components/TextEditor/InsertVideo.vue
+++ b/src/components/TextEditor/InsertVideo.vue
@@ -81,9 +81,7 @@ export default {
     },
 
     addVideo(src) {
-      if (!src) {
-        return
-      }
+      if (!src) return
       this.editor
         .chain()
         .focus()


### PR DESCRIPTION
Image and Video Controls are returning empty video and img element if no url/ src is present. E.g.
 
![Screenshot 2024-12-18 at 4 16 41 PM](https://github.com/user-attachments/assets/f5f190d2-b2d6-4dde-8114-ddf0ca1383c1)

![image](https://github.com/user-attachments/assets/3ed1b5ba-0d81-45ef-bef9-1320ad5400cc)


**Solution:**
Only add image and video to editor if url/ src is present in any of these 2 elements. 