### PR TITLE
fix(TextEditor): Could not find image node with uploadId

### DIFF
--- a/src/components/TextEditor/TextEditor.vue
+++ b/src/components/TextEditor/TextEditor.vue
@@ -125,7 +125,19 @@ watch(
     if (editor.value) {
       let currentHTML = editor.value.getHTML()
       if (currentHTML !== val) {
-        editor.value.commands.setContent(val)
+        // Check if there are any uploading images
+        let hasUploadingImages = false
+        editor.value.state.doc.descendants((node: any) => {
+          if (node.type.name === 'image' && node.attrs.loading) {
+            hasUploadingImages = true
+            return false
+          }
+        })
+
+        // Don't update content while images are uploading to preserve uploadId references
+        if (!hasUploadingImages) {
+          editor.value.commands.setContent(val)
+        }
       }
     }
   },


### PR DESCRIPTION
When pasting images without typing or making immediate edits, the image `src` remains as base64 instead of being updated to the uploaded file URL.

This is caused because the content watcher calls `setContent()` while images are still uploading, destroying image nodes with `uploadId` references before the upload callback can update them with the final file URL. 

Adding a check to skip `setContent()` calls when images have the `loading` attribute fixes the issue.