### PR TITLE
fix(FormControl): add explicit variant prop

### DIFF
--- a/src/components/FormControl/FormControl.vue
+++ b/src/components/FormControl/FormControl.vue
@@ -14,7 +14,7 @@
     <Select
       v-if="type === 'select'"
       :id="id"
-      v-bind="{ ...controlAttrs, size }"
+      v-bind="{ ...controlAttrs, size, variant }"
       v-model="model"
     >
       <template #prefix v-if="$slots.prefix">
@@ -36,13 +36,13 @@
     <Textarea
       v-else-if="type === 'textarea'"
       :id="id"
-      v-bind="{ ...controlAttrs, size }"
+      v-bind="{ ...controlAttrs, size, variant }"
       v-model="model"
     />
     <TextInput
       v-else
       :id="id"
-      v-bind="{ ...controlAttrs, type, size, required }"
+      v-bind="{ ...controlAttrs, type, size, variant, required }"
       v-model="model"
     >
       <template #prefix v-if="$slots.prefix">
@@ -78,6 +78,7 @@ const id = useId()
 const props = withDefaults(defineProps<FormControlProps>(), {
   type: 'text',
   size: 'sm',
+  variant: 'subtle',
 })
 
 const model = defineModel()

--- a/src/components/FormControl/types.ts
+++ b/src/components/FormControl/types.ts
@@ -5,5 +5,6 @@ export interface FormControlProps {
   description?: string
   type?: TextInputTypes | 'textarea' | 'select' | 'checkbox' | 'autocomplete'
   size?: 'sm' | 'md'
+  variant?: 'subtle' | 'outline'
   required?: boolean
 }


### PR DESCRIPTION
This was already mapped internally via `controlAttrs`, but making it explicit for a transparent component definition
For the same reason as: https://github.com/frappe/frappe-ui/pull/305

Note: Autocomplete & Checkbox don't have variants