### PR TITLE
feat: add switch to dropdown

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -118,6 +118,7 @@ declare module 'vue' {
     LoadingIndicator: typeof import('./src/components/LoadingIndicator.vue')['default']
     LoadingText: typeof import('./src/components/LoadingText.vue')['default']
     LucideCalendar: typeof import('~icons/lucide/calendar')['default']
+    LucideCheck: typeof import('~icons/lucide/check')['default']
     LucideChevronDown: typeof import('~icons/lucide/chevron-down')['default']
     LucideChevronRight: typeof import('~icons/lucide/chevron-right')['default']
     LucideX: typeof import('~icons/lucide/x')['default']

--- a/src/components/Dropdown/Dropdown.story.vue
+++ b/src/components/Dropdown/Dropdown.story.vue
@@ -156,6 +156,31 @@ const submenuActions = [
       },
     ],
   },
+  {
+    label: 'Collaborate',
+    switch: true,
+    icon: 'file-text',
+  },
+]
+
+const switchActions = [
+  {
+    label: 'Rename',
+    icon: 'edit',
+    onClick: () => console.log('Rename clicked'),
+  },
+  {
+    label: 'Lock',
+    icon: 'lock',
+    switch: true,
+    onClick: (val) => console.log('Lock switch value:', val),
+  },
+  {
+    label: 'Collaborate',
+    switch: true,
+    icon: 'users',
+    onClick: (val) => console.log('Collaborate switch value:', val),
+  },
 ]
 </script>
 
@@ -187,6 +212,9 @@ const submenuActions = [
 
     <Variant title="With Submenus">
       <Dropdown :options="submenuActions" />
+    </Variant>
+    <Variant title="With Switches">
+      <Dropdown :options="switchActions" />
     </Variant>
 
     <Variant title="With Nested Submenus">

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -30,150 +30,153 @@
               {{ group.group }}
             </DropdownMenuLabel>
 
-            <DropdownMenuItem
-              v-for="item in group.items"
-              :key="item.label"
-              as-child
-              @select="item.onClick"
-            >
-              <slot v-if="$slots.item" name="item" v-bind="{ item, close }" />
-              <component
-                v-else-if="item.component"
-                :is="item.component"
-                :active="false"
+            <template v-for="item in group.items" :key="item.label">
+              <Switch
+                v-if="item.switch"
+                :label="item.label"
+                @change="item.onClick?.($event)"
               />
-              <DropdownMenuSub v-else-if="item.submenu">
-                <DropdownMenuSubTrigger as-child>
-                  <button
-                    :class="[
-                      cssClasses.submenuTrigger,
-                      getSubmenuBackgroundColor(item),
-                    ]"
-                  >
-                    <FeatherIcon
-                      v-if="item.icon && typeof item.icon === 'string'"
-                      :name="item.icon"
-                      :class="[cssClasses.itemIcon, getIconColor(item)]"
-                      aria-hidden="true"
-                    />
-                    <component
-                      :class="[cssClasses.itemIcon, getIconColor(item)]"
-                      v-else-if="item.icon"
-                      :is="item.icon"
-                    />
-                    <div
-                      v-else-if="groupHasIcons(group)"
-                      :class="cssClasses.itemIconPlaceholder"
-                    />
-                    <span :class="[cssClasses.itemLabel, getTextColor(item)]">
-                      {{ item.label }}
-                    </span>
-                    <FeatherIcon
-                      name="chevron-right"
-                      :class="[cssClasses.chevronIcon, getIconColor(item)]"
-                      aria-hidden="true"
-                    />
-                  </button>
-                </DropdownMenuSubTrigger>
-                <DropdownMenuPortal>
-                  <DropdownMenuSubContent
-                    :class="cssClasses.dropdownContent"
-                    :side-offset="4"
-                  >
-                    <div
-                      v-for="submenuGroup in getSubmenuGroups(item.submenu)"
-                      :key="submenuGroup.key"
-                      :class="cssClasses.groupContainer"
-                    >
-                      <DropdownMenuLabel
-                        v-if="submenuGroup.group && !submenuGroup.hideLabel"
-                        :class="cssClasses.groupLabel"
-                      >
-                        {{ submenuGroup.group }}
-                      </DropdownMenuLabel>
+              <DropdownMenuItem v-else as-child @select="item.onClick">
+                <slot v-if="$slots.item" name="item" v-bind="{ item, close }" />
+                <component
+                  v-else-if="item.component"
+                  :is="item.component"
+                  :active="false"
+                />
 
