### PR TITLE
fix: add collision padding for popovers

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -25,6 +25,7 @@
         :side="placementSide"
         :align="placementAlign"
         :sideOffset="offset"
+        :collisionPadding="collisionPadding"
         :style="{
           minWidth: matchTargetWidth
             ? 'var(--reka-popover-trigger-width)'
@@ -82,6 +83,7 @@ const props = withDefaults(defineProps<PopoverProps>(), {
   popoverClass: '',
   transition: null,
   hideOnBlur: true,
+  collisionPadding: 10,
 })
 
 const emit = defineEmits<{

--- a/src/components/Popover/types.ts
+++ b/src/components/Popover/types.ts
@@ -36,4 +36,5 @@ export interface PopoverProps {
   /** Whether the popover width should match the target element */
   matchTargetWidth?: boolean
   offset?: number
+  collisionPadding?: number
 }


### PR DESCRIPTION
Handles cases automatically where popovers too close to the edge of the screen receive some safety padding.

before:
<img width="674" height="545" alt="image" src="https://github.com/user-attachments/assets/49d2564c-33c0-4235-a021-b0f41661bd36" />

after:
| | |
|---|---|
| <img width="474" height="545" alt="image" src="https://github.com/user-attachments/assets/92e47423-26df-403f-ab1b-054177ad79b9" /> | <img width="474" height="545" alt="image" src="https://github.com/user-attachments/assets/02ecac0a-d751-4618-82c7-cb383140b1f9" /> |

