### PR TITLE
fix(autocomplete): null error when search is empty

### DIFF
--- a/src/components/Autocomplete/Autocomplete.vue
+++ b/src/components/Autocomplete/Autocomplete.vue
@@ -226,14 +226,7 @@ const props = withDefaults(defineProps<AutocompleteProps>(), {
   multiple: false,
   maxOptions: 50,
   hideSearch: false,
-  compareFn: (a, b) => {
-    if (a == null || b == null) return a === b
-    const left =
-      typeof a === 'object' && 'value' in a && a.value !== undefined ? a.value : a
-    const right =
-      typeof b === 'object' && 'value' in b && b.value !== undefined ? b.value : b
-    return left === right
-  },
+  compareFn: (a, b) => a.value === b.value,
 })
 const emit = defineEmits(['update:modelValue', 'update:query', 'change'])
 
@@ -328,6 +321,7 @@ const findOption = (option: AutocompleteOption) => {
 }
 
 const makeOption = (option: AutocompleteOption) => {
+  if (option == null) return { label: '', value: '' }
   return isOption(option) ? option : { label: option, value: option }
 }
 

--- a/src/components/Autocomplete/Autocomplete.vue
+++ b/src/components/Autocomplete/Autocomplete.vue
@@ -226,7 +226,14 @@ const props = withDefaults(defineProps<AutocompleteProps>(), {
   multiple: false,
   maxOptions: 50,
   hideSearch: false,
-  compareFn: (a, b) => a.value === b.value,
+  compareFn: (a, b) => {
+    if (a == null || b == null) return a === b
+    const left =
+      typeof a === 'object' && 'value' in a && a.value !== undefined ? a.value : a
+    const right =
+      typeof b === 'object' && 'value' in b && b.value !== undefined ? b.value : b
+    return left === right
+  },
 })
 const emit = defineEmits(['update:modelValue', 'update:query', 'change'])
 


### PR DESCRIPTION
The autocomplete single option can be of the type
`string | { label: string; value: string }`


And if the options prop is of type `string[]`

When we type something in the search query box and then remove it, in the compareFn the "a" value becomes `null`.


then we get the following error

```
runtime-core.esm-bundler.js:4671 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'emitsOptions')
    at shouldUpdateComponent (runtime-core.esm-bundler.js:4671:27)
    at updateComponent (runtime-core.esm-bundler.js:5960:9)
    at processComponent (runtime-core.esm-bundler.js:5906:7)
    at patch (runtime-core.esm-bundler.js:5401:11)
    at patchKeyedChildren (runtime-core.esm-bundler.js:6312:9)
    at patchChildren (runtime-core.esm-bundler.js:6189:9)
    at processFragment (runtime-core.esm-bundler.js:5869:9)
    at patch (runtime-core.esm-bundler.js:5375:9)
    at patchKeyedChildren (runtime-core.esm-bundler.js:6312:9)
    at patchChildren (runtime-core.esm-bundler.js:6226:11)
Autocomplete.vue?t=1776664414038:24 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'value')
    at Proxy.default (Autocomplete.vue?t=1776664414038:24:72)
Autocomplete.vue?t=1776664414038:488 TypeError: Cannot read properties of null (reading 'emitsOptions')
    at shouldUpdateComponent (runtime-core.esm-bundler.js:4671:27)
    at updateComponent (runtime-core.esm-bundler.js:5960:9)
    at processComponent (runtime-core.esm-bundler.js:5906:7)
    at patch (runtime-core.esm-bundler.js:5401:11)
    at patchKeyedChildren (runtime-core.esm-bundler.js:6312:9)
    at patchChildren (runtime-core.esm-bundler.js:6189:9)
    at processFragment (runtime-core.esm-bundler.js:5869:9)
    at patch (runtime-core.esm-bundler.js:5375:9)
    at patchKeyedChildren (runtime-core.esm-bundler.js:6312:9)
    at patchChildren (runtime-core.esm-bundler.js:6226:11)

```

**Solution**
When we are making option using makeOption and if Option value is null, make the option `{ label: '', value: '' }`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Autocomplete now gracefully handles missing/null values, avoiding incorrect option normalization.
  * Fix prevents spurious selections or empty entries in single- and multi-select modes.
  * Improves reliability and consistency of matching and display across varied input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->