### PR TITLE
refactor(FormControl): explicitly add modelValue prop using defineModel

### DIFF
--- a/src/components/FormControl.vue
+++ b/src/components/FormControl.vue
@@ -11,6 +11,7 @@
       v-if="type === 'select'"
       :id="id"
       v-bind="{ ...controlAttrs, size }"
+      v-model="model"
     >
       <template #prefix v-if="$slots.prefix">
         <slot name="prefix" />
@@ -19,6 +20,7 @@
     <Autocomplete
       v-else-if="type === 'autocomplete'"
       v-bind="{ ...controlAttrs }"
+      v-model="model"
     >
       <template #prefix v-if="$slots.prefix">
         <slot name="prefix" />
@@ -31,11 +33,13 @@
       v-else-if="type === 'textarea'"
       :id="id"
       v-bind="{ ...controlAttrs, size }"
+      v-model="model"
     />
     <TextInput
       v-else
       :id="id"
       v-bind="{ ...controlAttrs, type, size, required }"
+      v-model="model"
     >
       <template #prefix v-if="$slots.prefix">
         <slot name="prefix" />
@@ -52,6 +56,7 @@
     v-else
     :id="id"
     v-bind="{ ...controlAttrs, label, size, class: attrs.class }"
+    v-model="model"
   />
 </template>
 <script setup lang="ts">
@@ -79,6 +84,8 @@ const props = withDefaults(defineProps<FormControlProps>(), {
   size: 'sm',
 })
 
+const model = defineModel()
+
 const attrs = useAttrs()
 const controlAttrs = computed(() => {
   // pass everything except class and style
@@ -89,16 +96,6 @@ const controlAttrs = computed(() => {
     }
   }
   return _attrs
-})
-
-const labelClasses = computed(() => {
-  return [
-    {
-      sm: 'text-xs',
-      md: 'text-base',
-    }[props.size],
-    'text-ink-gray-5',
-  ]
 })
 
 const descriptionClasses = computed(() => {


### PR DESCRIPTION
### Before

FormControl did not have an explicit `modelValue` prop. The binding worked with individual controls because of fallthrough attributes mapped via `controlAttrs`. But when you check the component definition, there is no explicit modelValue prop in the definition, so Studio cannot render it in props editor

![modelValue-before](https://github.com/user-attachments/assets/1a14d825-ace1-4561-a7f8-914f495548b0)

### After

Explicitly added and mapped modelValue prop using defineModel

![modelValue](https://github.com/user-attachments/assets/10c010c6-1faa-4fd9-b796-8d834176eeb2)

Also, removed unused labelClasses computed property
 