### PR TITLE
fix: explicitly expose Button's root DOM node

### DIFF
--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -6,6 +6,7 @@
       @click="handleClick"
       :disabled="isDisabled"
       :ariaLabel="ariaLabel"
+      ref="rootRef"
     >
       <LoadingIndicator
         v-if="loading"
@@ -54,12 +55,14 @@
   </Tooltip>
 </template>
 <script lang="ts" setup>
-import { computed, useSlots } from 'vue'
+import { computed, useSlots, ref } from 'vue'
 import FeatherIcon from '../FeatherIcon.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import { useRouter } from 'vue-router'
 import type { ButtonProps, ThemeVariant } from './types'
 import Tooltip from '../Tooltip/Tooltip.vue'
+
+defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<ButtonProps>(), {
   theme: 'gray',
@@ -205,4 +208,9 @@ const handleClick = () => {
     return window.open(props.link, '_blank')
   }
 }
+
+const rootRef = ref()
+defineExpose({
+  rootRef,
+})
 </script>


### PR DESCRIPTION
After https://github.com/frappe/frappe-ui/pull/369, [`component.$el`](https://vuejs.org/api/component-instance#el) points to a Text node (due to tooltip) instead of the actual button node, even if the tooltip is disabled. So Studio can't render the component selector on the button. Explicitly expose Button's `rootRef` (root DOM node).

Also, setting `inheritAttrs` to false since attrs are now internally bound to button and not the actual template root.
