### PR TITLE
fix: #390

### DIFF
--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -34,7 +34,7 @@ import {
 
 defineOptions({ inheritAttrs: false })
 
-import { Editor, EditorContent, VueNodeViewRenderer } from '@tiptap/vue-3'
+import { Editor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import TextAlign from '@tiptap/extension-text-align'
@@ -52,9 +52,7 @@ import TaskItem from '@tiptap/extension-task-item'
 import TaskList from '@tiptap/extension-task-list'
 import NamedColorExtension from './extensions/color'
 import NamedHighlightExtension from './extensions/highlight'
-import { common, createLowlight } from 'lowlight'
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
-import CodeBlockComponent from './CodeBlockComponent.vue'
+
 import { MentionExtension } from './extensions/mention'
 import TextEditorFixedMenu from './TextEditorFixedMenu.vue'
 import TextEditorBubbleMenu from './TextEditorBubbleMenu.vue'
@@ -65,10 +63,9 @@ import { ContentPasteExtension } from './extensions/content-paste-extension'
 import { TagNode, TagExtension } from './extensions/tag/tag-extension'
 import { Heading } from './extensions/heading/heading'
 import { ImageGroup } from './extensions/image-group/image-group-extension'
+import { ExtendedCodeBlock } from './extensions/code-block'
 import { useFileUpload } from '../../utils/useFileUpload'
 import { TextEditorEmits, TextEditorProps } from './types'
-
-const lowlight = createLowlight(common)
 
 function defaultUploadFunction(file: File) {
   // useFileUpload is frappe specific
@@ -179,11 +176,7 @@ onMounted(() => {
       TextStyle,
       NamedColorExtension,
       NamedHighlightExtension,
-      CodeBlockLowlight.extend({
-        addNodeView() {
-          return VueNodeViewRenderer(CodeBlockComponent)
-        },
-      }).configure({ lowlight }),
+      ExtendedCodeBlock,
       ImageExtension.configure({
         uploadFunction: props.uploadFunction || defaultUploadFunction,
       }),

--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -152,6 +152,20 @@ onMounted(() => {
         ...props.starterkitOptions,
         codeBlock: false,
         heading: false,
+      }).extend({
+        addKeyboardShortcuts() {
+          return {
+            Backspace: () => {
+              const { $from } = this.editor.view.state.selection
+              if (
+                !this.editor.can().liftListItem('listItem') ||
+                $from.parentOffset > 0
+              )
+                return false
+              return this.editor.commands.liftListItem('listItem')
+            },
+          }
+        },
       }),
       Heading.configure({
         ...(typeof props.starterkitOptions?.heading === 'object' &&

--- a/src/components/TextEditor/extensions/code-block.ts
+++ b/src/components/TextEditor/extensions/code-block.ts
@@ -1,0 +1,89 @@
+import { common, createLowlight } from 'lowlight'
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
+import CodeBlockComponent from '../CodeBlockComponent.vue'
+import { VueNodeViewRenderer } from '@tiptap/vue-3'
+
+const INDENT = '    '
+
+function getCodeBlockCtx(state: any) {
+  const { $from, from, to } = state.selection
+  let d = $from.depth
+  while (d > 0 && $from.node(d).type.name !== 'codeBlock') d--
+  if (d === 0) return null
+
+  const node = $from.node(d)
+  const start = $from.start(d)
+  const text: string = node.textContent
+  const fromOffset = from - start
+  const toOffset = to - start
+  return { start, text, fromOffset, toOffset }
+}
+
+function lineStartsBetween(text: string, fromOffset: number, toOffset: number) {
+  let startOff = text.lastIndexOf('\n', Math.max(0, fromOffset - 1)) + 1
+  let endOff = toOffset
+  if (endOff > 0 && text[endOff - 1] === '\n') endOff--
+
+  const starts: number[] = [startOff]
+  let i = startOff
+  while (true) {
+    const nl = text.indexOf('\n', i)
+    if (nl === -1 || nl >= endOff) break
+    starts.push(nl + 1)
+    i = nl + 1
+  }
+  return starts
+}
+
+const lowlight = createLowlight(common)
+
+export const ExtendedCodeBlock = CodeBlockLowlight.extend({
+  addNodeView() {
+    return VueNodeViewRenderer(CodeBlockComponent)
+  },
+  addKeyboardShortcuts() {
+    return {
+      Tab: () => {
+        const { state, dispatch } = this.editor.view
+        const ctx = getCodeBlockCtx(state)
+        if (!ctx) return false
+
+        const { start, text, fromOffset, toOffset } = ctx
+        const multiline = text.slice(fromOffset, toOffset).includes('\n')
+        const tr = state.tr
+        if (multiline) {
+          for (const off of lineStartsBetween(text, fromOffset, toOffset)) {
+            const pos = tr.mapping.map(start + off)
+            tr.insertText(INDENT, pos)
+          }
+        } else {
+          tr.insertText(INDENT, state.selection.from)
+        }
+        dispatch(tr)
+        return true
+      },
+      'Shift-Tab': () => {
+        const { state, dispatch } = this.editor.view
+        const ctx = getCodeBlockCtx(state)
+        if (!ctx) return false
+
+        const { start, text, fromOffset, toOffset } = ctx
+        const tr = state.tr
+        for (const off of lineStartsBetween(text, fromOffset, toOffset)) {
+          let len = 0
+          if (text.substr(off, 4) === INDENT) len = 4
+          else if (text[off] === '\t') len = 1
+
+          if (len > 0) {
+            const s = tr.mapping.map(start + off)
+            const e = tr.mapping.map(start + off + len)
+            tr.delete(s, e)
+          }
+        }
+
+        dispatch(tr)
+        return true
+      },
+    }
+  },
+}).configure({ lowlight })

--- a/src/components/TextEditor/types.ts
+++ b/src/components/TextEditor/types.ts
@@ -15,6 +15,7 @@ export interface TextEditorProps {
   placeholder?: string | (() => string)
   editorClass?: string | string[] | object
   editable?: boolean
+  autofocus?: boolean
   bubbleMenu?: boolean | any[]
   bubbleMenuOptions?: object
   fixedMenu?: boolean | any[]


### PR DESCRIPTION

https://github.com/user-attachments/assets/7bcb38de-7a8f-45b6-84f9-25966302e385


Also allows `backspace` to de-indent inside lists - a more intuitive (well, GDocs) approach than `shift-tab`.