### PR TITLE
fix: set resourceFetcher to frappeRequest for Link field query

### DIFF
--- a/frappe/Link/Link.vue
+++ b/frappe/Link/Link.vue
@@ -25,6 +25,7 @@ import FormLabel from '../../src/components/FormLabel.vue'
 import debounce from '../../src/utils/debounce'
 // @ts-ignore - Vue SFC without explicit types
 import { createResource } from '../../src/resources'
+import { frappeRequest } from '../../src/utils/frappeRequest'
 import type { LinkProps, SelectOption } from './types'
 import LucidePlus from '~icons/lucide/plus'
 
@@ -53,6 +54,7 @@ const options = createResource({
     filters: props.filters,
   },
   method: 'POST',
+  resourceFetcher: frappeRequest,
   transform: (data: SelectOption[]) => {
     return data.map((doc) => ({
       label: doc.label || doc.value,


### PR DESCRIPTION
`search_link` calls fail in dev setup (without submodule) for Link field. Works fine in prod and dev environment with submodule setup

tries to hit `/studio/app/test/frappe.desk.search.search_link` instead of `api/method/frappe.desk.search.search_link`
<img width="1306" height="77" alt="image" src="https://github.com/user-attachments/assets/fdcfcafe-92cb-4109-ab25-b1ad8d140f18" />

We set frappeRequest as the resource fetcher in frappe apps using frappe-ui but need to explicitly pass it here when used internally.

Follow-up fix for https://github.com/frappe/frappe-ui/pull/430