### PR TITLE
revert: "fix: Add delay to dropdown item click handling to prevent close glitch"

### DIFF
--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -299,13 +299,11 @@ function close() {
 
 // Unified click handling for all dropdown items
 const handleItemClick = (item: DropdownOption, event: PointerEvent) => {
-  setTimeout(() => {
-    if (item.route) {
-      router.push(item.route)
-    } else if (item.onClick) {
-      item.onClick(event)
-    }
-  }, 75)
+  if (item.route) {
+    router.push(item.route)
+  } else if (item.onClick) {
+    item.onClick(event)
+  }
 }
 
 const normalizeDropdownItem = (option: DropdownOption) => {


### PR DESCRIPTION
Reverts frappe/frappe-ui#532

Because it breaks native click lifecycle and we cannot do things like `e.preventDefault()`

--

Will try and find a better solution for the original issue.