### PR TITLE
fix(TextEditor): allow video controls to be used while editing

### DIFF
--- a/src/components/TextEditor/video-extension.ts
+++ b/src/components/TextEditor/video-extension.ts
@@ -112,9 +112,6 @@ export default Node.create<VideoOptions>({
         (editor.isEditable ? ' cursor-pointer' : '')
 
       const video = document.createElement('video')
-      if (editor.isEditable) {
-        video.className = 'pointer-events-none'
-      }
       video.src = node.attrs.src
       video.setAttribute('controls', '')
 


### PR DESCRIPTION
Previously you can upload a video to the text editor but cant play it while editing this PR fixes that

Before 

https://github.com/user-attachments/assets/9cc8e0cc-eede-4ea9-9912-ba35113c2285

After

https://github.com/user-attachments/assets/bf70f556-be5f-4ed2-aebd-51c383c635a4

