### PR TITLE
fix: show trial banner regardless of setup completed or not

### DIFF
--- a/frappe/Billing/TrialBanner.vue
+++ b/frappe/Billing/TrialBanner.vue
@@ -61,8 +61,7 @@ createResource({
     trialEndDays.value = calculateTrialEndDays(data.trial_end_date)
     baseEndpoint.value = data.base_url
     siteName.value = data.site_name
-    showBanner.value =
-      data.setup_complete && data.plan.is_trial_plan && trialEndDays.value > 0
+    showBanner.value = data.plan.is_trial_plan && trialEndDays.value > 0
   },
 })
 


### PR DESCRIPTION
Trial banner is not visible with the condition
`showBanner.value = data.setup_complete && data.plan.is_trial_plan && trialEndDays.value > 0`



The reason is that `setup_complete` is only completed when the user completes the framework's onboarding. But new apps redirect the users directly to the app, not the framework, so the framework setup wizard will not be complete and TrialBanner will not be displayed.