### PR TITLE
fix(createResource): onError() called thrice

### DIFF
--- a/src/utils/frappeRequest.js
+++ b/src/utils/frappeRequest.js
@@ -100,12 +100,10 @@ export function frappeRequest(options) {
             ? [error._error_message]
             : ['Internal Server Error']
         }
-        options.onError && options.onError(e)
         throw e
       }
     },
     transformError: (error) => {
-      options.onError && options.onError(error)
       throw error
     },
   })


### PR DESCRIPTION
Closes: #67

onError() is already being called inside `resources.js`, no need to call it in  `frappeRequest.js`

https://github.com/user-attachments/assets/6a9073ac-f92c-4064-8901-327d17b93e26

