### PR TITLE
fix(breadcrumbs): truncate whenever items overflow

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -65,11 +65,11 @@ import { useRouter } from 'vue-router'
 import { Dropdown } from '../Dropdown'
 import { Button } from '../Button'
 import type { BreadcrumbsProps } from './types'
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, nextTick, useTemplateRef } from 'vue'
 import { useResizeObserver } from '@vueuse/core'
 import LucideEllipsis from '~icons/lucide/ellipsis'
 
-const crumbsRef = ref<HTMLDivElement>()
+const crumbsEl = useTemplateRef<HTMLDivElement>('crumbsRef')
 
 const props = defineProps<BreadcrumbsProps>()
 
@@ -81,19 +81,19 @@ const items = computed(() => {
 })
 
 const checkOverflow = () => {
-  if (!crumbsRef.value) return
+  if (!crumbsEl.value) return
 
   // tmp show all items to measure item width
   overflowedX.value = false
 
   nextTick(() => {
-    const scrollWidth = crumbsRef.value?.scrollWidth || 0
-    const clientWidth = crumbsRef.value?.clientWidth || 0
+    const scrollWidth = crumbsEl.value?.scrollWidth || 0
+    const clientWidth = crumbsEl.value?.clientWidth || 0
     overflowedX.value = scrollWidth > clientWidth
   })
 }
 
-useResizeObserver(crumbsRef, checkOverflow)
+useResizeObserver(crumbsEl, checkOverflow)
 
 const dropdownItems = computed(() => {
   let allExceptLastTwo = items.value.slice(0, -2)


### PR DESCRIPTION
closes: #291

Whenever the crumbs would overflow the parent container, we just show the elipsis and 2 crumbs.

Screen Recording 2025-11-18 at 9.57.45 PM

https://github.com/user-attachments/assets/1ee597a3-d824-467d-bcc3-c227bd3d15ce

