### PR TITLE
fix(FormControl): use picker components for date inputs

### DIFF
--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -13,14 +13,17 @@
         <TextInput
           v-model="inputValue"
           type="text"
+          :id="props.inputId"
           class="cursor-text w-full"
           :class="props.inputClass"
           :label="props.label"
+          :size="props.size"
           :variant="props.variant"
           :placeholder="props.placeholder"
           :disabled="props.disabled"
+          :required="props.required"
           :readonly="props.readonly || !props.allowCustom"
-          @focus="activateInput(isOpen, togglePopover)"
+          @focus="activateInput(isOpen, togglePopover, $event)"
           @click="activateInput(isOpen, togglePopover)"
           @blur="onBlur"
           @keydown.enter.prevent="onEnter(togglePopover)"
@@ -221,12 +224,14 @@ const props = withDefaults(defineProps<DatePickerProps>(), {
   value: '',
   modelValue: '',
   placement: 'bottom-start',
+  size: 'sm',
   variant: 'subtle',
   placeholder: 'Select date',
   readonly: false,
   allowCustom: true,
   autoClose: true,
   disabled: false,
+  required: false,
   clearable: true,
 })
 const emit = defineEmits<DatePickerEmits>()
@@ -373,6 +378,7 @@ function commitInput(close = false, togglePopover?: () => void): void {
 const popoverContentRef = ref<HTMLElement | null>(null)
 
 function onBlur(e: FocusEvent) {
+  emit('blur', e)
   const next = e.relatedTarget as Node | null
   if (next && popoverContentRef.value?.contains(next)) return
   commitInput()
@@ -382,7 +388,12 @@ function onEnter(togglePopover: () => void) {
   commitInput(true, togglePopover)
   isTyping.value = false
 }
-function activateInput(isOpen: boolean | undefined, togglePopover: () => void) {
+function activateInput(
+  isOpen: boolean | undefined,
+  togglePopover: () => void,
+  event?: FocusEvent,
+) {
+  if (event) emit('focus', event)
   isTyping.value = true
   if (!isOpen) togglePopover()
 }

--- a/src/components/DatePicker/DateTimePicker.vue
+++ b/src/components/DatePicker/DateTimePicker.vue
@@ -13,14 +13,17 @@
         <TextInput
           v-model="inputValue"
           type="text"
+          :id="props.inputId"
           class="cursor-text w-full"
           :class="props.inputClass"
           :label="props.label"
+          :size="props.size"
           :variant="props.variant"
           :placeholder="props.placeholder || 'Select date & time'"
           :disabled="props.disabled"
+          :required="props.required"
           :readonly="props.readonly || !props.allowCustom"
-          @focus="activateInput(isOpen, togglePopover)"
+          @focus="activateInput(isOpen, togglePopover, $event)"
           @click="activateInput(isOpen, togglePopover)"
           @blur="onBlur"
           @keydown.enter.prevent="onEnter(togglePopover)"
@@ -250,12 +253,14 @@ const props = withDefaults(
     value: '',
     modelValue: '',
     placement: 'bottom-start',
+    size: 'sm',
     variant: 'subtle',
     placeholder: 'Select date & time',
     readonly: false,
     allowCustom: true,
     autoClose: true,
     disabled: false,
+    required: false,
     clearable: true,
     allowCustomTime: true,
   },
@@ -396,6 +401,7 @@ function commitInput(close = false, togglePopover?: () => void): void {
 
 const popoverContentRef = ref<HTMLElement | null>(null)
 function onBlur(e: FocusEvent) {
+  emit('blur', e)
   const next = e.relatedTarget as Node | null
   if (next && popoverContentRef.value?.contains(next)) return
   commitInput()
@@ -405,7 +411,12 @@ function onEnter(togglePopover: () => void) {
   commitInput(true, togglePopover)
   isTyping.value = false
 }
-function activateInput(isOpen: boolean | undefined, togglePopover: () => void) {
+function activateInput(
+  isOpen: boolean | undefined,
+  togglePopover: () => void,
+  event?: FocusEvent,
+) {
+  if (event) emit('focus', event)
   isTyping.value = true
   if (!isOpen) togglePopover()
 }

--- a/src/components/DatePicker/types.ts
+++ b/src/components/DatePicker/types.ts
@@ -1,4 +1,5 @@
 import type { Dayjs } from 'dayjs'
+import type { InputSize } from '../../composables/inputTypes'
 
 // Shared props for both single date and range pickers
 export interface CommonDatePickerProps {
@@ -10,6 +11,9 @@ export interface CommonDatePickerProps {
 
   /** Visual style variant passed through to the input. */
   variant?: 'subtle' | 'ghost' | 'outline'
+
+  /** Size passed through to the trigger input. */
+  size?: InputSize
 
   /** Prevents manual typing while keeping the picker interactive. */
   readonly?: boolean
@@ -31,6 +35,12 @@ export interface CommonDatePickerProps {
 
   /** Optional label forwarded to the trigger input. */
   label?: string
+
+  /** HTML id forwarded to the trigger input. */
+  inputId?: string
+
+  /** Marks the trigger input as required. */
+  required?: boolean
 
   /** Shows clear and quick-action controls when enabled. */
   clearable?: boolean
@@ -58,6 +68,12 @@ export type DatePickerEmits = {
 
   /** Fired after the picker commits a normalized value. */
   (event: 'change', value: string): void
+
+  /** Fired when the trigger input receives focus. */
+  (event: 'focus', value: FocusEvent): void
+
+  /** Fired when the trigger input loses focus. */
+  (event: 'blur', value: FocusEvent): void
 }
 
 export type DatePickerPlacement =

--- a/src/components/FormControl/FormControl.cy.ts
+++ b/src/components/FormControl/FormControl.cy.ts
@@ -69,6 +69,72 @@ describe('FormControl', () => {
       })
   })
 
+  it('uses DatePicker for date controls without dropping input props or slots', () => {
+    cy.mount(FormControl, {
+      props: {
+        type: 'date',
+        label: 'Posting Date',
+        placeholder: 'Select a date',
+        required: true,
+      },
+      slots: {
+        prefix: () => h('span', { 'data-cy': 'prefix' }, 'P'),
+        suffix: () => h('span', { 'data-cy': 'suffix' }, 'S'),
+      },
+    })
+
+    cy.contains('label', 'Posting Date')
+      .invoke('attr', 'for')
+      .then((id) => {
+        cy.get('input')
+          .should('have.attr', 'id', id)
+          .and('have.attr', 'placeholder', 'Select a date')
+          .and('have.attr', 'required')
+      })
+
+    cy.get('[data-cy="prefix"]').should('exist')
+    cy.get('[data-cy="suffix"]').should('exist')
+  })
+
+  it('uses TimePicker for time controls while preserving focus and blur listeners', () => {
+    cy.mount(FormControl, {
+      props: {
+        type: 'time',
+        label: 'Start Time',
+        required: true,
+        onFocus: cy.spy().as('onFocus'),
+        onBlur: cy.spy().as('onBlur'),
+      },
+    })
+
+    cy.contains('label', 'Start Time')
+      .invoke('attr', 'for')
+      .then((id) => {
+        cy.get('input')
+          .should('have.attr', 'id', id)
+          .and('have.attr', 'required')
+      })
+
+    cy.get('input').focus().blur()
+    cy.get('@onFocus').should('have.been.called')
+    cy.get('@onBlur').should('have.been.called')
+  })
+
+  it('normalizes datetime-local updates to the native input value shape', () => {
+    cy.mount(FormControl, {
+      props: {
+        type: 'datetime-local',
+        label: 'Starts At',
+        'onUpdate:modelValue': cy.spy().as('onUpdate'),
+        onChange: cy.spy().as('onChange'),
+      },
+    })
+
+    cy.get('input').type('2025-01-02T14:30{enter}')
+    cy.get('@onUpdate').should('have.been.calledWith', '2025-01-02T14:30')
+    cy.get('@onChange').should('have.been.calledWith', '2025-01-02T14:30')
+  })
+
   it('warns when type="autocomplete" is used', () => {
     cy.window().then((win) => {
       cy.spy(win.console, 'warn').as('consoleWarn')
@@ -93,6 +159,9 @@ describe('FormControl', () => {
       cy.spy(win.console, 'warn').as('consoleWarn')
     })
     cy.mount(FormControl, { props: { label: 'Title' } })
-    cy.get('@consoleWarn').should('not.have.been.calledWithMatch', /FormControl/)
+    cy.get('@consoleWarn').should(
+      'not.have.been.calledWithMatch',
+      /FormControl/,
+    )
   })
 })

--- a/src/components/FormControl/FormControl.vue
+++ b/src/components/FormControl/FormControl.vue
@@ -1,9 +1,5 @@
 <template>
-  <div
-    v-if="type != 'checkbox'"
-    :class="['space-y-1.5', attrs.class]"
-    :style="attrs.style"
-  >
+  <div v-if="type != 'checkbox'" :class="rootClasses" :style="rootStyle">
     <FormLabel
       v-if="label"
       :label="label"
@@ -45,6 +41,46 @@
       :id="id"
       v-bind="{ ...controlAttrs, size, variant }"
     />
+    <DatePicker
+      v-else-if="type === 'date'"
+      :input-id="id"
+      v-bind="{ ...controlAttrs, size, variant, required }"
+    >
+      <template #prefix v-if="$slots.prefix">
+        <slot name="prefix" />
+      </template>
+      <template #suffix v-if="$slots.suffix">
+        <slot name="suffix" />
+      </template>
+    </DatePicker>
+    <DateTimePicker
+      v-else-if="type === 'datetime-local'"
+      :input-id="id"
+      :model-value="dateTimeModelValue"
+      v-bind="{ ...dateTimeControlAttrs, size, variant, required }"
+      @update:model-value="handleDateTimeUpdate"
+      @change="handleDateTimeChange"
+    >
+      <template #prefix v-if="$slots.prefix">
+        <slot name="prefix" />
+      </template>
+      <template #suffix v-if="$slots.suffix">
+        <slot name="suffix" />
+      </template>
+    </DateTimePicker>
+    <TimePicker
+      v-else-if="type === 'time'"
+      :input-id="id"
+      v-bind="{ ...controlAttrs, size, variant, required }"
+    >
+      <template #prefix v-if="$slots.prefix">
+        <slot name="prefix" />
+      </template>
+      <template #suffix v-if="$slots.suffix">
+        <slot name="suffix" />
+      </template>
+    </TimePicker>
+
     <TextInput
       v-else
       :id="id"
@@ -77,8 +113,11 @@ import { Checkbox } from '../Checkbox'
 import { Autocomplete } from '../Autocomplete'
 import { autocompleteDeprecationSuppressed } from '../Autocomplete/deprecationKey'
 import { Combobox } from '../Combobox'
+import { DatePicker, DateTimePicker } from '../DatePicker'
+import { TimePicker } from '../TimePicker'
 import FormLabel from '../FormLabel.vue'
 import { warnDeprecated } from '../../utils/warnDeprecated'
+import type { StyleValue } from 'vue'
 import type { FormControlProps } from './types'
 
 defineOptions({
@@ -101,6 +140,9 @@ watchEffect(() => {
 })
 
 const attrs = useAttrs()
+const rootClasses = computed(() => ['space-y-1.5', attrs.class])
+const rootStyle = computed(() => attrs.style as StyleValue)
+
 const controlAttrs = computed(() => {
   // pass everything except class and style
   let _attrs: typeof attrs = {}
@@ -111,6 +153,66 @@ const controlAttrs = computed(() => {
   }
   return _attrs
 })
+
+const dateTimeControlAttrs = computed(() => {
+  let _attrs: typeof attrs = {}
+  for (let key in controlAttrs.value) {
+    if (
+      key !== 'modelValue' &&
+      key !== 'onUpdate:modelValue' &&
+      key !== 'onChange'
+    ) {
+      _attrs[key] = controlAttrs.value[key]
+    }
+  }
+  return _attrs
+})
+
+const dateTimeModelValue = computed<string | undefined>(() => {
+  let value = controlAttrs.value.modelValue
+  return typeof value === 'string' ? value.replace('T', ' ') : undefined
+})
+
+function normalizeDateTimeLocalValue(value: string) {
+  if (!value) return value
+
+  let normalized = value.replace(' ', 'T')
+  let step = controlAttrs.value.step
+  let keepsSeconds =
+    (typeof step === 'number' && step % 60 !== 0) ||
+    (typeof step === 'string' && Number(step) % 60 !== 0) ||
+    /T\d{2}:\d{2}:\d{2}/.test(String(controlAttrs.value.modelValue || ''))
+
+  if (!keepsSeconds) {
+    normalized = normalized.replace(/(:\d{2})$/, '')
+  }
+
+  return normalized
+}
+
+function callAttrHandler(handler: unknown, ...args: any[]) {
+  if (Array.isArray(handler)) {
+    handler.forEach((fn) => callAttrHandler(fn, ...args))
+    return
+  }
+  if (typeof handler === 'function') {
+    handler(...args)
+  }
+}
+
+function handleDateTimeUpdate(value: string) {
+  callAttrHandler(
+    controlAttrs.value['onUpdate:modelValue'],
+    normalizeDateTimeLocalValue(value),
+  )
+}
+
+function handleDateTimeChange(value: string) {
+  callAttrHandler(
+    controlAttrs.value.onChange,
+    normalizeDateTimeLocalValue(value),
+  )
+}
 
 const descriptionClasses = computed(() => {
   return [

--- a/src/components/TimePicker/TimePicker.vue
+++ b/src/components/TimePicker/TimePicker.vue
@@ -8,11 +8,14 @@
       <TextInput
         ref="inputRef"
         v-model="displayValue"
+        :id="props.inputId"
+        :size="props.size"
         :variant="variant"
         type="text"
         class="text-sm w-full cursor-text"
         :placeholder="placeholder"
         :disabled="disabled"
+        :required="required"
         :readonly="!props.allowCustom"
         @focus="onFocus"
         @click="onClickInput(isOpen, togglePopover)"
@@ -86,11 +89,13 @@ const props = withDefaults(defineProps<TimePickerProps>(), {
   options: () => [],
   placement: 'bottom-start' as Placement,
   placeholder: 'Select time',
+  size: 'sm',
   variant: 'subtle' as Variant,
   allowCustom: true,
   autoClose: true,
   use12Hour: true,
   disabled: false,
+  required: false,
   scrollMode: 'center' as const,
   minTime: '',
   maxTime: '',
@@ -497,12 +502,14 @@ function onClickInput(isOpen: boolean | undefined, togglePopover: () => void) {
   if (props.allowCustom) selectAll()
 }
 
-function onFocus() {
+function onFocus(event: FocusEvent) {
+  emit('focus', event)
   isFocused.value = true
   if (props.allowCustom && !hasSelectedOnFirstClick.value) selectAll()
 }
 
-function onBlur() {
+function onBlur(event: FocusEvent) {
+  emit('blur', event)
   if (showOptions.value) {
     isFocused.value = false
     return
@@ -560,10 +567,6 @@ defineSlots<{
    * Slot rendered after the input value.
    * Exposes popover controls.
    */
-  suffix?: (props: {
-    togglePopover: () => void
-    isOpen: boolean
-  }) => any
+  suffix?: (props: { togglePopover: () => void; isOpen: boolean }) => any
 }>()
-
 </script>

--- a/src/components/TimePicker/types.ts
+++ b/src/components/TimePicker/types.ts
@@ -1,4 +1,5 @@
 // Shared type definitions for TimePicker component
+import type { InputSize } from '../../composables/inputTypes'
 
 export type Placement =
   | 'bottom-start'
@@ -31,6 +32,9 @@ export interface ParsedTimeInvalid {
 export type ParsedTime = ParsedTimeValid | ParsedTimeInvalid
 
 export interface TimePickerProps {
+  /** HTML id forwarded to the trigger input. */
+  inputId?: string
+
   /** Selected time (uncontrolled) */
   value?: string
 
@@ -52,6 +56,9 @@ export interface TimePickerProps {
   /** Visual style variant */
   variant?: Variant
 
+  /** Size passed through to the trigger input. */
+  size?: InputSize
+
   /** Allow entering custom time values */
   allowCustom?: boolean
 
@@ -63,6 +70,9 @@ export interface TimePickerProps {
 
   /** Disable the time picker */
   disabled?: boolean
+
+  /** Marks the trigger input as required. */
+  required?: boolean
 
   /** Scroll behavior when opening the list */
   scrollMode?: 'center' | 'start' | 'nearest'
@@ -92,4 +102,10 @@ export type TimePickerEmits = {
 
   /** Emitted when the picker is closed */
   (e: 'close'): void
+
+  /** Emitted when the trigger input receives focus */
+  (e: 'focus', event: FocusEvent): void
+
+  /** Emitted when the trigger input loses focus */
+  (e: 'blur', event: FocusEvent): void
 }


### PR DESCRIPTION
## Summary

This PR updates `FormControl` to use the newer picker components for date and time inputs.

It replaces the old `TextInput` rendering path for `date`, `datetime-local`, and `time` with `DatePicker`, `DateTimePicker`, and `TimePicker` respectively.

Fixes #626.

## What changed

- rendered `DatePicker` for `FormControl type="date"`
- rendered `DateTimePicker` for `FormControl type="datetime-local"`
- rendered `TimePicker` for `FormControl type="time"`
- added minimal compatibility props to picker trigger inputs
- preserved `FormControl` prefix/suffix slots for date and time controls
- preserved `focus` and `blur` listeners from the old `TextInput` path
- added focused Cypress tests for date, datetime, and time controls

## Compatibility notes

- `date` values continue to use `YYYY-MM-DD`
- `time` values continue to use picker time values such as `HH:mm`
- `datetime-local` values are normalized back to native-style `YYYY-MM-DDTHH:mm`
- `size`, `required`, `variant`, label association, and slots are preserved through `FormControl`
- `DateRangePicker` is intentionally unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date, time, and datetime-local input type support to FormControl component
  * Added `required`, `size`, and `inputId` customization options for date/time pickers
  * Added `focus` and `blur` event emissions for date/time picker components

* **Tests**
  * Added comprehensive test coverage for date and time input modes in FormControl

<!-- end of auto-generated comment: release notes by coderabbit.ai -->