### PR TITLE
fix(Combobox): Combobox input not focusable when rendered inside a Dialog

### DIFF
--- a/.github/workflows/coverage-pr-comment.yml
+++ b/.github/workflows/coverage-pr-comment.yml
@@ -1,0 +1,68 @@
+name: Coverage PR comment
+
+# Runs after the Tests workflow finishes. workflow_run executes in the base
+# repo's context with a write-capable GITHUB_TOKEN, so it can edit PRs from
+# forks (which the Tests workflow itself cannot). It never checks out PR code,
+# only consumes artifacts.
+on:
+  workflow_run:
+    workflows: [Tests]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+  contents: read
+
+jobs:
+  comment:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Download HEAD coverage summary
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-summary
+          path: coverage/final
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download PR info
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-info
+          path: pr-info
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve PR number
+        run: echo "PR_NUMBER=$(cat pr-info/pr-number.txt)" >> "$GITHUB_ENV"
+
+      - name: Download main baseline coverage summary
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: tests.yml
+          branch: main
+          event: push
+          name: coverage-summary
+          path: coverage-baseline
+          if_no_artifact_found: warn
+        continue-on-error: true
+
+      - name: Update PR description with coverage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn tsx scripts/update-pr-coverage.ts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,21 +137,16 @@ jobs:
           name: coverage-summary
           path: coverage/final/coverage-summary.json
 
-      - name: Download main baseline coverage summary
+      # PR description edits run in a separate workflow_run-triggered workflow
+      # (see coverage-pr-comment.yml). That workflow has write access to the
+      # base repo even for fork PRs, which this one does not.
+      - name: Record PR number for follow-up workflow
         if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          workflow: tests.yml
-          branch: main
-          event: push
-          name: coverage-summary
-          path: coverage-baseline
-          if_no_artifact_found: warn
-        continue-on-error: true
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
 
-      - name: Update PR description with coverage
+      - name: Upload PR info artifact
         if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: yarn tsx scripts/update-pr-coverage.ts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-info
+          path: pr-number.txt

--- a/docs/content/docs/components/combobox.md
+++ b/docs/content/docs/components/combobox.md
@@ -32,4 +32,9 @@ Avatar rows with a contextual invite action authored through a template slot.
 
 <ComponentPreview name="Combobox-MemberPicker" css='justify-center !py-20 grid' />
 
+## In Dialog
+Combobox rendered inside a Dialog. Verifies focus restores to the trigger after the popover closes, even when wrapped by the Dialog's focus scope.
+
+<ComponentPreview name="Combobox-InDialog" layout="stacked" css='justify-center !py-20 grid' />
+
 <!-- @include: ../../../meta/Combobox.md -->

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -15,6 +15,7 @@ import {
   ComboboxPortal,
   ComboboxRoot,
   ComboboxTrigger,
+  FocusScope,
 } from 'reka-ui'
 import { isEmojiIconString, isLucideIconString } from '../../utils/iconString'
 import ComboboxResults from './ComboboxResults.vue'
@@ -296,19 +297,16 @@ function handleCreateOptionSelect(event: Event) {
   commitCustomValue(query.value)
 }
 
