### PR TITLE
fix: resolve circular dependency in frappe-ui

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// old data-fetching: resources
+export * from './resources/index.ts'
+
 // components
 export * from './components/Alert'
 export * from './components/Autocomplete'
@@ -91,9 +94,6 @@ export * from './utils/useFileUpload'
 export * from './utils/theme'
 export * from './components/TextEditor/extensions/image'
 export * from './components/TextEditor/extensions/suggestion'
-
-// old data-fetching: resources
-export * from './resources/index.ts'
 
 export { request } from './utils/request.js'
 export { frappeRequest } from './utils/frappeRequest.js'


### PR DESCRIPTION
After [frappe-ui update in Builder](https://github.com/frappe/builder/pull/448) I started getting following error. 

<img width="1470" height="62" alt="Screenshot 2025-12-18 at 3 27 04 PM" src="https://github.com/user-attachments/assets/5db7027f-c069-4a1b-a6fd-6d7be33626a7" />


`createListResource` was being called before `listCache` was initialised due to some unknown import chain. Resources must be exported first as they have no internal dependencies but are required by other modules during their initialisation.


**Note:** I used to get this error before as well and I had handled it by [importing utilities through absolute path](https://github.com/frappe/builder/pull/448/changes#diff-95bc1e04ae9e350b40fb525e33ed7df4ae78727b9ecdb8ed953a803f124ab170L1). But [after this change](https://github.com/frappe/frappe-ui/pull/445) I can't do that anymore.