### PR TITLE
fix: adjust icon grid spacing and width for better layout

### DIFF
--- a/icons/IconPicker.vue
+++ b/icons/IconPicker.vue
@@ -182,7 +182,7 @@ defineExpose({
       </ComboboxAnchor>
       <ComboboxPortal>
         <ComboboxContent
-          class="z-10 w-[--reka-combobox-trigger-width] mt-1 bg-surface-modal overflow-hidden rounded-lg shadow-2xl"
+          class="z-10 w-60 mt-1 bg-surface-modal overflow-hidden rounded-lg shadow-2xl"
           position="popper"
           @openAutoFocus.prevent
           @closeAutoFocus.prevent
@@ -198,7 +198,7 @@ defineExpose({
               </template>
               <template v-else> No icons available. </template>
             </ComboboxEmpty>
-            <div v-if="filteredIcons.length > 0" class="flex flex-wrap gap-1">
+            <div v-if="filteredIcons.length > 0" class="flex flex-wrap">
               <button
                 v-for="iconName in filteredIcons.slice(0, props.maxIcons)"
                 :key="iconName"


### PR DESCRIPTION
### Before:


<img width="850" height="702" alt="CleanShot 2025-12-29 at 13 28 29@2x" src="https://github.com/user-attachments/assets/c8fcb812-afef-44ac-b01d-273fad533c6a" />


### After:

<img width="882" height="794" alt="CleanShot 2025-12-29 at 16 01 30@2x" src="https://github.com/user-attachments/assets/1c9ee461-2b6c-448e-a4d1-760809a1610f" />
