### PR TITLE
fix(autocomplete): show placeholder if no option is selected instead of 'No Label'

### DIFF
--- a/src/components/Autocomplete/Autocomplete.vue
+++ b/src/components/Autocomplete/Autocomplete.vue
@@ -322,7 +322,7 @@ const makeOption = (option: AutocompleteOption) => {
 
 const getLabel = (option: AutocompleteOption) => {
   if (isOption(option)) {
-    return option?.label || option?.value || 'No label'
+    return option?.label || option?.value
   }
   return option
 }


### PR DESCRIPTION
### Before
![image](https://github.com/user-attachments/assets/9b9e8b6e-0e5a-447b-a679-e4a87fb9ceaf)

### After
![image](https://github.com/user-attachments/assets/a0b7f203-18e9-43ec-b715-43f820602e69)

> [!NOTE]
> Only the 'No Label' components are `Autocomplete` rest are `Select`