### PR TITLE
fix: add space after mentioning user in the editor

### DIFF
--- a/src/components/TextEditor/extensions/mention/mention-extension.ts
+++ b/src/components/TextEditor/extensions/mention/mention-extension.ts
@@ -1,10 +1,10 @@
-import { MaybeRefOrGetter, toValue, type Component } from 'vue'
 import { Extension, Node, mergeAttributes } from '@tiptap/core'
-import { VueNodeViewRenderer } from '@tiptap/vue-3'
 import { PluginKey } from '@tiptap/pm/state'
+import { VueNodeViewRenderer } from '@tiptap/vue-3'
+import { MaybeRefOrGetter, toValue, type Component } from 'vue'
 import {
-  createSuggestionExtension,
   BaseSuggestionItem,
+  createSuggestionExtension,
 } from '../suggestion/createSuggestionExtension'
 import SuggestionList from '../suggestion/SuggestionList.vue'
 import './style.css'
@@ -140,6 +140,10 @@ const MentionSuggestionExtension =
           {
             type: 'mention',
             attrs: attributes,
+          },
+          {
+            type: 'text',
+            text: ' ',
           },
         ])
         .run()

--- a/src/components/TextEditor/extensions/mention/mention-extension.ts
+++ b/src/components/TextEditor/extensions/mention/mention-extension.ts
@@ -1,10 +1,10 @@
-import { Extension, Node, mergeAttributes } from '@tiptap/core'
-import { PluginKey } from '@tiptap/pm/state'
-import { VueNodeViewRenderer } from '@tiptap/vue-3'
 import { MaybeRefOrGetter, toValue, type Component } from 'vue'
+import { Extension, Node, mergeAttributes } from '@tiptap/core'
+import { VueNodeViewRenderer } from '@tiptap/vue-3'
+import { PluginKey } from '@tiptap/pm/state'
 import {
-  BaseSuggestionItem,
   createSuggestionExtension,
+  BaseSuggestionItem,
 } from '../suggestion/createSuggestionExtension'
 import SuggestionList from '../suggestion/SuggestionList.vue'
 import './style.css'


### PR DESCRIPTION
**Issue:**
mention/tag user in the text editor should autoinsert single space.

closes: https://github.com/frappe/helpdesk/issues/3238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mention insertion to properly add trailing space after mentioned items in the text editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->