### PR TITLE
fix(Tabs): explicitly define model

### DIFF
--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -11,6 +11,7 @@ import type { TabProps } from './types'
 import { h } from 'vue'
 
 const props = defineProps<TabProps>()
+const model = defineModel<string | number>({ default: 0 })
 
 const indicatorXCss = `left-0 bottom-0 h-[2px] w-[--reka-tabs-indicator-size] transition-[width,transform]
                           translate-x-[--reka-tabs-indicator-position] translate-y-[1px]`
@@ -29,6 +30,7 @@ const Btn = h('button')
     class="flex flex-1 overflow-hidden flex-col data-[orientation=vertical]:flex-row"
     :orientation="props.vertical ? 'vertical' : 'horizontal'"
     :default-value="props.tabs[0].label"
+    v-model="model"
   >
     <TabsList
       class="relative min-h-fit flex data-[orientation=vertical]:flex-col p-1 border-b data-[orientation=vertical]:border-r gap-5"

--- a/src/components/Tabs/types.ts
+++ b/src/components/Tabs/types.ts
@@ -1,11 +1,11 @@
 type Tab = {
   label: string
   icon?: string
-	route?:string
+  route?: string
 }
 
 export interface TabProps {
   as?: string
   tabs: Tab[]
-  vertical?: Boolean
+  vertical?: boolean
 }


### PR DESCRIPTION
Before the Tabs component rewrite https://github.com/frappe/frappe-ui/pull/457, the old component used to explicitly register modelValue as a prop due to
`const tabIndex = defineModel()`

Now, it acts as a fall through attribute. Explicitly define model and wire it with `TabsRoot`