### PR TITLE
fix: request type for document resource get method

### DIFF
--- a/src/resources/documentResource.js
+++ b/src/resources/documentResource.js
@@ -74,6 +74,7 @@ export function createDocumentResource(options, vm) {
     get: createResource(
       {
         url: defaultDocGetUrl,
+        method: 'GET',
         makeParams() {
           return {
             doctype: out.doctype,


### PR DESCRIPTION
### Problem
When using document resource, the default request type when `.get.fetch()` is called is **POST**. Would probably fallback to the default request type **GET** correctly but `frappeRequest` sets the default request type to **POST** so when setting resourceFetcher to `frappeRequest`, the default even for get method happens to be **POST** unless set explicitly.

https://github.com/frappe/frappe-ui/blob/0816e134e6ce53c0802a49cb35034d3962c05662/src/utils/frappeRequest.js#L24-L30


#### Screenshot

<img width="1470" height="451" alt="Screenshot 2026-01-15 at 8 22 50 PM" src="https://github.com/user-attachments/assets/f05f90ac-cfe4-4642-9145-af042ff9a37b" />

<br>

### Fix

Set the method type explicitly in the get function for document resource.
