### PR TITLE
feat: add `label`, `loading`, `placement` & `show-footer` props

### DIFF
--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -318,13 +318,17 @@ const filterOptions = (options: Option[]) => {
 const selectedValue = computed({
   get() {
     if (!props.multiple) {
-      return findOption(props.modelValue as AutocompleteOption)
+      return (
+        findOption(props.modelValue as AutocompleteOption) ||
+        // if the modelValue is not found in the option list
+        // return the modelValue as is
+        makeOption(props.modelValue as AutocompleteOption)
+      )
     }
     // in case of `multiple`, modelValue is an array of values
     // if the modelValue is a list of values, convert them to options
-    let values = props.modelValue as AutocompleteOption[]
-    if (!values) return []
-    return isOption(values[0]) ? values : values.map((v) => findOption(v))
+    const values = (props.modelValue || []) as AutocompleteOption[]
+    return isOption(values[0]) ? values : values.map((v) => findOption(v) || makeOption(v))
   },
   set(val) {
     query.value = ''
@@ -341,6 +345,10 @@ const findOption = (option: AutocompleteOption) => {
   if (!option) return option
   const value = isOption(option) ? option.value : option
   return allOptions.value.find((o) => o.value === value)
+}
+
+const makeOption = (option: AutocompleteOption) => {
+  return isOption(option) ? option : { label: option, value: option }
 }
 
 const getLabel = (option: AutocompleteOption) => {

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -231,7 +231,7 @@ type AutocompleteOptionGroup = {
 type AutocompleteOptions = AutocompleteOption[] | AutocompleteOptionGroup[]
 
 type AutocompleteProps = {
-  label: string
+  label?: string
   options: AutocompleteOptions
   hideSearch?: boolean
   placeholder?: string

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -45,12 +45,7 @@
                 </span>
                 <slot name="suffix" />
               </div>
-              <LoadingIndicator
-                v-if="props.loading && isComboboxOpen"
-                class="h-4 w-4 text-gray-600"
-              />
               <FeatherIcon
-                v-else
                 name="chevron-down"
                 class="h-4 w-4 text-ink-gray-5"
                 aria-hidden="true"
@@ -84,12 +79,17 @@
                     autocomplete="off"
                     placeholder="Search"
                   />
-                  <button
+                  <div
                     class="absolute right-0 inline-flex h-7 w-7 items-center justify-center"
-                    @click="clearAll"
                   >
-                    <FeatherIcon name="x" class="w-4 text-ink-gray-8" />
-                  </button>
+                    <LoadingIndicator
+                      v-if="!props.loading"
+                      class="h-4 w-4 text-ink-gray-5"
+                    />
+                    <button v-else @click="clearAll">
+                      <FeatherIcon name="x" class="w-4 text-ink-gray-8" />
+                    </button>
+                  </div>
                 </div>
               </div>
               <div
@@ -328,7 +328,9 @@ const selectedValue = computed({
     // in case of `multiple`, modelValue is an array of values
     // if the modelValue is a list of values, convert them to options
     const values = (props.modelValue || []) as AutocompleteOption[]
-    return isOption(values[0]) ? values : values.map((v) => findOption(v) || makeOption(v))
+    return isOption(values[0])
+      ? values
+      : values.map((v) => findOption(v) || makeOption(v))
   },
   set(val) {
     query.value = ''

--- a/src/components/Rating/Rating.vue
+++ b/src/components/Rating/Rating.vue
@@ -12,7 +12,7 @@
       >
         <FeatherIcon
           name="star"
-          class="fill-gray-400 text-ink-gray-1 stroke-1 mr-1"
+          class="fill-gray-300 text-transparent mr-0.5"
           :class="iconClasses(index)"
           @click="markRating(index)"
         />
@@ -55,9 +55,9 @@ const iconClasses = (index: number) => {
   ]
 
   if (index <= hoveredRating.value && index > rating.value) {
-    classes.push('fill-yellow-200')
+    classes.push('!fill-yellow-200')
   } else if (index <= rating.value) {
-    classes.push('fill-yellow-500')
+    classes.push('!fill-yellow-500')
   }
 
   if (!props.readonly) {


### PR DESCRIPTION
1. Add `label` prop similar to `FormControl`
2. Add `loading` prop to display loading indicator
3. Add `show-footer` prop to show `clear` button even in case of `single` value

![CleanShot 2025-03-14 at 15 16 06@2x](https://github.com/user-attachments/assets/35b66c98-b24d-475d-a43a-65e0162d9990)

4. minor change in rating styles
  - Before:
     ![CleanShot 2025-03-14 at 16 06 21@2x](https://github.com/user-attachments/assets/c7301ac5-44f3-4647-91ba-b4d7314ffc42)

  - After
    ![CleanShot 2025-03-14 at 16 05 45@2x](https://github.com/user-attachments/assets/ea572b65-7b4c-4e35-8193-ef1ca6cfd6d7)


