### PR TITLE
feat: add known tiptap shortcuts to editor props

### DIFF
--- a/src/components/TextEditor/commands.js
+++ b/src/components/TextEditor/commands.js
@@ -36,6 +36,7 @@ export default {
     label: 'Paragraph',
     icon: Text,
     action: (editor) => editor.chain().focus().setParagraph().run(),
+    shortcut: 'Meta-Alt-0',
     isActive: (editor) => editor.isActive('paragraph'),
   },
   'Heading 1': {
@@ -44,6 +45,7 @@ export default {
     icon: H1,
     action: (editor) =>
       editor.chain().focus().toggleHeading({ level: 1 }).run(),
+    shortcut: 'Meta-Alt-1',
     isActive: (editor) => editor.isActive('heading', { level: 1 }),
   },
   'Heading 2': {
@@ -52,6 +54,7 @@ export default {
     icon: H2,
     action: (editor) =>
       editor.chain().focus().toggleHeading({ level: 2 }).run(),
+    shortcut: 'Meta-Alt-2',
     isActive: (editor) => editor.isActive('heading', { level: 2 }),
   },
   'Heading 3': {
@@ -60,6 +63,7 @@ export default {
     icon: H3,
     action: (editor) =>
       editor.chain().focus().toggleHeading({ level: 3 }).run(),
+    shortcut: 'Meta-Alt-3',
     isActive: (editor) => editor.isActive('heading', { level: 3 }),
   },
   'Heading 4': {
@@ -68,6 +72,7 @@ export default {
     icon: H4,
     action: (editor) =>
       editor.chain().focus().toggleHeading({ level: 4 }).run(),
+    shortcut: 'Meta-Alt-4',
     isActive: (editor) => editor.isActive('heading', { level: 4 }),
   },
   'Heading 5': {
@@ -76,6 +81,7 @@ export default {
     icon: H5,
     action: (editor) =>
       editor.chain().focus().toggleHeading({ level: 5 }).run(),
+    shortcut: 'Meta-Alt-5',
     isActive: (editor) => editor.isActive('heading', { level: 5 }),
   },
   'Heading 6': {
@@ -84,48 +90,56 @@ export default {
     icon: H6,
     action: (editor) =>
       editor.chain().focus().toggleHeading({ level: 6 }).run(),
+    shortcut: 'Meta-Alt-6',
     isActive: (editor) => editor.isActive('heading', { level: 6 }),
   },
   Bold: {
     label: 'Bold',
     icon: Bold,
     action: (editor) => editor.chain().focus().toggleBold().run(),
+    shortcut: 'Meta-B',
     isActive: (editor) => editor.isActive('bold'),
   },
   Italic: {
     label: 'Italic',
     icon: Italic,
     action: (editor) => editor.chain().focus().toggleItalic().run(),
+    shortcut: 'Meta-I',
     isActive: (editor) => editor.isActive('italic'),
   },
   Underline: {
     label: 'Underline',
     icon: Underline,
     action: (editor) => editor.chain().focus().toggleUnderline().run(),
+    shortcut: 'Meta-U',
     isActive: (editor) => editor.isActive('underline'),
   },
   Strikethrough: {
     label: 'Strikethrough',
     icon: Strikethrough,
     action: (editor) => editor.chain().focus().toggleStrike().run(),
+    shortcut: 'Meta-Shift-S',
     isActive: (editor) => editor.isActive('strike'),
   },
   'Bullet List': {
     label: 'Bullet List',
     icon: ListUnordered,
     action: (editor) => editor.chain().focus().toggleBulletList().run(),
+    shortcut: 'Meta-Shift-8',
     isActive: (editor) => editor.isActive('bulletList'),
   },
   'Numbered List': {
     label: 'Numbered List',
     icon: ListOrdered,
     action: (editor) => editor.chain().focus().toggleOrderedList().run(),
+    shortcut: 'Meta-Shift-7',
     isActive: (editor) => editor.isActive('orderedList'),
   },
   'Task List': {
     label: 'Task List',
     icon: ListTask,
     action: (editor) => editor.chain().focus().toggleTaskList().run(),
+    shortcut: 'Meta-Shift-9',
     isActive: (editor) => editor.isActive('taskList'),
   },
   IndentList: {
@@ -144,18 +158,21 @@ export default {
     label: 'Align Center',
     icon: AlignCenter,
     action: (editor) => editor.chain().focus().setTextAlign('center').run(),
+    shortcut: 'Meta-Shift-E',
     isActive: (editor) => editor.isActive({ textAlign: 'center' }),
   },
   'Align Left': {
     label: 'Align Left',
     icon: AlignLeft,
     action: (editor) => editor.chain().focus().setTextAlign('left').run(),
+    shortcut: 'Meta-Shift-L',
     isActive: (editor) => editor.isActive({ textAlign: 'left' }),
   },
   'Align Right': {
     label: 'Align Right',
     icon: AlignRight,
     action: (editor) => editor.chain().focus().setTextAlign('right').run(),
+    shortcut: 'Meta-Shift-R',
     isActive: (editor) => editor.isActive({ textAlign: 'right' }),
   },
   FontColor: {
@@ -169,12 +186,14 @@ export default {
     label: 'Blockquote',
     icon: DoubleQuotes,
     action: (editor) => editor.chain().focus().toggleBlockquote().run(),
+    shortcut: 'Meta-Shift-B',
     isActive: (editor) => editor.isActive('blockquote'),
   },
   Code: {
     label: 'Code',
     icon: CodeView,
     action: (editor) => editor.chain().focus().toggleCodeBlock().run(),
+    shortcut: 'Meta-Alt-C',
     isActive: (editor) => editor.isActive('codeBlock'),
   },
   'Horizontal Rule': {
@@ -219,12 +238,14 @@ export default {
     label: 'Undo',
     icon: Undo,
     action: (editor) => editor.chain().focus().undo().run(),
+    shortcut: 'Meta-Z',
     isDisabled: (editor) => !editor.can().chain().focus().undo().run(),
   },
   Redo: {
     label: 'Redo',
     icon: Redo,
     action: (editor) => editor.chain().focus().redo().run(),
+    shortcut: 'Meta-Shift-Z',
     isDisabled: (editor) => !editor.can().chain().focus().redo().run(),
   },
   InsertTable: {


### PR DESCRIPTION
Used in https://github.com/frappe/writer to display shortcuts, but also more generally useful.