### PR TITLE
fix(tailwind): do not manipulate img in dark mode

### DIFF
--- a/tailwind/plugin.js
+++ b/tailwind/plugin.js
@@ -39,9 +39,6 @@ let componentStyles = {
   "[data-theme='dark'] [type='checkbox']:checked": {
     'background-image': `url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%230F0F0F' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e")`,
   },
-  "[data-theme='dark'] img": {
-    filter: 'brightness(.8) contrast(1.2)',
-  },
 }
 
 export default plugin(

--- a/tailwind/plugin.js
+++ b/tailwind/plugin.js
@@ -198,9 +198,6 @@ let componentStyles = {
   "[data-theme='dark'] [type='checkbox']:checked": {
     'background-image': `url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%230F0F0F' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e")`,
   },
-  "[data-theme='dark'] img": {
-    filter: 'brightness(.8) contrast(1.2)',
-  },
 }
 
 export default plugin(


### PR DESCRIPTION
Do not change image brightness and contrast in dark mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted dark mode image styling by removing the brightness and contrast filter from images displayed in dark theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-630/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 58.50% (±0.00% vs `main`)
<!-- coverage-report:end -->
