### PR TITLE
refactor: Tabs layout (BREAKING CHANGE)

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -1,16 +1,12 @@
 <template>
   <TabGroup
-    as="div"
-    class="flex flex-1 flex-col overflow-y-hidden"
-    :style="`height: calc(100vh - ${tabListRef?.$el.offsetTop}px)`"
     :defaultIndex="changedIndex"
     :selectedIndex="changedIndex"
     @change="(idx) => (changedIndex = idx)"
   >
     <TabList
-      ref="tabListRef"
       class="relative flex items-center gap-7.5 overflow-x-auto border-b px-5"
-      :class="tablistClass"
+      v-bind="$attrs"
     >
       <Tab
         ref="tabRef"
@@ -19,6 +15,7 @@
         :key="i"
         v-slot="{ selected }"
         class="focus:outline-none focus:transition-none"
+        :class="tabClass"
       >
         <slot name="tab" v-bind="{ tab, selected }">
           <button
@@ -61,7 +58,7 @@ const props = defineProps({
     type: Number,
     default: 0,
   },
-  tablistClass: {
+  tabClass: {
     type: String,
     default: '',
   },
@@ -78,7 +75,6 @@ const changedIndex = computed({
   set: (index) => emit('update:modelValue', index),
 })
 
-const tabListRef = ref(null)
 const tabRef = ref([])
 const indicator = ref(null)
 const tabsLength = computed(() => props.tabs?.length)


### PR DESCRIPTION
**ISSUE**
Because of the extra div it is hard to control the scrolling behaviour.
E.g. In Frappe Cloud we have a sticky header below which tabs component is used, now it is hard to keep the tabs header sticky and only the tabs panel scrollable because of the extra div.

```html
<div> <--- Extra div
	<div>  <---------------  tab list
		<div></div> <-------  tab 1
		<div></div> <-------  tab 2
		<div></div> <-------  tab 3
	</div>
	<div>  <---------------  tab panels
		<div></div> <-------  tab panel 1
		<div></div> <-------  tab panel 2
		<div></div> <-------  tab panel 3
	</div>
<div>
```

**FIX**
Now there is two way to implement tabs one with container and one without container
**Variant 1:** With div container
```vue
<Tabs as="div" v-model="tabIndex" :tabs="tabs">
	<template #tab-panel={ tab }>
		<!-- tab panel area -->
	</template>
</Tabs>
```
Output
```html
<div> <--- div container
	<div>  <---------------  tab list
		<div></div> <-------  tab 1
		<div></div> <-------  tab 2
		<div></div> <-------  tab 3
	</div>
	<div>  <---------------  tab panels
		<div></div> <-------  tab panel 1
		<div></div> <-------  tab panel 2
		<div></div> <-------  tab panel 3
	</div>
<div>
```
**Variant 2:** Without div container
```vue
<Tabs v-model="tabIndex" :tabs="tabs">
	<template #tab-panel={ tab }>
		<!-- tab panel area -->
	</template>
</Tabs>
```
Output
```html
<div>  <---------------  tab list
	<div></div> <-------  tab 1
	<div></div> <-------  tab 2
	<div></div> <-------  tab 3
</div>
<div>  <---------------  tab panels
	<div></div> <-------  tab panel 1
	<div></div> <-------  tab panel 2
	<div></div> <-------  tab panel 3
</div>
```

**BREAKING CHANGE**
Implement this changes to resolve the breaking change caused by this PR
Before
```vue
<Tabs v-model="tabIndex" :tabs="tabs">
  <!-- tab panel area -->
</Tabs>
```
After
```vue
<Tabs as="div" v-model="tabIndex" :tabs="tabs">
  <template #tab-panel>
    <!-- tab panel area -->
  </template>
</Tabs>
```