### PR TITLE
fix(ui): change shade of collapsable icon in grouped view

### DIFF
--- a/src/components/ListView/ListGroupHeader.vue
+++ b/src/components/ListView/ListGroupHeader.vue
@@ -8,11 +8,6 @@
         class="h-4 w-4 text-ink-gray-6 transition-transform duration-200"
         :class="[group.collapsed ? '-rotate-90' : '']"
       />
-      <!-- <FeatherIcon
-        name="chevron-down"
-        class="h-4 w-4 text-ink-gray-6 transition-transform duration-200"
-        :class="[group.collapsed ? '-rotate-90' : '']"
-      /> -->
     </button>
     <slot>
       <div class="w-full py-1.5 pr-2">
@@ -31,7 +26,6 @@
 </template>
 <script setup>
 import { inject } from 'vue'
-import { FeatherIcon } from 'frappe-ui'
 import DownSolid from '../../icons/DownSolid.vue'
 
 const props = defineProps({

--- a/src/components/ListView/ListGroupHeader.vue
+++ b/src/components/ListView/ListGroupHeader.vue
@@ -5,9 +5,14 @@
       class="ml-[3px] mr-[11px] rounded p-1 hover:bg-surface-gray-2"
     >
       <DownSolid
-        class="h-4 w-4 text-ink-gray-9 transition-transform duration-200"
+        class="h-4 w-4 text-ink-gray-6 transition-transform duration-200"
         :class="[group.collapsed ? '-rotate-90' : '']"
       />
+      <!-- <FeatherIcon
+        name="chevron-down"
+        class="h-4 w-4 text-ink-gray-6 transition-transform duration-200"
+        :class="[group.collapsed ? '-rotate-90' : '']"
+      /> -->
     </button>
     <slot>
       <div class="w-full py-1.5 pr-2">
@@ -26,6 +31,7 @@
 </template>
 <script setup>
 import { inject } from 'vue'
+import { FeatherIcon } from 'frappe-ui'
 import DownSolid from '../../icons/DownSolid.vue'
 
 const props = defineProps({


### PR DESCRIPTION
change shade from text-ink-gray-9 to text-ink-gray-6 in collapsable icon in Grouped List View


**Before**
![image](https://github.com/user-attachments/assets/a153e4c9-37b1-4ba4-a79a-85e4d12da82d)


**After**
![image](https://github.com/user-attachments/assets/f8a70dde-8573-4622-b50a-ef27a1001f42)
