### PR TITLE
fix: add space after using mentions

### DIFF
--- a/src/components/TextEditor/extensions/mention/mention-extension.ts
+++ b/src/components/TextEditor/extensions/mention/mention-extension.ts
@@ -141,6 +141,10 @@ const MentionSuggestionExtension =
             type: 'mention',
             attrs: attributes,
           },
+          {
+            type: 'text',
+            text: ' ',
+          },
         ])
         .run()
     },


### PR DESCRIPTION
Add a whitespace after adding mentions in editors.
before:

https://github.com/user-attachments/assets/984fe4e8-8f06-472e-bd3a-6f79d533898f


after fix:
https://github.com/user-attachments/assets/ee1f7e67-75dd-4843-9a4a-f1655ebf7e2a

