### PR TITLE
[editor] improve code UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/typography": "^0.5.16",
     "@tiptap/core": "^2.26.1",
+    "@tiptap/extension-code": "^2.26.1",
     "@tiptap/extension-code-block": "^2.26.1",
     "@tiptap/extension-code-block-lowlight": "^2.26.1",
     "@tiptap/extension-color": "^2.26.1",

--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -64,7 +64,7 @@ import { ContentPasteExtension } from './extensions/content-paste-extension'
 import { TagNode, TagExtension } from './extensions/tag/tag-extension'
 import { Heading } from './extensions/heading/heading'
 import { ImageGroup } from './extensions/image-group/image-group-extension'
-import { ExtendedCodeBlock } from './extensions/code-block'
+import { ExtendedCode, ExtendedCodeBlock } from './extensions/code-block'
 import { useFileUpload } from '../../utils/useFileUpload'
 import { TextEditorEmits, TextEditorProps } from './types'
 
@@ -151,6 +151,7 @@ onMounted(() => {
     extensions: [
       StarterKit.configure({
         ...props.starterkitOptions,
+        code: false,
         codeBlock: false,
         heading: false,
       }).extend({
@@ -191,6 +192,7 @@ onMounted(() => {
       TextStyle,
       NamedColorExtension,
       NamedHighlightExtension,
+      ExtendedCode,
       ExtendedCodeBlock,
       ImageExtension.configure({
         uploadFunction: props.uploadFunction || defaultUploadFunction,

--- a/src/components/TextEditor/extensions/code-block.ts
+++ b/src/components/TextEditor/extensions/code-block.ts
@@ -1,9 +1,12 @@
 import { common, createLowlight } from 'lowlight'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
+import Code from '@tiptap/extension-code'
 import CodeBlockComponent from '../CodeBlockComponent.vue'
 import { VueNodeViewRenderer } from '@tiptap/vue-3'
+import { markInputRule } from '@tiptap/core'
 
 const INDENT = ' '.repeat(4)
+export const inputRegex = /(?<=^|[^`])`([^`]+)`(?!`)$/
 
 function getCodeBlockCtx(state: any) {
   const { $from, from, to } = state.selection
@@ -92,3 +95,24 @@ export const ExtendedCodeBlock = CodeBlockLowlight.extend({
     }
   },
 }).configure({ lowlight })
+
+export const ExtendedCode = Code.extend({
+  addKeyboardShortcuts() {
+    return {
+      '`': () => {
+        const { from, to } = this.editor.state.selection
+        if (from === to) return false
+        return this.editor.commands.toggleCode()
+      },
+    }
+  },
+  
+  addInputRules() {
+    return [
+      markInputRule({
+        find: inputRegex,
+        type: this.type,
+      }),
+    ]
+  },
+})


### PR DESCRIPTION
Does a number of things:
1. Allows indentation inside code
2. Allows using \` to mark a word as inline code
3. Fixes a bug where the previous character is replaced while an inline code is added

Closes #390, closes: #395, closes: #415