### PR TITLE
fix: style propogation through components with `inheritAttrs: false`

### DIFF
--- a/src/components/FormControl.vue
+++ b/src/components/FormControl.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="type != 'checkbox'" :class="['space-y-1.5', attrs.class]">
+  <div v-if="type != 'checkbox'" :class="['space-y-1.5', attrs.class]" :style="attrs.style">
     <FormLabel
       v-if="label"
       :label="label"

--- a/src/components/Input.vue
+++ b/src/components/Input.vue
@@ -1,5 +1,5 @@
 <template>
-  <label :class="[type == 'checkbox' ? 'flex' : 'block', $attrs.class]">
+  <label :class="[type == 'checkbox' ? 'flex' : 'block', $attrs.class]" :style="$attrs.style">
     <span
       v-if="label && type != 'checkbox'"
       class="mb-2 block text-sm leading-4 text-gray-700"

--- a/src/components/ListView/ListView.vue
+++ b/src/components/ListView/ListView.vue
@@ -3,6 +3,7 @@
     <div
       class="flex w-max min-w-full flex-col overflow-y-hidden"
       :class="$attrs.class"
+      :style="$attrs.style"
     >
       <slot v-bind="{ showGroupedRows, selectable }">
         <ListHeader />

--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative w-full" :class="$attrs.class" v-if="editor">
+  <div class="relative w-full" :class="$attrs.class" :style="$attrs.style" v-if="editor">
     <TextEditorBubbleMenu :buttons="bubbleMenu" :options="bubbleMenuOptions" />
     <TextEditorFixedMenu
       class="w-full overflow-x-auto rounded-t-lg border border-outline-gray-modals"


### PR DESCRIPTION
Studio applies raw styles to components via the style panel. But some compnents did not have style binding to the actual divs. Fix style propogation for such components:
- ListView
- FormControl
- Input
- TextEditor