### PR TITLE
fix(Popover): emit `update:show` when show prop is passed

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -104,14 +104,14 @@ const anchorRef = ref<HTMLElement | null>(null)
 
 const isOpen = computed({
   get: () => (isShowPropPassed.value ? props.show : _isOpen.value),
-	set: (value: boolean) => {
-		if (!isShowPropPassed.value) {
-			if (value !== _isOpen.value) {
-				_isOpen.value = value
-				onUpdateOpen(value)
-			}
-		}
-	},
+  set: (value: boolean) => {
+    if (isShowPropPassed.value) {
+      emit('update:show', value)
+    } else {
+      _isOpen.value = value
+      onUpdateOpen(value)
+    }
+  },
 })
 
 const isShowPropPassed = computed(() => {
@@ -273,7 +273,6 @@ defineSlots<{
     isOpen: boolean
   }) => any
 }>()
-
 </script>
 
 <style>


### PR DESCRIPTION
After [this](https://github.com/frappe/frappe-ui/pull/563) change, the `update:show` event wasn't being emitted when the `show` prop was passed. 
This broke Popover in Autocomplete with a custom target

**Before**:

Popover not showing up on clicking the Autocomplete target:
<img width="273" height="147" alt="image" src="https://github.com/user-attachments/assets/e7c9cc0b-a5b7-4b58-b309-b2366981fe28" />

**After**:

<img width="273" height="164" alt="image" src="https://github.com/user-attachments/assets/fe29951b-f7ed-4588-8bfe-6b1f8f822078" />
