### PR TITLE
feat: add tooltip to button

### DIFF
--- a/src/components/Button/Button.story.vue
+++ b/src/components/Button/Button.story.vue
@@ -9,6 +9,7 @@ const state = reactive({
   loadingText: null,
   disabled: false,
   link: null,
+  tooltip: 'Hover for more!',
 })
 const variants = ['solid', 'subtle', 'outline', 'ghost']
 const themes = ['gray', 'blue', 'green', 'red']

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -1,55 +1,57 @@
 <template>
-  <button
-    v-bind="$attrs"
-    :class="buttonClasses"
-    @click="handleClick"
-    :disabled="isDisabled"
-    :ariaLabel="ariaLabel"
-  >
-    <LoadingIndicator
-      v-if="loading"
-      :class="{
-        'h-3 w-3': size == 'sm',
-        'h-[13.5px] w-[13.5px]': size == 'md',
-        'h-[15px] w-[15px]': size == 'lg',
-        'h-4.5 w-4.5': size == 'xl' || size == '2xl',
-      }"
-    />
-    <slot name="prefix" v-else-if="$slots['prefix'] || iconLeft">
-      <FeatherIcon
-        v-if="iconLeft && typeof iconLeft === 'string'"
-        :name="iconLeft"
-        :class="slotClasses"
-        aria-hidden="true"
+  <Tooltip :text="tooltip" :disabled="!tooltip?.length">
+    <button
+      v-bind="$attrs"
+      :class="buttonClasses"
+      @click="handleClick"
+      :disabled="isDisabled"
+      :ariaLabel="ariaLabel"
+    >
+      <LoadingIndicator
+        v-if="loading"
+        :class="{
+          'h-3 w-3': size == 'sm',
+          'h-[13.5px] w-[13.5px]': size == 'md',
+          'h-[15px] w-[15px]': size == 'lg',
+          'h-4.5 w-4.5': size == 'xl' || size == '2xl',
+        }"
       />
-      <component v-else-if="iconLeft" :is="iconLeft" :class="slotClasses" />
-    </slot>
+      <slot name="prefix" v-else-if="$slots['prefix'] || iconLeft">
+        <FeatherIcon
+          v-if="iconLeft && typeof iconLeft === 'string'"
+          :name="iconLeft"
+          :class="slotClasses"
+          aria-hidden="true"
+        />
+        <component v-else-if="iconLeft" :is="iconLeft" :class="slotClasses" />
+      </slot>
 
-    <template v-if="loading && loadingText">{{ loadingText }}</template>
-    <template v-else-if="isIconButton && !loading">
-      <FeatherIcon
-        v-if="icon && typeof icon === 'string'"
-        :name="icon"
-        :class="slotClasses"
-        :aria-label="label"
-      />
-      <component v-else-if="icon" :is="icon" :class="slotClasses" />
-      <slot name="icon" v-else-if="$slots.icon" />
-    </template>
-    <span v-else :class="{ 'sr-only': isIconButton }" class="truncate">
-      <slot>{{ label }}</slot>
-    </span>
+      <template v-if="loading && loadingText">{{ loadingText }}</template>
+      <template v-else-if="isIconButton && !loading">
+        <FeatherIcon
+          v-if="icon && typeof icon === 'string'"
+          :name="icon"
+          :class="slotClasses"
+          :aria-label="label"
+        />
+        <component v-else-if="icon" :is="icon" :class="slotClasses" />
+        <slot name="icon" v-else-if="$slots.icon" />
+      </template>
+      <span v-else :class="{ 'sr-only': isIconButton }" class="truncate">
+        <slot>{{ label }}</slot>
+      </span>
 
-    <slot name="suffix">
-      <FeatherIcon
-        v-if="iconRight && typeof iconRight === 'string'"
-        :name="iconRight"
-        :class="slotClasses"
-        aria-hidden="true"
-      />
-      <component v-else-if="iconRight" :is="iconRight" :class="slotClasses" />
-    </slot>
-  </button>
+      <slot name="suffix">
+        <FeatherIcon
+          v-if="iconRight && typeof iconRight === 'string'"
+          :name="iconRight"
+          :class="slotClasses"
+          aria-hidden="true"
+        />
+        <component v-else-if="iconRight" :is="iconRight" :class="slotClasses" />
+      </slot>
+    </button>
+  </Tooltip>
 </template>
 <script lang="ts" setup>
 import { computed, useSlots } from 'vue'
@@ -57,6 +59,7 @@ import FeatherIcon from '../FeatherIcon.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import { useRouter } from 'vue-router'
 import type { ButtonProps, ThemeVariant } from './types'
+import Tooltip from '../Tooltip/Tooltip.vue'
 
 const props = withDefaults(defineProps<ButtonProps>(), {
   theme: 'gray',

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -13,6 +13,7 @@ export interface ButtonProps {
   icon?: string | Component
   iconLeft?: string | Component
   iconRight?: string | Component
+  tooltip?: string
   loading?: boolean
   loadingText?: string
   disabled?: boolean


### PR DESCRIPTION
Wraps button in a tooltip.

`disabled` is set to true if the tooltip isn't provided in Button - this saves rendering as `Tooltip.vue` renders only tooltip related components only if `disabled == false`.

