### PR TITLE
fix: import Button in TabButtons

### DIFF
--- a/src/components/TabButtons/TabButtons.vue
+++ b/src/components/TabButtons/TabButtons.vue
@@ -39,6 +39,7 @@
 <script>
 import { RadioGroup, RadioGroupLabel, RadioGroupOption } from '@headlessui/vue'
 import FeatherIcon from '../FeatherIcon.vue'
+import Button from '../Button/Button.vue'
 
 export default {
   name: 'TabButtons',
@@ -53,6 +54,7 @@ export default {
   },
   emits: ['update:modelValue'],
   components: {
+    Button,
     FeatherIcon,
     RadioGroup,
     RadioGroupOption,


### PR DESCRIPTION
The missing import was breaking the UI

<img width="1204" height="111" alt="Screenshot 2025-07-15 at 3 02 47 PM" src="https://github.com/user-attachments/assets/4caea9e3-cec7-4a8d-94bb-641750b09300" />