-                      <DropdownMenuItem
-                        v-for="subItem in submenuGroup.items"
-                        :key="subItem.label"
-                        as-child
-                        @select="
-                          (event: PointerEvent) =>
-                            handleItemClick(subItem, event)
-                        "
+                <DropdownMenuSub v-else-if="item.submenu">
+                  <DropdownMenuSubTrigger as-child>
+                    <button
+                      :class="[
+                        cssClasses.submenuTrigger,
+                        getSubmenuBackgroundColor(item),
+                      ]"
+                    >
+                      <FeatherIcon
+                        v-if="item.icon && typeof item.icon === 'string'"
+                        :name="item.icon"
+                        :class="[cssClasses.itemIcon, getIconColor(item)]"
+                        aria-hidden="true"
+                      />
+                      <component
+                        :class="[cssClasses.itemIcon, getIconColor(item)]"
+                        v-else-if="item.icon"
+                        :is="item.icon"
+                      />
+                      <div
+                        v-else-if="groupHasIcons(group)"
+                        :class="cssClasses.itemIconPlaceholder"
+                      />
+                      <span :class="[cssClasses.itemLabel, getTextColor(item)]">
+                        {{ item.label }}
+                      </span>
+                      <FeatherIcon
+                        name="chevron-right"
+                        :class="[cssClasses.chevronIcon, getIconColor(item)]"
+                        aria-hidden="true"
+                      />
+                    </button>
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuPortal>
+                    <DropdownMenuSubContent
+                      :class="cssClasses.dropdownContent"
+                      :side-offset="4"
+                    >
+                      <div
+                        v-for="submenuGroup in getSubmenuGroups(item.submenu)"
+                        :key="submenuGroup.key"
+                        :class="cssClasses.groupContainer"
                       >
-                        <component
-                          v-if="subItem.component"
-                          :is="subItem.component"
-                          :active="false"
-                        />
-                        <button
-                          v-else
-                          :class="[
-                            cssClasses.itemButton,
-                            getBackgroundColor(subItem),
-                          ]"
+                        <DropdownMenuLabel
+                          v-if="submenuGroup.group && !submenuGroup.hideLabel"
+                          :class="cssClasses.groupLabel"
                         >
-                          <FeatherIcon
-                            v-if="
-                              subItem.icon && typeof subItem.icon === 'string'
-                            "
-                            :name="subItem.icon"
-                            :class="[
-                              cssClasses.itemIcon,
-                              getIconColor(subItem),
-                            ]"
-                            aria-hidden="true"
-                          />
+                          {{ submenuGroup.group }}
+                        </DropdownMenuLabel>
+
+                        <DropdownMenuItem
+                          v-for="subItem in submenuGroup.items"
+                          :key="subItem.label"
+                          as-child
+                          @select="
+                            (event: PointerEvent) =>
+                              handleItemClick(subItem, event)
+                          "
+                        >
                           <component
-                            :class="[
-                              cssClasses.itemIcon,
-                              getIconColor(subItem),
-                            ]"
-                            v-else-if="subItem.icon"
-                            :is="subItem.icon"
+                            v-if="subItem.component"
+                            :is="subItem.component"
+                            :active="false"
                           />
-                          <div
-                            v-else-if="groupHasIcons(submenuGroup)"
-                            :class="cssClasses.itemIconPlaceholder"
-                          />
-                          <span
+                          <button
+                            v-else
                             :class="[
-                              cssClasses.itemLabel,
-                              getTextColor(subItem),
+                              cssClasses.itemButton,
+                              getBackgroundColor(subItem),
                             ]"
                           >
