### PR TITLE
fix: update from & to date based on default value

### DIFF
--- a/src/components/DatePicker/DateRangePicker.vue
+++ b/src/components/DatePicker/DateRangePicker.vue
@@ -120,15 +120,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 
 import { Button } from '../Button'
-import { Popover } from '../Popover'
 import FeatherIcon from '../FeatherIcon.vue'
+import { Popover } from '../Popover'
 import { TextInput } from '../TextInput'
 
-import { getDate, getDateValue } from './utils'
 import { useDatePicker } from './useDatePicker'
+import { getDate, getDateValue } from './utils'
 
 import type { DatePickerEmits, DatePickerProps } from './types'
 
@@ -163,6 +163,21 @@ const dateValue = computed(() => {
 
 const fromDate = ref<string>(dateValue.value ? dateValue.value[0] : '')
 const toDate = ref<string>(dateValue.value ? dateValue.value[1] : '')
+
+watch(
+  () => dateValue.value,
+  (newValue) => {
+    if (newValue) {
+      const values = newValue.split(',')
+      fromDate.value = values[0] || ''
+      toDate.value = values[1] || ''
+    } else {
+      fromDate.value = ''
+      toDate.value = ''
+    }
+  },
+  { immediate: true },
+)
 
 function handleDateClick(date: Date) {
   if (fromDate.value && toDate.value) {


### PR DESCRIPTION
**Issue:**
When we provide a default value in the `v-model`, the date is not properly rendered in the fromDate & toDate variables. because of which it isn't easy to pick a date.

E.g.
When we pass `2025-05-17,2025-06-16` as a value to DatePicker,  this is displayed like this in the UI
<img width="243" alt="image" src="https://github.com/user-attachments/assets/f6c0f4f0-dd03-4f40-8ce3-22badfd5168f" />


**Fix:**
If we use an immediate watcher, then the value of
`fromDate` & `toDate` is parsed properly from the `dateValue` computed property.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/f9a14f84-3894-4171-b164-078aa832952f" />


