### PR TITLE
feat: add default collapsed prop for tree component

### DIFF
--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -75,6 +75,7 @@ const props = withDefaults(defineProps<TreeProps>(), {
     rowHeight: '25px',
     indentWidth: '20px',
     showIndentationGuides: true,
+    defaultCollapsed: true,
   }),
 })
 
@@ -96,7 +97,7 @@ const slots = defineSlots<{
   }
 }>()
 
-const isCollapsed = ref(true)
+const isCollapsed = ref(props.options.defaultCollapsed ?? true)
 
 const linePadding = ref('')
 

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -9,6 +9,7 @@ export type TreeOptions = {
   rowHeight?: string
   indentWidth?: string
   showIndentationGuides?: boolean
+  defaultCollapsed?: boolean
 }
 
 export interface TreeProps {


### PR DESCRIPTION
Allow passing the initial collapsed state for all nodes in the Tree component.