### PR TITLE
fix: nullish coalescing in sidebar collapse logic

### DIFF
--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -70,7 +70,7 @@ const isCollapsed = defineModel('collapsed', {
 })
 provide('isSidebarCollapsed', isCollapsed)
 const shouldCollapse = computed(
-  () => (isCollapsed.value || isMobile.value) && !props.disableCollapse,
+  () => (isCollapsed.value ?? isMobile.value) && !props.disableCollapse,
 )
 
 const breakpoints = useBreakpoints(breakpointsTailwind)


### PR DESCRIPTION
When the || operator is used, isMobile.value is always true on mobile so the Sidebar is always collapsed on mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar collapse behavior on mobile devices by refining state fallback logic. The sidebar now correctly defaults to mobile detection when the collapse state is undefined, ensuring consistent behavior across different device types and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->