### PR TITLE
fix: import LucideCalendar icon

### DIFF
--- a/src/components/DatePicker/DatePicker.ts
+++ b/src/components/DatePicker/DatePicker.ts
@@ -5,7 +5,8 @@ export interface DatePickerProps {
   formatter?: (date: string) => string
   readonly?: boolean
   inputClass?: string | Array<string> | Record<string, boolean>
-  placement?: string
+  placement?: string,
+  hideIcon?: boolean
 }
 
 export type DatePickerEmits = {

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -131,6 +131,7 @@ import { Button } from '../Button'
 import Popover from '../Popover.vue'
 import FeatherIcon from '../FeatherIcon.vue'
 import TextInput from '../TextInput.vue'
+import LucideCalendar from '~icons/lucide/calendar'
 
 import { getDate, getDateValue } from './utils'
 import { useDatePicker } from './useDatePicker'

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -15,7 +15,7 @@
         :class="inputClass"
         v-bind="$attrs"
       >
-        <template #prefix><LucideCalendar class="size-4" /></template>
+        <template v-if="!hideIcon" #prefix><LucideCalendar class="size-4" /></template>
       </TextInput>
     </template>
 

--- a/src/components/DatePicker/DateTimePicker.vue
+++ b/src/components/DatePicker/DateTimePicker.vue
@@ -195,6 +195,7 @@ import { Button } from '../Button'
 import Popover from '../Popover.vue'
 import FeatherIcon from '../FeatherIcon.vue'
 import TextInput from '../TextInput.vue'
+import LucideCalendar from '~icons/lucide/calendar'
 
 import { getDate } from './utils'
 import { useDatePicker } from './useDatePicker'

--- a/src/components/DatePicker/DateTimePicker.vue
+++ b/src/components/DatePicker/DateTimePicker.vue
@@ -16,7 +16,7 @@
         :class="inputClass"
         v-bind="$attrs"
       >
-        <template #prefix><LucideCalendar class="size-4" /></template>
+        <template v-if="!hideIcon" #prefix><LucideCalendar class="size-4" /></template>
       </TextInput>
     </template>
 


### PR DESCRIPTION
1. Calendar icon is not getting rendered 
<img width="262" alt="image" src="https://github.com/user-attachments/assets/2ce23211-6957-4fc2-ab83-b727cf6057e0" />

2. Allow hiding calendar icon in Date & DateTime Picker
