### PR TITLE
fix: tsconfig file

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,9 +14,7 @@
     "skipLibCheck": true,
     "noEmit": true,
     "types": ["vitest/globals", "unplugin-icons/types/vue"],
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "declaration": true,
+    "emitDeclarationOnly": true,
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,11 @@
     "vitest.setup.ts"
   ],
   "extends": "./tsconfig.base.json",
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "references": [{ "path": "./tsconfig.node.json" }],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+  },
 }


### PR DESCRIPTION
1. Remove "paths" from the ts base config.

2. Add "declaration": true, this is needed because there are exports like `export * from './components/Alert'`, which has a separate barrel file, with the config exports like these are resolved as well.