### PR TITLE
fix: image pasting via clipboard

### DIFF
--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -21,50 +21,50 @@
 
 <script setup lang="ts">
 import {
-  computed,
   normalizeClass,
   normalizeStyle,
-  onBeforeUnmount,
+  computed,
+  watch,
   onMounted,
+  onBeforeUnmount,
   provide,
   ref,
   useAttrs,
-  watch,
 } from 'vue'
 
 defineOptions({ inheritAttrs: false })
 
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
+import { Editor, EditorContent, VueNodeViewRenderer } from '@tiptap/vue-3'
+import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
+import TextAlign from '@tiptap/extension-text-align'
 import Table from '@tiptap/extension-table'
 import TableCell from '@tiptap/extension-table-cell'
 import TableHeader from '@tiptap/extension-table-header'
 import TableRow from '@tiptap/extension-table-row'
-import TextAlign from '@tiptap/extension-text-align'
-import TextStyle from '@tiptap/extension-text-style'
-import Typography from '@tiptap/extension-typography'
-import StarterKit from '@tiptap/starter-kit'
-import { Editor, EditorContent, VueNodeViewRenderer } from '@tiptap/vue-3'
-import { common, createLowlight } from 'lowlight'
-import { useFileUpload } from '../../utils/useFileUpload'
-import CodeBlockComponent from './CodeBlockComponent.vue'
-import NamedColorExtension from './extensions/color'
-import { ContentPasteExtension } from './extensions/content-paste-extension'
-import EmojiExtension from './extensions/emoji/emoji-extension'
-import { Heading } from './extensions/heading/heading'
-import NamedHighlightExtension from './extensions/highlight'
 import { ImageExtension } from './extensions/image'
-import { ImageGroup } from './extensions/image-group/image-group-extension'
-import SlashCommands from './extensions/slash-commands/slash-commands-extension'
-import { TagExtension, TagNode } from './extensions/tag/tag-extension'
 import ImageViewerExtension from './image-viewer-extension'
-import LinkExtension from './link-extension'
-import configureMention from './mention'
-import TextEditorBubbleMenu from './TextEditorBubbleMenu.vue'
-import TextEditorFixedMenu from './TextEditorFixedMenu.vue'
-import TextEditorFloatingMenu from './TextEditorFloatingMenu.vue'
-import { TextEditorEmits, TextEditorProps } from './types'
 import VideoExtension from './video-extension'
+import LinkExtension from './link-extension'
+import Typography from '@tiptap/extension-typography'
+import TextStyle from '@tiptap/extension-text-style'
+import NamedColorExtension from './extensions/color'
+import NamedHighlightExtension from './extensions/highlight'
+import { common, createLowlight } from 'lowlight'
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
+import CodeBlockComponent from './CodeBlockComponent.vue'
+import configureMention from './mention'
+import TextEditorFixedMenu from './TextEditorFixedMenu.vue'
+import TextEditorBubbleMenu from './TextEditorBubbleMenu.vue'
+import TextEditorFloatingMenu from './TextEditorFloatingMenu.vue'
+import EmojiExtension from './extensions/emoji/emoji-extension'
+import SlashCommands from './extensions/slash-commands/slash-commands-extension'
+import { ContentPasteExtension } from './extensions/content-paste-extension'
+import { TagNode, TagExtension } from './extensions/tag/tag-extension'
+import { Heading } from './extensions/heading/heading'
+import { ImageGroup } from './extensions/image-group/image-group-extension'
+import { useFileUpload } from '../../utils/useFileUpload'
+import { TextEditorEmits, TextEditorProps } from './types'
 
 const lowlight = createLowlight(common)
 

