### PR TITLE
fix(ConfirmDialog): Add onCancel handler

### DIFF
--- a/docs/components/confirm-dialog.md
+++ b/docs/components/confirm-dialog.md
@@ -18,6 +18,7 @@ You need to make sure you include the `Dialogs` component in your root component
           // deleteFile()
           // hideDialog() // closes dialog
         },
+        onCancel: () => {}
       })
     "
   >
@@ -37,6 +38,7 @@ You need to make sure you include the `Dialogs` component in your root component
           // deleteFile()
           // hideDialog() // closes dialog
         },
+        onCancel: () => {}
       })
     "
   >

--- a/src/components/ConfirmDialog.vue
+++ b/src/components/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <Dialog v-model="showDialog" :options="{ title }">
+  <Dialog v-model="showDialog" :options="{ title }" @close="closeDialog">
     <template #body-content>
       <div class="space-y-4">
         <p class="text-p-base text-gray-800" v-if="message" v-html="message" />
@@ -27,6 +27,10 @@ export default {
       type: Function,
       default: null,
     },
+    onCancel: {
+      type: Function,
+      default: null,
+    },
   },
   expose: ['show', 'hide'],
   components: {
@@ -51,6 +55,10 @@ export default {
     },
     show() {
       this.showDialog = true
+    },
+    closeDialog() {
+      this.hide()
+      this.onCancel?.()
     },
     hide() {
       this.showDialog = false

--- a/src/utils/confirmDialog.js
+++ b/src/utils/confirmDialog.js
@@ -1,12 +1,13 @@
 import ConfirmDialog from '../components/ConfirmDialog.vue'
 import { h, ref } from 'vue'
 
-export function confirmDialog({ title = 'Untitled', message = '', onConfirm }) {
+export function confirmDialog({ title = 'Untitled', message = '', onConfirm, onCancel }) {
   renderDialog(
     h(ConfirmDialog, {
       title,
       message,
       onConfirm,
+      onCancel
     }),
   )
 }


### PR DESCRIPTION
There was no way of identifying if user discarded the confirmation.

`onCancel` will now be called when user closes the confirmation dialog.