### PR TITLE
fix: bind attrs without class & style to TextEditor's root div

### DIFF
--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -4,6 +4,8 @@
     class="relative w-full"
     :class="attrsClass"
     :style="attrsStyle"
+    v-bind="attrsWithoutClassStyle"
+    ref="rootRef"
   >
     <TextEditorBubbleMenu :buttons="bubbleMenu" :options="bubbleMenuOptions" />
     <TextEditorFixedMenu
@@ -30,6 +32,7 @@ import {
   provide,
   ref,
   useAttrs,
+  useTemplateRef,
 } from 'vue'
 
 defineOptions({ inheritAttrs: false })
@@ -100,6 +103,11 @@ const editor = ref<Editor | null>(null)
 const attrs = useAttrs()
 const attrsClass = computed(() => normalizeClass(attrs.class))
 const attrsStyle = computed(() => normalizeStyle(attrs.style))
+const attrsWithoutClassStyle = computed(() => {
+  return Object.fromEntries(
+    Object.entries(attrs).filter(([key]) => key !== 'class' && key !== 'style'),
+  )
+})
 
 const editorProps = computed(() => {
   return {
@@ -254,8 +262,10 @@ provide(
   computed(() => editor.value),
 )
 
+const rootRef = useTemplateRef('rootRef')
 defineExpose({
   editor,
+  rootRef,
 })
 </script>
 


### PR DESCRIPTION
Apart from class and style, no attributes were bound to TextEditor's root div, so the editor (blue box) was not visible in Studio when this component was selected.
Also exposing rootRef explicitly since component's [$el](https://vuejs.org/api/component-instance#el) is a comment node and not a DOM element (due to conditional rendering) https://github.com/vuejs/vue/issues/5156

**Before**:

<img width="1512" height="801" alt="data-attr-missing" src="https://github.com/user-attachments/assets/ff5f6c06-248b-4a07-a88c-d11ddd312d5e" />


**After**:

<img width="1512" height="801" alt="editor-for-texteditor" src="https://github.com/user-attachments/assets/f5da0a8c-528b-42de-85ac-1145f0fb833d" />

