### PR TITLE
fix: format time with dayjs in calendar

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -94,6 +94,7 @@ declare module 'vue' {
     InsertLink: typeof import('./src/components/TextEditor/InsertLink.vue')['default']
     InsertVideo: typeof import('./src/components/TextEditor/InsertVideo.vue')['default']
     Italic: typeof import('./src/components/TextEditor/icons/italic.vue')['default']
+    Layout: typeof import('./src/components/VueGridLayout/Layout.vue')['default']
     Link: typeof import('./src/components/Link.vue')['default']
     ListEmptyState: typeof import('./src/components/ListView/ListEmptyState.vue')['default']
     ListFilter: typeof import('./src/components/ListFilter/ListFilter.vue')['default']

--- a/src/components/Calendar/Calendar.vue
+++ b/src/components/Calendar/Calendar.vue
@@ -89,9 +89,9 @@ import { TabButtons } from '../TabButtons'
 import {
   getCalendarDates,
   monthList,
-  handleSeconds,
   parseDate,
 } from './calendarUtils'
+import { dayjs } from "../../utils/dayjs"
 import CalendarMonthly from './CalendarMonthly.vue'
 import CalendarWeekly from './CalendarWeekly.vue'
 import CalendarDaily from './CalendarDaily.vue'
@@ -178,8 +178,8 @@ const parseEvents = computed(() => {
     props.events?.map((event) => {
       const { fromDate, toDate, ...rest } = event
       const date = parseDate(fromDate)
-      const from_time = new Date(fromDate).toLocaleTimeString()
-      const to_time = new Date(toDate).toLocaleTimeString()
+      const from_time = dayjs(fromDate).format("HH:mm:ss")
+      const to_time = dayjs(toDate).format("HH:mm:ss")
       if (event.isFullDay) {
         return { ...rest, date }
       }
@@ -192,14 +192,6 @@ const events = ref(parseEvents.value)
 function reloadEvents() {
   events.value = parseEvents.value
 }
-
-events.value.forEach((event) => {
-  if (!event.from_time || !event.to_time) {
-    return
-  }
-  event.from_time = handleSeconds(event.from_time)
-  event.to_time = handleSeconds(event.to_time)
-})
 
 const { showEventModal, newEvent, openNewEventModal } = useEventModal()
 

--- a/src/tailwind/colorPalette.js
+++ b/src/tailwind/colorPalette.js
@@ -1,5 +1,5 @@
 import tailwindColors from 'tailwindcss/colors'
-import colorsData from './colors.json' assert { type: 'json' }
+import colorsData from './colors.json'
 
 function generateColorPalette() {
   const colorPalette = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,11 @@
     "lib": ["ESNext", "DOM"],
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["vitest/globals", "unplugin-icons/types/vue"]
+    "types": ["vitest/globals", "unplugin-icons/types/vue"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Came across a weird issue today, passing 16:30 to the calendar, was showing 4:30 am on the UI. Noticed this in Learning and then also on [Frappe UI story](https://ui.frappe.io/story/src-components-calendar-calendar-story-vue?variantId=src-components-calendar-calendar-story-vue-0). 

On conversing with a few other folks, I found that they are seeing 4:30 pm correctly at their end. 😕

On debugging, we found that `toLocaleTimeString` used in `Calendar.vue` is causing the problem. The output of `toLocaleTimeString` depends on the system's locale if no locale is passed explicitly.

Replaced `toLocalTimeString` with `dayjs` to fix the issue.