### PR TITLE
fix(MultiSelect): 'Select All' to correctly assign option values instead of labels 

### DIFF
--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -29,7 +29,7 @@ const getValues = (arr: String[]) =>
   arr.map((x) => props.options.find((y) => y.value === x)?.label);
 
 const optionToStr = (options: MultiSelectOption[]) =>
-  options.map((x) => x.label);
+  options.map((x) => x.value);
 
 const selectedOptions = computed(() => {
   const values = getValues(model.value).join(", ");


### PR DESCRIPTION
MultiSelect added in https://github.com/frappe/frappe-ui/pull/448

## Before

<img width="262" height="300" alt="image" src="https://github.com/user-attachments/assets/47caaafe-64b8-4d2b-b513-4f461f0151fa" />


## After

<img width="395" height="300" alt="image" src="https://github.com/user-attachments/assets/ce693d68-7224-4f80-8a64-32efbd0e91a2" />