-                            {{ subItem.label }}
-                          </span>
-                        </button>
-                      </DropdownMenuItem>
-                    </div>
-                  </DropdownMenuSubContent>
-                </DropdownMenuPortal>
-              </DropdownMenuSub>
-              <button
-                v-else
-                :class="[cssClasses.itemButton, getBackgroundColor(item)]"
-              >
-                <FeatherIcon
-                  v-if="item.icon && typeof item.icon === 'string'"
-                  :name="item.icon"
-                  :class="[cssClasses.itemIcon, getIconColor(item)]"
-                  aria-hidden="true"
-                />
-                <component
-                  :class="[cssClasses.itemIcon, getIconColor(item)]"
-                  v-else-if="item.icon"
-                  :is="item.icon"
-                />
-                <div
-                  v-else-if="groupHasIcons(group)"
-                  :class="cssClasses.itemIconPlaceholder"
-                />
-                <span :class="[cssClasses.itemLabel, getTextColor(item)]"
-                  >{{ item.label }}
-                </span>
-              </button>
-            </DropdownMenuItem>
+                            <FeatherIcon
+                              v-if="
+                                subItem.icon && typeof subItem.icon === 'string'
+                              "
+                              :name="subItem.icon"
+                              :class="[
+                                cssClasses.itemIcon,
+                                getIconColor(subItem),
+                              ]"
+                              aria-hidden="true"
+                            />
+                            <component
+                              :class="[
+                                cssClasses.itemIcon,
+                                getIconColor(subItem),
+                              ]"
+                              v-else-if="subItem.icon"
+                              :is="subItem.icon"
+                            />
+                            <div
+                              v-else-if="groupHasIcons(submenuGroup)"
+                              :class="cssClasses.itemIconPlaceholder"
+                            />
+                            <span
+                              :class="[
+                                cssClasses.itemLabel,
+                                getTextColor(subItem),
+                              ]"
+                            >
+                              {{ subItem.label }}
+                            </span>
+                          </button>
+                        </DropdownMenuItem>
+                      </div>
+                    </DropdownMenuSubContent>
+                  </DropdownMenuPortal>
+                </DropdownMenuSub>
+                <button
+                  v-else
+                  :class="[cssClasses.itemButton, getBackgroundColor(item)]"
+                >
+                  <FeatherIcon
+                    v-if="item.icon && typeof item.icon === 'string'"
+                    :name="item.icon"
+                    :class="[cssClasses.itemIcon, getIconColor(item)]"
+                    aria-hidden="true"
+                  />
+                  <component
+                    :class="[cssClasses.itemIcon, getIconColor(item)]"
+                    v-else-if="item.icon"
+                    :is="item.icon"
+                  />
+                  <div
+                    v-else-if="groupHasIcons(group)"
+                    :class="cssClasses.itemIconPlaceholder"
+                  />
+                  <span :class="[cssClasses.itemLabel, getTextColor(item)]"
+                    >{{ item.label }}
+                  </span>
+                </button>
+              </DropdownMenuItem>
+            </template>
           </div>
         </template>
       </DropdownMenuContent>
@@ -204,12 +207,14 @@ import type {
   DropdownOptions,
   DropdownItem,
 } from './types'
+import Switch from '../Switch/Switch.vue'
 
 defineOptions({
   inheritAttrs: false,
 })
 
 const toggleState = ref(false)
+const test = ref(true)
 const router = useRouter()
 const attrs = useAttrs()
 

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -34,6 +34,8 @@
               <Switch
                 v-if="item.switch"
                 :label="item.label"
+                label-classes="font-normal"
+                :icon="item.icon"
                 @change="item.onClick?.($event)"
               />
               <DropdownMenuItem v-else as-child @select="item.onClick">

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -33,8 +33,9 @@
             <template v-for="item in group.items" :key="item.label">
               <Switch
                 v-if="item.switch"
+                class="!px-2 !py-0 h-7"
                 :label="item.label"
-                label-classes="font-normal"
+                label-classes="font-normal cursor-pointer"
                 :icon="item.icon"
                 @change="item.onClick?.($event)"
               />

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -96,61 +96,73 @@
                         >
                           {{ submenuGroup.group }}
                         </DropdownMenuLabel>