-// When a custom trigger is used, move focus to the search input inside the
-// popover as it opens. reka's default `openAutoFocus` would put focus on
-// the first item; we want the user typing to filter, not navigate.
-const popoverInputRef = ref<{ $el?: HTMLElement } | null>(null)
-
-function handleContentOpenAutoFocus(event: Event) {
-  event.preventDefault()
-  if (!isButtonMode.value) return
-
-  nextTick(() => {
-    const el = popoverInputRef.value?.$el as HTMLElement | undefined
-    el?.focus()
-  })
+function handleFocusScopeMountAutoFocus(event: Event) {
+  // In input mode the trigger is the search input — keep focus there so the
+  // user can keep typing. FocusScope's default would yank focus to the first
+  // tabbable inside the popover (an item).
+  // In button mode, let FocusScope's default run: it focuses the first
+  // tabbable inside the popover (our search input). Critically, this fires
+  // AFTER FocusScope adds itself to the focus-scope stack, so it works even
+  // when the Combobox is rendered inside a Dialog whose FocusScope is
+  // trapping focus.
+  if (!isButtonMode.value) event.preventDefault()
 }
 
 function reset() {
@@ -575,50 +573,75 @@ defineSlots<ComboboxSlots>()
         :side="side"
         :align="resolvedAlign"
         :side-offset="offset"
-        @openAutoFocus="handleContentOpenAutoFocus"
-        @closeAutoFocus.prevent
       >
-        <div
-          data-slot="content-body"
-          :data-motion="contentMotion"
-          class="overflow-hidden rounded-lg bg-surface-modal shadow-2xl ring-1 ring-black ring-opacity-5"
+        <!--
+          Why FocusScope lives here (inside ComboboxContent) and not around it:
+
+          ComboboxContent is a <Presence> wrapper — it renders null when the
+          popover is closed. Placing FocusScope outside with `as-child` means
+          its container is null while closed, so it never registers on reka's
+          global focus-scope stack, and the fix has no effect.
+
+          By sitting on the always-present content-body div, FocusScope mounts
+          the moment the popover opens. It pushes itself onto the stack, which
+          pauses any parent Dialog's trapped FocusScope. That allows focus to
+          move freely into the portaled popover.
+
+          Why we don't prevent mountAutoFocus (in button mode):
+          ComboboxContentImpl.onMounted synchronously calls inputElement.focus()
+          before our FocusScope has had a chance to register — the dialog trap
+          immediately reverts it. FocusScope's own auto-focus fires after the
+          stack push, so it re-focuses the first tabbable (the search input)
+          once the dialog trap is paused. In input mode we prevent it so the
+          trigger input keeps focus while the list opens.
+        -->
+        <FocusScope
+          as-child
+          loop
+          @mount-auto-focus="handleFocusScopeMountAutoFocus"
+          @unmount-auto-focus.prevent
         >
           <div
-            v-if="isButtonMode"
-            data-slot="content-search"
-            class="flex items-center gap-2 border-b border-outline-gray-1 px-3"
+            data-slot="content-body"
+            :data-motion="contentMotion"
+            class="overflow-hidden rounded-lg bg-surface-modal shadow-2xl ring-1 ring-black ring-opacity-5"
           >
-            <ComboboxInput
-              :id="id"
-              ref="popoverInputRef"
-              v-bind="inputAttrs"
-              data-slot="input"
-              :value="query"
-              :disabled="disabled"
-              :placeholder="placeholder"
-              class="min-w-0 flex-1 px-0 border-0 bg-transparent py-2 text-base text-ink-gray-8 outline-none placeholder:text-ink-gray-4 focus:ring-0"
-              @input="handleInputChange"
-              @focus="emit('focus', $event)"
-              @blur="emit('blur', $event)"
-              @keydown.enter="handleInputEnter"
+            <div
+              v-if="isButtonMode"
+              data-slot="content-search"
+              class="flex items-center gap-2 border-b border-outline-gray-1 px-3"
+            >
+              <ComboboxInput
+                :id="id"
+                v-bind="inputAttrs"
+                data-slot="input"
+                :value="query"
+                :disabled="disabled"
+                :placeholder="placeholder"
+                class="min-w-0 flex-1 px-0 border-0 bg-transparent py-2 text-base text-ink-gray-8 outline-none placeholder:text-ink-gray-4 focus:ring-0"
+                @input="handleInputChange"
+                @focus="emit('focus', $event)"
+                @blur="emit('blur', $event)"
+                @keydown.enter="handleInputEnter"
+              />
+            </div>
+
+            <ComboboxResults
+              :groups="filteredGroups"
+              :size="size"
+              :query="typedQuery"
+              :model="model ?? null"
+              :loading="loading"
+              :empty-text="emptyText"
+              :show-create-option="showCreateOption"
+              :show-empty="showEmpty"
+              :slot-fns="slots"
+              :all-selectable-options="allSelectableOptions"
+              @select-custom="handleCustomItemSelect"
+              @select-create="handleCreateOptionSelect"
             />
           </div>
-
-          <ComboboxResults
-            :groups="filteredGroups"
-            :size="size"
-            :query="typedQuery"
-            :model="model ?? null"
-            :loading="loading"
-            :empty-text="emptyText"
-            :show-create-option="showCreateOption"
-            :show-empty="showEmpty"
-            :slot-fns="slots"
-            :all-selectable-options="allSelectableOptions"
-            @select-custom="handleCustomItemSelect"
-            @select-create="handleCreateOptionSelect"
-          />
-        </div>
+        </FocusScope>
       </ComboboxContent>
     </ComboboxPortal>
   </ComboboxRoot>

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -597,7 +597,6 @@ defineSlots<ComboboxSlots>()
         -->
         <FocusScope
           as-child
-          loop
           @mount-auto-focus="handleFocusScopeMountAutoFocus"
           @unmount-auto-focus.prevent
         >

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -611,7 +611,7 @@ defineSlots<ComboboxSlots>()
               class="flex items-center gap-2 border-b border-outline-gray-1 px-3"
             >
               <ComboboxInput
-                :id="id"
+                :id="id ? `${id}-search-input` : undefined"
                 v-bind="inputAttrs"
                 data-slot="input"
                 :value="query"

--- a/src/components/Combobox/stories/InDialog.vue
+++ b/src/components/Combobox/stories/InDialog.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Button, Combobox, Dialog } from 'frappe-ui'
+
+const open = ref(false)
+const repo = ref('frappe-ui')
+const reaction = ref('')
+
+const repos = [
+  'gameplan',
+  'frappe-ui',
+  'frappe',
+  'erpnext',
+  'helpdesk',
+  'crm',
+  'wiki',
+  'insights',
+]
+
+const emojis = [
+  {
+    group: 'Smileys',
+    options: [
+      { label: 'Grinning', value: 'grinning', icon: '😀' },
+      { label: 'Laughing', value: 'laughing', icon: '😂' },
+      { label: 'Heart Eyes', value: 'heart-eyes', icon: '😍' },
+      { label: 'Thinking', value: 'thinking', icon: '🤔' },
+    ],
+  },
+  {
+    group: 'Gestures',
+    options: [
+      { label: 'Thumbs Up', value: 'thumbs-up', icon: '👍' },
+      { label: 'Party', value: 'party', icon: '🎉' },
+      { label: 'Fire', value: 'fire', icon: '🔥' },
+    ],
+  },
+]
+</script>
+
+<template>
+  <Button @click="open = true">Open dialog</Button>
+
+  <Dialog v-model="open">
+    <template #body-title>
+      <h3 class="text-2xl font-semibold text-ink-gray-9">
+        Combobox inside Dialog
+      </h3>
+    </template>
+
+    <template #body-content>
+      <div class="space-y-4">
+        <div class="flex flex-col gap-1">
+          <label class="text-sm text-ink-gray-7">Repository</label>
+          <Combobox
+            v-model="repo"
+            :options="repos"
+            placeholder="Pick a repo"
+            open-on-focus
+          />
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <label class="text-sm text-ink-gray-7">Reaction</label>
+          <Combobox
+            v-model="reaction"
+            trigger="button"
+            :options="emojis"
+            placeholder="Pick a reaction"
+          >
+            <template #prefix>
+              <span class="lucide-smile size-4 text-ink-gray-6" />
+            </template>
+          </Combobox>
+        </div>
+
+        <div class="rounded bg-surface-gray-1 p-3 text-sm text-ink-gray-7">
+          <div>
+            Repo: <code>{{ repo || 'None' }}</code>
+          </div>
+          <div>
+            Reaction: <code>{{ reaction || 'None' }}</code>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <template #actions="{ close }">
+      <Button variant="solid" @click="close">Done</Button>
+    </template>
+  </Dialog>
+</template>


### PR DESCRIPTION
When a Combobox in button/trigger-slot mode is rendered inside a Dialog, the search input inside the popover cannot receive focus — neither from
  auto-focus on open nor from direct clicks. Typing does nothing.

  Root cause: reka's DialogContent wraps its children in a trapped FocusScope. Any focus that moves outside that scope is immediately reverted. Unlike
   PopoverContentImpl, ComboboxContentImpl does not establish its own FocusScope, so when the Combobox popover is portaled to <body>, the dialog's
  trap reverts focus with no counter-scope to pause it.

  What was tried first (and why it failed)

  Wrapping <ComboboxContent> itself with <FocusScope as-child> doesn't work because ComboboxContent is a <Presence> wrapper that renders null while
  the popover is closed. An as-child FocusScope with a null root never gets a container element, never registers on reka's global focus-scope stack,
  and has no effect.

  Fix

  Place FocusScope inside ComboboxContent, around the content-body div. This gives it a real DOM container exactly when the popover is open.

  Focus flow with the fix:
  1. User opens the popover → FocusScope mounts, pushes itself onto reka's global stack, pausing the Dialog's trapped scope
  2. ComboboxContentImpl.onMounted synchronously calls inputElement.focus() — the dialog trap reverts it (our scope isn't on the stack yet at this
  point, that's async)
  3. FocusScope.mountAutoFocus fires after the stack push — re-focuses the first tabbable (the search input), now with the dialog trap paused ✓
  4. All subsequent clicks and keyboard events work normally
  5. On close, FocusScope removes itself from the stack, resuming the dialog's trapped scope

  Input mode (no trigger slot): mountAutoFocus is prevented so the trigger input keeps focus while the list opens — same as before.

  Files changed

  - frappe-ui/src/components/Combobox/Combobox.vue
    - Import FocusScope from reka-ui
    - Replace dead handleContentOpenAutoFocus (the @openAutoFocus event is never emitted by ComboboxContentImpl) with handleFocusScopeMountAutoFocus
    - Wrap content-body div in <FocusScope as-child loop>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus management in the combobox component for enhanced keyboard navigation and accessibility when opening dropdown lists.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/frappe-ui/pull/644)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->