### PR TITLE
fix(switch)!: remove horizontal padding

### DIFF
--- a/docs/content/components.d.ts
+++ b/docs/content/components.d.ts
@@ -12,6 +12,7 @@ declare module 'vue' {
     LucideBolt: typeof import('~icons/lucide/bolt')['default']
     LucideDownload: typeof import('~icons/lucide/download')['default']
     LucideMail: typeof import('~icons/lucide/mail')['default']
+    LucideX: typeof import('~icons/lucide/x')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
   }

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -105,7 +105,7 @@ const switchGroupClasses = computed(() => {
   const classes = ['flex justify-between']
   if (!props.description) {
     classes.push(
-      'group items-center space-x-3 cursor-pointer rounded focus-visible:bg-surface-gray-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-outline-gray-3',
+      'group items-center space-x-3 py-1.5 cursor-pointer rounded focus-visible:bg-surface-gray-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-outline-gray-3',
     )
 
     classes.push(
@@ -113,13 +113,9 @@ const switchGroupClasses = computed(() => {
         ? 'cursor-not-allowed'
         : 'hover:bg-surface-gray-3 active:bg-surface-gray-4',
     )
-
-    classes.push(props.size === 'md' ? 'px-3 py-1.5' : 'px-2.5 py-1.5')
   } else {
     classes.push('items-start')
-    classes.push(
-      props.size === 'md' ? 'px-3 space-x-3.5' : 'px-2.5 space-x-2.5',
-    )
+    classes.push(props.size === 'md' ? 'space-x-3.5' : 'space-x-2.5')
   }
 
   return classes


### PR DESCRIPTION
### Before

<img width="1480" height="376" alt="image" src="https://github.com/user-attachments/assets/2dc77035-d8d7-4885-b2aa-69598d87749f" />

### After

<img width="1480" height="376" alt="image" src="https://github.com/user-attachments/assets/897739a0-569a-48a3-8584-590d0fa4b619" />

### Why?

To avoid situations like this (notice Switch's alignment with the rest of the options out of the box)

<img width="804" height="316" alt="Screenshot 2026-02-17 at 10 15 33 AM" src="https://github.com/user-attachments/assets/956c9e6c-6138-49ce-b926-4f767d09a8dd" />
