### PR TITLE
fix(Filter): checkbox values should be parsed as boolean

### DIFF
--- a/frappe/Filter/utils.ts
+++ b/frappe/Filter/utils.ts
@@ -140,7 +140,7 @@ export const getValueControl = (row: StateRow) => {
   }
 
   if (typeSelect.includes(fieldType) || typeCheck.includes(fieldType)) {
-    let _options = options || ['yes', 'no']
+    let _options = options || ['Yes', 'No']
 
     return h(Select, { placeholder: 'Select Option', options: _options })
   }
@@ -225,9 +225,10 @@ export const parseFilters = (filters: any) => {
 
   return _filters.map(transformIn).reduce((acc, cur) => {
     if (['equals', '='].includes(cur.operator)) {
-      cur.value = cur.toBoolean ? 'Yes' : cur.value
-    } //
-    else if (cur.operator === 'between') cur.value = [...cur.value.split(',')]
+      cur.value = cur.value == 'Yes' ? true : cur.value == 'No' ? false : cur.value
+    } else if (cur.operator === 'between') {
+      cur.value = [...cur.value.split(',')]
+    }
 
     return [
       ...acc,


### PR DESCRIPTION
Filter applied for User doctype:

<img width="546" height="287" alt="image" src="https://github.com/user-attachments/assets/44a5e2f3-e5b0-4614-8a8a-67cdc4c98057" />

## Before:

"yes" is an incorrect filter value. It should be boolean

<img width="241" height="80" alt="image" src="https://github.com/user-attachments/assets/9759e314-eec7-491a-886a-13bc22d37197" />

## After:

<img width="241" height="80" alt="image" src="https://github.com/user-attachments/assets/1ee42eae-7c44-4683-b865-7e6521b4f15f" />

Also capitalize "Yes" and "No" options. That's how it is everywhere in Frappe desk + business apps. Eg: in desk

<img width="989" height="257" alt="image" src="https://github.com/user-attachments/assets/9cc00cf3-cd34-4481-a7e3-c6b2f2ba633c" />
