### PR TITLE
fix(listview): include group-empty slot

### DIFF
--- a/src/components/ListView/ListGroupRows.vue
+++ b/src/components/ListView/ListGroupRows.vue
@@ -2,6 +2,11 @@
   <div class="mb-5 mt-2" v-if="!group.collapsed">
     <slot>
       <ListRow v-for="row in group.rows" :key="row[list.rowKey]" :row="row" />
+      <component
+        v-if="list.slots['group-empty'] && group.rows.length == 0"
+        :is="list.slots['group-empty']"
+        v-bind="{ group }"
+      />
     </slot>
   </div>
 </template>


### PR DESCRIPTION
closes: #210

```vue
 <Listview ...>
    <template #group-empty="{ group }">
	  <div class='p-2'> {{ group.group }} is empty! </div>
    </template>
 </Listview>
 ```
 

https://github.com/user-attachments/assets/af7338b3-5213-461c-97ba-5a4121e93146


