### PR TITLE
fix: three error fn calling bug

### DIFF
--- a/src/resources/resources.js
+++ b/src/resources/resources.js
@@ -98,6 +98,7 @@ export function createResource(options, vm) {
     try {
       out.promise = resourceFetcher({
         ...options,
+        onError: undefined,
         params: params || options.params,
       })
       let data = await out.promise


### PR DESCRIPTION
Fixed a bug where the error handler function was getting executed three times