### PR TITLE
feat: tree-shakeable string icons <Button icon="menu" />

### DIFF
--- a/src/components/Button/Button.cy.ts
+++ b/src/components/Button/Button.cy.ts
@@ -49,7 +49,7 @@ describe('<Button />', () => {
     cy.get('svg').should('exist') // Loading Spinner
   })
 
-  it('handles prefix and suffix slots (replacing deprecated icon props)', () => {
+  it('handles prefix and suffix slots', () => {
     const TestIcon = {
       render() {
         return h('svg', { 'data-cy': 'test-icon' })

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -2,12 +2,12 @@
   <Tooltip :text="tooltip" :disabled="!tooltip?.length">
     <button
       v-bind="$attrs"
-      :class="buttonClasses"
-      @click="handleClick"
-      :disabled="isDisabled"
-      :ariaLabel="label"
-      :type = "props.type"
       ref="rootRef"
+      :class="buttonClasses"
+      :disabled="isDisabled"
+      :aria-label="label"
+      :type="props.type"
+      @click="handleClick"
     >
       <LoadingIndicator
         v-if="loading"
@@ -18,24 +18,22 @@
           'h-4.5 w-4.5': size == 'xl' || size == '2xl',
         }"
       />
-      <slot name="prefix" v-else-if="$slots['prefix'] || iconLeft">
-        <FeatherIcon
-          v-if="iconLeft && typeof iconLeft === 'string'"
-          :name="iconLeft"
+      <slot name="prefix" v-else-if="$slots.prefix || iconLeftComponent">
+        <component
+          v-if="iconLeftComponent"
+          :is="iconLeftComponent"
           :class="slotClasses"
           aria-hidden="true"
         />
-        <component v-else-if="iconLeft" :is="iconLeft" :class="slotClasses" />
       </slot>
 
       <template v-if="loading && loadingText">{{ loadingText }}</template>
       <template v-else-if="isIconButton && !loading">
-        <FeatherIcon
-          v-if="icon && typeof icon === 'string'"
-          :name="icon"
+        <component
+          v-if="iconComponent"
+          :is="iconComponent"
           :class="slotClasses"
         />
-        <component v-else-if="icon" :is="icon" :class="slotClasses" />
         <slot name="icon" v-else-if="$slots.icon" />
         <div v-else-if="hasLucideIconInDefaultSlot" :class="slotClasses">
           <slot>{{ label }}</slot>
@@ -46,28 +44,25 @@
       </span>
 
       <slot name="suffix">
-        <FeatherIcon
-          v-if="iconRight && typeof iconRight === 'string'"
-          :name="iconRight"
+        <component
+          v-if="iconRightComponent"
+          :is="iconRightComponent"
           :class="slotClasses"
           aria-hidden="true"
         />
-          <component
-            v-else-if="iconRight"
-            :is="iconRight"
-            :class="slotClasses"
-          />
       </slot>
     </button>
   </Tooltip>
 </template>
+
 <script lang="ts" setup>
-import { computed, useSlots, ref } from 'vue'
-import FeatherIcon from '../FeatherIcon.vue'
-import LoadingIndicator from '../LoadingIndicator.vue'
+import { computed, ref, useSlots, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
-import type { ButtonProps, ThemeVariant } from './types'
+import LoadingIndicator from '../LoadingIndicator.vue'
 import Tooltip from '../Tooltip/Tooltip.vue'
+import type { ButtonProps, ThemeVariant } from './types'
+
+const warnedRuntimeStringIcons = new Set<string>()
 
 defineOptions({ inheritAttrs: false })
 
@@ -77,14 +72,14 @@ const props = withDefaults(defineProps<ButtonProps>(), {
   variant: 'subtle',
   loading: false,
   disabled: false,
-  type: "button"
+  type: 'button',
 })
 
 const slots = useSlots()
 const router = useRouter()
 
 const buttonClasses = computed(() => {
-  let solidClasses = {
+  const solidClasses = {
     gray: 'text-ink-white bg-surface-gray-7 hover:bg-surface-gray-6 active:bg-surface-gray-5',
     blue: 'text-ink-white bg-blue-500 hover:bg-surface-blue-3 active:bg-blue-700',
     green:
@@ -92,7 +87,7 @@ const buttonClasses = computed(() => {
     red: 'text-ink-white bg-surface-red-5 hover:bg-surface-red-6 active:bg-surface-red-7',
   }[props.theme]
 
-  let subtleClasses = {
+  const subtleClasses = {
     gray: 'text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4',
     blue: 'text-ink-blue-3 bg-surface-blue-2 hover:bg-blue-200 active:bg-blue-300',
     green:
@@ -100,7 +95,7 @@ const buttonClasses = computed(() => {
     red: 'text-red-700 bg-surface-red-2 hover:bg-surface-red-3 active:bg-surface-red-4',
   }[props.theme]
 
-  let outlineClasses = {
+  const outlineClasses = {
     gray: 'text-ink-gray-8 bg-surface-white bg-surface-white border border-outline-gray-2 hover:border-outline-gray-3 active:border-outline-gray-3 active:bg-surface-gray-4',
     blue: 'text-ink-blue-3 bg-surface-white border border-outline-blue-1 hover:border-blue-400 active:border-blue-400 active:bg-blue-300',
     green:
@@ -108,7 +103,7 @@ const buttonClasses = computed(() => {
     red: 'text-red-700 bg-surface-white border border-outline-red-1 hover:border-outline-red-2 active:border-outline-red-2 active:bg-surface-red-3',
   }[props.theme]
 
-  let ghostClasses = {
+  const ghostClasses = {
     gray: 'text-ink-gray-8 bg-transparent hover:bg-surface-gray-3 active:bg-surface-gray-4',
     blue: 'text-ink-blue-3 bg-transparent hover:bg-blue-200 active:bg-blue-300',
     green:
@@ -116,23 +111,23 @@ const buttonClasses = computed(() => {
     red: 'text-red-700 bg-transparent hover:bg-surface-red-3 active:bg-surface-red-4',
   }[props.theme]
 
-  let focusClasses = {
+  const focusClasses = {
     gray: 'focus-visible:ring focus-visible:ring-outline-gray-3',
     blue: 'focus-visible:ring focus-visible:ring-blue-400',
     green: 'focus-visible:ring focus-visible:ring-outline-green-2',
     red: 'focus-visible:ring focus-visible:ring-outline-red-2',
   }[props.theme]
 
-  let variantClasses = {
+  const variantClasses = {
     subtle: subtleClasses,
     solid: solidClasses,
     outline: outlineClasses,
     ghost: ghostClasses,
   }[props.variant]
 
-  let themeVariant: ThemeVariant = `${props.theme}-${props.variant}`
+  const themeVariant: ThemeVariant = `${props.theme}-${props.variant}`
 
-  let disabledClassesMap: Record<ThemeVariant, string> = {
+  const disabledClassesMap: Record<ThemeVariant, string> = {
     'gray-solid': 'bg-surface-gray-2 text-ink-gray-4',
     'gray-subtle': 'bg-surface-gray-2 text-ink-gray-4',
     'gray-outline':
@@ -157,7 +152,7 @@ const buttonClasses = computed(() => {
       'bg-surface-red-2 text-ink-red-2 border border-outline-red-1',
     'red-ghost': 'text-ink-red-2',
   }
-  let disabledClasses = disabledClassesMap[themeVariant]
+  const disabledClasses = disabledClassesMap[themeVariant]
 
   let sizeClasses = {
     sm: 'h-7 text-base px-2 rounded',
@@ -186,23 +181,27 @@ const buttonClasses = computed(() => {
 })
 
 const slotClasses = computed(() => {
-  let classes = {
+  return {
     sm: 'h-4',
     md: 'h-4.5',
     lg: 'h-5',
     xl: 'h-6',
     '2xl': 'h-6',
   }[props.size]
-
-  return classes
 })
 
 const isDisabled = computed(() => {
   return props.disabled || props.loading
 })
 
+const iconComponent = computed(() => getRenderableIcon(props.icon))
+const iconLeftComponent = computed(() => getRenderableIcon(props.iconLeft))
+const iconRightComponent = computed(() => getRenderableIcon(props.iconRight))
+
 const isIconButton = computed(() => {
-  return props.icon || slots.icon || hasLucideIconInDefaultSlot.value
+  return Boolean(
+    iconComponent.value || slots.icon || hasLucideIconInDefaultSlot.value,
+  )
 })
 
 const hasLucideIconInDefaultSlot = computed(() => {
@@ -210,27 +209,53 @@ const hasLucideIconInDefaultSlot = computed(() => {
 
   const slotContent = slots.default()
   if (!Array.isArray(slotContent)) return false
-  // if the slot contains only one element and it's a lucide icon
-  // render it as an icon button
-  let firstVNode = slotContent[0]
-  if (
-    typeof firstVNode.type?.name == 'string' &&
-    firstVNode.type?.name?.startsWith('lucide-')
-  ) {
-    return true
-  }
-  return false
+
+  const firstVNode = slotContent[0]
+  return (
+    typeof firstVNode.type?.name === 'string' &&
+    firstVNode.type.name.startsWith('lucide-')
+  )
 })
 
-const handleClick = () => {
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    warnForRuntimeStringIcon('icon', props.icon)
+    warnForRuntimeStringIcon('iconLeft', props.iconLeft)
+    warnForRuntimeStringIcon('iconRight', props.iconRight)
+  })
+}
+
+function getRenderableIcon(icon?: ButtonProps['icon']) {
+  if (!icon || typeof icon === 'string') return null
+  return icon
+}
+
+function warnForRuntimeStringIcon(
+  propName: 'icon' | 'iconLeft' | 'iconRight',
+  icon?: string | ButtonProps['icon'],
+) {
+  if (!icon || typeof icon !== 'string') return
+
+  const key = `${propName}:${icon}`
+  if (warnedRuntimeStringIcons.has(key)) return
+
+  warnedRuntimeStringIcons.add(key)
+  console.warn(
+    `[frappe-ui] Button ${propName}="${icon}" requires the frappe-ui/vite transform or a component binding like :${propName}="LucideX".`,
+  )
+}
+
+function handleClick() {
   if (props.route) {
     return router.push(props.route)
-  } else if (props.link) {
+  }
+
+  if (props.link) {
     return window.open(props.link, '_blank')
   }
 }
 
-const rootRef = ref()
+const rootRef = ref<HTMLElement | null>(null)
 defineExpose({ rootRef })
 
 defineSlots<{

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -18,13 +18,25 @@ export interface ButtonProps {
   /** Text label displayed inside the button */
   label?: string
 
-  /** Icon shown when no left or right icon is specified */
+  /**
+   * Icon shown when no left or right icon is specified.
+   * Static literals like `icon="menu"` are rewritten to per-icon Lucide imports
+   * when using `frappe-ui/vite`.
+   */
   icon?: string | Component
 
-  /** Icon shown before the label */
+  /**
+   * Icon shown before the label.
+   * Static literals like `icon-left="menu"` are rewritten to per-icon Lucide
+   * imports when using `frappe-ui/vite`.
+   */
   iconLeft?: string | Component
 
-  /** Icon shown after the label */
+  /**
+   * Icon shown after the label.
+   * Static literals like `icon-right="menu"` are rewritten to per-icon Lucide
+   * imports when using `frappe-ui/vite`.
+   */
   iconRight?: string | Component
 
   /** Tooltip text shown on hover */

--- a/vite/README.md
+++ b/vite/README.md
@@ -36,10 +36,10 @@ export default defineConfig({
 })
 ```
 
-All plugins except `frappeTypes` are **enabled by default**. `frontendRoute`
-and `frappeTypes` require explicit configuration — `frontendRoute` sets the app route,
-and `frappeTypes` needs an `input` map of app names to doctype names. Pass
-custom options to override any plugin, or `false` to disable it.
+All plugins except `frappeTypes` are **enabled by default**. `frontendRoute` and
+`frappeTypes` require explicit configuration — `frontendRoute` sets the app
+route, and `frappeTypes` needs an `input` map of app names to doctype names.
+Pass custom options to override any plugin, or `false` to disable it.
 
 ---
 
@@ -50,8 +50,8 @@ custom options to override any plugin, or `false` to disable it.
 The route where your app is served (e.g. `'/g'`). This top-level option is
 shared across plugins and controls:
 
-- **Dev server site banner** — prints clickable URLs for all sites where the
-  app is installed on startup.
+- **Dev server site banner** — prints clickable URLs for all sites where the app
+  is installed on startup.
 - **Build output path** — `indexHtmlPath` is auto-inferred as
   `../<appName>/www/<path>.html`.
 
@@ -73,10 +73,10 @@ instance.
 - Proxies routes like `/api`, `/app`, `/assets`, `/files`, etc.
 - Auto-detects the Frappe port from `common_site_config.json`
 
-| Option   | Description                                    | Default                                          |
-| -------- | ---------------------------------------------- | ------------------------------------------------ |
-| `port`   | Vite dev server port                           | Auto-calculated from `webserver_port`            |
-| `source` | Regex for routes to proxy                      | `'^/(app\|login\|api\|assets\|files\|private)'`  |
+| Option   | Description               | Default                                         |
+| -------- | ------------------------- | ----------------------------------------------- |
+| `port`   | Vite dev server port      | Auto-calculated from `webserver_port`           |
+| `source` | Regex for routes to proxy | `'^/(app\|login\|api\|assets\|files\|private)'` |
 
 ```javascript
 frappeui({
@@ -106,15 +106,27 @@ standardized stroke-width of 1.5.
 import LucideArrowRight from '~icons/lucide/arrow-right'
 ```
 
+**Static `Button` icon props** — literal string props on `Button` are rewritten
+at build time to direct Lucide imports, so the icon stays tree-shakeable:
+
+```vue
+<Button icon="menu" />
+<Button icon-left="search" icon-right="chevron-down" />
+```
+
+This only applies to static string literals in `.vue` templates. Dynamic string
+values are not transformed; prefer passing the imported Lucide component in
+those cases.
+
 ### Frappe Types
 
 Auto-generates TypeScript interfaces from Frappe DocType JSON files. Interfaces
 are regenerated only when the source DocType changes.
 
-| Option   | Description                                | Default                  |
-| -------- | ------------------------------------------ | ------------------------ |
-| `input`  | Map of `app_name` → array of doctype names | *(required)*             |
-| `output` | Output file path for generated types       | `src/types/doctypes.ts`  |
+| Option   | Description                                | Default                 |
+| -------- | ------------------------------------------ | ----------------------- |
+| `input`  | Map of `app_name` → array of doctype names | _(required)_            |
+| `output` | Output file path for generated types       | `src/types/doctypes.ts` |
 
 ```javascript
 frappeui({
@@ -166,13 +178,13 @@ directory structure.
 - Sets correct base URLs for Frappe's asset serving
 - Copies the built `index.html` to the specified location (typically in `www/`)
 
-| Option          | Description                          | Default                                   |
-| --------------- | ------------------------------------ | ----------------------------------------- |
-| `outDir`        | Build output directory               | `'../app_name/public/frontend'` (auto)    |
-| `baseUrl`       | Base URL for assets                  | `'/assets/app_name/frontend/'` (auto)     |
-| `indexHtmlPath` | Where to copy built `index.html`     | Inferred from `frontendRoute`             |
-| `emptyOutDir`   | Clear output directory before build  | `true`                                    |
-| `sourcemap`     | Generate source maps                 | `true`                                    |
+| Option          | Description                         | Default                                |
+| --------------- | ----------------------------------- | -------------------------------------- |
+| `outDir`        | Build output directory              | `'../app_name/public/frontend'` (auto) |
+| `baseUrl`       | Base URL for assets                 | `'/assets/app_name/frontend/'` (auto)  |
+| `indexHtmlPath` | Where to copy built `index.html`    | Inferred from `frontendRoute`          |
+| `emptyOutDir`   | Clear output directory before build | `true`                                 |
+| `sourcemap`     | Generate source maps                | `true`                                 |
 
 ```javascript
 frappeui({

--- a/vite/lucideIcons.js
+++ b/vite/lucideIcons.js
@@ -5,9 +5,15 @@ import IconsResolver from 'unplugin-icons/resolver'
 
 const VIRTUAL_PREFIX = '~icons/lucide/'
 const RESOLVED_PREFIX = '\0~icons/lucide/'
+const TEMPLATE_OPEN_RE = /<template\b[^>]*>/
+const BUTTON_TAG_RE = /<Button(?=[\s>/])/g
+const BUTTON_ICON_ATTR_RE =
+  /(\s)(icon|iconLeft|iconRight|icon-left|icon-right)\s*=\s*(['"])([^'"`\s<>]+)\3/g
+const STATIC_BUTTON_ICON_ATTR_RE =
+  /\s(?:icon|iconLeft|iconRight|icon-left|icon-right)\s*=\s*(['"])[^'"]+\1/
 
 export function lucideIcons() {
-  const resolverObj = {
+  const resolver = {
     resolvers: [
       IconsResolver({
         prefix: false,
@@ -15,15 +21,203 @@ export function lucideIcons() {
       }),
     ],
   }
+
   const icons = getIcons()
+
   return [
-    AutoImport(resolverObj),
-    Components(resolverObj),
-    LucideIconsPlugin(icons),
+    AutoImport(resolver),
+    Components(resolver),
+    buttonIconPropsPlugin(icons),
+    lucideIconsPlugin(icons),
   ]
 }
 
-function LucideIconsPlugin(icons) {
+function buttonIconPropsPlugin(icons) {
+  return {
+    name: 'frappe-ui-button-lucide-icon-props',
+    enforce: 'pre',
+    transform(code, id) {
+      const filepath = id.split('?')[0]
+      if (!isVueFile(filepath) || !hasStaticButtonIconAttrs(code)) {
+        return null
+      }
+
+      const transformedCode = transformButtonIconPropsSfc(code, icons)
+      if (!transformedCode) return null
+
+      return {
+        code: transformedCode,
+        map: null,
+      }
+    },
+  }
+}
+
+function isVueFile(filepath) {
+  return filepath.endsWith('.vue')
+}
+
+function hasStaticButtonIconAttrs(code) {
+  return code.includes('<Button') && STATIC_BUTTON_ICON_ATTR_RE.test(code)
+}
+
+function transformButtonIconPropsSfc(code, icons) {
+  const templateBlock = findTemplateBlock(code)
+  if (!templateBlock) return null
+
+  const template = code.slice(templateBlock.start, templateBlock.end)
+  const transformedTemplate = transformButtonIconPropsTemplate(template, icons)
+  if (!transformedTemplate) return null
+
+  const nextCode =
+    code.slice(0, templateBlock.start) +
+    transformedTemplate.template +
+    code.slice(templateBlock.end)
+
+  return injectScriptSetupImports(
+    nextCode,
+    createIconImportStatements(transformedTemplate.imports),
+  )
+}
+
+function createIconImportStatements(imports) {
+  return Array.from(imports.entries()).map(
+    ([iconName, bindingName]) =>
+      `import ${bindingName} from '${VIRTUAL_PREFIX}${iconName}'`,
+  )
+}
+
+function findTemplateBlock(code) {
+  const openMatch = code.match(TEMPLATE_OPEN_RE)
+  if (!openMatch || openMatch.index == null) return null
+
+  const start = openMatch.index + openMatch[0].length
+  const end = code.indexOf('</template>', start)
+  if (end === -1) return null
+
+  return { start, end }
+}
+
+function transformButtonIconPropsTemplate(template, icons) {
+  let match
+  let lastIndex = 0
+  let changed = false
+  let output = ''
+  const imports = new Map()
+
+  BUTTON_TAG_RE.lastIndex = 0
+
+  while ((match = BUTTON_TAG_RE.exec(template))) {
+    const tagStart = match.index
+    const tagEnd = findTagEnd(template, tagStart)
+
+    if (tagEnd === -1) {
+      break
+    }
+
+    const tag = template.slice(tagStart, tagEnd + 1)
+    const transformedTag = transformButtonTag(tag, icons, imports)
+
+    output += template.slice(lastIndex, tagStart)
+    output += transformedTag
+    lastIndex = tagEnd + 1
+    changed ||= transformedTag !== tag
+
+    BUTTON_TAG_RE.lastIndex = tagEnd + 1
+  }
+
+  if (!changed) return null
+
+  output += template.slice(lastIndex)
+
+  return {
+    template: output,
+    imports,
+  }
+}
+
+function findTagEnd(template, startIndex) {
+  let quote = null
+
+  for (let index = startIndex + 1; index < template.length; index++) {
+    const char = template[index]
+
+    if (quote) {
+      if (char === quote && template[index - 1] !== '\\') {
+        quote = null
+      }
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+
+    if (char === '>') {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function transformButtonTag(tag, icons, imports) {
+  let changed = false
+
+  const transformedTag = tag.replace(
+    BUTTON_ICON_ATTR_RE,
+    (full, leadingWhitespace, attrName, _quote, iconName) => {
+      if (!icons[iconName]) {
+        return full
+      }
+
+      changed = true
+
+      let bindingName = imports.get(iconName)
+      if (!bindingName) {
+        bindingName = `__FrappeUiLucideIcon${imports.size}`
+        imports.set(iconName, bindingName)
+      }
+
+      return `${leadingWhitespace}:${attrName}="${bindingName}"`
+    },
+  )
+
+  return changed ? transformedTag : tag
+}
+
+function injectScriptSetupImports(code, importStatements) {
+  if (!importStatements.length) return code
+
+  const importBlock = `\n${importStatements.join('\n')}`
+  const scriptSetupMatch = code.match(/<script\b(?=[^>]*\bsetup\b)[^>]*>/)
+
+  if (scriptSetupMatch && scriptSetupMatch.index != null) {
+    const insertAt = scriptSetupMatch.index + scriptSetupMatch[0].length
+    return code.slice(0, insertAt) + importBlock + code.slice(insertAt)
+  }
+
+  const lang = getFirstScriptLang(code)
+  const scriptSetupBlock = `\n<script setup${lang ? ` lang="${lang}"` : ''}>${importBlock}\n</script>\n`
+  const templateEnd = code.indexOf('</template>')
+
+  if (templateEnd !== -1) {
+    const insertAt = templateEnd + '</template>'.length
+    return code.slice(0, insertAt) + scriptSetupBlock + code.slice(insertAt)
+  }
+
+  return scriptSetupBlock + code
+}
+
+function getFirstScriptLang(code) {
+  const scriptLangMatch = code.match(
+    /<script\b[^>]*\blang=(['"])([^'"]+)\1[^>]*>/,
+  )
+  return scriptLangMatch?.[2] || ''
+}
+
+function lucideIconsPlugin(icons) {
   return {
     name: 'frappe-ui-lucide-icons',
     resolveId(id) {
@@ -44,7 +238,9 @@ function generateIconModule(icons, iconName) {
   if (!svg) return null
 
   const innerMatch = svg.match(/<svg[^>]*>([\s\S]*)<\/svg>/)
-  const innerHTML = innerMatch ? innerMatch[1].replace(/>\s+</g, '><').trim() : ''
+  const innerHTML = innerMatch
+    ? innerMatch[1].replace(/>\s+</g, '><').trim()
+    : ''
 
   return `
 import { h } from 'vue'
@@ -70,44 +266,52 @@ export default {
 }
 
 function getIcons() {
-  let icons = {}
+  const icons = {}
+
   for (const icon in LucideIcons) {
     if (icon === 'default') {
       continue
     }
+
     let iconSvg = LucideIcons[icon]
 
-    // set stroke-width to 1.5
     if (typeof iconSvg === 'string' && iconSvg.includes('stroke-width')) {
       iconSvg = iconSvg.replace(/stroke-width="2"/g, 'stroke-width="1.5"')
     }
+
     icons[icon] = iconSvg
 
-    let dashKeys = camelToDash(icon)
-    for (let dashKey of dashKeys) {
+    const dashKeys = camelToDash(icon)
+    for (const dashKey of dashKeys) {
       if (dashKey !== icon) {
         icons[dashKey] = iconSvg
       }
     }
   }
+
   return icons
 }
 
 function camelToDash(key) {
-  // barChart2 -> bar-chart-2
-  let withNumber = key.replace(/[A-Z0-9]/g, (m) => '-' + m.toLowerCase())
+  let withNumber = key.replace(
+    /[A-Z0-9]/g,
+    (match) => `-${match.toLowerCase()}`,
+  )
   if (withNumber.startsWith('-')) {
-    withNumber = withNumber.substring(1)
+    withNumber = withNumber.slice(1)
   }
-  // barChart2 -> bar-chart2
-  let withoutNumber = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase())
+
+  let withoutNumber = key.replace(
+    /[A-Z]/g,
+    (match) => `-${match.toLowerCase()}`,
+  )
   if (withoutNumber.startsWith('-')) {
-    withoutNumber = withoutNumber.substring(1)
+    withoutNumber = withoutNumber.slice(1)
   }
 
   if (withNumber !== withoutNumber) {
-    // both are required because unplugin icon resolver doesn't put a dash before numbers
     return [withNumber, withoutNumber]
   }
+
   return [withNumber]
 }

--- a/vite/lucideIcons.test.ts
+++ b/vite/lucideIcons.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { lucideIcons } from './lucideIcons.js'
+
+function getButtonIconTransform() {
+  return lucideIcons().find(
+    (plugin) => plugin.name === 'frappe-ui-button-lucide-icon-props',
+  )
+}
+
+describe('frappe-ui button icon transform', () => {
+  it('rewrites static Button icon props to direct lucide imports', async () => {
+    const plugin = getButtonIconTransform()
+    const input = `<template>
+  <Button icon="menu" icon-left="search" iconRight="chevron-down" />
+</template>
+<script setup lang="ts">
+const label = 'Menu'
+</script>
+`
+
+    const result = await plugin.transform(input, '/tmp/ButtonIcons.vue')
+
+    expect(result).toBeTruthy()
+    expect(result.code).toContain(
+      '<Button :icon="__FrappeUiLucideIcon0" :icon-left="__FrappeUiLucideIcon1" :iconRight="__FrappeUiLucideIcon2" />',
+    )
+    expect(result.code).toContain(
+      "import __FrappeUiLucideIcon0 from '~icons/lucide/menu'",
+    )
+    expect(result.code).toContain(
+      "import __FrappeUiLucideIcon1 from '~icons/lucide/search'",
+    )
+    expect(result.code).toContain(
+      "import __FrappeUiLucideIcon2 from '~icons/lucide/chevron-down'",
+    )
+  })
+
+  it('creates a script setup block when needed and preserves the existing script lang', async () => {
+    const plugin = getButtonIconTransform()
+    const input = `<template>
+  <Button iconRight="chevron-down" />
+</template>
+<script lang="ts">
+export default {}
+</script>
+`
+
+    const result = await plugin.transform(input, '/tmp/ButtonIcons.vue')
+
+    expect(result).toBeTruthy()
+    expect(result.code).toContain('<script setup lang="ts">')
+    expect(result.code).toContain(
+      "import __FrappeUiLucideIcon0 from '~icons/lucide/chevron-down'",
+    )
+    expect(result.code).toContain(
+      '<Button :iconRight="__FrappeUiLucideIcon0" />',
+    )
+  })
+
+  it('skips dynamic bindings and unknown icon names', () => {
+    const plugin = getButtonIconTransform()
+
+    expect(
+      plugin.transform(
+        `<template><Button :icon="menu" /></template>`,
+        '/tmp/ButtonIcons.vue',
+      ),
+    ).toBeNull()
+
+    expect(
+      plugin.transform(
+        `<template><Button icon="not-a-real-icon" /></template>`,
+        '/tmp/ButtonIcons.vue',
+      ),
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- rewrite static `Button` icon string props to direct Lucide imports in `frappe-ui/vite`
- remove `FeatherIcon` runtime handling from `Button.vue`
- document the `Button icon="x"` transform behavior and add transform tests

This keeps the nice DX of:

```vue
<Button icon="x" />
```

while making the transformed path tree-shakeable.

## How it works
When `frappe-ui/vite` is enabled, static string literals on `Button` props are rewritten at build time:

```vue
<Button icon="menu" icon-left="search" icon-right="chevron-down" />
```

becomes direct per-icon Lucide imports, so only the used icons are pulled into the bundle.

`Button.vue` no longer renders string icon props through `FeatherIcon` at runtime. In development, runtime string values now warn so consumers can switch to the Vite transform or explicit Lucide component bindings for dynamic cases.

## Verification
- `yarn vitest run vite/lucideIcons.test.ts`
- `yarn build`

## Follow-up migration plan for removing `FeatherIcon` from frappe-ui
This PR only removes `FeatherIcon` from `Button` runtime and adds the Lucide transform path. To fully remove `FeatherIcon` from frappe-ui, the next steps are:

### Phase 1: direct component replacements
- replace direct `<FeatherIcon ... />` usages in core components and frappe module components with direct Lucide imports
- remove dead `FeatherIcon` imports in stories/tests while touching those files

### Phase 2: public API cleanup
- migrate string-based icon APIs that still interpret strings as icon names, especially:
  - `DropdownOption.icon`
  - `Input.iconLeft`
  - `Switch.icon`
  - any remaining component props that still branch on `typeof icon === 'string'`
- keep `Button` on the compile-time transform path for static template literals

### Phase 3: consumer migration
- update internal stories/examples/tests to pass Lucide components where runtime strings are still used
- migrate downstream consumers that pass icon names in JS/TS option objects, especially dropdown option arrays

### Phase 4: final removal
- remove `src/components/FeatherIcon.vue`
- remove the `FeatherIcon` export from `src/index.ts`
- remove the `feather-icons` package dependency
- clean up any remaining `feather-*` classes in icon components/docs

That plan can be handled incrementally in follow-up PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Button component with automatic transformation of static icon string values to imported components at build time.

* **Documentation**
  * Added Lucide Icons integration guide explaining how static icon props in Button components are automatically rewritten at build time, with usage examples and dynamic value limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->