### PR TITLE
fix(Popover): trigger open and close events correctly

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -104,12 +104,14 @@ const anchorRef = ref<HTMLElement | null>(null)
 
 const isOpen = computed({
   get: () => (isShowPropPassed.value ? props.show : _isOpen.value),
-  set: (value: boolean) => {
-    if (!isShowPropPassed.value) {
-      _isOpen.value = value
-    }
-    emit('update:show', value)
-  },
+	set: (value: boolean) => {
+		if (!isShowPropPassed.value) {
+			if (value !== _isOpen.value) {
+				_isOpen.value = value
+				onUpdateOpen(value)
+			}
+		}
+	},
 })
 
 const isShowPropPassed = computed(() => {


### PR DESCRIPTION
Currently, whenever the togglePopover function is used to open the Popover component, by default the open event is not emitted along with it even though the popover toggles it's display. This is handled by the `@update:open` event that occurs on the `PopoverRoot` component by reka-ui. 

<br>

However, since `@update:open` only gets triggered by tracking changes to the open prop that is passed to the root component directly, it doesn't get triggered for the computed value here because it relies on a getter and setter which uses `_isOpen.value` being changed and returned instead of **direct** changes to `isOpen.value` -

https://github.com/frappe/frappe-ui/blob/03c9b18a3d809a5e3476e3d532f7548e6442c642/src/components/Popover/Popover.vue#L105-L113

<br>

#### PS:

These events were triggered previously directly by the computed value while setting the new value like so - 

https://github.com/frappe/frappe-ui/commit/f7211e9313dd237b4027c3a49fe4d63a45de6c45#diff-6227be297736de3cfd95255a1009cea60ca35ef0086ce9477c6357c88ee5b3acL163-L183
