### PR TITLE
chore: update documentation link in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ In 2019, I began building [Frappe Books](https://github.com/frappe/books) which 
 
 ## Links
 
-- [Documentation](https://frappeui.com)
+- [Documentation](https://ui.frappe.io)
 - [Vite Plugins](vite/README.md)
 - [Frappe UI Starter Boilerplate](https://github.com/netchampfaris/frappe-ui-starter)
 - [Community](https://github.com/frappe/frappe-ui/discussions)


### PR DESCRIPTION
Previous link was dead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation link in the README to the correct URL for easier access to project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->