-
-                        <DropdownMenuItem
+                        <template
                           v-for="subItem in submenuGroup.items"
                           :key="subItem.label"
-                          as-child
-                          @select="
-                            (event: PointerEvent) =>
-                              handleItemClick(subItem, event)
-                          "
                         >
-                          <component
-                            v-if="subItem.component"
-                            :is="subItem.component"
-                            :active="false"
+                          <Switch
+                            v-if="subItem.switch"
+                            class="!px-2 !py-0 h-7"
+                            :label="subItem.label"
+                            label-classes="font-normal cursor-pointer"
+                            :icon="subItem.icon"
+                            @change="subItem.onClick?.($event)"
                           />
-                          <button
+                          <DropdownMenuItem
                             v-else
-                            :class="[
-                              cssClasses.itemButton,
-                              getBackgroundColor(subItem),
-                            ]"
+                            as-child
+                            @select="
+                              (event: PointerEvent) =>
+                                handleItemClick(subItem, event)
+                            "
                           >
-                            <FeatherIcon
-                              v-if="
-                                subItem.icon && typeof subItem.icon === 'string'
-                              "
-                              :name="subItem.icon"
-                              :class="[
-                                cssClasses.itemIcon,
-                                getIconColor(subItem),
-                              ]"
-                              aria-hidden="true"
-                            />
                             <component
-                              :class="[
-                                cssClasses.itemIcon,
-                                getIconColor(subItem),
-                              ]"
-                              v-else-if="subItem.icon"
-                              :is="subItem.icon"
+                              v-if="subItem.component"
+                              :is="subItem.component"
+                              :active="false"
                             />
-                            <div
-                              v-else-if="groupHasIcons(submenuGroup)"
-                              :class="cssClasses.itemIconPlaceholder"
-                            />
-                            <span
+                            <button
+                              v-else
                               :class="[
-                                cssClasses.itemLabel,
-                                getTextColor(subItem),
+                                cssClasses.itemButton,
+                                getBackgroundColor(subItem),
                               ]"
                             >
-                              {{ subItem.label }}
-                            </span>
-                          </button>
-                        </DropdownMenuItem>
+                              <FeatherIcon
+                                v-if="
+                                  subItem.icon &&
+                                  typeof subItem.icon === 'string'
+                                "
+                                :name="subItem.icon"
+                                :class="[
+                                  cssClasses.itemIcon,
+                                  getIconColor(subItem),
+                                ]"
+                                aria-hidden="true"
+                              />
+                              <component
+                                :class="[
+                                  cssClasses.itemIcon,
+                                  getIconColor(subItem),
+                                ]"
+                                v-else-if="subItem.icon"
+                                :is="subItem.icon"
+                              />
+                              <div
+                                v-else-if="groupHasIcons(submenuGroup)"
+                                :class="cssClasses.itemIconPlaceholder"
+                              />
+                              <span
+                                :class="[
+                                  cssClasses.itemLabel,
+                                  getTextColor(subItem),
+                                ]"
+                              >
+                                {{ subItem.label }}
+                              </span>
+                            </button>
+                          </DropdownMenuItem>
+                        </template>
                       </div>
                     </DropdownMenuSubContent>
                   </DropdownMenuPortal>

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -96,7 +96,10 @@
                         v-for="subItem in submenuGroup.items"
                         :key="subItem.label"
                         as-child
-                        @select="() => handleItemClick(subItem)"
+                        @select="
+                          (event: PointerEvent) =>
+                            handleItemClick(subItem, event)
+                        "
                       >
                         <component
                           v-if="subItem.component"
@@ -220,11 +223,11 @@ function close() {
 }
 
 // Unified click handling for all dropdown items
