### PR TITLE
refactor(vite): add frontendRoute option and site banner plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ In 2019, I began building [Frappe Books](https://github.com/frappe/books) which 
 ## Links
 
 - [Documentation](https://frappeui.com)
+- [Vite Plugins](vite/README.md)
 - [Frappe UI Starter Boilerplate](https://github.com/netchampfaris/frappe-ui-starter)
 - [Community](https://github.com/frappe/frappe-ui/discussions)
 

--- a/vite/README.md
+++ b/vite/README.md
@@ -1,39 +1,34 @@
 # Frappe UI Vite Plugins
 
 A collection of Vite plugins for Frappe applications that handle common
-development tasks when building modern frontends for Frappe.
+development tasks like dev server proxying, icon auto-imports, TypeScript type
+generation, boot data injection, and production builds.
 
-## Installation
+## Getting Started
+
+### Installation
 
 ```bash
 npm install frappe-ui
 ```
 
-## Usage
+### Basic Setup
 
-In your `vite.config.js` file:
+Add the plugin to your `vite.config.js`:
 
 ```javascript
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import path from 'path'
 import frappeui from 'frappe-ui/vite'
 
 export default defineConfig({
   plugins: [
     frappeui({
-      frappeProxy: true, // Setup proxy to Frappe backend
-      lucideIcons: true, // Configure Lucide icons
-      jinjaBootData: true, // Inject server-side boot data
-      // Generate TypeScript interfaces from DocTypes
+      frontendRoute: '/g',
       frappeTypes: {
         input: {
           app_name: ['doctype_1', 'doctype_2'],
         },
-      },
-      // Production build config for asset paths and HTML output
-      buildConfig: {
-        indexHtmlPath: '../your_app/www/frontend.html',
       },
     }),
     vue(),
@@ -41,42 +36,63 @@ export default defineConfig({
 })
 ```
 
+All plugins except `frappeTypes` are **enabled by default**. `frontendRoute`
+and `frappeTypes` require explicit configuration — `frontendRoute` sets the app route,
+and `frappeTypes` needs an `input` map of app names to doctype names. Pass
+custom options to override any plugin, or `false` to disable it.
+
+---
+
+## Configuration Reference
+
+### `frontendRoute`
+
+The route where your app is served (e.g. `'/g'`). This top-level option is
+shared across plugins and controls:
+
+- **Dev server site banner** — prints clickable URLs for all sites where the
+  app is installed on startup.
+- **Build output path** — `indexHtmlPath` is auto-inferred as
+  `../<appName>/www/<path>.html`.
+
+```javascript
+frappeui({
+  frontendRoute: '/g',
+})
+```
+
+---
+
 ## Plugins
 
-### Frappe Proxy Plugin
+### Frappe Proxy
 
-Automatically configures a development server that proxies requests to your
-Frappe backend.
+Configures the Vite dev server to proxy backend requests to your Frappe
+instance.
 
-#### Features
+- Proxies routes like `/api`, `/app`, `/assets`, `/files`, etc.
+- Auto-detects the Frappe port from `common_site_config.json`
 
-- Sets up a proxy for backend routes (`/api`, `/app`, etc.)
-- Automatically detects Frappe port from `common_site_config.json`
-
-#### Configuration
+| Option   | Description                                    | Default                                          |
+| -------- | ---------------------------------------------- | ------------------------------------------------ |
+| `port`   | Vite dev server port                           | Auto-calculated from `webserver_port`            |
+| `source` | Regex for routes to proxy                      | `'^/(app\|login\|api\|assets\|files\|private)'`  |
 
 ```javascript
 frappeui({
   frappeProxy: {
-    port: 8080, // Frontend dev server port
-    source: '^/(app|login|api|assets|files|private)', // Routes to proxy
+    port: 8080,
+    source: '^/(app|login|api|assets|files|private)',
   },
 })
 ```
 
-### Lucide Icons Plugin
+### Lucide Icons
 
-Integrates [Lucide icons](https://lucide.dev/) with your app, providing access
-to all Lucide icons with some customization.
+Integrates [Lucide icons](https://lucide.dev/) with auto-import support and a
+standardized stroke-width of 1.5.
 
-#### Features
-
-- Automatically registers all Lucide icons for use in Vue components
-- Configures icons with standardized stroke-width 1.5 according to our design
-  system
-- Support auto-import
-
-#### Implicit import
+**Auto-import** — use directly in templates, no import needed:
 
 ```vue
 <template>
@@ -84,30 +100,21 @@ to all Lucide icons with some customization.
 </template>
 ```
 
-#### Explicit import
+**Explicit import** — for use in `<script setup>`:
 
-```vue
-<template>
-  <LucideArrowRight class="size-4" />
-  <LucideBarChart class="size-4" />
-</template>
-<script setup lang="ts">
+```ts
 import LucideArrowRight from '~icons/lucide/arrow-right'
-import LucideBarChart from '~icons/lucide/bar-chart'
-</script>
 ```
 
-### Frappe Types Plugin
+### Frappe Types
 
-Generates TypeScript interfaces for your Frappe DocTypes, providing type safety
-when working with Frappe data.
+Auto-generates TypeScript interfaces from Frappe DocType JSON files. Interfaces
+are regenerated only when the source DocType changes.
 
-#### Features
-
-- Automatically generates TypeScript interfaces from DocType JSON files
-- Creates and updates interfaces only when DocTypes change
-
-#### Configuration
+| Option   | Description                                | Default                  |
+| -------- | ------------------------------------------ | ------------------------ |
+| `input`  | Map of `app_name` → array of doctype names | *(required)*             |
+| `output` | Output file path for generated types       | `src/types/doctypes.ts`  |
 
 ```javascript
 frappeui({
@@ -115,17 +122,15 @@ frappeui({
     input: {
       your_app_name: ['doctype1', 'doctype2'],
     },
-    output: 'src/types/doctypes.ts', // (optional)
+    output: 'src/types/doctypes.ts',
   },
 })
 ```
 
-### Jinja Boot Data Plugin
+### Jinja Boot Data
 
-Injects jinja block that reads keys from `boot` context object and sets in
-`window`. Useful to set global values like `csrf_token`, `site_name`, etc.
-
-#### Configuration
+Injects a Jinja block that reads keys from the `boot` context object and sets
+them on `window`. Useful for global values like `csrf_token` and `site_name`.
 
 ```javascript
 frappeui({
@@ -133,12 +138,9 @@ frappeui({
 })
 ```
 
-#### Usage
-
-In your Python/Jinja template:
+**Server side** — populate `context.boot` in your Python handler:
 
 ```python
-
 def get_context(context):
     context.boot = {
         "csrf_token": "...",
@@ -148,37 +150,38 @@ def get_context(context):
     return context
 ```
 
-In your JavaScript code:
+**Client side** — access values directly from `window`:
 
 ```javascript
-// Access injected data
 console.log(window.user)
 console.log(window.user_info)
 ```
 
-### Build Configuration Plugin
+### Build Configuration
 
-Handles production builds with proper asset paths and HTML output.
-
-#### Features
+Handles production builds with proper asset paths and HTML output for Frappe's
+directory structure.
 
 - Configures output directories for build assets
-- Sets up correct asset paths for Frappe's standard directory structure
-- Copies the built index.html to a specified location (typically in www)
+- Sets correct base URLs for Frappe's asset serving
+- Copies the built `index.html` to the specified location (typically in `www/`)
 
-#### Configuration
+| Option          | Description                          | Default                                   |
+| --------------- | ------------------------------------ | ----------------------------------------- |
+| `outDir`        | Build output directory               | `'../app_name/public/frontend'` (auto)    |
+| `baseUrl`       | Base URL for assets                  | `'/assets/app_name/frontend/'` (auto)     |
+| `indexHtmlPath` | Where to copy built `index.html`     | Inferred from `frontendRoute`             |
+| `emptyOutDir`   | Clear output directory before build  | `true`                                    |
+| `sourcemap`     | Generate source maps                 | `true`                                    |
 
 ```javascript
 frappeui({
   buildConfig: {
-    // default: '../app_name/public/frontend', auto-detected if not specified
     outDir: '../app_name/public/frontend',
-    // Base URL for assets (auto-detected from outDir if not specified)
     baseUrl: '/assets/app_name/frontend/',
-    // required, typically "../app_name/www/app_name.html"
     indexHtmlPath: '../app_name/www/app_name.html',
-    emptyOutDir: true, // Clear output directory before build
-    sourcemap: true, // Generate sourcemaps
+    emptyOutDir: true,
+    sourcemap: true,
   },
 })
 ```

--- a/vite/buildConfig.js
+++ b/vite/buildConfig.js
@@ -1,5 +1,6 @@
 import path from 'path'
 import fs from 'fs'
+import { findAppName } from './utils.js'
 
 export function buildConfig(options = {}) {
   let outDir = options.outDir || findOutputDir()
@@ -10,11 +11,20 @@ export function buildConfig(options = {}) {
     return
   }
 
+  let indexHtmlPath = options.indexHtmlPath
+  if (!indexHtmlPath && options.frontendRoute) {
+    const appName = findAppName()
+    if (appName) {
+      const htmlName = options.frontendRoute.replace(/^\//, '')
+      indexHtmlPath = `../${appName}/www/${htmlName}.html`
+    }
+  }
+
   const defaultOptions = {
     outDir,
     emptyOutDir: true,
     sourcemap: true,
-    indexHtmlPath: null,
+    indexHtmlPath: indexHtmlPath || null,
     baseUrl: options.baseUrl || getBaseUrl(outDir),
   }
 

--- a/vite/index.js
+++ b/vite/index.js
@@ -3,31 +3,38 @@ import { frappeProxy } from './frappeProxy.js'
 import { frappeTypes } from './frappeTypes.js'
 import { jinjaBootData } from './jinjaBootData.js'
 import { buildConfig } from './buildConfig.js'
+import { siteBanner } from './siteBanner.js'
 
-function frappeuiPlugin(
-  options = {
-    lucideIcons: true,
-    frappeProxy: true,
-    frappeTypes: true,
-    jinjaBootData: true,
-    buildConfig: true,
-  },
-) {
+function frappeuiPlugin(options = {}) {
   let plugins = []
-  if (options.lucideIcons) {
-    plugins.push(lucideIcons(options.lucideIcons))
+  const frontendRoute = options.frontendRoute
+
+  const lucideIconsOpt = options.lucideIcons ?? true
+  const frappeProxyOpt = options.frappeProxy ?? true
+  const jinjaBootDataOpt = options.jinjaBootData ?? true
+  const buildConfigOpt = options.buildConfig ?? true
+
+  if (lucideIconsOpt) {
+    plugins.push(lucideIcons(lucideIconsOpt))
   }
-  if (options.frappeProxy) {
-    plugins.push(frappeProxy(options.frappeProxy))
+  if (frappeProxyOpt) {
+    const proxyOpts = typeof frappeProxyOpt === 'object' ? frappeProxyOpt : {}
+    plugins.push(frappeProxy(proxyOpts))
+  }
+
+  const bannerPlugin = siteBanner({ frontendRoute })
+  if (bannerPlugin) {
+    plugins.push(bannerPlugin)
   }
   if (options.frappeTypes) {
     plugins.push(frappeTypes(options.frappeTypes))
   }
-  if (options.jinjaBootData) {
-    plugins.push(jinjaBootData(options.jinjaBootData))
+  if (jinjaBootDataOpt) {
+    plugins.push(jinjaBootData(jinjaBootDataOpt))
   }
-  if (options.buildConfig) {
-    plugins.push(buildConfig(options.buildConfig))
+  if (buildConfigOpt) {
+    const buildOpts = typeof buildConfigOpt === 'object' ? buildConfigOpt : {}
+    plugins.push(buildConfig({ frontendRoute, ...buildOpts }))
   }
 
   const DepsIncludePlugin = {
@@ -44,6 +51,19 @@ function frappeuiPlugin(
   }
 
   plugins.push(DepsIncludePlugin)
+
+  if (frontendRoute) {
+    plugins.push({
+      name: 'frappeui-define-frontend-route',
+      config() {
+        return {
+          define: {
+            __FRONTEND_ROUTE__: JSON.stringify(frontendRoute),
+          },
+        }
+      },
+    })
+  }
 
   return plugins
 }

--- a/vite/siteBanner.js
+++ b/vite/siteBanner.js
@@ -1,0 +1,41 @@
+import { findAppName, getInstalledAppSites } from './utils.js'
+
+export function siteBanner({ frontendRoute } = {}) {
+  if (!frontendRoute) return null
+
+  let hasPrintedBanner = false
+
+  return {
+    name: 'frappeui-site-banner-plugin',
+    configureServer(server) {
+      server.httpServer?.once('listening', async () => {
+        if (hasPrintedBanner) return
+        hasPrintedBanner = true
+
+        const appName = findAppName()
+        if (!appName) return
+
+        try {
+          const sites = await getInstalledAppSites(appName)
+          if (!sites.length) return
+
+          const resolvedPort = server.resolvedUrls?.local[0]
+            ? Number(new URL(server.resolvedUrls.local[0]).port)
+            : server.config.server.port
+
+          const boldAppName = `\u001b[1m${appName}\u001b[22m`
+          console.log('')
+          console.log(`${boldAppName} sites:`)
+          for (const site of sites) {
+            console.log(`http://${site}:${resolvedPort}${frontendRoute}`)
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          console.warn(
+            `Failed to list installed sites for ${appName}: ${message}`,
+          )
+        }
+      })
+    },
+  }
+}

--- a/vite/utils.js
+++ b/vite/utils.js
@@ -9,18 +9,27 @@ export function getConfig() {
 }
 
 export function getCommonSiteConfig() {
+  const benchPath = findBenchPath()
+  if (!benchPath) {
+    return null
+  }
+
+  let configPath = path.join(benchPath, 'sites', 'common_site_config.json')
+  if (fs.existsSync(configPath)) {
+    return JSON.parse(fs.readFileSync(configPath))
+  }
+
+  return null
+}
+
+export function findBenchPath() {
   let currentDir = path.resolve('.')
-  // traverse up till we find frappe-bench with sites directory
   while (currentDir !== '/') {
     if (
       fs.existsSync(path.join(currentDir, 'sites')) &&
       fs.existsSync(path.join(currentDir, 'apps'))
     ) {
-      let configPath = path.join(currentDir, 'sites', 'common_site_config.json')
-      if (fs.existsSync(configPath)) {
-        return JSON.parse(fs.readFileSync(configPath))
-      }
-      return null
+      return currentDir
     }
     currentDir = path.resolve(currentDir, '..')
   }
@@ -28,15 +37,66 @@ export function getCommonSiteConfig() {
 }
 
 export function findAppsFolder() {
-  let currentDir = process.cwd()
-  while (currentDir !== '/') {
-    if (
-      fs.existsSync(path.join(currentDir, 'apps')) &&
-      fs.existsSync(path.join(currentDir, 'sites'))
-    ) {
-      return path.join(currentDir, 'apps')
-    }
-    currentDir = path.resolve(currentDir, '..')
+  const benchPath = findBenchPath()
+  if (!benchPath) {
+    return null
   }
+
+  return path.join(benchPath, 'apps')
+}
+
+export function findAppName() {
+  const appsFolder = findAppsFolder()
+  if (!appsFolder) {
+    return null
+  }
+
+  // Walk up from cwd until we find a directory whose parent is the apps folder
+  let currentDir = path.resolve('.')
+  while (currentDir !== '/') {
+    const parent = path.dirname(currentDir)
+    if (path.resolve(parent) === path.resolve(appsFolder)) {
+      return path.basename(currentDir)
+    }
+    currentDir = parent
+  }
+
   return null
+}
+
+export async function getInstalledAppSites(appName) {
+  const { execFile } = await import('node:child_process')
+  const { promisify } = await import('node:util')
+  const execFileAsync = promisify(execFile)
+
+  const benchPath = findBenchPath()
+  if (!benchPath) {
+    return []
+  }
+
+  let stdout
+  try {
+    const result = await execFileAsync('bench', ['list-app-sites', appName], {
+      cwd: benchPath,
+    })
+    stdout = result.stdout
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`Could not run 'bench list-app-sites': ${message}`)
+    return []
+  }
+
+  const sitePattern = /^[a-z0-9.-]+$/i
+
+  return Array.from(
+    new Set(
+      stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(
+          (line) =>
+            Boolean(line) && sitePattern.test(line) && line.includes('.'),
+        ),
+    ),
+  )
 }


### PR DESCRIPTION
### Add `frontendRoute` option to Vite plugins

Pass `frontendRoute` once in your vite config and frappe-ui handles the rest — build output path, dev server site banner with clickable URLs, and a `__FRONTEND_ROUTE__` compile-time constant you can use in your router.

```js
// vite.config.js

frappeui({
  frontendRoute: '/g',
  frappeTypes: { input: { my_app: ['DocType1'] } },
})
```


```js
// router.js

let router = createRouter({
  history: createWebHistory(__FRONTEND_ROUTE__ + '/'),
  routes: []
})
```

No more need to manually set `buildConfig.indexHtmlPath` or hardcode routes in multiple places.

### Print app sites to quickly open the site in browser
```
$ yarn dev

  VITE v4.5.14  ready in 460 ms

  ➜  Local:   http://localhost:8080/
  ➜  Network: http://192.168.29.64:8080/
  ➜  press h to show help

gameplan sites:
http://gameplan-demo.localhost:8080/g
http://gameplan.frappe.test:8080/g
http://gpdemo.test:8080/g

Frappe Type Generation Summary:
- Total processed: 17 doctypes
- Updated: 0 interfaces
- Skipped: 17 (no changes)

No new schema changes.
```
---

Small tweaks for bigger impact