### PR TITLE
revert: explicitly add modelValue prop using defineMode #305

### DIFF
--- a/src/components/FormControl/FormControl.vue
+++ b/src/components/FormControl/FormControl.vue
@@ -15,7 +15,6 @@
       v-if="type === 'select'"
       :id="id"
       v-bind="{ ...controlAttrs, size, variant }"
-      v-model="model"
     >
       <template #prefix v-if="$slots.prefix">
         <slot name="prefix" />
@@ -24,7 +23,6 @@
     <Autocomplete
       v-else-if="type === 'autocomplete'"
       v-bind="{ ...controlAttrs }"
-      v-model="model"
     >
       <template #prefix v-if="$slots.prefix">
         <slot name="prefix" />
@@ -37,13 +35,11 @@
       v-else-if="type === 'textarea'"
       :id="id"
       v-bind="{ ...controlAttrs, size, variant }"
-      v-model="model"
     />
     <TextInput
       v-else
       :id="id"
       v-bind="{ ...controlAttrs, type, size, variant, required }"
-      v-model="model"
     >
       <template #prefix v-if="$slots.prefix">
         <slot name="prefix" />
@@ -60,7 +56,6 @@
     v-else
     :id="id"
     v-bind="{ ...controlAttrs, label, size, class: attrs.class }"
-    v-model="model"
   />
 </template>
 <script setup lang="ts">
@@ -80,8 +75,6 @@ const props = withDefaults(defineProps<FormControlProps>(), {
   size: 'sm',
   variant: 'subtle',
 })
-
-const model = defineModel()
 
 const attrs = useAttrs()
 const controlAttrs = computed(() => {

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -12,7 +12,6 @@ export interface SelectProps {
   placeholder?: string
   disabled?: boolean
   id?: string
-  value?: string | number
   modelValue?: string | number
   options?: SelectOption[]
 }

--- a/src/components/TextInput/types.ts
+++ b/src/components/TextInput/types.ts
@@ -7,7 +7,6 @@ export interface TextInputProps {
   placeholder?: string
   disabled?: boolean
   id?: string
-  value?: string | number
   modelValue?: string | number
   debounce?: number
   required?: boolean


### PR DESCRIPTION
Reverting #305 since it does not handle `value` prop along with `modelValue`

![image](https://github.com/user-attachments/assets/383ac03d-eace-4caa-be84-2c9770ab2ee8)

If value is passed it gets ignore which is causing the issue in some existing components like DatePicker's input field