### PR TITLE
fix(styles): echart width on mobile

### DIFF
--- a/src/components/Charts/ECharts.vue
+++ b/src/components/Charts/ECharts.vue
@@ -52,7 +52,7 @@ watch(
   <div
     ref="chartDiv"
     v-show="!error"
-    class="h-full w-full min-w-[400px] min-h-[300px] px-4 py-2"
+    class="h-full w-full min-w-[300px] md:min-w-[400px] min-h-[300px] px-4 py-2"
   ></div>
   <div
     v-show="error"


### PR DESCRIPTION
**Issue:**
The trend chart overflows on mobile because it has a minimum width of 400px

<img width="286" alt="image" src="https://github.com/user-attachments/assets/51a16c86-3228-4557-a851-cf749857c7c1" />

**Solution:**
Making it 300 px for mobile and 400 px for medium screen and above solves the chart overflow

<img width="265" alt="image" src="https://github.com/user-attachments/assets/b630c875-02f3-4dfc-80f4-b440a46cd8ce" />
