### PR TITLE
fix: Combobox empty state

### DIFF
--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -366,7 +366,7 @@ defineSlots<{
             <ComboboxEmpty
               class="text-ink-gray-5 text-base text-center py-1.5 px-2.5"
             >
-              No results found for "{{ searchTerm }}"
+              {{ searchTerm ? `No results found for "${searchTerm}"` : "No results found" }}
             </ComboboxEmpty>
             <template
               v-for="(optionOrGroup, index) in filteredOptions"


### PR DESCRIPTION
**Before:**

Combobox empty state when options and searchterm both are empty

<img width="265" height="113" alt="image" src="https://github.com/user-attachments/assets/6faa6304-b064-4c75-a8b1-038b47394141" />

**After:**

<img width="265" height="113" alt="image" src="https://github.com/user-attachments/assets/1dffc04c-d7ed-4922-866a-0c3ddadac5d9" />