--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -205,6 +205,7 @@ onMounted(() => {
       MarkdownPasteExtension.configure({
         enabled: true,
         showConfirmation: true,
+        uploadFunction: props.uploadFunction || defaultUploadFunction,
       }),
       ...(props.extensions || []),
     ],

--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -21,50 +21,50 @@
 
 <script setup lang="ts">
 import {
+  computed,
   normalizeClass,
   normalizeStyle,
-  computed,
-  watch,
-  onMounted,
   onBeforeUnmount,
+  onMounted,
   provide,
   ref,
   useAttrs,
+  watch,
 } from 'vue'
 
 defineOptions({ inheritAttrs: false })
 
-import { Editor, EditorContent, VueNodeViewRenderer } from '@tiptap/vue-3'
-import StarterKit from '@tiptap/starter-kit'
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import Placeholder from '@tiptap/extension-placeholder'
-import TextAlign from '@tiptap/extension-text-align'
 import Table from '@tiptap/extension-table'
 import TableCell from '@tiptap/extension-table-cell'
 import TableHeader from '@tiptap/extension-table-header'
 import TableRow from '@tiptap/extension-table-row'
-import { ImageExtension } from './extensions/image'
-import ImageViewerExtension from './image-viewer-extension'
-import VideoExtension from './video-extension'
-import LinkExtension from './link-extension'
-import Typography from '@tiptap/extension-typography'
+import TextAlign from '@tiptap/extension-text-align'
 import TextStyle from '@tiptap/extension-text-style'
-import NamedColorExtension from './extensions/color'
-import NamedHighlightExtension from './extensions/highlight'
+import Typography from '@tiptap/extension-typography'
+import StarterKit from '@tiptap/starter-kit'
+import { Editor, EditorContent, VueNodeViewRenderer } from '@tiptap/vue-3'
 import { common, createLowlight } from 'lowlight'
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
-import CodeBlockComponent from './CodeBlockComponent.vue'
-import configureMention from './mention'
-import TextEditorFixedMenu from './TextEditorFixedMenu.vue'
-import TextEditorBubbleMenu from './TextEditorBubbleMenu.vue'
-import TextEditorFloatingMenu from './TextEditorFloatingMenu.vue'
-import EmojiExtension from './extensions/emoji/emoji-extension'
-import SlashCommands from './extensions/slash-commands/slash-commands-extension'
-import { MarkdownPasteExtension } from './extensions/markdown-paste-extension'
-import { TagNode, TagExtension } from './extensions/tag/tag-extension'
-import { Heading } from './extensions/heading/heading'
-import { ImageGroup } from './extensions/image-group/image-group-extension'
 import { useFileUpload } from '../../utils/useFileUpload'
+import CodeBlockComponent from './CodeBlockComponent.vue'
+import NamedColorExtension from './extensions/color'
+import { ContentPasteExtension } from './extensions/content-paste-extension'
+import EmojiExtension from './extensions/emoji/emoji-extension'
+import { Heading } from './extensions/heading/heading'
+import NamedHighlightExtension from './extensions/highlight'
+import { ImageExtension } from './extensions/image'
+import { ImageGroup } from './extensions/image-group/image-group-extension'
+import SlashCommands from './extensions/slash-commands/slash-commands-extension'
+import { TagExtension, TagNode } from './extensions/tag/tag-extension'
+import ImageViewerExtension from './image-viewer-extension'
+import LinkExtension from './link-extension'
+import configureMention from './mention'
+import TextEditorBubbleMenu from './TextEditorBubbleMenu.vue'
+import TextEditorFixedMenu from './TextEditorFixedMenu.vue'
+import TextEditorFloatingMenu from './TextEditorFloatingMenu.vue'
 import { TextEditorEmits, TextEditorProps } from './types'
+import VideoExtension from './video-extension'
 
 const lowlight = createLowlight(common)
 
@@ -202,7 +202,7 @@ onMounted(() => {
       TagExtension.configure({
         tags: () => props.tags,
       }),
-      MarkdownPasteExtension.configure({
+      ContentPasteExtension.configure({
         enabled: true,
         showConfirmation: true,
         uploadFunction: props.uploadFunction || defaultUploadFunction,

--- a/src/components/TextEditor/extensions/content-paste-extension.ts
+++ b/src/components/TextEditor/extensions/content-paste-extension.ts
@@ -12,7 +12,7 @@ export interface ContentPasteOptions {
 }
 
 export const ContentPasteExtension = Extension.create<ContentPasteOptions>({
-  name: 'markdownPaste',
+  name: 'contentPaste',
 
   addOptions() {
     return {
@@ -26,7 +26,7 @@ export const ContentPasteExtension = Extension.create<ContentPasteOptions>({
     const extensionThis = this
     return [
       new Plugin({
-        key: new PluginKey('markdownPaste'),
+        key: new PluginKey('contentPaste'),
         props: {
           handlePaste: (
             view: EditorView,
@@ -35,7 +35,7 @@ export const ContentPasteExtension = Extension.create<ContentPasteOptions>({
           ) => {
             if (!this.options.enabled) return false
 
-            // upload images from clipboard
+            // handle image pasting
             const files: File[] | [] = Array.from(
               event.clipboardData?.files || [],
             )
@@ -47,6 +47,7 @@ export const ContentPasteExtension = Extension.create<ContentPasteOptions>({
               return true
             }
 
+            // handle markdown pasting
             const text = event.clipboardData?.getData('text/plain')
             if (!text) return false
 

--- a/src/components/TextEditor/extensions/content-paste-extension.ts
+++ b/src/components/TextEditor/extensions/content-paste-extension.ts
@@ -1,6 +1,6 @@
 import { Extension } from '@tiptap/core'
-import { DOMParser } from '@tiptap/pm/model'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { DOMParser } from '@tiptap/pm/model'
 import { EditorView } from 'prosemirror-view'
 import { detectMarkdown, markdownToHTML } from '../../../utils/markdown'
 import { processMultipleImages } from './image/image-extension'

--- a/src/components/TextEditor/extensions/content-paste-extension.ts
+++ b/src/components/TextEditor/extensions/content-paste-extension.ts
@@ -1,17 +1,17 @@
 import { Extension } from '@tiptap/core'
-import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { DOMParser } from '@tiptap/pm/model'
-import { detectMarkdown, markdownToHTML } from '../../../utils/markdown'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { EditorView } from 'prosemirror-view'
+import { detectMarkdown, markdownToHTML } from '../../../utils/markdown'
 import { processMultipleImages } from './image/image-extension'
 
-export interface MarkdownPasteOptions {
+export interface ContentPasteOptions {
   enabled: boolean
   showConfirmation: boolean
   uploadFunction: Function | null
 }
 
-export const MarkdownPasteExtension = Extension.create<MarkdownPasteOptions>({
+export const ContentPasteExtension = Extension.create<ContentPasteOptions>({
   name: 'markdownPaste',
 
   addOptions() {

--- a/src/components/TextEditor/extensions/image/image-extension.ts
+++ b/src/components/TextEditor/extensions/image/image-extension.ts
@@ -554,7 +554,7 @@ function getImageDimensions(
 /**
  * Process multiple image uploads sequentially
  */
-function processMultipleImages(
+export function processMultipleImages(
   images: File[],
   view: EditorView,
   pos: number | null,

--- a/src/components/TextEditor/extensions/markdown-paste-extension.ts
+++ b/src/components/TextEditor/extensions/markdown-paste-extension.ts
@@ -2,6 +2,8 @@ import { Extension } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { DOMParser } from '@tiptap/pm/model'
 import { detectMarkdown, markdownToHTML } from '../../../utils/markdown'
+import { EditorView } from 'prosemirror-view'
+import { processMultipleImages } from './image/image-extension'
 
 export interface MarkdownPasteOptions {
   enabled: boolean
@@ -19,12 +21,29 @@ export const MarkdownPasteExtension = Extension.create<MarkdownPasteOptions>({
   },
 
   addProseMirrorPlugins() {
+    const extensionThis = this
     return [
       new Plugin({
         key: new PluginKey('markdownPaste'),
         props: {
-          handlePaste: (view, event, slice) => {
+          handlePaste: (
+            view: EditorView,
+            event: ClipboardEvent,
+            slice: any,
+          ) => {
             if (!this.options.enabled) return false
+
+            // Check for images first
+            const files: File[] | [] = Array.from(
+              event.clipboardData?.files || [],
+            )
+            const images = Array.from(files).filter((file) =>
+              file.type.startsWith('image/'),
+            )
+            if (images.length > 0) {
+              processMultipleImages(images, view, null, extensionThis.options)
+              return true
+            }
 
             const text = event.clipboardData?.getData('text/plain')
             if (!text) return false

--- a/src/components/TextEditor/extensions/markdown-paste-extension.ts
+++ b/src/components/TextEditor/extensions/markdown-paste-extension.ts
@@ -8,6 +8,7 @@ import { processMultipleImages } from './image/image-extension'
 export interface MarkdownPasteOptions {
   enabled: boolean
   showConfirmation: boolean
+  uploadFunction: Function | null
 }
 
 export const MarkdownPasteExtension = Extension.create<MarkdownPasteOptions>({
@@ -17,6 +18,7 @@ export const MarkdownPasteExtension = Extension.create<MarkdownPasteOptions>({
     return {
       enabled: true,
       showConfirmation: true,
+      uploadFunction: null,
     }
   },
 
@@ -33,7 +35,7 @@ export const MarkdownPasteExtension = Extension.create<MarkdownPasteOptions>({
           ) => {
             if (!this.options.enabled) return false
 
-            // Check for images first
+            // upload images from clipboard
             const files: File[] | [] = Array.from(
               event.clipboardData?.files || [],
             )

--- a/src/utils/fileUploadHandler.ts
+++ b/src/utils/fileUploadHandler.ts
@@ -1,17 +1,4 @@
-interface UploadOptions {
-  private?: boolean
-  folder?: string
-  file_url?: string
-  doctype?: string
-  docname?: string
-  fieldname?: string
-  method?: string
-  type?: string
-  upload_endpoint?: string
-  optimize?: boolean
-  max_width?: number
-  max_height?: number
-}
+import { UploadOptions } from "./useFileUpload"
 
 type EventListenerOption = 'start' | 'progress' | 'finish' | 'error'
 


### PR DESCRIPTION
**Issue:**
When we paste images via clipboard into the text editor we get the following result:
![telegram-cloud-photo-size-5-6278269630518773974-y](https://github.com/user-attachments/assets/40098a3b-792e-4927-bb71-ff81eaa74224)

**Reason:**
We only handle Text pasting from clipboard
ref:
![telegram-cloud-photo-size-5-6280429891694479811-y](https://github.com/user-attachments/assets/4943e857-006b-4054-bae9-ec72bf47f953)



**Fix:**
Find images from clipboard and use `processMultipleImages` function to upload images via clipboard


1. Image drop works like before
2. Image pasting via clipboard also works

https://github.com/user-attachments/assets/8d583d01-f095-4b86-8ac0-9060b48bc685



