### PR TITLE
fix: default function to upload files in TextEditor

### DIFF
--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -20,36 +20,37 @@
 </template>
 
 <script lang="ts">
-import { normalizeClass, computed } from 'vue'
-import { Editor, EditorContent, VueNodeViewRenderer } from '@tiptap/vue-3'
-import StarterKit from '@tiptap/starter-kit'
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import Placeholder from '@tiptap/extension-placeholder'
-import TextAlign from '@tiptap/extension-text-align'
 import Table from '@tiptap/extension-table'
 import TableCell from '@tiptap/extension-table-cell'
 import TableHeader from '@tiptap/extension-table-header'
 import TableRow from '@tiptap/extension-table-row'
-import { ImageExtension } from './extensions/image'
-import ImageViewerExtension from './image-viewer-extension'
-import VideoExtension from './video-extension'
-import LinkExtension from './link-extension'
-import Typography from '@tiptap/extension-typography'
+import TextAlign from '@tiptap/extension-text-align'
 import TextStyle from '@tiptap/extension-text-style'
-import NamedColorExtension from './extensions/color'
-import NamedHighlightExtension from './extensions/highlight'
+import Typography from '@tiptap/extension-typography'
+import StarterKit from '@tiptap/starter-kit'
+import { Editor, EditorContent, VueNodeViewRenderer } from '@tiptap/vue-3'
 import { common, createLowlight } from 'lowlight'
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
-import CodeBlockComponent from './CodeBlockComponent.vue'
-import configureMention from './mention'
-import TextEditorFixedMenu from './TextEditorFixedMenu.vue'
-import TextEditorBubbleMenu from './TextEditorBubbleMenu.vue'
-import TextEditorFloatingMenu from './TextEditorFloatingMenu.vue'
-import EmojiExtension from './extensions/emoji/emoji-extension'
-import SlashCommands from './extensions/slash-commands/slash-commands-extension'
-import { detectMarkdown, markdownToHTML } from '../../utils/markdown'
 import { DOMParser } from 'prosemirror-model'
-import { TagNode, TagExtension } from './extensions/tag/tag-extension'
+import { computed, normalizeClass } from 'vue'
+import { detectMarkdown, markdownToHTML } from '../../utils/markdown'
+import { useFileUpload } from '../../utils/useFileUpload'
+import CodeBlockComponent from './CodeBlockComponent.vue'
+import NamedColorExtension from './extensions/color'
+import EmojiExtension from './extensions/emoji/emoji-extension'
 import { Heading } from './extensions/heading/heading'
+import NamedHighlightExtension from './extensions/highlight'
+import { ImageExtension } from './extensions/image'
+import SlashCommands from './extensions/slash-commands/slash-commands-extension'
+import { TagExtension, TagNode } from './extensions/tag/tag-extension'
+import ImageViewerExtension from './image-viewer-extension'
+import LinkExtension from './link-extension'
+import configureMention from './mention'
+import TextEditorBubbleMenu from './TextEditorBubbleMenu.vue'
+import TextEditorFixedMenu from './TextEditorFixedMenu.vue'
+import TextEditorFloatingMenu from './TextEditorFloatingMenu.vue'
+import VideoExtension from './video-extension'
 
 const lowlight = createLowlight(common)
 
@@ -113,7 +114,12 @@ export default {
     },
     uploadFunction: {
       type: Function,
-      default: () => null,
+      default: (file: File) => {
+        let fileUpload = useFileUpload()
+        return fileUpload.upload(file).then((fileDoc: any) => {
+          return { src: fileDoc.file_url }
+        })
+      },
     },
   },
   emits: ['change', 'focus', 'blur'],


### PR DESCRIPTION
**Issue:**

When we upload an Image or Video in TextEditor, we receive the following error:

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/4496e9d5-c022-4c77-b7f5-e36f799ef1a3" /> <br>

This is because TextEditor requires a prop called `uploadFunction`, which by default is null. So we get this error.

**Fix:**
Add default functionality to `uploadFunction` prop, which uploads the file and adds `src` to the ImageNode.

