### PR TITLE
fix: Add delay to dropdown item click handling to prevent close glitch

### DIFF
--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -299,11 +299,13 @@ function close() {
 
 // Unified click handling for all dropdown items
 const handleItemClick = (item: DropdownOption, event: PointerEvent) => {
-  if (item.route) {
-    router.push(item.route)
-  } else if (item.onClick) {
-    item.onClick(event)
-  }
+  setTimeout(() => {
+    if (item.route) {
+      router.push(item.route)
+    } else if (item.onClick) {
+      item.onClick(event)
+    }
+  }, 75)
 }
 
 const normalizeDropdownItem = (option: DropdownOption) => {


### PR DESCRIPTION
Dropdown close animation was glitching sometimes because animation was conflicting with re-render triggered by state change.

**Before:**

https://github.com/user-attachments/assets/718eda90-1b25-4a15-98bf-e332bdde83ec


**Solution:** Wait for animation to end before executing click event handlers. This [delay matches](https://github.com/frappe/frappe-ui/compare/main...surajshetty3416:frappe-ui:fix-dropdown-close-glitch?expand=1#diff-7f1b18bd5ac53dc52806f08983b5a265c6f5f8e6b9d21fa42f8a98dc74a0be80R308) with the [animation duration](https://github.com/frappe/frappe-ui/compare/main...surajshetty3416:frappe-ui:fix-dropdown-close-glitch?expand=1#diff-7f1b18bd5ac53dc52806f08983b5a265c6f5f8e6b9d21fa42f8a98dc74a0be80R466).

**After:**

https://github.com/user-attachments/assets/7b2d6a6d-f883-44f7-966c-f3ea60823b8e


