### PR TITLE
feat: add telemetry plugin

### DIFF
--- a/frappe/index.js
+++ b/frappe/index.js
@@ -1,5 +1,6 @@
 // components dependent on frappe backend
 export * from './Link'
+export { default as Filter } from './Filter/Filter.vue'
 
 // help components
 export { default as HelpModal } from './Help/HelpModal.vue'
@@ -26,4 +27,5 @@ export { useOnboarding } from './Onboarding/onboarding.js'
 export { showHelpModal, minimize } from './Help/help.js'
 export { showHelpCenter } from './HelpCenter/helpCenter.js'
 
-export { default as Filter } from './Filter/Filter.vue'
+// plugins
+export { default as telemetryPlugin } from './telemetry.ts'

--- a/frappe/telemetry.ts
+++ b/frappe/telemetry.ts
@@ -1,0 +1,81 @@
+import { call } from 'frappe-ui'
+import type { App } from 'vue'
+// @ts-expect-error
+import { pulse_provider } from '../../../frappe/frappe/public/js/telemetry/pulse.js'
+
+type TelemetryPluginOptions = {
+  app_name: string
+}
+
+declare global {
+  interface Window {
+    frappe: any
+  }
+}
+
+type TelemetryConfig = {
+  is_enabled: boolean
+  capture: (event_name: string, data?: any) => void
+}
+
+export default {
+  install(app: App, options = {} as TelemetryPluginOptions): void {
+    initializeFrappeBoot()
+    enableTelemetry(app, options.app_name)
+  },
+}
+
+const silentCall = <T>(method: string): Promise<T> => {
+  // To prevent console errors/logs from being shown
+  const originalError = console.error
+  const originalLog = console.log
+  console.error = () => {}
+  console.log = () => {}
+
+  return call(method).finally(() => {
+    console.log = originalLog
+    console.error = originalError
+  })
+}
+
+const enableTelemetry = (app: App, app_name: string): void => {
+  silentCall<boolean>('frappe.utils.telemetry.pulse.client.is_enabled')
+    .then((is_enabled: boolean) => {
+      setupTelemetry(app, is_enabled, app_name)
+    })
+    .catch(() => {
+      console.warn('Failed to fetch telemetry settings. Disabling telemetry.')
+      setupTelemetry(app, false, app_name)
+    })
+}
+
+const setupTelemetry = (
+  app: App,
+  is_enabled: boolean,
+  app_name: string,
+): void => {
+  window.frappe.boot.enable_telemetry = is_enabled
+  window.frappe.boot.telemetry_provider = is_enabled ? ['pulse'] : []
+
+  if (is_enabled) {
+    setupPulseProvider(app_name)
+    app.config.globalProperties.$telemetry = {
+      is_enabled: pulse_provider.is_enabled,
+      capture: pulse_provider.capture,
+    } as TelemetryConfig
+  }
+}
+
+const setupPulseProvider = (app_name: string): void => {
+  const originalCapture = pulse_provider.capture
+  pulse_provider.capture = (event_name: string, data: any = {}) =>
+    originalCapture(event_name, app_name, data)
+  pulse_provider.init()
+}
+
+const initializeFrappeBoot = (): void => {
+  window.frappe ??= {}
+  window.frappe.boot = {
+    ...window.frappe.boot,
+  }
+}


### PR DESCRIPTION
#### Setup

```js
// main.js
app.use(telemetryPlugin, { app_name: "helpdesk" });
```

#### Usage

```vue
<script>
$telemetry.capture("ticket_resolved", {
	sla_met: sla_met,
});
</script>
```

Note: using this plugin will break app builds on v14 benches