### PR TITLE
feat(createResources): abort method to cancel ongoing fetch requests

### DIFF
--- a/src/resources/resources.js
+++ b/src/resources/resources.js
@@ -31,6 +31,8 @@ export function createResource(options, vm) {
     ? debounce(fetch, options.debounce)
     : fetch
 
+  const controller = new AbortController()
+
   let out = reactive({
     method: options.method,
     url: options.url,
@@ -45,6 +47,7 @@ export function createResource(options, vm) {
     fetch: fetchFunction,
     reload: fetchFunction,
     submit: fetchFunction,
+    abort: () => controller.abort(),
     reset,
     update,
     setData,
@@ -94,6 +97,8 @@ export function createResource(options, vm) {
         return
       }
     }
+
+    options.signal = controller.signal
 
     try {
       out.promise = resourceFetcher({

--- a/src/resources/resources.js
+++ b/src/resources/resources.js
@@ -31,7 +31,7 @@ export function createResource(options, vm) {
     ? debounce(fetch, options.debounce)
     : fetch
 
-  const controller = new AbortController()
+  let controller = new AbortController()
 
   let out = reactive({
     method: options.method,
@@ -98,6 +98,8 @@ export function createResource(options, vm) {
       }
     }
 
+    // fresh controller per fetch; a signal stays aborted forever once used
+    controller = new AbortController()
     options.signal = controller.signal
 
     try {
@@ -120,7 +122,10 @@ export function createResource(options, vm) {
         }
       }
     } catch (error) {
-      handleError(error, errorFunctions)
+      // a deliberate abort() isn't a resource error; just stop quietly
+      if (error?.name !== 'AbortError') {
+        handleError(error, errorFunctions)
+      }
     }
     out.loading = false
     return out.data

--- a/src/resources/resources.test.ts
+++ b/src/resources/resources.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment node
+ */
+
+import { createResource } from './resources'
+import { url } from '../mocks/utils'
+
+describe('createResource abort', () => {
+  it('aborts an in-flight request without surfacing an error', async () => {
+    const resource = createResource({
+      url: url('/api/v2/method/slow'),
+      auto: false,
+    })
+
+    const promise = resource.fetch()
+    expect(resource.loading).toBe(true)
+
+    resource.abort()
+    await promise
+
+    expect(resource.loading).toBe(false)
+    expect(resource.data).toBe(null)
+    // a deliberate abort is not a resource error
+    expect(resource.error).toBe(null)
+  })
+
+  it('stays usable after an abort (controller is recreated per fetch)', async () => {
+    const resource = createResource({
+      url: url('/api/v2/method/slow'),
+      auto: false,
+    })
+
+    // first fetch is aborted mid-flight
+    const aborted = resource.fetch()
+    resource.abort()
+    await aborted
+    expect(resource.data).toBe(null)
+
+    // a fresh fetch must succeed — the old single-controller version would
+    // reuse the already-aborted signal and reject immediately
+    await resource.fetch()
+    expect(resource.data).toEqual({ data: { success: true } })
+    expect(resource.error).toBe(null)
+  })
+})

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -31,6 +31,7 @@ export function request(_options) {
     method: options.method || 'GET',
     headers: options.headers,
     body,
+    signal: options.signal,
   })
     .then((response) => {
       if (options.transformResponse) {


### PR DESCRIPTION
Closes: #26

## Usage   

```js
const resp = createResources()

unMounted(() => {
     resp.abort()
})
```

https://github.com/user-attachments/assets/b573971d-d8d6-4f8a-8168-c0bdec50ce7f

To those who want to do this automatically , just make a wrapper over createResources()

```js

const wrapperFetch = (opts) => {
  const resp = createResource(opts)
  onUnmounted(resp.abort)
  return resp
}
```

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-494/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 49.34% (+0.02% vs `main`)
<!-- coverage-report:end -->