-const handleItemClick = (item: DropdownOption) => {
+const handleItemClick = (item: DropdownOption, event: PointerEvent) => {
   if (item.route) {
     router.push(item.route)
   } else if (item.onClick) {
-    item.onClick()
+    item.onClick(event)
   }
 }
 
@@ -235,7 +238,7 @@ const normalizeDropdownItem = (option: DropdownOption) => {
     theme: option.theme || 'gray',
     icon: option.icon,
     component: option.component,
-    onClick: () => handleItemClick(option),
+    onClick: (event: PointerEvent) => handleItemClick(option, event),
     submenu: option.submenu,
   }
 }

--- a/src/components/Dropdown/types.ts
+++ b/src/components/Dropdown/types.ts
@@ -7,7 +7,7 @@ export type DropdownOption = {
   icon?: string | Component | null
   theme?: 'gray' | 'red'
   component?: any
-  onClick?: () => void
+  onClick?: (event: PointerEvent) => void
   route?: RouterLinkProps['to']
   condition?: () => boolean
   submenu?: DropdownOptions

--- a/src/components/Dropdown/types.ts
+++ b/src/components/Dropdown/types.ts
@@ -5,9 +5,10 @@ import { type Component } from 'vue'
 export type DropdownOption = {
   label: string
   icon?: string | Component | null
+  switch?: boolean
   theme?: 'gray' | 'red'
   component?: any
-  onClick?: (event: PointerEvent) => void
+  onClick?: (val: any) => void
   route?: RouterLinkProps['to']
   condition?: () => boolean
   submenu?: DropdownOptions

--- a/src/components/Switch/Switch.story.vue
+++ b/src/components/Switch/Switch.story.vue
@@ -1,24 +1,55 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { reactive } from 'vue'
 import Switch from './Switch.vue'
 const state = reactive({
   size: 'sm',
   label: 'Enable Notifications',
-  description: 'Get notified when something happens.',
   disabled: false,
   modelValue: false,
 })
-const checked = ref(false)
 const sizes = ['sm', 'md']
 </script>
 
 <template>
   <Story :layout="{ type: 'grid', width: 300 }">
-    <Variant title="Label">
-      <Switch v-bind="state" v-model="checked" description="" />
+    <Variant title="Plain">
+      <Switch />
     </Variant>
-    <Variant title="Label and Description">
-      <Switch v-bind="state" v-model="checked" />
+    <Variant title="Label">
+      <Switch v-bind="state" />
+    </Variant>
+    <Variant title="Description and icon">
+      <div class="flex flex-col gap-2">
+        <Switch
+          v-bind="state"
+          description="Get notified when something happens."
+        />
+        <Switch v-bind="state" icon="inbox" description="This has an icon." />
+      </div>
+    </Variant>
+    <Variant title="Size ">
+      <div class="flex flex-col gap-2">
+        <Switch v-bind="state" size="sm" />
+        <Switch v-bind="state" size="md" />
+      </div>
+    </Variant>
+    <Variant title="Disabled">
+      <div class="flex flex-col gap-2">
+        <Switch v-bind="state" :disabled="true" />
+
+        <Switch
+          v-bind="state"
+          description="This is a description."
+          :disabled="true"
+        />
+      </div>
+    </Variant>
+    <Variant title="Classes">
+      <Switch
+        v-bind="state"
+        label-classes="font-normal"
+        description="This switch has a normal font."
+      />
     </Variant>
 
     <template #controls>

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -2,7 +2,7 @@
   <SwitchGroup
     as="div"
     :tabindex="switchType == SwitchVariant.ONLY_LABEL ? 0 : -1"
-    @keyup.space.self="emit('update:modelValue', !modelValue)"
+    @keyup.space.self="model = !model"
     :class="switchGroupClasses"
   >
     <span :class="labelContainerClasses">
@@ -19,9 +19,9 @@
     </span>
     <Switch
       :disabled="props.disabled"
-      :model-value="modelValue ? true : false"
+      :model-value="model ? true : false"
       :class="switchClasses"
-      @update:model-value="emit('update:modelValue', !modelValue)"
+      @update:model-value="model = !model"
     >
       <span aria-hidden="true" :class="switchCircleClasses"></span>
     </Switch>
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import {
   Switch,
   SwitchDescription,
@@ -50,8 +50,11 @@ const props = withDefaults(defineProps<SwitchProps>(), {
   description: '',
   disabled: false,
 })
-
-const emit = defineEmits(['change', 'update:modelValue'])
+const model = defineModel<boolean | number | string>({ default: false })
+const emit = defineEmits(['change'])
+watch(model, (val) => {
+  emit('change', val)
+})
 
 const switchType = computed(() => {
   if (props.label && props.description) {
@@ -70,7 +73,7 @@ const switchClasses = computed(() => {
     'relative inline-flex flex-shrink-0 cursor-pointer rounded-full border-transparent transition-colors duration-100 ease-in-out items-center',
     'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-outline-gray-3',
     'disabled:cursor-not-allowed disabled:bg-surface-gray-3',
-    props.modelValue
+    model.value
       ? 'bg-surface-gray-7 enabled:hover:bg-surface-gray-6 active:bg-surface-gray-5 group-hover:enabled:bg-surface-gray-6'
       : 'bg-surface-gray-4 enabled:hover:bg-gray-400 active:bg-gray-500 group-hover:enabled:bg-gray-400',
     props.size === 'md' ? 'h-5 w-8 border-[3px]' : 'h-4 w-[26px] border-2',
@@ -82,10 +85,10 @@ const switchCircleClasses = computed(() => {
     'pointer-events-none inline-block transform rounded-full bg-surface-white shadow ring-0 transition duration-100 ease-in-out',
     props.size === 'md' ? 'h-3.5 w-3.5' : 'h-3 w-3',
     props.size === 'md'
-      ? props.modelValue
+      ? model.value
         ? 'translate-x-3 rtl:-translate-x-3'
         : 'translate-x-0'
-      : props.modelValue
+      : model.value
         ? 'translate-x-2.5 rtl:-translate-x-2.5'
         : 'translate-x-0',
   ]

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -1,73 +1,62 @@
 <template>
-  <SwitchGroup
-    as="div"
-    :tabindex="switchType == SwitchVariant.ONLY_LABEL ? 0 : -1"
-    @keyup.space.self="model = !model"
-    :class="switchGroupClasses"
-  >
-    <span :class="labelContainerClasses">
-      <SwitchLabel v-if="props.label" as="span" :class="switchLabelClasses">{{
-        props.label
-      }}</SwitchLabel>
-      <SwitchDescription
+  <div :class="switchGroupClasses">
+    <div class="flex flex-col gap-1">
+      <div class="flex items-center">
+        <FeatherIcon
+          v-if="props.icon && typeof props.icon === 'string'"
+          :name="props.icon"
+          :class="iconClasses"
+          aria-hidden="true"
+        />
+        <component
+          :class="iconClasses"
+          v-else-if="props.icon"
+          :is="props.icon"
+        />
+        <label :class="switchLabelClasses" :for="id">
+          {{ props.label }}
+        </label>
+      </div>
+
+      <span
         v-if="props.description"
-        as="span"
-        :class="switchDescriptionClasses"
+        class="max-w-xs text-p-sm text-ink-gray-7"
+        >{{ props.description }}</span
       >
-        {{ props.description }}
-      </SwitchDescription>
-    </span>
-    <Switch
-      :disabled="props.disabled"
-      :model-value="model ? true : false"
+    </div>
+    <SwitchRoot
+      :id
+      v-model="model"
+      @keyup.space.self="model = !model"
       :class="switchClasses"
-      @update:model-value="model = !model"
+      :disabled="props.disabled"
     >
-      <span aria-hidden="true" :class="switchCircleClasses"></span>
-    </Switch>
-  </SwitchGroup>
+      <SwitchThumb :class="switchCircleClasses" />
+    </SwitchRoot>
+  </div>
 </template>
 
 <script lang="ts" setup>
 import { computed, watch } from 'vue'
-import {
-  Switch,
-  SwitchDescription,
-  SwitchGroup,
-  SwitchLabel,
-} from '@headlessui/vue'
+import { useId } from '../../utils/useId'
+import { SwitchRoot, SwitchThumb } from 'reka-ui'
 import type { SwitchProps } from './types'
-
-enum SwitchVariant {
-  DEFAULT,
-  ONLY_LABEL,
-  WITH_LABEL_AND_DESCRIPTION,
-}
 
 const props = withDefaults(defineProps<SwitchProps>(), {
   size: 'sm',
   label: '',
   description: '',
   disabled: false,
+  labelClasses: '',
 })
-const model = defineModel<boolean | number | string>({ default: false })
+
+const model = defineModel<boolean>({ default: false })
 const emit = defineEmits(['change'])
 watch(model, (val) => {
   emit('change', val)
 })
 
-const switchType = computed(() => {
-  if (props.label && props.description) {
-    return SwitchVariant.WITH_LABEL_AND_DESCRIPTION
-  }
-
-  if (props.label) {
-    return SwitchVariant.ONLY_LABEL
-  }
-
-  return SwitchVariant.DEFAULT
-})
-
+const id = useId()
 const switchClasses = computed(() => {
   return [
     'relative inline-flex flex-shrink-0 cursor-pointer rounded-full border-transparent transition-colors duration-100 ease-in-out items-center',
@@ -94,24 +83,22 @@ const switchCircleClasses = computed(() => {
   ]
 })
 
+const iconClasses = 'mr-2 h-4 w-4 flex-shrink-0 text-ink-gray-6'
 const switchLabelClasses = computed(() => {
   return [
     'font-medium leading-normal',
-    props.disabled && switchType.value === SwitchVariant.ONLY_LABEL
+    props.disabled && !props.description
       ? 'text-ink-gray-4'
       : 'text-ink-gray-8',
     props.size === 'md' ? 'text-lg' : 'text-base',
+    props.labelClasses,
   ]
 })
 
-const switchDescriptionClasses = computed(() => {
-  return ['max-w-xs text-p-base text-ink-gray-7']
-})
-
 const switchGroupClasses = computed(() => {
+  if (!props.label) return
   const classes = ['flex justify-between']
-
-  if (switchType.value === SwitchVariant.ONLY_LABEL) {
+  if (!props.description) {
     classes.push(
       'group items-center space-x-3 cursor-pointer rounded focus-visible:bg-surface-gray-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-outline-gray-3',
     )
@@ -123,15 +110,13 @@ const switchGroupClasses = computed(() => {
     )
 
     classes.push(props.size === 'md' ? 'px-3 py-1.5' : 'px-2.5 py-1.5')
-  } else if (switchType.value === SwitchVariant.WITH_LABEL_AND_DESCRIPTION) {
+  } else {
     classes.push('items-start')
-    classes.push(props.size === 'md' ? 'space-x-3.5' : 'space-x-2.5')
+    classes.push(
+      props.size === 'md' ? 'px-3 space-x-3.5' : 'px-2.5 space-x-2.5',
+    )
   }
 
   return classes
-})
-
-const labelContainerClasses = computed(() => {
-  return ['flex flex-col space-y-0.5']
 })
 </script>

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -39,6 +39,7 @@
 <script lang="ts" setup>
 import { computed, watch } from 'vue'
 import { useId } from '../../utils/useId'
+import FeatherIcon from '../FeatherIcon.vue'
 import { SwitchRoot, SwitchThumb } from 'reka-ui'
 import type { SwitchProps } from './types'
 

--- a/src/components/Switch/types.ts
+++ b/src/components/Switch/types.ts
@@ -3,4 +3,6 @@ export interface SwitchProps {
   label?: string
   description?: string
   disabled?: boolean
+  icon?: any
+  labelClasses?: string 
 }

--- a/src/components/Switch/types.ts
+++ b/src/components/Switch/types.ts
@@ -3,5 +3,4 @@ export interface SwitchProps {
   label?: string
   description?: string
   disabled?: boolean
-  modelValue?: boolean | number | string
 }


### PR DESCRIPTION
Makes switch a first class component of Dropdown.

This allows users to, for example, keep the dropdown open after clicking:

https://github.com/user-attachments/assets/75b420ae-2ad4-45ef-a0cd-e7abd6611504


