### PR TITLE
feat(resources): add provision to handle frappe.msgprint

### DIFF
--- a/src/utils/frappeRequest.js
+++ b/src/utils/frappeRequest.js
@@ -51,7 +51,7 @@ export function frappeRequest(options) {
 
         if (data._server_messages) {
           let onMessageHandler =
-            getConfig('messageHandler') || options.onMessage || null
+            getConfig('serverMessagesHandler') || options.onServerMessages || null
           if (onMessageHandler) {
             onMessageHandler(JSON.parse(data?._server_messages) || [])
           }


### PR DESCRIPTION
In Resources, we have no way to handle frappe.msgprint, which becomes crucial if you want to convey something to a user without throwing any error.

This PR solves the problem.

To get messages in the frontend, we have two ways

1. Having an onServerMessages handler in your resource
```
createResource({
    url: "frappe.client.set_value",
    params: {
      doctype: "HD Ticket",
      name: props.ticketId,
      fieldname,
      value,
    },
    debounce: 500,
    auto: true,
    onServerMessages: (msgs: any) => {
      msgs.forEach((msg: any) => {
        msg = JSON.parse(msg);
        toast.warning(msg.message);
      });
    },
    onSuccess:(d)=>console.log(d)
})

```

2. Having a config set in resources using setConfig
```
setConfig("serverMessagesHandler", (msgs) => {
  msgs.forEach((msg) => {
    msg = JSON.parse(msg);
    toast.warning(msg.message);
  });
});
```

The data returned is in the format of

```
['{"message": "Please update your SLA condition", "title": "Message"}', '{"message": "Please update your escalation rule condition", "title": "Message"}']
```


Example use case:

<img width="821" alt="image" src="https://github.com/user-attachments/assets/b8f053bf-0251-4f40-85f2-cd3b761f3647" />


<img width="1432" alt="image" src="https://github.com/user-attachments/assets/276b9d56-09a0-4f06-bde0-b2f0bba20c45" />


