### PR TITLE
Add unique in  Autocomplete to handle duplicates

### DIFF
--- a/src/components/Autocomplete.story.vue
+++ b/src/components/Autocomplete.story.vue
@@ -99,5 +99,17 @@ const options = [
         />
       </div>
     </Variant>
+    <Variant title="Multiple options without duplicates">
+      <div class="p-2">
+        <Autocomplete
+          :options="options"
+          v-model="people"
+          placeholder="Select people"
+          :multiple="true"
+          :hideSearch="true"
+          :unique="true"
+        />
+      </div>
+    </Variant>
   </Story>
 </template>

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -239,6 +239,7 @@ type AutocompleteProps = {
   loading?: boolean
   placement?: string
   showFooter?: boolean
+  unique?: boolean
 } & (
   | {
       multiple: true
@@ -339,6 +340,22 @@ const selectedValue = computed({
       emit('update:modelValue', val)
       return
     }
+
+    if (props.unique) {
+      // Only allow unique values when unique is true
+      const uniqueVals = []
+      const seen = new Set()
+      for (const v of val) {
+        const value = isOption(v) ? v.value : v
+        if (!seen.has(value)) {
+          seen.add(value)
+          uniqueVals.push(v)
+        }
+      }
+      emit('update:modelValue', uniqueVals)
+      return
+    } 
+    
     emit('update:modelValue', val)
   },
 })


### PR DESCRIPTION
Added unique prop to Autocomplete field to prevent duplicate selections.
This update introduces a unique boolean prop to the Autocomplete component. When enabled, it ensures that the same item cannot be selected multiple times, improving data integrity in multi-select scenarios.