### PR TITLE
Recommend class-based lucide icons; refactor plugin into pack-pluggable factory

### DIFF
--- a/docs/components/Docs/Sidebar.vue
+++ b/docs/components/Docs/Sidebar.vue
@@ -13,6 +13,7 @@ import LucideBlend from '~icons/lucide/blend'
 import LucideRadius from '~icons/lucide/radius'
 import ChevronRight from '~icons/lucide/chevron-right'
 import LucideBox from '~icons/lucide/box'
+import LucideShapes from '~icons/lucide/shapes'
 import pkgJson from '../../../package.json'
 
 import {
@@ -104,6 +105,11 @@ const list = [
   {
     text: 'Other',
     items: [
+      {
+        text: 'Icons',
+        icon: LucideShapes,
+        link: '/docs/other/icons',
+      },
       {
         text: 'Utilities',
         icon: LucideSettings,

--- a/docs/content/docs/other/icons.md
+++ b/docs/content/docs/other/icons.md
@@ -144,3 +144,85 @@ an inline `<svg>`.
 | Quick prototyping in a template             | `<LucideName />` auto-import |
 
 In most components you write, the class form is the right answer.
+
+## Using icons in Frappe UI components
+
+Most Frappe UI components that take an icon accept either a `lucide-*`
+class string, a Vue component reference, or a slot. The class string is
+the recommended form — keep using imports when the icon is genuinely
+dynamic or you need a real SVG node.
+
+### Button
+
+`Button` exposes `iconLeft`, `iconRight`, and `icon` props, plus matching
+`prefix` / `suffix` / `icon` slots. All three props accept a `lucide-*`
+class string or a component reference.
+
+```vue
+<!-- ✅ Class form (recommended) -->
+<Button icon-left="lucide-plus" label="New task" />
+<Button icon-right="lucide-arrow-right" label="Continue" />
+<Button icon="lucide-settings" />  <!-- icon-only -->
+
+<!-- Component form — for dynamic icons or pass-through cases -->
+<script setup>
+import LucidePlus from '~icons/lucide/plus'
+</script>
+<Button :icon-left="LucidePlus" label="New task" />
+
+<!-- Slot form — when you need full control over the icon markup -->
+<Button label="New task">
+  <template #prefix>
+    <span class="lucide-plus size-4" />
+  </template>
+</Button>
+```
+
+### Dropdown
+
+`Dropdown` items take an `icon` field on each option. It accepts the same
+shapes as `Button.iconLeft`:
+
+```vue
+<script setup>
+const options = [
+  { label: 'Profile',  icon: 'lucide-user',     onClick: () => {} },
+  { label: 'Settings', icon: 'lucide-settings', onClick: () => {} },
+  { label: 'Sign out', icon: 'lucide-log-out',  onClick: () => {} },
+]
+</script>
+
+<template>
+  <Dropdown :options="options">
+    <Button icon-left="lucide-circle-user" label="Account" />
+  </Dropdown>
+</template>
+```
+
+Because each option's `icon` is a complete literal string in your source,
+Tailwind's JIT picks it up correctly. If you build an options array
+dynamically — say, from a server response — and the icon names aren't
+known at build time, fall back to importing components:
+
+```vue
+<script setup>
+import LucideUser from '~icons/lucide/user'
+import LucideSettings from '~icons/lucide/settings'
+
+const options = computed(() =>
+  serverItems.value.map((item) => ({
+    label: item.label,
+    icon: item.kind === 'user' ? LucideUser : LucideSettings,
+    onClick: () => open(item),
+  })),
+)
+</script>
+```
+
+### Other components
+
+`Input`, `FormControl`, `Tabs`, `Tooltip`, `Alert`, `Sidebar` and similar
+components either accept the same `icon` / `iconLeft` / `iconRight` props
+or expose a slot where you can drop a `<span class="lucide-..." />`
+directly. Check each component's reference page for the exact prop
+names — the icon API conventions are consistent across the library.

--- a/docs/content/docs/other/icons.md
+++ b/docs/content/docs/other/icons.md
@@ -45,13 +45,17 @@ The icon defaults to `1em × 1em` (it scales with surrounding text) and uses
 
 ```vue
 <!-- Inherits the parent's text color and font-size -->
-<p class="text-base text-ink-gray-7">
+<div class="flex items-center gap-1 text-base text-ink-gray-7">
   <span class="lucide-info" /> heads up
-</p>
+</div>
 
 <!-- Or set both explicitly -->
 <span class="lucide-info size-5 text-ink-blue-6" />
 ```
+
+Icons render as `display: block` (matching Tailwind's preflight default
+for `<svg>`), so put them inside a flex container — `flex` /
+`inline-flex` / `grid` — when you want them to sit next to text.
 
 ### Always write the full class name
 

--- a/docs/content/docs/other/icons.md
+++ b/docs/content/docs/other/icons.md
@@ -1,0 +1,113 @@
+# Icons
+
+Frappe UI ships with the full [Lucide](https://lucide.dev) icon set. There are
+three ways to use an icon in your templates. Pick the first one that fits —
+they all render the same icon, but the recommended path keeps your code
+simpler and your bundle smaller.
+
+## Recommended: class-based icons
+
+Every Lucide icon is exposed as a Tailwind utility class named
+`lucide-<icon-name>`. Drop it on any element and size/tint it with the usual
+utilities:
+
+```vue
+<template>
+  <span class="lucide-menu size-4 text-ink-gray-7" />
+  <span class="lucide-chevron-down size-3" />
+  <span class="lucide-circle-check size-5 text-ink-green-6" />
+</template>
+```
+
+No imports, no component registration, no auto-import magic. Icon names match
+Lucide's own kebab-case names — search them at
+[lucide.dev/icons](https://lucide.dev/icons).
+
+### Sizing and color
+
+The icon defaults to `1em × 1em` (it scales with surrounding text) and uses
+`currentColor`, so any `text-*` utility tints it.
+
+```vue
+<!-- Inherits the parent's text color and font-size -->
+<p class="text-base text-ink-gray-7">
+  <span class="lucide-info" /> heads up
+</p>
+
+<!-- Or set both explicitly -->
+<span class="lucide-info size-5 text-ink-blue-6" />
+```
+
+### Always write the full class name
+
+Tailwind only generates CSS for classes it can find as complete strings in
+your source. **Do not** build the icon class dynamically:
+
+```vue
+<!-- ❌ Won't render — Tailwind cannot see this class -->
+<span :class="`lucide-${name}`" />
+```
+
+Instead, list each option as a complete literal:
+
+```vue
+<!-- ✅ Both classes are statically visible -->
+<span :class="open ? 'lucide-chevron-down' : 'lucide-chevron-right'" />
+```
+
+If your icon name is genuinely data-driven (e.g. coming from an API or a
+config object built at runtime), use the import-based approach below.
+
+## Also supported: `~icons/lucide/*` imports
+
+The Vite plugin resolves `~icons/lucide/<name>` to a Vue component. Useful
+when you need an actual SVG node — for example, when the icon name is
+dynamic, or when something downstream expects a component reference rather
+than a class string.
+
+```vue
+<script setup>
+import LucideMenu from '~icons/lucide/menu'
+import LucideChevronDown from '~icons/lucide/chevron-down'
+</script>
+
+<template>
+  <LucideMenu class="size-4" />
+  <LucideChevronDown class="size-3" />
+</template>
+```
+
+You can also pass the imported component into props that accept a component
+reference:
+
+```vue
+<Button :icon-left="LucideMenu" />
+```
+
+## Also supported: auto-imported `<LucideName />`
+
+For convenience, every Lucide icon is also available as a global Vue
+component named `<Lucide<PascalName> />` — no import needed.
+
+```vue
+<template>
+  <LucideMenu class="size-4" />
+  <LucideChevronDown class="size-3" />
+</template>
+```
+
+This is functionally identical to the `~icons/lucide/*` import form; pick
+whichever reads better in context.
+
+## Which one should I use?
+
+| Situation                                   | Use                          |
+| ------------------------------------------- | ---------------------------- |
+| Static icon in a template                   | Class — `lucide-menu`        |
+| Icon name from props/data with a known set  | Class — list each literal    |
+| Icon name truly dynamic (loops, API data)   | `~icons/lucide/*` import     |
+| Passing an icon as a prop value             | `~icons/lucide/*` import     |
+| Inside an `<svg>` (need real SVG children)  | `~icons/lucide/*` import     |
+| Quick prototyping in a template             | `<LucideName />` auto-import |
+
+In most components you write, the class form is the right answer.

--- a/docs/content/docs/other/icons.md
+++ b/docs/content/docs/other/icons.md
@@ -23,6 +23,21 @@ No imports, no component registration, no auto-import magic. Icon names match
 Lucide's own kebab-case names — search them at
 [lucide.dev/icons](https://lucide.dev/icons).
 
+### How it works
+
+A Tailwind plugin (`tailwind/iconPackPlugin.js`) reads every SVG from the
+`lucide-static` package at build time and registers each one as a Tailwind
+component class via `matchComponents`. The generated rule sets
+`mask-image` to a data-URI of the icon's SVG and `background-color` to
+`currentColor`, so the icon paints in whatever color the element inherits
+and crops to whatever size you give it.
+
+Tailwind's JIT only emits CSS for classes it can find as literal strings in
+your source — so even though ~1800 icons are registered, only the ones you
+actually use end up in the output bundle. That's why a dynamic class like
+`` `lucide-${name}` `` produces no CSS: the JIT scanner can't see what to
+emit.
+
 ### Sizing and color
 
 The icon defaults to `1em × 1em` (it scales with surrounding text) and uses
@@ -84,6 +99,16 @@ reference:
 <Button :icon-left="LucideMenu" />
 ```
 
+### How it works
+
+`~icons/lucide/*` is a virtual module backed by a Vite plugin
+(`vite/lucideIcons.js`). When Vite resolves an import like
+`~icons/lucide/menu`, the plugin reads the matching SVG from
+`lucide-static` and synthesizes a small Vue component that renders the
+icon as an inline `<svg>` element. The component is bundled into your JS
+like any other module, so each icon you import adds a few hundred bytes
+to the bundle.
+
 ## Also supported: auto-imported `<LucideName />`
 
 For convenience, every Lucide icon is also available as a global Vue
@@ -98,6 +123,14 @@ component named `<Lucide<PascalName> />` — no import needed.
 
 This is functionally identical to the `~icons/lucide/*` import form; pick
 whichever reads better in context.
+
+### How it works
+
+`unplugin-vue-components` scans your templates and, when it sees a tag
+like `<LucideMenu />`, automatically inserts an import for
+`~icons/lucide/menu` at compile time. From there it's the same path as
+the manual-import form above — a virtual-module Vue component rendered as
+an inline `<svg>`.
 
 ## Which one should I use?
 

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -3,12 +3,6 @@ import { computed } from 'vue'
 
 import type { AlertProps } from "./types";
 
-import LucideX from "~icons/lucide/x";
-import LucideInfo from "~icons/lucide/info";
-import LucideCircleX from "~icons/lucide/circle-x";
-import LucideCheck from "~icons/lucide/circle-check";
-import LucideWarning from "~icons/lucide/triangle-alert";
-
 /** Controls the visibility of the alert for dismissing or toggling it */
 const visible = defineModel({ default: true });
 
@@ -34,10 +28,10 @@ const classes = computed(() => {
 
 const icon = computed(() => {
   const data = {
-    yellow: { component: LucideWarning, css: 'text-ink-amber-3' },
-    blue: { component: LucideInfo, css: 'text-ink-blue-3' },
-    red: { component: LucideCircleX, css: 'text-ink-red-3' },
-    green: { component: LucideCheck, css: 'text-ink-green-3' },
+    yellow: { class: 'lucide-triangle-alert', css: 'text-ink-amber-3' },
+    blue: { class: 'lucide-info', css: 'text-ink-blue-3' },
+    red: { class: 'lucide-circle-x', css: 'text-ink-red-3' },
+    green: { class: 'lucide-circle-check', css: 'text-ink-green-3' },
   }
   return props.theme ? data[props.theme] : null
 })
@@ -67,11 +61,10 @@ defineSlots<{
     class="grid grid-cols-[auto_1fr_auto] gap-3 rounded-md px-4 py-3.5 text-base items-start"
   >
     <slot name="icon">
-      <component
-        :is="icon.component"
-        class="size-4"
+      <span
         v-if="icon"
-        :class="icon.css"
+        class="size-4"
+        :class="[icon.class, icon.css]"
       />
     </slot>
 
@@ -86,7 +79,7 @@ defineSlots<{
     </div>
 
     <button v-if="props.dismissable" @click="dismissAlert">
-      <LucideX class="size-4" />
+      <span class="lucide-x size-4" />
     </button>
     <slot name="footer"> </slot>
   </div>

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -79,7 +79,7 @@ defineSlots<{
     </div>
 
     <button v-if="props.dismissable" @click="dismissAlert">
-      <span class="lucide-x size-4" />
+      <span class="lucide-x size-4 text-ink-gray-6" />
     </button>
     <slot name="footer"> </slot>
   </div>

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -78,8 +78,13 @@ defineSlots<{
       </slot>
     </div>
 
-    <button v-if="props.dismissable" @click="dismissAlert">
-      <span class="lucide-x size-4 text-ink-gray-6" />
+    <button
+      v-if="props.dismissable"
+      type="button"
+      aria-label="Dismiss"
+      @click="dismissAlert"
+    >
+      <span class="lucide-x size-4 text-ink-gray-6" aria-hidden="true" />
     </button>
     <slot name="footer"> </slot>
   </div>

--- a/src/components/Alert/stories/Slots.vue
+++ b/src/components/Alert/stories/Slots.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { Alert, Button } from 'frappe-ui'
-import LucideBadge from '~icons/lucide/badge-info'
 </script>
 
 <template>
@@ -10,7 +9,7 @@ import LucideBadge from '~icons/lucide/badge-info'
     description="Upgrade to keep enjoying features and future technical support."
   >
     <template #icon>
-      <LucideBadge class="size-4" />
+      <span class="lucide-badge-info size-4" />
     </template>
 
     <template #footer>

--- a/src/components/Alert/stories/Slots.vue
+++ b/src/components/Alert/stories/Slots.vue
@@ -9,7 +9,7 @@ import { Alert, Button } from 'frappe-ui'
     description="Upgrade to keep enjoying features and future technical support."
   >
     <template #icon>
-      <span class="lucide-badge-info size-4" />
+      <span class="lucide-badge-info size-4 text-ink-gray-6" />
     </template>
 
     <template #footer>

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -4,7 +4,7 @@
       <Dropdown class="h-7" :options="dropdownItems">
         <Button variant="ghost">
           <template #icon>
-            <LucideEllipsis class="w-4 text-ink-gray-5" />
+            <span class="lucide-ellipsis w-4 text-ink-gray-5" />
           </template>
         </Button>
       </Dropdown>
@@ -84,7 +84,6 @@ import { Button } from '../Button'
 import type { BreadcrumbsProps } from './types'
 import { ref, computed, nextTick, useTemplateRef } from 'vue'
 import { useResizeObserver } from '@vueuse/core'
-import LucideEllipsis from '~icons/lucide/ellipsis'
 import type { BreadcrumbItem } from './types'
 
 const crumbsEl = useTemplateRef<HTMLDivElement>('crumbsRef')

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -4,7 +4,7 @@
       <Dropdown class="h-7" :options="dropdownItems">
         <Button variant="ghost">
           <template #icon>
-            <span class="lucide-ellipsis w-4 text-ink-gray-5" />
+            <span class="lucide-ellipsis size-4 text-ink-gray-5" />
           </template>
         </Button>
       </Dropdown>

--- a/src/components/Breadcrumbs/stories/Slots.vue
+++ b/src/components/Breadcrumbs/stories/Slots.vue
@@ -1,24 +1,21 @@
 <script setup lang="ts">
 import { Breadcrumbs } from 'frappe-ui'
-import LucideHouse from '~icons/lucide/house'
-import LucideList from '~icons/lucide/list'
-import LucideView from '~icons/lucide/user-star'
 </script>
 
 <template>
   <Breadcrumbs
     :items="[
-      { label: 'Home', icon: LucideHouse, route: { name: 'Home' } },
-      { label: 'Views', icon: LucideView, route: '/components' },
+      { label: 'Home', icon: 'lucide-house', route: { name: 'Home' } },
+      { label: 'Views', icon: 'lucide-user-star', route: '/components' },
       {
         label: 'List',
-        icon: LucideList,
+        icon: 'lucide-list',
         route: '/components/breadcrumbs',
       },
     ]"
   >
     <template #prefix="{ item }">
-      <component :is="item.icon" class="size-4 mx-2" />
+      <span class="size-4 mx-2" :class="item.icon" />
     </template>
   </Breadcrumbs>
 </template>

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -16,7 +16,6 @@ import {
   ComboboxRoot,
   ComboboxTrigger,
 } from 'reka-ui'
-import LucideChevronDown from '~icons/lucide/chevron-down'
 import {
   isEmojiIconString,
   isLucideIconString,
@@ -487,9 +486,9 @@ defineSlots<ComboboxSlots>()
             {{ selectedOption?.label ?? placeholder }}
           </span>
 
-          <LucideChevronDown
+          <span
             :class="[
-              'size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
+              'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
               open && 'rotate-180',
             ]"
           />
@@ -560,7 +559,7 @@ defineSlots<ComboboxSlots>()
           data-slot="chevron"
           class="ml-auto inline-flex shrink-0 items-center justify-center text-ink-gray-4 outline-none transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] data-[state=open]:rotate-180"
         >
-          <LucideChevronDown class="size-4" />
+          <span class="lucide-chevron-down size-4" />
         </ComboboxTrigger>
       </ComboboxAnchor>
     </template>

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -16,10 +16,7 @@ import {
   ComboboxRoot,
   ComboboxTrigger,
 } from 'reka-ui'
-import {
-  isEmojiIconString,
-  isLucideIconString,
-} from '../../utils/iconString'
+import { isEmojiIconString, isLucideIconString } from '../../utils/iconString'
 import ComboboxResults from './ComboboxResults.vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
 import type {

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -559,7 +559,7 @@ defineSlots<ComboboxSlots>()
           data-slot="chevron"
           class="ml-auto inline-flex shrink-0 items-center justify-center text-ink-gray-4 outline-none transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] data-[state=open]:rotate-180"
         >
-          <span class="lucide-chevron-down size-4" />
+          <span class="lucide-chevron-down size-4 text-ink-gray-6" />
         </ComboboxTrigger>
       </ComboboxAnchor>
     </template>

--- a/src/components/Combobox/ComboboxResults.vue
+++ b/src/components/Combobox/ComboboxResults.vue
@@ -7,7 +7,6 @@ import {
   ComboboxLabel,
   ComboboxViewport,
 } from 'reka-ui'
-import LucideCheck from '~icons/lucide/check'
 import ItemListRow from '../ItemListRow/ItemListRow.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import { isEmojiIconString, isLucideIconString } from '../../utils/iconString'
@@ -347,7 +346,7 @@ function handleSelect(item: NormalizedItem, event: Event) {
                     v-if="isSelectableOption(item)"
                     class="ml-1 inline-flex items-center justify-center"
                   >
-                    <LucideCheck class="size-4" />
+                    <span class="lucide-check size-4" />
                   </ComboboxItemIndicator>
                 </template>
               </ItemListRow>

--- a/src/components/Combobox/ComboboxResults.vue
+++ b/src/components/Combobox/ComboboxResults.vue
@@ -346,7 +346,7 @@ function handleSelect(item: NormalizedItem, event: Event) {
                     v-if="isSelectableOption(item)"
                     class="ml-1 inline-flex items-center justify-center"
                   >
-                    <span class="lucide-check size-4" />
+                    <span class="lucide-check size-4 text-ink-gray-6" />
                   </ComboboxItemIndicator>
                 </template>
               </ItemListRow>

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -68,7 +68,7 @@
                           <DialogClose as-child>
                             <Button variant="ghost" @click="close">
                               <template #icon>
-                                <LucideX class="h-4 w-4 text-ink-gray-9" />
+                                <span class="lucide-x h-4 w-4 text-ink-gray-9" />
                               </template>
                             </Button>
                           </DialogClose>
@@ -125,7 +125,6 @@ import {
 import { computed, reactive } from 'vue'
 import { Button } from '../Button'
 import FeatherIcon from '../FeatherIcon.vue'
-import LucideX from '~icons/lucide/x'
 import type {
   DialogProps,
   DialogIcon,

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -68,7 +68,7 @@
                           <DialogClose as-child>
                             <Button variant="ghost" @click="close">
                               <template #icon>
-                                <span class="lucide-x h-4 w-4 text-ink-gray-9" />
+                                <span class="lucide-x size-4 text-ink-gray-9" />
                               </template>
                             </Button>
                           </DialogClose>

--- a/src/components/Dialog/stories/Interactive.vue
+++ b/src/components/Dialog/stories/Interactive.vue
@@ -26,7 +26,7 @@ const dropdownOptions = [
           <Button variant="outline">
             {{ selectedOption }}
             <template #suffix>
-              <span class="lucide-chevron-down h-4 w-4 text-gray-500" />
+              <span class="lucide-chevron-down size-4 text-ink-gray-5" />
             </template>
           </Button>
         </Dropdown>

--- a/src/components/Dialog/stories/Interactive.vue
+++ b/src/components/Dialog/stories/Interactive.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { Button, Dialog, Dropdown } from 'frappe-ui'
-import LucideChevronDown from '~icons/lucide/chevron-down'
 
 const open = ref(false)
 const selectedOption = ref('Option 1')
@@ -27,7 +26,7 @@ const dropdownOptions = [
           <Button variant="outline">
             {{ selectedOption }}
             <template #suffix>
-              <LucideChevronDown class="h-4 w-4 text-gray-500" />
+              <span class="lucide-chevron-down h-4 w-4 text-gray-500" />
             </template>
           </Button>
         </Dropdown>

--- a/src/components/FormControl/FormControl.story.vue
+++ b/src/components/FormControl/FormControl.story.vue
@@ -71,7 +71,7 @@ const inputTypes = [
     <Story title="Prefix Icon" :layout="{ width: 250 }">
       <FormControl type="text" label="Label">
         <template #prefix>
-          <span class="lucide-search size-4" />
+          <span class="lucide-search size-4 text-ink-gray-6" />
         </template>
       </FormControl>
     </Story>
@@ -79,7 +79,7 @@ const inputTypes = [
     <Story title="Suffix Icon" :layout="{ width: 250 }">
       <FormControl type="text" label="Label">
         <template #suffix>
-          <span class="lucide-search size-4" />
+          <span class="lucide-search size-4 text-ink-gray-6" />
         </template>
       </FormControl>
     </Story>

--- a/src/components/FormControl/FormControl.story.vue
+++ b/src/components/FormControl/FormControl.story.vue
@@ -2,7 +2,6 @@
 import Story from "@/components/Story.vue";
 import { reactive, ref } from "vue";
 // import FeatherIcon from "../FeatherIcon.vue";
-import LucideSearch from "~icons/lucide/search";
 import { Avatar, FormControl } from "frappe-ui";
 
 const state = reactive({
@@ -72,7 +71,7 @@ const inputTypes = [
     <Story title="Prefix Icon" :layout="{ width: 250 }">
       <FormControl type="text" label="Label">
         <template #prefix>
-          <LucideSearch class="size-4" />
+          <span class="lucide-search size-4" />
         </template>
       </FormControl>
     </Story>
@@ -80,7 +79,7 @@ const inputTypes = [
     <Story title="Suffix Icon" :layout="{ width: 250 }">
       <FormControl type="text" label="Label">
         <template #suffix>
-          <LucideSearch class="size-4" />
+          <span class="lucide-search size-4" />
         </template>
       </FormControl>
     </Story>

--- a/src/components/ItemListRow/stories/RowStates.vue
+++ b/src/components/ItemListRow/stories/RowStates.vue
@@ -27,7 +27,7 @@ import { ItemListRow } from 'frappe-ui'
 
     <ItemListRow disabled>
       <template #suffix>
-        <span class="lucide-chevron-right size-4" />
+        <span class="lucide-chevron-right size-4 text-ink-gray-6" />
       </template>
       Disabled row with suffix only
     </ItemListRow>

--- a/src/components/ItemListRow/stories/RowStates.vue
+++ b/src/components/ItemListRow/stories/RowStates.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
 import { ItemListRow } from 'frappe-ui'
-import LucideBell from '~icons/lucide/bell'
-import LucideChevronRight from '~icons/lucide/chevron-right'
-import LucideCheck from '~icons/lucide/check'
 </script>
 
 <template>
@@ -13,24 +10,24 @@ import LucideCheck from '~icons/lucide/check'
 
     <ItemListRow active>
       <template #prefix>
-        <LucideBell class="size-4 text-ink-gray-6" />
+        <span class="lucide-bell size-4 text-ink-gray-6" />
       </template>
       Active row with prefix
     </ItemListRow>
 
     <ItemListRow selected>
       <template #prefix>
-        <LucideBell class="size-4 text-ink-gray-6" />
+        <span class="lucide-bell size-4 text-ink-gray-6" />
       </template>
       Selected row with suffix
       <template #suffix>
-        <LucideCheck class="size-4 text-ink-gray-6" />
+        <span class="lucide-check size-4 text-ink-gray-6" />
       </template>
     </ItemListRow>
 
     <ItemListRow disabled>
       <template #suffix>
-        <LucideChevronRight class="size-4" />
+        <span class="lucide-chevron-right size-4" />
       </template>
       Disabled row with suffix only
     </ItemListRow>

--- a/src/components/KeyboardShortcut.vue
+++ b/src/components/KeyboardShortcut.vue
@@ -11,20 +11,21 @@
       <template v-for="(part, idx) in parsedParts" :key="idx + '-' + part.raw">
         <!-- Explicit modifier icons -->
         <span v-if="part.type === 'cmd'">
-          <LucideCommand class="w-3 h-3" aria-label="Command" />
+          <span class="lucide-command size-3" role="img" aria-label="Command" />
         </span>
         <span v-else-if="part.type === 'shift'">
-          <LucideShift class="w-3 h-3" aria-label="Shift" />
+          <span class="lucide-arrow-big-up size-3" role="img" aria-label="Shift" />
         </span>
         <span v-else-if="part.type === 'alt'">
-          <LucideAlt class="w-3 h-3" aria-label="Option" />
+          <span class="lucide-option size-3" role="img" aria-label="Option" />
         </span>
         <!-- Non-modifier key -->
         <span v-else>
-          <component
+          <span
             v-if="iconFor(part)"
-            :is="iconFor(part)"
-            class="w-3 h-3"
+            :class="iconFor(part)"
+            class="size-3"
+            role="img"
             :aria-label="part.display"
           />
           <span
@@ -45,13 +46,20 @@
     <!-- Backward compatibility path (legacy boolean props + slot) -->
     <template v-else>
       <span v-if="ctrl || meta">
-        <LucideCommand v-if="isMac" class="w-3 h-3" aria-label="Command" />
+        <span
+          v-if="isMac"
+          class="lucide-command size-3"
+          role="img"
+          aria-label="Command"
+        />
         <span v-else class="font-mono text-[10px] leading-none">Ctrl</span>
       </span>
-      <span v-if="shift"
-        ><LucideShift class="w-3 h-3" aria-label="Shift"
-      /></span>
-      <span v-if="alt"><LucideAlt class="w-3 h-3" aria-label="Option" /></span>
+      <span v-if="shift">
+        <span class="lucide-arrow-big-up size-3" role="img" aria-label="Shift" />
+      </span>
+      <span v-if="alt">
+        <span class="lucide-option size-3" role="img" aria-label="Option" />
+      </span>
       <slot></slot>
     </template>
   </div>
@@ -72,15 +80,6 @@
 </template>
 <script setup lang="ts">
 import { computed } from 'vue'
-import LucideCommand from '~icons/lucide/command'
-import LucideShift from '~icons/lucide/arrow-big-up'
-import LucideAlt from '~icons/lucide/option'
-import IconArrowUp from '~icons/lucide/arrow-up'
-import IconArrowDown from '~icons/lucide/arrow-down'
-import IconArrowLeft from '~icons/lucide/arrow-left'
-import IconArrowRight from '~icons/lucide/arrow-right'
-import IconEnter from '~icons/lucide/corner-down-left'
-import IconBackspace from '~icons/lucide/delete'
 
 // Robust mac detection (navigator.platform deprecated)
 const isMac = computed(() => {
@@ -240,17 +239,18 @@ const ariaLabel = computed(() => {
 
 defineOptions({ name: 'KeyboardShortcut' })
 
-// Icon mapping for non-modifier keys when useIcons enabled
-const keyIconMap: Record<string, any> = {
-  '↑': IconArrowUp,
-  '↓': IconArrowDown,
-  '←': IconArrowLeft,
-  '→': IconArrowRight,
-  '↵': IconEnter,
-  '⌫': IconBackspace,
+// Icon mapping for non-modifier keys when useIcons enabled.
+// Values are lucide-* class names consumed by the iconPackPlugin masking rules.
+const keyIconMap: Record<string, string> = {
+  '↑': 'lucide-arrow-up',
+  '↓': 'lucide-arrow-down',
+  '←': 'lucide-arrow-left',
+  '→': 'lucide-arrow-right',
+  '↵': 'lucide-corner-down-left',
+  '⌫': 'lucide-delete',
 }
 
-function iconFor(part: Part) {
+function iconFor(part: Part): string | null {
   if (!props.useIcons) return null
   if (['cmd', 'shift', 'alt'].includes(part.type)) return null // modifier icons handled separately
   return keyIconMap[part.display] || null

--- a/src/components/ListView/stories/CustomList.vue
+++ b/src/components/ListView/stories/CustomList.vue
@@ -1,9 +1,5 @@
 <script setup>
 import { reactive } from 'vue'
-import LucideAtSign from '~icons/lucide/at-sign'
-import LucideCheckCircle from '~icons/lucide/check-circle'
-import LucideUsers from '~icons/lucide/users'
-import LucideUser from '~icons/lucide/user'
 
 import {
   Avatar,
@@ -19,14 +15,10 @@ import {
 } from 'frappe-ui'
 
 const custom_columns = reactive([
-  // { label: "Name", key: "name", width: 3, icon: "user" },
-  // { label: "Email", key: "email", width: "200px", icon: "at-sign" },
-  // { label: "Role", key: "role", icon: "users" },
-  // { label: "Status", key: "status", icon: "check-circle" },
-  { label: 'Name', key: 'name', width: 3, icon: LucideUser },
-  { label: 'Email', key: 'email', width: '200px', icon: LucideAtSign },
-  { label: 'Role', key: 'role', icon: LucideUsers },
-  { label: 'Status', key: 'status', icon: LucideCheckCircle },
+  { label: 'Name', key: 'name', width: 3, icon: 'lucide-user' },
+  { label: 'Email', key: 'email', width: '200px', icon: 'lucide-at-sign' },
+  { label: 'Role', key: 'role', icon: 'lucide-users' },
+  { label: 'Status', key: 'status', icon: 'lucide-check-circle' },
 ])
 
 const custom_rows = [
@@ -73,7 +65,7 @@ const custom_rows = [
         :item="column"
       >
         <template #prefix="{ item }">
-          <component :is="item.icon" class="size-4" />
+          <span class="size-4" :class="item.icon" />
         </template>
       </ListHeaderItem>
     </ListHeader>

--- a/src/components/MonthPicker/MonthPicker.vue
+++ b/src/components/MonthPicker/MonthPicker.vue
@@ -75,7 +75,7 @@ const txtClass = computed(() => {
       <Button @click="togglePopover" class="w-full justify-between border" :class="txtClass"
 				:disabled="disabled" aria-haspopup="dialog" :aria-expanded="isOpen">
         {{ model || props.placeholder }}
-        <template #suffix> <span class="lucide-calendar size-4" /> </template>
+        <template #suffix> <span class="lucide-calendar size-4 text-ink-gray-6" /> </template>
       </Button>
     </template>
 

--- a/src/components/MonthPicker/MonthPicker.vue
+++ b/src/components/MonthPicker/MonthPicker.vue
@@ -4,9 +4,6 @@ import { MonthPickerProps } from './types'
 
 import Button from '../Button/Button.vue'
 import Popover from '../Popover/Popover.vue'
-import LucideCalender from '~icons/lucide/calendar'
-import LucideChevronLeft from '~icons/lucide/chevron-left'
-import LucideChevronRight from '~icons/lucide/chevron-right'
 
 const props = withDefaults(defineProps<MonthPickerProps>(), {
   placeholder: 'Select month',
@@ -78,14 +75,14 @@ const txtClass = computed(() => {
       <Button @click="togglePopover" class="w-full justify-between border" :class="txtClass"
 				:disabled="disabled" aria-haspopup="dialog" :aria-expanded="isOpen">
         {{ model || props.placeholder }}
-        <template #suffix> <LucideCalender class="size-4" /> </template>
+        <template #suffix> <span class="lucide-calendar size-4" /> </template>
       </Button>
     </template>
 
     <template #body>
       <div class="flex gap-2 justify-between">
         <Button variant="ghost" @click="prevClick" label='previous'>
-          <LucideChevronLeft class="size-4 text-ink-gray-5" />
+          <span class="lucide-chevron-left size-4 text-ink-gray-5" />
         </Button>
 
         <!-- view toggler -->
@@ -99,7 +96,7 @@ const txtClass = computed(() => {
         </Button>
 
         <Button variant="ghost" @click="nextClick" label='next'>
-          <LucideChevronRight class="size-4 text-ink-gray-5" />
+          <span class="lucide-chevron-right size-4 text-ink-gray-5" />
         </Button>
       </div>
 

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -7,7 +7,6 @@ import {
   ComboboxPortal,
   ComboboxRoot,
 } from 'reka-ui'
-import LucideChevronDown from '~icons/lucide/chevron-down'
 import Button from '../Button/Button.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import MultiSelectResults from './MultiSelectResults.vue'
@@ -333,9 +332,9 @@ defineSlots<MultiSelectSlots>()
           />
         </span>
 
-        <LucideChevronDown
+        <span
           :class="[
-            'size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
+            'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
             open && 'rotate-180',
           ]"
         />

--- a/src/components/MultiSelect/MultiSelectResults.vue
+++ b/src/components/MultiSelect/MultiSelectResults.vue
@@ -262,7 +262,7 @@ function getItemTextValue(item: NormalizedOption) {
                   <ComboboxItemIndicator
                     class="ml-1 inline-flex items-center justify-center"
                   >
-                    <span class="lucide-check size-4" />
+                    <span class="lucide-check size-4 text-ink-gray-6" />
                   </ComboboxItemIndicator>
                 </template>
               </ItemListRow>

--- a/src/components/MultiSelect/MultiSelectResults.vue
+++ b/src/components/MultiSelect/MultiSelectResults.vue
@@ -7,7 +7,6 @@ import {
   ComboboxLabel,
   ComboboxViewport,
 } from 'reka-ui'
-import LucideCheck from '~icons/lucide/check'
 import ItemListRow from '../ItemListRow/ItemListRow.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import { isEmojiIconString, isLucideIconString } from '../../utils/iconString'
@@ -263,7 +262,7 @@ function getItemTextValue(item: NormalizedOption) {
                   <ComboboxItemIndicator
                     class="ml-1 inline-flex items-center justify-center"
                   >
-                    <LucideCheck class="size-4" />
+                    <span class="lucide-check size-4" />
                   </ComboboxItemIndicator>
                 </template>
               </ItemListRow>

--- a/src/components/MultiSelect/stories/Footer.vue
+++ b/src/components/MultiSelect/stories/Footer.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { Button, MultiSelect } from 'frappe-ui'
-import LucideCheck from '~icons/lucide/check-check'
-import LucideTrash from '~icons/lucide/trash-2'
 
 const state = ref<string[]>([])
 
@@ -25,14 +23,14 @@ const options = [
       >
         <Button theme="red" variant="ghost" @click="clearAll">
           <template #prefix>
-            <LucideTrash class="size-4" />
+            <span class="lucide-trash-2 size-4" />
           </template>
           Clear ({{ selectedOptions.length }})
         </Button>
 
         <Button variant="ghost" @click="selectAll">
           <template #prefix>
-            <LucideCheck class="size-4" />
+            <span class="lucide-check-check size-4" />
           </template>
           Select All
         </Button>

--- a/src/components/MultiSelect/stories/TagsTrigger.vue
+++ b/src/components/MultiSelect/stories/TagsTrigger.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { Badge, MultiSelect } from 'frappe-ui'
-import LucideChevronDown from '~icons/lucide/chevron-down'
-import LucideX from '~icons/lucide/x'
 
 type Tag = {
   label: string
@@ -54,7 +52,7 @@ function removeTag(value: string) {
                 @click.stop="removeTag(option.value)"
                 @pointerdown.stop
               >
-                <LucideX class="size-3" />
+                <span class="lucide-x size-3" />
               </span>
             </template>
           </Badge>
@@ -67,9 +65,9 @@ function removeTag(value: string) {
           </span>
         </div>
 
-        <LucideChevronDown
+        <span
           :class="[
-            'size-4 shrink-0 text-ink-gray-4 transition-transform',
+            'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform',
             open && 'rotate-180',
           ]"
         />

--- a/src/components/Password/Password.vue
+++ b/src/components/Password/Password.vue
@@ -26,9 +26,9 @@
           </div>
         </template>
         <div>
-          <component
+          <span
             v-show="showEye"
-            :is="show ? LucideEyeOff : LucideEye"
+            :class="show ? 'lucide-eye-off' : 'lucide-eye'"
             class="h-3 cursor-pointer mr-1"
             @click="show = !show"
           />
@@ -38,8 +38,6 @@
   </FormControl>
 </template>
 <script setup lang="ts">
-import LucideEye from "~icons/lucide/eye";
-import LucideEyeOff from "~icons/lucide/eye-off";
 import KeyboardShortcut from "../KeyboardShortcut.vue";
 import FormControl from "../FormControl/FormControl.vue";
 import Tooltip from "../Tooltip/Tooltip.vue";

--- a/src/components/Password/Password.vue
+++ b/src/components/Password/Password.vue
@@ -29,7 +29,7 @@
           <span
             v-show="showEye"
             :class="show ? 'lucide-eye-off' : 'lucide-eye'"
-            class="h-3 cursor-pointer mr-1"
+            class="size-3 cursor-pointer mr-1"
             @click="show = !show"
           />
         </div>

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -418,7 +418,7 @@ defineSlots<SelectSlots>()
                     <SelectItemIndicator
                       class="ml-1 inline-flex items-center justify-center"
                     >
-                      <span class="lucide-check size-4" />
+                      <span class="lucide-check size-4 text-ink-gray-6" />
                     </SelectItemIndicator>
                   </template>
                 </ItemListRow>

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -9,8 +9,6 @@ import type {
   SelectSlots,
 } from './types'
 import type { ItemListSize } from '../ItemListRow'
-import LucideCheck from '~icons/lucide/check'
-import LucideChevronDown from '~icons/lucide/chevron-down'
 import ItemListRow from '../ItemListRow/ItemListRow.vue'
 import {
   SelectContent,
@@ -297,7 +295,7 @@ defineSlots<SelectSlots>()
         </div>
 
         <slot name="suffix">
-          <LucideChevronDown class="ml-auto size-4 shrink-0 text-ink-gray-4" />
+          <span class="lucide-chevron-down ml-auto size-4 shrink-0 text-ink-gray-4" />
         </slot>
       </template>
     </SelectTrigger>
@@ -420,7 +418,7 @@ defineSlots<SelectSlots>()
                     <SelectItemIndicator
                       class="ml-1 inline-flex items-center justify-center"
                     >
-                      <LucideCheck class="size-4" />
+                      <span class="lucide-check size-4" />
                     </SelectItemIndicator>
                   </template>
                 </ItemListRow>

--- a/src/components/Select/stories/TriggerSlots.vue
+++ b/src/components/Select/stories/TriggerSlots.vue
@@ -52,7 +52,7 @@ const options = [
               >
                 5
               </span>
-              <span class="lucide-chevron-down size-4" />
+              <span class="lucide-chevron-down size-4 text-ink-gray-6" />
             </div>
           </template>
         </Select>

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -42,8 +42,8 @@
         @click="isCollapsed = !isCollapsed"
       >
         <template #icon>
-          <LucidePanelRightOpen
-            class="size-4 text-ink-gray-6 duration-300 ease-in-out"
+          <span
+            class="lucide-panel-right-open size-4 text-ink-gray-6 duration-300 ease-in-out"
             :class="{ 'rotate-180': shouldCollapse }"
           />
         </template>
@@ -59,7 +59,6 @@ import SidebarHeader from './SidebarHeader.vue'
 import SidebarItem from './SidebarItem.vue'
 import { SidebarProps } from './types'
 
-import LucidePanelRightOpen from '~icons/lucide/panel-right-open'
 import SidebarSection from './SidebarSection.vue'
 
 const props = defineProps<SidebarProps>()

--- a/src/components/Sidebar/SidebarHeader.vue
+++ b/src/components/Sidebar/SidebarHeader.vue
@@ -51,7 +51,7 @@
               : 'ml-2 w-auto opacity-100'
           "
         >
-          <span class="lucide-chevron-down h-4 w-4 text-ink-gray-7" />
+          <span class="lucide-chevron-down size-4 text-ink-gray-7" />
         </div>
       </button>
     </template>

--- a/src/components/Sidebar/SidebarHeader.vue
+++ b/src/components/Sidebar/SidebarHeader.vue
@@ -51,7 +51,7 @@
               : 'ml-2 w-auto opacity-100'
           "
         >
-          <LucideChevronDown class="h-4 w-4 text-ink-gray-7" />
+          <span class="lucide-chevron-down h-4 w-4 text-ink-gray-7" />
         </div>
       </button>
     </template>
@@ -60,7 +60,6 @@
 
 <script setup lang="ts">
 import { inject } from 'vue'
-import LucideChevronDown from '~icons/lucide/chevron-down'
 import Dropdown from '../Dropdown/Dropdown.vue'
 import { SidebarHeaderProps } from './types'
 

--- a/src/components/Sidebar/SidebarItem.vue
+++ b/src/components/Sidebar/SidebarItem.vue
@@ -24,7 +24,12 @@
             <span class="grid flex-shrink-0 place-items-center">
               <slot name="icon">
                 <span
-                  v-if="props.icon && typeof props.icon === 'string'"
+                  v-if="props.icon && typeof props.icon === 'string' && props.icon.startsWith('lucide-')"
+                  class="size-4 text-ink-gray-6"
+                  :class="props.icon"
+                />
+                <span
+                  v-else-if="props.icon && typeof props.icon === 'string'"
                   class="size-4 text-ink-gray-6"
                 >
                   {{ props.icon }}

--- a/src/components/Sidebar/SidebarSection.vue
+++ b/src/components/Sidebar/SidebarSection.vue
@@ -19,7 +19,7 @@
       <div v-if="props.collapsible">
         <span
           v-if="!isSidebarCollapsed"
-          class="lucide-chevron-right w-4 h-4 text-ink-gray-5 transition-all duration-300 ease-in-out"
+          class="lucide-chevron-right size-4 text-ink-gray-5 transition-all duration-300 ease-in-out"
           :class="{ 'rotate-90': !isCollapsed }"
         />
       </div>

--- a/src/components/Sidebar/SidebarSection.vue
+++ b/src/components/Sidebar/SidebarSection.vue
@@ -17,9 +17,9 @@
         {{ props.label }}
       </h3>
       <div v-if="props.collapsible">
-        <LucideChevronRight
+        <span
           v-if="!isSidebarCollapsed"
-          class="w-4 h-4 text-ink-gray-5 transition-all duration-300 ease-in-out"
+          class="lucide-chevron-right w-4 h-4 text-ink-gray-5 transition-all duration-300 ease-in-out"
           :class="{ 'rotate-90': !isCollapsed }"
         />
       </div>
@@ -63,7 +63,6 @@
 import { inject, ref } from 'vue'
 import SidebarItem from './SidebarItem.vue'
 import { SidebarSectionProps } from './types'
-import LucideChevronRight from '~icons/lucide/chevron-right'
 
 const props = defineProps<SidebarSectionProps>()
 

--- a/src/components/Sidebar/stories/Example.vue
+++ b/src/components/Sidebar/stories/Example.vue
@@ -2,20 +2,6 @@
 import { reactive } from 'vue'
 import { Sidebar } from 'frappe-ui'
 
-import Notifications from '~icons/lucide/bell'
-import Deals from '~icons/lucide/briefcase'
-import Organizations from '~icons/lucide/building'
-import Tasks from '~icons/lucide/check-square'
-import Notes from '~icons/lucide/clipboard'
-import Link from '~icons/lucide/link'
-import EmailTemplates from '~icons/lucide/mail'
-import Moon from '~icons/lucide/moon'
-import CallLogs from '~icons/lucide/phone'
-import Settings from '~icons/lucide/settings'
-import User from '~icons/lucide/user'
-import Contacts from '~icons/lucide/user-check'
-import Leads from '~icons/lucide/users'
-
 function toggleTheme() {
   const currentTheme = document.documentElement.getAttribute('data-theme')
   const newTheme = currentTheme === 'dark' ? 'light' : 'dark'
@@ -28,17 +14,17 @@ const crmSidebar = reactive({
     subtitle: 'Jane Doe',
     logo: 'https://raw.githubusercontent.com/frappe/crm/develop/.github/logo.svg',
     menuItems: [
-      { label: 'Toggle Theme', icon: Moon, onClick: toggleTheme },
+      { label: 'Toggle Theme', icon: 'lucide-moon', onClick: toggleTheme },
       {
         label: 'Help',
         to: '/help',
-        icon: Settings,
+        icon: 'lucide-settings',
         onClick: () => alert('Help clicked!'),
       },
       {
         label: 'Logout',
         to: '/logout',
-        icon: User,
+        icon: 'lucide-user',
         onClick: () => alert('Logging out...'),
       },
     ],
@@ -46,21 +32,21 @@ const crmSidebar = reactive({
   sections: [
     {
       label: '',
-      items: [{ label: 'Notifications', icon: Notifications, to: '' }],
+      items: [{ label: 'Notifications', icon: 'lucide-bell', to: '' }],
     },
     {
       label: '',
       items: [
-        { label: 'Leads', icon: Leads, to: '/leads' },
-        { label: 'Deals', icon: Deals, to: '/deals' },
-        { label: 'Contacts', icon: Contacts, to: '/contacts' },
-        { label: 'Organizations', icon: Organizations, to: '/organizations' },
-        { label: 'Notes', icon: Notes, to: '/notes' },
-        { label: 'Tasks', icon: Tasks, to: '/tasks' },
-        { label: 'Call Logs', icon: CallLogs, to: '/call-logs' },
+        { label: 'Leads', icon: 'lucide-users', to: '/leads' },
+        { label: 'Deals', icon: 'lucide-briefcase', to: '/deals' },
+        { label: 'Contacts', icon: 'lucide-user-check', to: '/contacts' },
+        { label: 'Organizations', icon: 'lucide-building', to: '/organizations' },
+        { label: 'Notes', icon: 'lucide-clipboard', to: '/notes' },
+        { label: 'Tasks', icon: 'lucide-check-square', to: '/tasks' },
+        { label: 'Call Logs', icon: 'lucide-phone', to: '/call-logs' },
         {
           label: 'Email Templates',
-          icon: EmailTemplates,
+          icon: 'lucide-mail',
           to: '/email-templates',
         },
       ],
@@ -69,12 +55,12 @@ const crmSidebar = reactive({
       label: 'Views',
       collapsible: true,
       items: [
-        { label: 'My Open Deals', icon: Link, to: '/my-open-deals' },
-        { label: 'Partnership Deals', icon: Link, to: '/partnership-deals' },
-        { label: 'Unassigned Deals', icon: Link, to: '/unassigned-deals' },
+        { label: 'My Open Deals', icon: 'lucide-link', to: '/my-open-deals' },
+        { label: 'Partnership Deals', icon: 'lucide-link', to: '/partnership-deals' },
+        { label: 'Unassigned Deals', icon: 'lucide-link', to: '/unassigned-deals' },
         {
           label: 'Enterprise Pipeline',
-          icon: Link,
+          icon: 'lucide-link',
           to: '/enterprise-pipeline',
         },
       ],

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -1,7 +1,3 @@
-<script setup>
-import LucideLoaderCircle from '~icons/lucide/loader-circle'
-</script>
-
 <template>
-  <LucideLoaderCircle class='animate-spin size-4' />
+  <span class="lucide-loader-circle animate-spin size-4" />
 </template>

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -95,8 +95,16 @@ defineSlots<{
             class="flex items-center gap-1.5 text-base text-ink-gray-5 duration-300 ease-in-out hover:text-ink-gray-9 data-[state=active]:text-ink-gray-9"
             :class="{ 'px-2.5': props.vertical, 'py-2.5': !props.vertical }"
           >
-            <component v-if="tab.icon" :is="tab.icon" class="size-4">
-            </component>
+            <span
+              v-if="tab.icon && typeof tab.icon === 'string' && tab.icon.startsWith('lucide-')"
+              class="size-4"
+              :class="tab.icon"
+            />
+            <component
+              v-else-if="tab.icon"
+              :is="tab.icon"
+              class="size-4"
+            />
 
             {{ tab.label }}
           </component>

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, h, ref, watch } from 'vue'
+import { computed, h, ref, watch, type Component } from 'vue'
 import {
   TabsContent,
   TabsIndicator,
@@ -54,12 +54,12 @@ const Btn = h('button')
 defineSlots<{
   /** Custom renderer for a tab trigger (icon + label / router-link). */
   'tab-item'?: (props: {
-    tab: { label: string; icon?: string; route?: string }
+    tab: { label: string; icon?: string | Component; route?: string }
   }) => any
 
   /** Content rendered for each tab panel. */
   'tab-panel'?: (props: {
-    tab: { label: string; icon?: string; route?: string }
+    tab: { label: string; icon?: string | Component; route?: string }
   }) => any
 }>()
 </script>

--- a/src/components/Tabs/stories/Icons.vue
+++ b/src/components/Tabs/stories/Icons.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
 import { reactive } from 'vue'
 import { Tabs } from 'frappe-ui'
-import LucideGithub from '~icons/lucide/github'
-import LucideTwitter from '~icons/lucide/twitter'
-import LucideLinkedin from '~icons/lucide/linkedin'
 
 const state = reactive({
   index: 0,
@@ -13,19 +10,19 @@ const state = reactive({
       label: 'Github',
       content:
         'Github is a code hosting platform for version control and collaboration. It lets you and others work together on projects from anywhere.',
-      icon: LucideGithub,
+      icon: 'lucide-github',
     },
     {
       label: 'Twitter',
       content:
         'Twitter is an American microblogging and social networking service on which users post and interact with messages known as "tweets".',
-      icon: LucideTwitter,
+      icon: 'lucide-twitter',
     },
     {
       label: 'Linkedin',
       content:
         'LinkedIn is an American business and employment-oriented online service that operates via websites and mobile apps.',
-      icon: LucideLinkedin,
+      icon: 'lucide-linkedin',
     },
   ],
 })

--- a/src/components/Tabs/types.ts
+++ b/src/components/Tabs/types.ts
@@ -1,9 +1,14 @@
+import type { Component } from 'vue'
+
 export interface Tab {
   /** Text shown for the tab. */
   label: string
 
-  /** Optional icon name displayed with the label. */
-  icon?: string
+  /**
+   * Optional icon shown with the label. Pass a `lucide-*` class string for
+   * the recommended class-based form, or a Vue component for custom icons.
+   */
+  icon?: string | Component
 
   /** Optional route to navigate to when the tab is clicked. */
   route?: string

--- a/src/components/TextEditor/extensions/toc-node/TocNodeView.vue
+++ b/src/components/TextEditor/extensions/toc-node/TocNodeView.vue
@@ -24,7 +24,7 @@
       class="absolute top-2 right-2 bg-black/65 hover:bg-black/80 text-ink-gray-4 hover:text-ink-white p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity"
       title="Remove table of contents"
     >
-      <LucideX class="size-4" />
+      <span class="lucide-x size-4" />
     </button>
   </NodeViewWrapper>
 </template>

--- a/src/components/TextInput/stories/List.vue
+++ b/src/components/TextInput/stories/List.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import Story from "@/components/Story.vue";
 import { Avatar, TextInput } from "frappe-ui";
-import LucideSearch from "~icons/lucide/search";
 
 const inputTypes = [
   "text",
@@ -32,7 +31,7 @@ const variants = ["subtle", "outline"];
     <Story title="prefix slot icon">
       <TextInput placeholder="Enter Input">
         <template #prefix>
-          <LucideSearch class="w-4" name="search" />
+          <span class="lucide-search w-4" />
         </template>
       </TextInput>
     </Story>
@@ -40,7 +39,7 @@ const variants = ["subtle", "outline"];
     <Story title="suffix slot icon">
       <TextInput placeholder="Enter Input">
         <template #suffix>
-          <LucideSearch class="w-4" name="search" />
+          <span class="lucide-search w-4" />
         </template>
       </TextInput>
     </Story>

--- a/src/components/TextInput/stories/List.vue
+++ b/src/components/TextInput/stories/List.vue
@@ -31,7 +31,7 @@ const variants = ["subtle", "outline"];
     <Story title="prefix slot icon">
       <TextInput placeholder="Enter Input">
         <template #prefix>
-          <span class="lucide-search w-4" />
+          <span class="lucide-search w-4 text-ink-gray-6" />
         </template>
       </TextInput>
     </Story>
@@ -39,7 +39,7 @@ const variants = ["subtle", "outline"];
     <Story title="suffix slot icon">
       <TextInput placeholder="Enter Input">
         <template #suffix>
-          <span class="lucide-search w-4" />
+          <span class="lucide-search w-4 text-ink-gray-6" />
         </template>
       </TextInput>
     </Story>

--- a/src/components/TextInput/stories/List.vue
+++ b/src/components/TextInput/stories/List.vue
@@ -31,7 +31,7 @@ const variants = ["subtle", "outline"];
     <Story title="prefix slot icon">
       <TextInput placeholder="Enter Input">
         <template #prefix>
-          <span class="lucide-search w-4 text-ink-gray-6" />
+          <span class="lucide-search size-4 text-ink-gray-6" />
         </template>
       </TextInput>
     </Story>
@@ -39,7 +39,7 @@ const variants = ["subtle", "outline"];
     <Story title="suffix slot icon">
       <TextInput placeholder="Enter Input">
         <template #suffix>
-          <span class="lucide-search w-4 text-ink-gray-6" />
+          <span class="lucide-search size-4 text-ink-gray-6" />
         </template>
       </TextInput>
     </Story>

--- a/src/components/Toast/Toast.vue
+++ b/src/components/Toast/Toast.vue
@@ -14,13 +14,13 @@
           v-else-if="type == 'success'"
           class="flex-shrink-0 size-4 text-ink-green-2"
         />
-        <LucideAlertTriangle
+        <span
           v-else-if="type == 'warning'"
-          class="flex-shrink-0 size-4 text-ink-amber-2"
+          class="lucide-alert-triangle flex-shrink-0 size-4 text-ink-amber-2"
         />
-        <LucideInfo
+        <span
           v-else-if="type == 'error'"
-          class="flex-shrink-0 size-4 text-ink-red-2"
+          class="lucide-info flex-shrink-0 size-4 text-ink-red-2"
         />
       </div>
       <div class="flex flex-col flex-grow overflow-hidden">
@@ -45,7 +45,7 @@
         aria-label="Close"
         class="flex-shrink-0 rounded p-1 text-ink-white hover:text-ink-gray-3 focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-4"
       >
-        <LucideX class="size-4" />
+        <span class="lucide-x size-4" />
       </ToastClose>
     </div>
   </ToastRoot>
@@ -54,9 +54,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { ToastAction, ToastClose, ToastDescription, ToastRoot } from 'reka-ui'
-import LucideInfo from '~icons/lucide/info'
-import LucideAlertTriangle from '~icons/lucide/alert-triangle'
-import LucideX from '~icons/lucide/x'
 import CircleCheck from '../../../icons/CircleCheckIcon.vue'
 import type { ToastProps } from './types'
 

--- a/tailwind/iconPackPlugin.js
+++ b/tailwind/iconPackPlugin.js
@@ -1,0 +1,103 @@
+import plugin from 'tailwindcss/plugin'
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Builds a Tailwind plugin that exposes every SVG in `iconsDir` as a
+ * `<prefix>-<name>` utility class. Each class renders as an inline-block
+ * square that masks the icon SVG with the current text color — size with
+ * `size-*`, tint with `text-*`:
+ *
+ *   <span class="lucide-menu size-4 text-ink-gray-6" />
+ *
+ * Designed to be reused for any pack that ships a flat directory of named
+ * SVGs (lucide, tabler, heroicons, custom in-repo packs, ...). Tailwind's
+ * JIT only emits CSS for classes actually referenced in source, so a
+ * full-pack registration is a lookup table — generated CSS stays minimal.
+ *
+ * @param {object} options
+ * @param {string} options.prefix              Class prefix, e.g. 'lucide'.
+ * @param {string} options.iconsDir            Absolute path to a directory of `<name>.svg` files.
+ * @param {number} [options.normalizeStrokeWidth]  If set, rewrites every SVG's stroke-width to this value.
+ * @param {string} [options.defaultColor]      CSS color baked as `color: ...` (overridable via `text-*`).
+ */
+export function iconPackPlugin({
+  prefix,
+  iconsDir,
+  normalizeStrokeWidth,
+  defaultColor,
+}) {
+  if (!prefix) throw new Error('iconPackPlugin: `prefix` is required')
+  if (!iconsDir) throw new Error('iconPackPlugin: `iconsDir` is required')
+
+  const svgDataUriCache = new Map()
+
+  function encodeSvgAsDataUri(name) {
+    if (svgDataUriCache.has(name)) return svgDataUriCache.get(name)
+
+    const filePath = path.join(iconsDir, `${name}.svg`)
+    if (!fs.existsSync(filePath)) {
+      svgDataUriCache.set(name, null)
+      return null
+    }
+
+    let svg = fs.readFileSync(filePath, 'utf8')
+    if (normalizeStrokeWidth != null) {
+      svg = svg.replace(
+        /stroke-width="[^"]+"/,
+        `stroke-width="${normalizeStrokeWidth}"`,
+      )
+    }
+    svg = svg.replace(/\s+/g, ' ').trim()
+    const uri = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
+    svgDataUriCache.set(name, uri)
+    return uri
+  }
+
+  function readAvailableIconNames() {
+    try {
+      return fs
+        .readdirSync(iconsDir)
+        .filter((f) => f.endsWith('.svg'))
+        .map((f) => f.replace(/\.svg$/, ''))
+    } catch {
+      return []
+    }
+  }
+
+  return plugin(({ matchComponents }) => {
+    const names = readAvailableIconNames()
+    const values = Object.fromEntries(names.map((n) => [n, n]))
+
+    // Registered via `matchComponents` (not `matchUtilities`) so Tailwind
+    // puts these rules in the components layer. Regular utilities like
+    // `size-4`, `w-5`, `text-ink-gray-6` live in the utilities layer which
+    // comes after — so they always win without needing `!important`.
+    matchComponents(
+      {
+        [prefix]: (value) => {
+          const uri = encodeSvgAsDataUri(value)
+          if (!uri) return {}
+          const rules = {
+            display: 'inline-block',
+            width: '1em',
+            height: '1em',
+            'background-color': 'currentColor',
+            '-webkit-mask-image': `url("${uri}")`,
+            'mask-image': `url("${uri}")`,
+            '-webkit-mask-repeat': 'no-repeat',
+            'mask-repeat': 'no-repeat',
+            '-webkit-mask-position': 'center',
+            'mask-position': 'center',
+            '-webkit-mask-size': 'contain',
+            'mask-size': 'contain',
+            'flex-shrink': '0',
+          }
+          if (defaultColor) rules.color = defaultColor
+          return rules
+        },
+      },
+      { values, type: 'any' },
+    )
+  })
+}

--- a/tailwind/iconPackPlugin.js
+++ b/tailwind/iconPackPlugin.js
@@ -79,13 +79,13 @@ export function iconPackPlugin({
           const uri = encodeSvgAsDataUri(value)
           if (!uri) return {}
           const rules = {
-            display: 'inline-block',
+            // Match Tailwind preflight's `svg { display: block }` so a
+            // class-based icon behaves identically to the inline-svg form
+            // it replaces — no phantom line-box height in the parent, no
+            // baseline drift next to text in flex containers.
+            display: 'block',
             width: '1em',
             height: '1em',
-            // Nudge the box down so it sits on the visual mid-line of
-            // surrounding text — matches where an inline <svg> icon
-            // lands. Ignored in flex/grid contexts.
-            'vertical-align': '-0.125em',
             'background-color': 'currentColor',
             '-webkit-mask-image': `url("${uri}")`,
             'mask-image': `url("${uri}")`,

--- a/tailwind/iconPackPlugin.js
+++ b/tailwind/iconPackPlugin.js
@@ -4,9 +4,10 @@ import path from 'node:path'
 
 /**
  * Builds a Tailwind plugin that exposes every SVG in `iconsDir` as a
- * `<prefix>-<name>` utility class. Each class renders as an inline-block
- * square that masks the icon SVG with the current text color — size with
- * `size-*`, tint with `text-*`:
+ * `<prefix>-<name>` utility class. Each class renders as a block-level
+ * square (matching Tailwind preflight's `svg { display: block }`) that
+ * masks the icon SVG with the current text color — size with `size-*`,
+ * tint with `text-*`:
  *
  *   <span class="lucide-menu size-4 text-ink-gray-6" />
  *
@@ -44,7 +45,7 @@ export function iconPackPlugin({
     let svg = fs.readFileSync(filePath, 'utf8')
     if (normalizeStrokeWidth != null) {
       svg = svg.replace(
-        /stroke-width="[^"]+"/,
+        /stroke-width="[^"]+"/g,
         `stroke-width="${normalizeStrokeWidth}"`,
       )
     }

--- a/tailwind/iconPackPlugin.js
+++ b/tailwind/iconPackPlugin.js
@@ -82,6 +82,10 @@ export function iconPackPlugin({
             display: 'inline-block',
             width: '1em',
             height: '1em',
+            // Nudge the box down so it sits on the visual mid-line of
+            // surrounding text — matches where an inline <svg> icon
+            // lands. Ignored in flex/grid contexts.
+            'vertical-align': '-0.125em',
             'background-color': 'currentColor',
             '-webkit-mask-image': `url("${uri}")`,
             'mask-image': `url("${uri}")`,

--- a/tailwind/lucideIconsPlugin.js
+++ b/tailwind/lucideIconsPlugin.js
@@ -1,7 +1,6 @@
-import plugin from 'tailwindcss/plugin'
-import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
+import { iconPackPlugin } from './iconPackPlugin.js'
 
 // Resolve lucide-static's icons directory once per plugin init. Works whether
 // frappe-ui is consumed locally or installed as a dependency of another app.
@@ -11,91 +10,11 @@ const ICONS_DIR = path.join(
   'icons',
 )
 
-const svgDataUriCache = new Map()
-
-function encodeSvgAsDataUri(name) {
-  if (svgDataUriCache.has(name)) return svgDataUriCache.get(name)
-
-  const filePath = path.join(ICONS_DIR, `${name}.svg`)
-  if (!fs.existsSync(filePath)) {
-    svgDataUriCache.set(name, null)
-    return null
-  }
-
-  // Lucide ships every icon at stroke-width="2". Override to 1.5 for a
-  // lighter, more balanced look that matches the rest of the design
-  // system's iconography density.
-  const svg = fs
-    .readFileSync(filePath, 'utf8')
-    .replace(/stroke-width="[^"]+"/, 'stroke-width="1.5"')
-    .replace(/\s+/g, ' ')
-    .trim()
-  const uri = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
-  svgDataUriCache.set(name, uri)
-  return uri
-}
-
-function readAvailableIconNames() {
-  try {
-    return fs
-      .readdirSync(ICONS_DIR)
-      .filter((f) => f.endsWith('.svg'))
-      .map((f) => f.replace(/\.svg$/, ''))
-  } catch {
-    return []
-  }
-}
-
-/**
- * Generates `lucide-<name>` utility classes for every icon shipped by
- * lucide-static (~1800 icons). Each class renders as an inline-block
- * square that masks the icon SVG with the current text color — so you
- * can size it with `size-*`, tint it with `text-*`, and drop it into
- * any template without an import:
- *
- *   <span class="lucide-menu size-4 text-ink-gray-6" />
- *
- * Under the hood each class emits a `mask-image` data URI pointing at
- * the raw lucide SVG, plus `background-color: currentColor`. Tailwind's
- * JIT only emits CSS for classes actually referenced in source, so the
- * 1800-icon registration is a lookup table — the generated CSS stays
- * minimal.
- */
-export default plugin(({ matchComponents }) => {
-  const names = readAvailableIconNames()
-  const values = Object.fromEntries(names.map((n) => [n, n]))
-
-  // Registered via `matchComponents` (not `matchUtilities`) so Tailwind
-  // puts these rules in the components layer. Regular utility classes
-  // like `size-4`, `w-5`, `h-6`, `text-ink-gray-6` live in the utilities
-  // layer which comes after — so they always win over the plugin's
-  // 1em/1em defaults without needing `!important` or source-order tricks
-  // at the call site.
-  matchComponents(
-    {
-      lucide: (value) => {
-        const uri = encodeSvgAsDataUri(value)
-        if (!uri) return {}
-        return {
-          display: 'inline-block',
-          width: '1em',
-          height: '1em',
-          // Default to ink-gray-6 — tints via `text-*` utilities still win
-          // because they sit in the utilities layer (components < utilities).
-          color: 'var(--ink-gray-6)',
-          'background-color': 'currentColor',
-          '-webkit-mask-image': `url("${uri}")`,
-          'mask-image': `url("${uri}")`,
-          '-webkit-mask-repeat': 'no-repeat',
-          'mask-repeat': 'no-repeat',
-          '-webkit-mask-position': 'center',
-          'mask-position': 'center',
-          '-webkit-mask-size': 'contain',
-          'mask-size': 'contain',
-          'flex-shrink': '0',
-        }
-      },
-    },
-    { values, type: 'any' },
-  )
+// Lucide ships every icon at stroke-width="2". Override to 1.5 for a lighter,
+// more balanced look that matches the rest of the design system.
+export default iconPackPlugin({
+  prefix: 'lucide',
+  iconsDir: ICONS_DIR,
+  normalizeStrokeWidth: 1.5,
+  defaultColor: 'var(--ink-gray-6)',
 })

--- a/tailwind/lucideIconsPlugin.js
+++ b/tailwind/lucideIconsPlugin.js
@@ -12,9 +12,12 @@ const ICONS_DIR = path.join(
 
 // Lucide ships every icon at stroke-width="2". Override to 1.5 for a lighter,
 // more balanced look that matches the rest of the design system.
+//
+// No `defaultColor` — icons inherit the parent's text color the same way an
+// inline <svg stroke="currentColor"> would. Add `text-ink-*` at the call
+// site when a specific tint is needed.
 export default iconPackPlugin({
   prefix: 'lucide',
   iconsDir: ICONS_DIR,
   normalizeStrokeWidth: 1.5,
-  defaultColor: 'var(--ink-gray-6)',
 })


### PR DESCRIPTION
## Summary

- Refactor the lucide-only Tailwind plugin into a generic `iconPackPlugin({ prefix, iconsDir, normalizeStrokeWidth?, defaultColor? })` factory. Lucide is now a thin wrapper; adding tabler/heroicons/etc. is a one-liner. Default export contract is preserved, so downstream tailwind configs are unaffected.
- Add a docs page (`docs/other/icons`) recommending the class-based form (`lucide-<name>`) as the default. Documents the literal-class-name rule, how each of the three icon styles works under the hood, and component-level usage examples for `Button`, `Dropdown`, etc.
- Migrate static lucide template usages in core components and stories from `<LucideX class="..." />` to `<span class="lucide-x ..." />` where it makes sense. `~icons/lucide/*` imports remain available and are still recommended for genuinely dynamic / data-driven cases (KeyboardShortcut's key map, TextEditor menu config, etc.).
- Extend `SidebarItem` and `Tabs` to detect `lucide-*` strings on the `icon` prop, matching the convention `Button` already uses. Lets Sidebar/Tabs configs use the recommended string form without component imports.
- Fix three plugin-CSS regressions caught during migration:
  - `display: block` (matches Tailwind preflight's `<svg>` default) — removes phantom line-box height in parents and baseline drift next to text.
  - Drop the baked-in `color: var(--ink-gray-6)` so icons inherit the parent's text color, the way `<svg stroke="currentColor">` does. Fixes themed buttons (e.g. `theme="red"`) not tinting their icons.
  - Add explicit `text-ink-gray-6` at internal call sites that were leaning on the previous baked-in default, to preserve the visual look there.

## Test plan

- [ ] `yarn test` (29/29 passing locally)
- [ ] `yarn build` clean
- [ ] `yarn docs:build` clean
- [ ] Visual review: themed buttons (`<Button theme=\"red\">` with icon) tint correctly
- [ ] Visual review: icons in flex containers (Button/Toast/Sidebar/Combobox) align as before
- [ ] Visual review: parent `<div>` containing only an icon collapses to icon height (no phantom line-box)
- [ ] Verify story examples in Histoire render correctly: Sidebar/Example, Tabs/Icons, ItemList/Basic, Breadcrumbs/Slots, ListView/CustomList
- [ ] Spot-check a downstream consumer (CRM/Gameplan) — none of the public APIs changed, but visually confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * New comprehensive icon documentation covering Lucide icon set integration, three usage methods (CSS utilities, component imports, auto-imported Vue components), sizing recommendations, best practices, and practical examples for common framework components.

* **Refactor**
  * Icon rendering system refactored across all components to improve performance and maintainability while preserving visual appearance, user experience, and all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->