### PR TITLE
refactor(selection): share utils, composables, and motion across Select / MultiSelect / Combobox

### DIFF
--- a/src/components/Combobox/Combobox.cy.ts
+++ b/src/components/Combobox/Combobox.cy.ts
@@ -620,4 +620,52 @@ describe('Combobox', () => {
       cy.get('@onUpdateQuery').should('have.been.calledWith', '')
     })
   })
+
+  // Regression: prevent a future change from re-introducing the
+  // phantom prefix container described in Select's matching block.
+  describe('item-prefix container', () => {
+    it('omits the prefix container when no icon and no #item-prefix slot', () => {
+      cy.mount(Combobox, {
+        props: { open: true, options: fruits },
+      })
+
+      cy.get('[role=option]')
+        .first()
+        .find('[data-slot="item-prefix"]')
+        .should('not.exist')
+    })
+
+    it('renders the prefix container when option has an icon', () => {
+      cy.mount(Combobox, {
+        props: {
+          open: true,
+          options: [{ label: 'Apple', value: 'apple', icon: 'lucide-apple' }],
+        },
+      })
+
+      cy.get('[role=option]')
+        .first()
+        .find('[data-slot="item-prefix"]')
+        .should('exist')
+      cy.get('[role=option]').first().find('.lucide-apple').should('exist')
+    })
+
+    it('renders the prefix container when consumer provides #item-prefix', () => {
+      cy.mount(Combobox, {
+        props: { open: true, options: fruits },
+        slots: {
+          'item-prefix': () => h('span', { 'data-cy': 'tpl-prefix' }, 'P'),
+        },
+      })
+
+      cy.get('[role=option]')
+        .first()
+        .find('[data-slot="item-prefix"]')
+        .should('exist')
+      cy.get('[role=option]')
+        .first()
+        .find('[data-cy="tpl-prefix"]')
+        .should('exist')
+    })
+  })
 })

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -17,6 +17,7 @@ import {
   ComboboxTrigger,
 } from 'reka-ui'
 import OptionIcon from '../shared/selection/OptionIcon.vue'
+import '../shared/selection/popoverMotion.css'
 import ComboboxResults from './ComboboxResults.vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
@@ -590,83 +591,13 @@ defineSlots<ComboboxSlots>()
   outline: none !important;
 }
 
-[data-slot='content-body'] {
-  animation-fill-mode: both;
-}
-
+/* Component-specific transform-origin; the rest of the motion lives in
+   shared/selection/popoverMotion.css. */
 [data-slot='content-body'][data-motion='animated'] {
-  backface-visibility: hidden;
   transform-origin: var(--reka-combobox-content-transform-origin);
 }
 
-[data-slot='content'][data-state='open']
-  [data-slot='content-body'][data-motion='animated'] {
-  animation: combobox-content-enter 180ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-[data-slot='content'][data-state='closed']
-  [data-slot='content-body'][data-motion='animated'] {
-  animation: combobox-content-exit 140ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-/*
- * Keyboard-opens skip the scale + translate enter animation, but a tiny
- * opacity fade still runs — it masks the 1-frame position-settle reka
- * performs after mount. ~80ms is below the perception threshold for
- * motion (feels instant) but long enough to hide the jump.
- */
-[data-slot='content'][data-state='open']
-  [data-slot='content-body'][data-motion='instant'] {
-  animation: combobox-content-instant-fade 80ms linear;
-}
-
-[data-slot='content'][data-state='closed']
-  [data-slot='content-body'][data-motion='instant'] {
-  animation: none;
-}
-
-@keyframes combobox-content-instant-fade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-[data-slot='content'][data-state='closed'] {
-  pointer-events: none;
-}
-
-@keyframes combobox-content-enter {
-  from {
-    opacity: 0;
-    transform: translateY(2px) scale(0.97);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes combobox-content-exit {
-  from {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-
-  to {
-    opacity: 0;
-    transform: translateY(1px) scale(0.985);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  [data-slot='content-body'] {
-    animation-duration: 0ms !important;
-  }
-
   [data-slot='chevron'] {
     transition-duration: 0ms !important;
   }

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -526,6 +526,7 @@ defineSlots<ComboboxSlots>()
     <ComboboxPortal :to="portalTo">
       <ComboboxContent
         data-slot="content"
+        data-selection
         :data-variant="variant"
         :data-size="size"
         :class="[

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -19,6 +19,7 @@ import {
 import { isEmojiIconString, isLucideIconString } from '../../utils/iconString'
 import ComboboxResults from './ComboboxResults.vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
+import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import type {
   ComboboxEmits,
   ComboboxExposed,
@@ -94,18 +95,10 @@ const allSelectableOptions = computed(() =>
   ),
 )
 
-function getSelectableInternalValue(item: NormalizedSelectableOption) {
-  if (item.value !== '') return item.value
-  return `${EMPTY_SELECTABLE_VALUE_PREFIX}${allSelectableOptions.value.indexOf(item)}`
-}
-
-function toExternalSelectableValue(value: string) {
-  return (
-    allSelectableOptions.value.find(
-      (item) => getSelectableInternalValue(item) === value,
-    )?.value ?? value
-  )
-}
+const {
+  toInternal: getSelectableInternalValue,
+  toExternal: toExternalSelectableValue,
+} = useEmptyValueMapping(allSelectableOptions, EMPTY_SELECTABLE_VALUE_PREFIX)
 
 const internalModelValue = computed(() => {
   if (model.value === null || model.value === undefined) return undefined

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -16,7 +16,7 @@ import {
   ComboboxRoot,
   ComboboxTrigger,
 } from 'reka-ui'
-import { isEmojiIconString, isLucideIconString } from '../../utils/iconString'
+import OptionIcon from '../shared/selection/OptionIcon.vue'
 import ComboboxResults from './ComboboxResults.vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
@@ -448,24 +448,10 @@ defineSlots<ComboboxSlots>()
               }"
             />
           </template>
-          <template v-else-if="selectedOption?.icon">
-            <span
-              v-if="isLucideIconString(selectedOption.icon)"
-              :class="[selectedOption.icon, 'size-4 shrink-0 text-ink-gray-6']"
-              aria-hidden="true"
-            />
-            <span
-              v-else-if="isEmojiIconString(selectedOption.icon)"
-              class="inline-flex size-4 shrink-0 items-center justify-center text-base leading-none"
-              aria-hidden="true"
-              >{{ selectedOption.icon }}</span
-            >
-            <component
-              v-else-if="typeof selectedOption.icon !== 'string'"
-              :is="selectedOption.icon"
-              class="size-4 shrink-0 text-ink-gray-6"
-            />
-          </template>
+          <OptionIcon
+            v-else-if="selectedOption?.icon"
+            :icon="selectedOption.icon"
+          />
           <slot v-else-if="!selectedOption && $slots.prefix" name="prefix" />
 
           <span
@@ -509,24 +495,10 @@ defineSlots<ComboboxSlots>()
             v-bind="{ item: selectedOption, query: '', selected: true }"
           />
         </template>
-        <template v-else-if="selectedOption?.icon">
-          <span
-            v-if="isLucideIconString(selectedOption.icon)"
-            :class="[selectedOption.icon, 'size-4 shrink-0 text-ink-gray-6']"
-            aria-hidden="true"
-          />
-          <span
-            v-else-if="isEmojiIconString(selectedOption.icon)"
-            class="inline-flex size-4 shrink-0 items-center justify-center text-base leading-none"
-            aria-hidden="true"
-            >{{ selectedOption.icon }}</span
-          >
-          <component
-            v-else-if="typeof selectedOption.icon !== 'string'"
-            :is="selectedOption.icon"
-            class="size-4 shrink-0 text-ink-gray-6"
-          />
-        </template>
+        <OptionIcon
+          v-else-if="selectedOption?.icon"
+          :icon="selectedOption.icon"
+        />
         <slot v-else name="prefix" />
 
         <ComboboxInput

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -20,6 +20,7 @@ import OptionIcon from '../shared/selection/OptionIcon.vue'
 import ComboboxResults from './ComboboxResults.vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
+import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
 import type {
   ComboboxEmits,
   ComboboxExposed,
@@ -170,21 +171,15 @@ const isButtonMode = computed(
   () => Boolean(slots.trigger) || props.trigger === 'button',
 )
 
-const filteredGroups = computed(() => {
-  if (!open.value || !hasTypedSinceOpen.value) {
-    return normalizedGroups.value
-  }
-
-  return normalizedGroups.value
-    .map((group) => ({
-      ...group,
-      options: group.options.filter((item) =>
-        item.type === 'custom'
-          ? matchesCustomOption(item, query.value)
-          : matchesSelectableOption(item, query.value),
-      ),
-    }))
-    .filter((group) => group.options.length > 0)
+const filteredGroups = useFilteredGroups({
+  groups: normalizedGroups,
+  open,
+  hasTypedSinceOpen,
+  query,
+  matches: (item, q) =>
+    item.type === 'custom'
+      ? matchesCustomOption(item, q)
+      : matchesSelectableOption(item, q),
 })
 
 const hasVisibleItems = computed(() => filteredGroups.value.length > 0)

--- a/src/components/Combobox/ComboboxResults.vue
+++ b/src/components/Combobox/ComboboxResults.vue
@@ -9,7 +9,7 @@ import {
 } from 'reka-ui'
 import ItemListRow from '../ItemListRow/ItemListRow.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
-import { isEmojiIconString, isLucideIconString } from '../../utils/iconString'
+import OptionIcon from '../shared/selection/OptionIcon.vue'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import type { ComboboxItemSlotProps, ComboboxSize } from './types'
 import {
@@ -277,22 +277,7 @@ function handleSelect(item: NormalizedItem, event: Event) {
                     text; component values render directly. Consumer slots
                     above still win.
                   -->
-                  <span
-                    v-else-if="isLucideIconString(item.icon)"
-                    :class="[item.icon, 'size-4 shrink-0 text-ink-gray-6']"
-                    aria-hidden="true"
-                  />
-                  <span
-                    v-else-if="isEmojiIconString(item.icon)"
-                    class="inline-flex size-4 shrink-0 items-center justify-center text-base leading-none"
-                    aria-hidden="true"
-                    >{{ item.icon }}</span
-                  >
-                  <component
-                    v-else-if="item.icon && typeof item.icon !== 'string'"
-                    :is="item.icon"
-                    class="size-4 shrink-0 text-ink-gray-6"
-                  />
+                  <OptionIcon v-else-if="item.icon" :icon="item.icon" />
                 </template>
 
                 <template #label>

--- a/src/components/Combobox/ComboboxResults.vue
+++ b/src/components/Combobox/ComboboxResults.vue
@@ -10,6 +10,7 @@ import {
 import ItemListRow from '../ItemListRow/ItemListRow.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import { isEmojiIconString, isLucideIconString } from '../../utils/iconString'
+import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import type { ComboboxItemSlotProps, ComboboxSize } from './types'
 import {
   CREATE_OPTION_VALUE,
@@ -116,11 +117,10 @@ function getItemKey(item: NormalizedItem) {
   return isSelectableOption(item) ? item.value : item.key
 }
 
-function getSelectableInternalValue(item: NormalizedSelectableOption) {
-  if (item.value !== '') return item.value
-
-  return `${EMPTY_SELECTABLE_VALUE_PREFIX}${props.allSelectableOptions.indexOf(item)}`
-}
+const { toInternal: getSelectableInternalValue } = useEmptyValueMapping(
+  () => props.allSelectableOptions,
+  EMPTY_SELECTABLE_VALUE_PREFIX,
+)
 
 function getComboboxItemValue(item: NormalizedItem) {
   return isSelectableOption(item) ? getSelectableInternalValue(item) : item.key

--- a/src/components/Combobox/ComboboxResults.vue
+++ b/src/components/Combobox/ComboboxResults.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { defineComponent } from 'vue'
 import {
   ComboboxGroup,
   ComboboxItem,
@@ -10,6 +9,7 @@ import {
 import ItemListRow from '../ItemListRow/ItemListRow.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import OptionIcon from '../shared/selection/OptionIcon.vue'
+import { createItemSlotRender } from '../shared/selection/createItemSlotRender'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import type { ComboboxItemSlotProps, ComboboxSize } from './types'
 import {
@@ -53,21 +53,7 @@ const emit = defineEmits<{
   selectCreate: [event: Event]
 }>()
 
-// Defined once at setup so Vue sees a stable component reference across
-// renders; passing the slot-fn inline would remount the wrapper every tick.
-const ItemSlotRender = defineComponent({
-  name: 'ComboboxItemSlotRender',
-  props: {
-    render: { type: Function, required: true },
-    slotProps: { type: Object, required: true },
-  },
-  setup(innerProps) {
-    return () =>
-      (innerProps.render as (p: ComboboxItemSlotProps) => any)(
-        innerProps.slotProps as ComboboxItemSlotProps,
-      )
-  },
-})
+const ItemSlotRender = createItemSlotRender('ComboboxItemSlotRender')
 
 function isItemSelected(item: NormalizedItem) {
   return isSelectableOption(item) && item.value === props.model

--- a/src/components/Combobox/utils.ts
+++ b/src/components/Combobox/utils.ts
@@ -1,3 +1,7 @@
+import {
+  matchesByLabelOrValue,
+  resolveItemSlotsFromRaw as resolveItemSlotsFromRawShared,
+} from '../shared/selection/utils'
 import type {
   ComboboxCustomOption,
   ComboboxCustomOptionContext,
@@ -7,10 +11,18 @@ import type {
   ComboboxOption,
   ComboboxSelectableOption,
   ComboboxSimpleOption,
-  ComboboxSize,
-  ComboboxVariant,
 } from './types'
-import type { ItemListSize } from '../ItemListRow'
+
+export {
+  inputFontSizeClasses,
+  itemClasses,
+  itemRootSizeClasses,
+  toItemListSize,
+  triggerSizeClasses,
+  triggerVariantClasses,
+} from '../shared/selection/utils'
+
+export { triggerBaseClassesFocusWithin as triggerBaseClasses } from '../shared/selection/utils'
 
 /** Sentinel values used internally — never exposed to consumers. */
 export const EMPTY_SELECTABLE_VALUE_PREFIX = '__frappe_ui_combobox_empty__:'
@@ -52,37 +64,10 @@ export function isSelectableOption(
   return item.type === 'option'
 }
 
-/** Resolve the deprecated `render` alias into a normalized `slots` object. */
 export function resolveItemSlotsFromRaw(
   raw: ComboboxSelectableOption | ComboboxCustomOption,
 ): ResolvedItemSlots {
-  // Legacy `render` alias: function form → slots.item (full-row takeover);
-  // object form → merged one-to-one into slots.
-  const legacy = raw.render
-  let legacySlots: ResolvedItemSlots | undefined
-
-  if (typeof legacy === 'function') {
-    legacySlots = { item: () => legacy() }
-  } else if (legacy && typeof legacy === 'object') {
-    legacySlots = legacy as ResolvedItemSlots
-  }
-
-  const resolved: ResolvedItemSlots = {
-    ...(legacySlots ?? {}),
-    ...(raw.slots ?? {}),
-  }
-
-  if (
-    import.meta.env.DEV &&
-    resolved.item &&
-    (resolved.prefix || resolved.label || resolved.suffix)
-  ) {
-    console.warn(
-      '[Combobox] `slots.item` is mutually exclusive with `slots.prefix` / `slots.label` / `slots.suffix`. `slots.item` wins.',
-    )
-  }
-
-  return resolved
+  return resolveItemSlotsFromRawShared<ResolvedItemSlots>(raw, 'Combobox')
 }
 
 export function normalizeSimpleOption(
@@ -174,14 +159,7 @@ export function matchesSelectableOption(
   item: NormalizedSelectableOption,
   currentQuery: string,
 ) {
-  const normalizedQuery = currentQuery.toLowerCase()
-
-  if (!normalizedQuery) return true
-
-  return (
-    item.label.toLowerCase().includes(normalizedQuery) ||
-    item.value.toLowerCase().includes(normalizedQuery)
-  )
+  return matchesByLabelOrValue(item, currentQuery)
 }
 
 export function matchesCustomOption(
@@ -205,64 +183,5 @@ export function buildCustomOptionContext(
   return { query, searchTerm: query }
 }
 
-export function triggerSizeClasses(size: ComboboxSize) {
-  return {
-    sm: 'min-h-7 rounded px-2',
-    md: 'min-h-8 rounded px-2.5',
-    lg: 'min-h-10 rounded-md px-3',
-    xl: 'min-h-10 rounded-md px-3',
-  }[size]
-}
-
-export function inputFontSizeClasses(size: ComboboxSize) {
-  return {
-    sm: 'text-base',
-    md: 'text-base',
-    lg: 'text-lg',
-    xl: 'text-xl',
-  }[size]
-}
-
-export function itemRootSizeClasses(size: ComboboxSize) {
-  return {
-    sm: 'min-h-7',
-    md: 'min-h-8',
-    lg: 'min-h-10',
-    xl: 'min-h-10',
-  }[size]
-}
-
-export function toItemListSize(size: ComboboxSize): ItemListSize {
-  return size
-}
-
-export function triggerVariantClasses(
-  variant: ComboboxVariant,
-  disabled: boolean,
-) {
-  if (disabled) {
-    return [
-      'cursor-not-allowed border text-ink-gray-4',
-      variant !== 'ghost' ? 'bg-surface-gray-1' : '',
-      variant === 'outline' ? 'border-outline-gray-2' : 'border-transparent',
-    ].join(' ')
-  }
-
-  return {
-    subtle:
-      'border border-[--surface-gray-2] bg-surface-gray-2 hover:border-outline-gray-modals hover:bg-surface-gray-3',
-    outline:
-      'border border-outline-gray-2 bg-surface-white hover:border-outline-gray-3',
-    ghost:
-      'border border-transparent bg-transparent hover:bg-surface-gray-3 focus-within:bg-surface-gray-3',
-  }[variant]
-}
-
-export const triggerBaseClasses =
-  'relative inline-flex items-center gap-2 text-left text-ink-gray-7 outline-none transition-[background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-within:ring-2 data-[state=open]:ring-2 ring-outline-gray-3'
-
 export const inputClasses =
   'min-w-0 flex-1 border-0 bg-transparent p-0 text-ink-gray-8 outline-none ring-0 placeholder:text-ink-gray-4 focus:border-0 focus:outline-none focus:ring-0'
-
-export const itemClasses =
-  'select-none rounded border-0 text-base text-ink-gray-9 transition-colors duration-100 ease-out data-[disabled]:text-ink-gray-4 data-[highlighted]:bg-surface-gray-2 data-[state=checked]:bg-surface-gray-3 data-[highlighted]:data-[state=checked]:bg-surface-gray-4'

--- a/src/components/MultiSelect/MultiSelect.cy.ts
+++ b/src/components/MultiSelect/MultiSelect.cy.ts
@@ -149,4 +149,52 @@ describe('MultiSelect', () => {
     cy.get('[role=option]').eq(0).click({ force: true })
     cy.get('@onUpdate').should('not.have.been.called')
   })
+
+  // Regression: prevent a future change from re-introducing the
+  // phantom prefix container described in Select's matching block.
+  describe('item-prefix container', () => {
+    it('omits the prefix container when no icon and no #item-prefix slot', () => {
+      cy.mount(MultiSelect, { props: { options } })
+
+      cy.get('[data-slot="trigger"]').click()
+      cy.get('[role=option]')
+        .first()
+        .find('[data-slot="item-prefix"]')
+        .should('not.exist')
+    })
+
+    it('renders the prefix container when option has an icon', () => {
+      cy.mount(MultiSelect, {
+        props: {
+          options: [{ label: 'Apple', value: 'apple', icon: 'lucide-apple' }],
+        },
+      })
+
+      cy.get('[data-slot="trigger"]').click()
+      cy.get('[role=option]')
+        .first()
+        .find('[data-slot="item-prefix"]')
+        .should('exist')
+      cy.get('[role=option]').first().find('.lucide-apple').should('exist')
+    })
+
+    it('renders the prefix container when consumer provides #item-prefix', () => {
+      cy.mount(MultiSelect, {
+        props: { options },
+        slots: {
+          'item-prefix': () => h('span', { 'data-cy': 'tpl-prefix' }, 'P'),
+        },
+      })
+
+      cy.get('[data-slot="trigger"]').click()
+      cy.get('[role=option]')
+        .first()
+        .find('[data-slot="item-prefix"]')
+        .should('exist')
+      cy.get('[role=option]')
+        .first()
+        .find('[data-cy="tpl-prefix"]')
+        .should('exist')
+    })
+  })
 })

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -12,6 +12,7 @@ import LoadingIndicator from '../LoadingIndicator.vue'
 import MultiSelectResults from './MultiSelectResults.vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
+import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
 import OptionIcon from '../shared/selection/OptionIcon.vue'
 import type {
   MultiSelectEmits,
@@ -133,17 +134,12 @@ const triggerSizingText = computed(() => {
 
 const typedQuery = computed(() => (hasTypedSinceOpen.value ? query.value : ''))
 
-const filteredGroups = computed(() => {
-  if (!open.value || !hasTypedSinceOpen.value) {
-    return normalizedGroups.value
-  }
-
-  return normalizedGroups.value
-    .map((group) => ({
-      ...group,
-      options: group.options.filter((item) => matchesOption(item, query.value)),
-    }))
-    .filter((group) => group.options.length > 0)
+const filteredGroups = useFilteredGroups({
+  groups: normalizedGroups,
+  open,
+  hasTypedSinceOpen,
+  query,
+  matches: matchesOption,
 })
 
 const hasVisibleItems = computed(() =>

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -11,6 +11,7 @@ import Button from '../Button/Button.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import MultiSelectResults from './MultiSelectResults.vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
+import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import {
   isEmojiIconString,
   isLucideIconString,
@@ -73,17 +74,8 @@ const allOptions = computed<NormalizedOption[]>(() =>
   normalizedGroups.value.flatMap((group) => group.options),
 )
 
-function getInternalValue(option: NormalizedOption) {
-  if (option.value !== '') return option.value
-  return `${EMPTY_VALUE_PREFIX}${allOptions.value.indexOf(option)}`
-}
-
-function toExternalValue(value: string) {
-  return (
-    allOptions.value.find((option) => getInternalValue(option) === value)
-      ?.value ?? value
-  )
-}
+const { toInternal: getInternalValue, toExternal: toExternalValue } =
+  useEmptyValueMapping(allOptions, EMPTY_VALUE_PREFIX)
 
 const safeModel = computed<string[]>(() =>
   Array.isArray(model.value) ? model.value : [],

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -313,6 +313,7 @@ defineSlots<MultiSelectSlots>()
     <ComboboxPortal :to="portalTo">
       <ComboboxContent
         data-slot="content"
+        data-selection
         :data-variant="variant"
         :data-size="size"
         :data-loading="loading ? '' : undefined"

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -14,6 +14,7 @@ import { usePopoverMotion } from '../../composables/usePopoverMotion'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
 import OptionIcon from '../shared/selection/OptionIcon.vue'
+import '../shared/selection/popoverMotion.css'
 import type {
   MultiSelectEmits,
   MultiSelectProps,
@@ -408,80 +409,9 @@ defineSlots<MultiSelectSlots>()
   visibility: hidden;
 }
 
-[data-slot='content-body'] {
-  animation-fill-mode: both;
-}
-
+/* Component-specific transform-origin; the rest of the motion lives in
+   shared/selection/popoverMotion.css. */
 [data-slot='content-body'][data-motion='animated'] {
-  backface-visibility: hidden;
   transform-origin: var(--reka-combobox-content-transform-origin);
-}
-
-[data-slot='content'][data-state='open']
-  [data-slot='content-body'][data-motion='animated'] {
-  animation: multiselect-content-enter 180ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-[data-slot='content'][data-state='closed']
-  [data-slot='content-body'][data-motion='animated'] {
-  animation: multiselect-content-exit 140ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-/*
- * Keyboard-opens skip the scale + translate enter animation, but a tiny
- * opacity fade still runs — it masks the 1-frame position-settle reka
- * performs after mount.
- */
-[data-slot='content'][data-state='open']
-  [data-slot='content-body'][data-motion='instant'] {
-  animation: multiselect-content-instant-fade 80ms linear;
-}
-
-[data-slot='content'][data-state='closed']
-  [data-slot='content-body'][data-motion='instant'] {
-  animation: none;
-}
-
-[data-slot='content'][data-state='closed'] {
-  pointer-events: none;
-}
-
-@keyframes multiselect-content-instant-fade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes multiselect-content-enter {
-  from {
-    opacity: 0;
-    transform: translateY(2px) scale(0.97);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes multiselect-content-exit {
-  from {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-
-  to {
-    opacity: 0;
-    transform: translateY(1px) scale(0.985);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  [data-slot='content-body'] {
-    animation-duration: 0ms !important;
-  }
 }
 </style>

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -12,10 +12,7 @@ import LoadingIndicator from '../LoadingIndicator.vue'
 import MultiSelectResults from './MultiSelectResults.vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
-import {
-  isEmojiIconString,
-  isLucideIconString,
-} from '../../utils/iconString'
+import OptionIcon from '../shared/selection/OptionIcon.vue'
 import type {
   MultiSelectEmits,
   MultiSelectProps,
@@ -286,27 +283,10 @@ defineSlots<MultiSelectSlots>()
             }"
           />
         </template>
-        <template v-else-if="singleSelectedOption?.icon">
-          <span
-            v-if="isLucideIconString(singleSelectedOption.icon)"
-            :class="[
-              singleSelectedOption.icon,
-              'size-4 shrink-0 text-ink-gray-6',
-            ]"
-            aria-hidden="true"
-          />
-          <span
-            v-else-if="isEmojiIconString(singleSelectedOption.icon)"
-            class="inline-flex size-4 shrink-0 items-center justify-center text-base leading-none"
-            aria-hidden="true"
-            >{{ singleSelectedOption.icon }}</span
-          >
-          <component
-            v-else-if="typeof singleSelectedOption.icon !== 'string'"
-            :is="singleSelectedOption.icon"
-            class="size-4 shrink-0 text-ink-gray-6"
-          />
-        </template>
+        <OptionIcon
+          v-else-if="singleSelectedOption?.icon"
+          :icon="singleSelectedOption.icon"
+        />
 
         <span class="grid min-w-0 flex-1 text-left font-normal">
           <span

--- a/src/components/MultiSelect/MultiSelectResults.vue
+++ b/src/components/MultiSelect/MultiSelectResults.vue
@@ -11,6 +11,7 @@ import ItemListRow from '../ItemListRow/ItemListRow.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import { isEmojiIconString, isLucideIconString } from '../../utils/iconString'
 import type { MultiSelectItemSlotProps, MultiSelectSize } from './types'
+import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import {
   EMPTY_VALUE_PREFIX,
   itemClasses,
@@ -75,10 +76,10 @@ function getGroupKey(group: NormalizedGroup, index: number) {
   return group.key ?? `${group.group || 'group'}-${index}`
 }
 
-function getInternalValue(item: NormalizedOption) {
-  if (item.value !== '') return item.value
-  return `${EMPTY_VALUE_PREFIX}${props.allOptions.indexOf(item)}`
-}
+const { toInternal: getInternalValue } = useEmptyValueMapping(
+  () => props.allOptions,
+  EMPTY_VALUE_PREFIX,
+)
 
 function getItemTextValue(item: NormalizedOption) {
   return `${item.label} ${item.value}`.trim()

--- a/src/components/MultiSelect/MultiSelectResults.vue
+++ b/src/components/MultiSelect/MultiSelectResults.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { defineComponent } from 'vue'
 import {
   ComboboxGroup,
   ComboboxItem,
@@ -11,6 +10,7 @@ import ItemListRow from '../ItemListRow/ItemListRow.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import OptionIcon from '../shared/selection/OptionIcon.vue'
 import type { MultiSelectItemSlotProps, MultiSelectSize } from './types'
+import { createItemSlotRender } from '../shared/selection/createItemSlotRender'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import {
   EMPTY_VALUE_PREFIX,
@@ -37,19 +37,7 @@ const props = defineProps<{
   allOptions: NormalizedOption[]
 }>()
 
-// Defined once at setup so Vue sees a stable component reference across
-// renders; passing the slot-fn inline would remount the wrapper every tick.
-const ItemSlotRender = defineComponent({
-  name: 'MultiSelectItemSlotRender',
-  props: {
-    render: { type: Function, required: true },
-    slotProps: { type: Object, required: true },
-  },
-  setup(innerProps) {
-    return () =>
-      (innerProps.render as (p: any) => any)(innerProps.slotProps)
-  },
-})
+const ItemSlotRender = createItemSlotRender('MultiSelectItemSlotRender')
 
 function isItemSelected(item: NormalizedOption) {
   return props.selectedValues.includes(item.value)

--- a/src/components/MultiSelect/MultiSelectResults.vue
+++ b/src/components/MultiSelect/MultiSelectResults.vue
@@ -9,7 +9,7 @@ import {
 } from 'reka-ui'
 import ItemListRow from '../ItemListRow/ItemListRow.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
-import { isEmojiIconString, isLucideIconString } from '../../utils/iconString'
+import OptionIcon from '../shared/selection/OptionIcon.vue'
 import type { MultiSelectItemSlotProps, MultiSelectSize } from './types'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import {
@@ -188,22 +188,7 @@ function getItemTextValue(item: NormalizedOption) {
                     :render="item.resolvedSlots.prefix"
                     :slot-props="getItemSlotProps(item)"
                   />
-                  <span
-                    v-else-if="isLucideIconString(item.icon)"
-                    :class="[item.icon, 'size-4 shrink-0 text-ink-gray-6']"
-                    aria-hidden="true"
-                  />
-                  <span
-                    v-else-if="isEmojiIconString(item.icon)"
-                    class="inline-flex size-4 shrink-0 items-center justify-center text-base leading-none"
-                    aria-hidden="true"
-                    >{{ item.icon }}</span
-                  >
-                  <component
-                    v-else-if="item.icon && typeof item.icon !== 'string'"
-                    :is="item.icon"
-                    class="size-4 shrink-0 text-ink-gray-6"
-                  />
+                  <OptionIcon v-else-if="item.icon" :icon="item.icon" />
                 </template>
 
                 <template #label>

--- a/src/components/MultiSelect/utils.ts
+++ b/src/components/MultiSelect/utils.ts
@@ -1,13 +1,25 @@
-import type { ItemListSize } from '../ItemListRow'
+import {
+  matchesByLabelOrValue,
+  resolveItemSlotsFromRaw as resolveItemSlotsFromRawShared,
+} from '../shared/selection/utils'
 import type {
   MultiSelectGroupedOption,
   MultiSelectItemSlotProps,
   MultiSelectItemSlots,
   MultiSelectOption,
   MultiSelectOptions,
-  MultiSelectSize,
-  MultiSelectVariant,
 } from './types'
+
+export {
+  inputFontSizeClasses,
+  itemClasses,
+  itemRootSizeClasses,
+  toItemListSize,
+  triggerSizeClasses,
+  triggerVariantClasses,
+} from '../shared/selection/utils'
+
+export { triggerBaseClassesFocusVisible as triggerBaseClasses } from '../shared/selection/utils'
 
 /** Sentinel used to disambiguate options whose value is an empty string. */
 export const EMPTY_VALUE_PREFIX = '__frappe_ui_multiselect_empty__:'
@@ -28,35 +40,10 @@ export function isGroupedOption(
   return typeof option === 'object' && option !== null && 'group' in option
 }
 
-/** Resolve the deprecated `render` alias into a normalized `slots` object. */
 export function resolveItemSlotsFromRaw(
   raw: MultiSelectOption,
 ): ResolvedItemSlots {
-  const legacy = raw.render
-  let legacySlots: ResolvedItemSlots | undefined
-
-  if (typeof legacy === 'function') {
-    legacySlots = { item: () => legacy() }
-  } else if (legacy && typeof legacy === 'object') {
-    legacySlots = legacy as ResolvedItemSlots
-  }
-
-  const resolved: ResolvedItemSlots = {
-    ...(legacySlots ?? {}),
-    ...(raw.slots ?? {}),
-  }
-
-  if (
-    import.meta.env.DEV &&
-    resolved.item &&
-    (resolved.prefix || resolved.label || resolved.suffix)
-  ) {
-    console.warn(
-      '[MultiSelect] `slots.item` is mutually exclusive with `slots.prefix` / `slots.label` / `slots.suffix`. `slots.item` wins.',
-    )
-  }
-
-  return resolved
+  return resolveItemSlotsFromRawShared<ResolvedItemSlots>(raw, 'MultiSelect')
 }
 
 export function normalizeOption(
@@ -122,70 +109,5 @@ export function normalizeMultiSelectOptions(
 }
 
 export function matchesOption(item: NormalizedOption, currentQuery: string) {
-  const normalizedQuery = currentQuery.toLowerCase()
-  if (!normalizedQuery) return true
-
-  return (
-    item.label.toLowerCase().includes(normalizedQuery) ||
-    item.value.toLowerCase().includes(normalizedQuery)
-  )
+  return matchesByLabelOrValue(item, currentQuery)
 }
-
-export function triggerSizeClasses(size: MultiSelectSize) {
-  return {
-    sm: 'min-h-7 rounded px-2',
-    md: 'min-h-8 rounded px-2.5',
-    lg: 'min-h-10 rounded-md px-3',
-    xl: 'min-h-10 rounded-md px-3',
-  }[size]
-}
-
-export function inputFontSizeClasses(size: MultiSelectSize) {
-  return {
-    sm: 'text-base',
-    md: 'text-base',
-    lg: 'text-lg',
-    xl: 'text-xl',
-  }[size]
-}
-
-export function itemRootSizeClasses(size: MultiSelectSize) {
-  return {
-    sm: 'min-h-7',
-    md: 'min-h-8',
-    lg: 'min-h-10',
-    xl: 'min-h-10',
-  }[size]
-}
-
-export function toItemListSize(size: MultiSelectSize): ItemListSize {
-  return size
-}
-
-export function triggerVariantClasses(
-  variant: MultiSelectVariant,
-  disabled: boolean,
-) {
-  if (disabled) {
-    return [
-      'cursor-not-allowed border text-ink-gray-4',
-      variant !== 'ghost' ? 'bg-surface-gray-1' : '',
-      variant === 'outline' ? 'border-outline-gray-2' : 'border-transparent',
-    ].join(' ')
-  }
-
-  return {
-    subtle:
-      'border border-[--surface-gray-2] bg-surface-gray-2 hover:border-outline-gray-modals hover:bg-surface-gray-3',
-    outline:
-      'border border-outline-gray-2 bg-surface-white hover:border-outline-gray-3',
-    ghost:
-      'border border-transparent bg-transparent hover:bg-surface-gray-3 focus-within:bg-surface-gray-3',
-  }[variant]
-}
-
-export const triggerBaseClasses =
-  'relative inline-flex items-center gap-2 text-left text-ink-gray-7 outline-none transition-[background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-visible:ring-2 data-[state=open]:ring-2 ring-outline-gray-3'
-
-export const itemClasses =
-  'select-none rounded border-0 text-base text-ink-gray-9 transition-colors duration-100 ease-out data-[disabled]:text-ink-gray-4 data-[highlighted]:bg-surface-gray-2 data-[state=checked]:bg-surface-gray-3 data-[highlighted]:data-[state=checked]:bg-surface-gray-4'

--- a/src/components/Select/Select.cy.ts
+++ b/src/components/Select/Select.cy.ts
@@ -313,4 +313,55 @@ describe('Select', () => {
 
     cy.get('button').should('have.class', 'cursor-not-allowed')
   })
+
+  // Regression: ItemListRow's `hasRenderableContent` treats any component
+  // vnode as renderable, so a fallback `<OptionIcon>` left in the slot
+  // tree (even when `icon` is falsy and OptionIcon itself renders nothing)
+  // was enough to keep ItemListRow painting an empty prefix container —
+  // visible as a stray left gap from the parent's `flex gap-2`.
+  describe('item-prefix container', () => {
+    it('omits the prefix container when no icon and no #item-prefix slot', () => {
+      cy.mount(Select, { props: { options } })
+
+      cy.get('[role=combobox]').click()
+      cy.get('[role=option]')
+        .first()
+        .find('[data-slot="item-prefix"]')
+        .should('not.exist')
+    })
+
+    it('renders the prefix container when option has an icon', () => {
+      cy.mount(Select, {
+        props: {
+          options: [{ label: 'Apple', value: 'apple', icon: 'lucide-apple' }],
+        },
+      })
+
+      cy.get('[role=combobox]').click()
+      cy.get('[role=option]')
+        .first()
+        .find('[data-slot="item-prefix"]')
+        .should('exist')
+      cy.get('[role=option]').first().find('.lucide-apple').should('exist')
+    })
+
+    it('renders the prefix container when consumer provides #item-prefix', () => {
+      cy.mount(Select, {
+        props: { options },
+        slots: {
+          'item-prefix': () => h('span', { 'data-cy': 'tpl-prefix' }, 'P'),
+        },
+      })
+
+      cy.get('[role=combobox]').click()
+      cy.get('[role=option]')
+        .first()
+        .find('[data-slot="item-prefix"]')
+        .should('exist')
+      cy.get('[role=option]')
+        .first()
+        .find('[data-cy="tpl-prefix"]')
+        .should('exist')
+    })
+  })
 })

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -277,18 +277,28 @@ defineSlots<SelectSlots>()
                   :disabled="internalOption.option.disabled"
                 >
                   <template #prefix>
-                    <slot
-                      name="item-prefix"
-                      v-bind="{ option: internalOption.option }"
-                    />
                     <!--
+                      v-if chain (not unconditional slot + v-if icon) so that
+                      with neither a consumer `#item-prefix` slot nor an
+                      `option.icon`, the prefix template renders only
+                      comment vnodes. Otherwise the unconditional `<slot>` /
+                      `<OptionIcon>` leaves a real vnode in the tree,
+                      `hasRenderableContent` returns true, and ItemListRow
+                      paints an empty prefix container — visible as a
+                      stray left gap from the parent's `gap-2`.
+
                       Auto-render `option.icon` when the consumer doesn't
-                      provide an `#item-prefix`. `lucide-*` strings route
+                      provide `#item-prefix`. `lucide-*` strings route
                       through the Tailwind plugin; component values render
                       directly.
                     -->
+                    <slot
+                      v-if="slots['item-prefix']"
+                      name="item-prefix"
+                      v-bind="{ option: internalOption.option }"
+                    />
                     <OptionIcon
-                      v-if="!slots['item-prefix']"
+                      v-else-if="internalOption.option.icon"
                       :icon="internalOption.option.icon"
                     />
                   </template>

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -245,6 +245,7 @@ defineSlots<SelectSlots>()
     <SelectPortal>
       <SelectContent
         data-slot="content"
+        data-selection
         class="z-[100] origin-[var(--reka-select-content-transform-origin)]"
       >
         <div

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, useAttrs, useSlots } from 'vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
+import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import type {
   SelectNormalizedOption,
   SelectOption,
@@ -111,28 +112,26 @@ const selectOptions = computed(() => {
     .filter((option): option is SelectNormalizedOption => Boolean(option))
 })
 
-const internalOptions = computed(() => {
-  return selectOptions.value.map((option, index) => ({
+const { toInternal, toExternal } = useEmptyValueMapping(
+  selectOptions,
+  EMPTY_VALUE_PREFIX,
+)
+
+const internalOptions = computed(() =>
+  selectOptions.value.map((option) => ({
     option,
-    internalValue:
-      option.value === '' ? `${EMPTY_VALUE_PREFIX}${index}` : option.value,
-  }))
-})
+    internalValue: toInternal(option),
+  })),
+)
 
 function toInternalValue(value: SelectOptionValue | undefined) {
   if (value !== '') return value
-
-  return (
-    internalOptions.value.find((option) => option.option.value === '')
-      ?.internalValue ?? value
-  )
+  const empty = selectOptions.value.find((option) => option.value === '')
+  return empty ? toInternal(empty) : value
 }
 
 function toExternalValue(value: SelectOptionValue | undefined) {
-  return (
-    internalOptions.value.find((option) => option.internalValue === value)
-      ?.option.value ?? value
-  )
+  return toExternal(value)
 }
 
 const internalModel = computed<SelectOptionValue | undefined>({

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -22,6 +22,7 @@ import {
   SelectViewport,
 } from 'reka-ui'
 import OptionIcon from '../shared/selection/OptionIcon.vue'
+import '../shared/selection/popoverMotion.css'
 import {
   EMPTY_VALUE_PREFIX,
   inputFontSizeClasses,
@@ -381,80 +382,4 @@ defineSlots<SelectSlots>()
   visibility: hidden;
 }
 
-[data-slot='content-body'] {
-  animation-fill-mode: both;
-}
-
-[data-slot='content-body'][data-motion='animated'] {
-  backface-visibility: hidden;
-}
-
-[data-slot='content'][data-state='open']
-  [data-slot='content-body'][data-motion='animated'] {
-  animation: select-content-enter 180ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-[data-slot='content'][data-state='closed']
-  [data-slot='content-body'][data-motion='animated'] {
-  animation: select-content-exit 140ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-/*
- * Keyboard opens skip the scale + translate entrance, but a tiny opacity
- * fade still runs — it masks the 1-frame position-settle reka performs
- * after mount. ~80ms is below the perception threshold for motion but
- * long enough to hide the jump.
- */
-[data-slot='content'][data-state='open']
-  [data-slot='content-body'][data-motion='instant'] {
-  animation: select-content-instant-fade 80ms linear;
-}
-
-[data-slot='content'][data-state='closed']
-  [data-slot='content-body'][data-motion='instant'] {
-  animation: none;
-}
-
-[data-slot='content'][data-state='closed'] {
-  pointer-events: none;
-}
-
-@keyframes select-content-instant-fade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes select-content-enter {
-  from {
-    opacity: 0;
-    transform: translateY(2px) scale(0.97);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes select-content-exit {
-  from {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-
-  to {
-    opacity: 0;
-    transform: translateY(1px) scale(0.985);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  [data-slot='content-body'] {
-    animation-duration: 0ms !important;
-  }
-}
 </style>

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -8,7 +8,6 @@ import type {
   SelectProps,
   SelectSlots,
 } from './types'
-import type { ItemListSize } from '../ItemListRow'
 import ItemListRow from '../ItemListRow/ItemListRow.vue'
 import {
   SelectContent,
@@ -25,6 +24,16 @@ import {
   isEmojiIconString,
   isLucideIconString,
 } from '../../utils/iconString'
+import {
+  EMPTY_VALUE_PREFIX,
+  inputFontSizeClasses,
+  itemRootSizeClasses,
+  toItemListSize,
+  triggerBaseClasses,
+  triggerContentPaddingClasses,
+  triggerSizeClasses,
+  triggerVariantClasses,
+} from './utils'
 
 defineOptions({
   inheritAttrs: false,
@@ -45,7 +54,6 @@ const attrs = useAttrs()
 const slots = useSlots()
 
 const formAttrKeys = ['name', 'required', 'autocomplete'] as const
-const emptyValuePrefix = '__frappe_ui_select_empty__'
 
 const { motion: contentMotion, onPointerDown: markPointerDown } =
   usePopoverMotion(open)
@@ -69,69 +77,20 @@ const triggerAttrs = computed(() => {
   return rest
 })
 
-const triggerSizeClasses = computed(() => {
-  return {
-    sm: 'min-h-7 rounded px-2',
-    md: 'min-h-8 rounded px-2.5',
-    lg: 'min-h-10 rounded-md px-3',
-    xl: 'min-h-10 rounded-md px-3',
-  }[props.size]
-})
+const itemSize = computed(() => toItemListSize(props.size))
 
-const triggerFontSizeClasses = computed(() => {
-  return {
-    sm: 'text-base',
-    md: 'text-base',
-    lg: 'text-lg',
-    xl: 'text-xl',
-  }[props.size]
-})
+const itemRootClasses = computed(() => itemRootSizeClasses(props.size))
 
-const triggerContentPaddingClasses = computed(() => {
-  return {
-    sm: 'px-2',
-    md: 'px-2.5',
-    lg: 'px-3',
-    xl: 'px-3',
-  }[props.size]
-})
+const triggerContentPadding = computed(() =>
+  triggerContentPaddingClasses(props.size),
+)
 
-const itemSize = computed<ItemListSize>(() => props.size)
-
-const itemRootSizeClasses = computed(() => {
-  return {
-    sm: 'min-h-7',
-    md: 'min-h-8',
-    lg: 'min-h-10',
-    xl: 'min-h-10',
-  }[props.size]
-})
-
-const triggerClasses = computed(() => {
-  const variant = props.disabled ? 'disabled' : props.variant
-  const variantClasses = {
-    subtle:
-      'border border-[--surface-gray-2] bg-surface-gray-2 hover:border-outline-gray-modals hover:bg-surface-gray-3',
-    outline:
-      'border border-outline-gray-2 bg-surface-white hover:border-outline-gray-3',
-    ghost:
-      'border border-transparent bg-transparent hover:bg-surface-gray-3 focus:bg-surface-gray-3',
-    disabled: [
-      'cursor-not-allowed border',
-      props.variant !== 'ghost' ? 'bg-surface-gray-1' : '',
-      props.variant === 'outline'
-        ? 'border-outline-gray-2'
-        : 'border-transparent',
-    ].join(' '),
-  }[variant]
-
-  return [
-    'relative inline-flex items-center gap-2 text-left outline-none transition-[background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-visible:ring-2 data-[state=open]:ring-2 ring-outline-gray-3 text-ink-gray-7 data-[placeholder]:text-ink-gray-4 data-[disabled]:text-ink-gray-4',
-    triggerSizeClasses.value,
-    triggerFontSizeClasses.value,
-    variantClasses,
-  ]
-})
+const triggerClasses = computed(() => [
+  triggerBaseClasses,
+  triggerSizeClasses(props.size),
+  inputFontSizeClasses(props.size),
+  triggerVariantClasses(props.variant, Boolean(props.disabled)),
+])
 
 function normalizeOption(option: SelectOption): SelectNormalizedOption | null {
   if (!option) return null
@@ -156,7 +115,7 @@ const internalOptions = computed(() => {
   return selectOptions.value.map((option, index) => ({
     option,
     internalValue:
-      option.value === '' ? `${emptyValuePrefix}${index}` : option.value,
+      option.value === '' ? `${EMPTY_VALUE_PREFIX}${index}` : option.value,
   }))
 })
 
@@ -231,7 +190,7 @@ defineSlots<SelectSlots>()
           data-slot="trigger-value"
           :class="[
             'pointer-events-none absolute inset-0 flex items-center overflow-hidden',
-            triggerContentPaddingClasses,
+            triggerContentPadding,
           ]"
           aria-hidden="true"
         >
@@ -326,7 +285,7 @@ defineSlots<SelectSlots>()
                 :disabled="internalOption.option.disabled"
                 :value="internalOption.internalValue"
                 data-slot="item"
-                :class="itemRootSizeClasses"
+                :class="itemRootClasses"
                 class="select-none rounded border-0 text-base text-ink-gray-9 data-[disabled]:text-ink-gray-4 data-[highlighted]:bg-surface-gray-2 data-[state=checked]:bg-surface-gray-3 data-[highlighted]:data-[state=checked]:bg-surface-gray-4"
               >
                 <ItemListRow

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -21,10 +21,7 @@ import {
   SelectValue,
   SelectViewport,
 } from 'reka-ui'
-import {
-  isEmojiIconString,
-  isLucideIconString,
-} from '../../utils/iconString'
+import OptionIcon from '../shared/selection/OptionIcon.vue'
 import {
   EMPTY_VALUE_PREFIX,
   inputFontSizeClasses,
@@ -216,24 +213,10 @@ defineSlots<SelectSlots>()
         <template v-if="selectedOption && slots['item-prefix']">
           <slot name="item-prefix" v-bind="{ option: selectedOption }" />
         </template>
-        <template v-else-if="selectedOption?.icon">
-          <span
-            v-if="isLucideIconString(selectedOption.icon)"
-            :class="[selectedOption.icon, 'size-4 shrink-0 text-ink-gray-6']"
-            aria-hidden="true"
-          />
-          <span
-            v-else-if="isEmojiIconString(selectedOption.icon)"
-            class="inline-flex size-4 shrink-0 items-center justify-center text-base leading-none"
-            aria-hidden="true"
-            >{{ selectedOption.icon }}</span
-          >
-          <component
-            v-else-if="typeof selectedOption.icon !== 'string'"
-            :is="selectedOption.icon"
-            class="size-4 shrink-0 text-ink-gray-6"
-          />
-        </template>
+        <OptionIcon
+          v-else-if="selectedOption?.icon"
+          :icon="selectedOption.icon"
+        />
         <slot v-else name="prefix" />
 
         <div class="grid min-w-0 text-left">
@@ -303,30 +286,10 @@ defineSlots<SelectSlots>()
                       through the Tailwind plugin; component values render
                       directly.
                     -->
-                    <template v-if="!slots['item-prefix']">
-                      <span
-                        v-if="isLucideIconString(internalOption.option.icon)"
-                        :class="[
-                          internalOption.option.icon,
-                          'size-4 shrink-0 text-ink-gray-6',
-                        ]"
-                        aria-hidden="true"
-                      />
-                      <span
-                        v-else-if="isEmojiIconString(internalOption.option.icon)"
-                        class="inline-flex size-4 shrink-0 items-center justify-center text-base leading-none"
-                        aria-hidden="true"
-                        >{{ internalOption.option.icon }}</span
-                      >
-                      <component
-                        v-else-if="
-                          internalOption.option.icon &&
-                          typeof internalOption.option.icon !== 'string'
-                        "
-                        :is="internalOption.option.icon"
-                        class="size-4 shrink-0 text-ink-gray-6"
-                      />
-                    </template>
+                    <OptionIcon
+                      v-if="!slots['item-prefix']"
+                      :icon="internalOption.option.icon"
+                    />
                   </template>
 
                   <template #label>

--- a/src/components/Select/utils.ts
+++ b/src/components/Select/utils.ts
@@ -1,0 +1,65 @@
+import type { SelectionSize, SelectionVariant } from '../shared/selection/utils'
+
+export {
+  inputFontSizeClasses,
+  itemRootSizeClasses,
+  toItemListSize,
+  triggerSizeClasses,
+} from '../shared/selection/utils'
+
+/** Sentinel used to disambiguate options whose value is an empty string. */
+export const EMPTY_VALUE_PREFIX = '__frappe_ui_select_empty__'
+
+/**
+ * Inner padding for the trigger's value area. Mirrors the px portion of
+ * `triggerSizeClasses` and is used to align the absolutely-positioned
+ * trigger-value overlay with the rest of the trigger content.
+ */
+export function triggerContentPaddingClasses(size: SelectionSize) {
+  return {
+    sm: 'px-2',
+    md: 'px-2.5',
+    lg: 'px-3',
+    xl: 'px-3',
+  }[size]
+}
+
+/**
+ * Variant classes for the Select trigger.
+ *
+ * Differs from the shared helper in two ways:
+ *   - The disabled branch omits `text-ink-gray-4`; Select handles disabled
+ *     text color via `data-[disabled]:text-ink-gray-4` on the base classes
+ *     (reka's `SelectTrigger` emits `data-disabled` when disabled).
+ *   - The ghost variant uses `focus:` rather than `focus-within:` because
+ *     the Select trigger is a single button with no focusable descendants.
+ */
+export function triggerVariantClasses(
+  variant: SelectionVariant,
+  disabled: boolean,
+) {
+  if (disabled) {
+    return [
+      'cursor-not-allowed border',
+      variant !== 'ghost' ? 'bg-surface-gray-1' : '',
+      variant === 'outline' ? 'border-outline-gray-2' : 'border-transparent',
+    ].join(' ')
+  }
+
+  return {
+    subtle:
+      'border border-[--surface-gray-2] bg-surface-gray-2 hover:border-outline-gray-modals hover:bg-surface-gray-3',
+    outline:
+      'border border-outline-gray-2 bg-surface-white hover:border-outline-gray-3',
+    ghost:
+      'border border-transparent bg-transparent hover:bg-surface-gray-3 focus:bg-surface-gray-3',
+  }[variant]
+}
+
+/**
+ * Base trigger classes for Select. Includes `data-[placeholder]:` and
+ * `data-[disabled]:` text-color rules driven by reka's `SelectTrigger`,
+ * which is why Select doesn't reuse the shared base string.
+ */
+export const triggerBaseClasses =
+  'relative inline-flex items-center gap-2 text-left outline-none transition-[background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-visible:ring-2 data-[state=open]:ring-2 ring-outline-gray-3 text-ink-gray-7 data-[placeholder]:text-ink-gray-4 data-[disabled]:text-ink-gray-4'

--- a/src/components/shared/selection/OptionIcon.vue
+++ b/src/components/shared/selection/OptionIcon.vue
@@ -39,5 +39,6 @@ defineProps<{
     v-else-if="icon && typeof icon !== 'string'"
     :is="icon"
     class="size-4 shrink-0 text-ink-gray-6"
+    aria-hidden="true"
   />
 </template>

--- a/src/components/shared/selection/OptionIcon.vue
+++ b/src/components/shared/selection/OptionIcon.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import type { Component } from 'vue'
+import {
+  isEmojiIconString,
+  isLucideIconString,
+} from '../../../utils/iconString'
+
+/**
+ * Auto-renders an option's `icon` value across the Select / MultiSelect /
+ * Combobox families:
+ *
+ *   - `lucide-*` strings  → `<span>` with the lucide utility class
+ *     (Tailwind mask plugin renders the glyph).
+ *   - emoji / symbol strings → `<span>` with text content.
+ *   - Component values → rendered via `<component :is>`.
+ *
+ * Renders nothing when `icon` is falsy. Other string forms (e.g. legacy
+ * feather names) are intentionally not handled here — those call sites
+ * (Dropdown) have their own renderer.
+ */
+defineProps<{
+  icon?: string | Component | null
+}>()
+</script>
+
+<template>
+  <span
+    v-if="isLucideIconString(icon)"
+    :class="[icon, 'size-4 shrink-0 text-ink-gray-6']"
+    aria-hidden="true"
+  />
+  <span
+    v-else-if="isEmojiIconString(icon)"
+    class="inline-flex size-4 shrink-0 items-center justify-center text-base leading-none"
+    aria-hidden="true"
+    >{{ icon }}</span
+  >
+  <component
+    v-else-if="icon && typeof icon !== 'string'"
+    :is="icon"
+    class="size-4 shrink-0 text-ink-gray-6"
+  />
+</template>

--- a/src/components/shared/selection/createItemSlotRender.ts
+++ b/src/components/shared/selection/createItemSlotRender.ts
@@ -1,0 +1,26 @@
+import { defineComponent } from 'vue'
+
+/**
+ * Render-function wrapper for slot functions passed via props.
+ *
+ * Each Results component (MultiSelectResults, ComboboxResults) needs to
+ * stamp out a per-item slot using a render function it received from its
+ * parent. Defining the wrapper at module scope (or inside each Results
+ * `setup`) keeps Vue's component identity stable across renders — passing
+ * the slot fn inline would remount the wrapper on every tick.
+ *
+ * The `name` arg only sets the displayed component name in Vue devtools.
+ */
+export function createItemSlotRender(name: string) {
+  return defineComponent({
+    name,
+    props: {
+      render: { type: Function, required: true },
+      slotProps: { type: Object, required: true },
+    },
+    setup(innerProps) {
+      return () =>
+        (innerProps.render as (p: any) => any)(innerProps.slotProps)
+    },
+  })
+}

--- a/src/components/shared/selection/popoverMotion.css
+++ b/src/components/shared/selection/popoverMotion.css
@@ -3,8 +3,11 @@
  * Combobox). Imported once per component from `<script setup>` so it is
  * deduped at build time.
  *
- * Targets `data-slot="content-body"` driven by `usePopoverMotion`'s
- * `data-motion` attribute. Each component still owns:
+ * All selectors are gated on `[data-selection]` (set on each component's
+ * content element) so this stylesheet cannot leak onto other popovers
+ * sharing the same `data-slot` hooks (e.g. Dropdown).
+ *
+ * Each component still owns:
  *   - its own `transform-origin` (Select uses the reka-select var via a
  *     Tailwind class on the element; MultiSelect/Combobox set the
  *     reka-combobox var via their own scoped rule),
@@ -15,20 +18,21 @@
  * scale-only (no translateY) — a different visual rhythm by design.
  */
 
-[data-slot='content-body'] {
+[data-slot='content'][data-selection] [data-slot='content-body'] {
   animation-fill-mode: both;
 }
 
-[data-slot='content-body'][data-motion='animated'] {
+[data-slot='content'][data-selection]
+  [data-slot='content-body'][data-motion='animated'] {
   backface-visibility: hidden;
 }
 
-[data-slot='content'][data-state='open']
+[data-slot='content'][data-selection][data-state='open']
   [data-slot='content-body'][data-motion='animated'] {
   animation: selection-content-enter 180ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
-[data-slot='content'][data-state='closed']
+[data-slot='content'][data-selection][data-state='closed']
   [data-slot='content-body'][data-motion='animated'] {
   animation: selection-content-exit 140ms cubic-bezier(0.23, 1, 0.32, 1);
 }
@@ -39,17 +43,17 @@
  * after mount. ~80ms is below the perception threshold for motion but
  * long enough to hide the jump.
  */
-[data-slot='content'][data-state='open']
+[data-slot='content'][data-selection][data-state='open']
   [data-slot='content-body'][data-motion='instant'] {
   animation: selection-content-instant-fade 80ms linear;
 }
 
-[data-slot='content'][data-state='closed']
+[data-slot='content'][data-selection][data-state='closed']
   [data-slot='content-body'][data-motion='instant'] {
   animation: none;
 }
 
-[data-slot='content'][data-state='closed'] {
+[data-slot='content'][data-selection][data-state='closed'] {
   pointer-events: none;
 }
 
@@ -85,7 +89,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-slot='content-body'] {
+  [data-slot='content'][data-selection] [data-slot='content-body'] {
     animation-duration: 0ms !important;
   }
 }

--- a/src/components/shared/selection/popoverMotion.css
+++ b/src/components/shared/selection/popoverMotion.css
@@ -1,0 +1,91 @@
+/*
+ * Popover open/close motion for the selection family (Select, MultiSelect,
+ * Combobox). Imported once per component from `<script setup>` so it is
+ * deduped at build time.
+ *
+ * Targets `data-slot="content-body"` driven by `usePopoverMotion`'s
+ * `data-motion` attribute. Each component still owns:
+ *   - its own `transform-origin` (Select uses the reka-select var via a
+ *     Tailwind class on the element; MultiSelect/Combobox set the
+ *     reka-combobox var via their own scoped rule),
+ *   - any component-specific reduced-motion overrides (e.g. Combobox's
+ *     chevron transition).
+ *
+ * Dropdown intentionally NOT migrated: its motion is shorter and uses
+ * scale-only (no translateY) — a different visual rhythm by design.
+ */
+
+[data-slot='content-body'] {
+  animation-fill-mode: both;
+}
+
+[data-slot='content-body'][data-motion='animated'] {
+  backface-visibility: hidden;
+}
+
+[data-slot='content'][data-state='open']
+  [data-slot='content-body'][data-motion='animated'] {
+  animation: selection-content-enter 180ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+[data-slot='content'][data-state='closed']
+  [data-slot='content-body'][data-motion='animated'] {
+  animation: selection-content-exit 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+/*
+ * Keyboard opens skip the scale + translate entrance, but a tiny opacity
+ * fade still runs — it masks the 1-frame position-settle reka performs
+ * after mount. ~80ms is below the perception threshold for motion but
+ * long enough to hide the jump.
+ */
+[data-slot='content'][data-state='open']
+  [data-slot='content-body'][data-motion='instant'] {
+  animation: selection-content-instant-fade 80ms linear;
+}
+
+[data-slot='content'][data-state='closed']
+  [data-slot='content-body'][data-motion='instant'] {
+  animation: none;
+}
+
+[data-slot='content'][data-state='closed'] {
+  pointer-events: none;
+}
+
+@keyframes selection-content-instant-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes selection-content-enter {
+  from {
+    opacity: 0;
+    transform: translateY(2px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes selection-content-exit {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(1px) scale(0.985);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-slot='content-body'] {
+    animation-duration: 0ms !important;
+  }
+}

--- a/src/components/shared/selection/useEmptyValueMapping.ts
+++ b/src/components/shared/selection/useEmptyValueMapping.ts
@@ -1,0 +1,34 @@
+import { toValue, type MaybeRefOrGetter } from 'vue'
+
+/**
+ * Maps options whose value is the empty string to a synthetic internal value.
+ *
+ * Reka's Select / Combobox primitives forbid `""` as an item value (it's
+ * reserved for "no selection"). To support consumer options with
+ * `value: ""`, we generate a stable internal value of the form
+ * `${prefix}${indexInList}` and translate back when the value crosses the
+ * boundary between Reka and the consumer.
+ *
+ * Disambiguation is internal only: every empty-string option gets a unique
+ * synthetic value (so Reka sees distinct items), but `toExternal` always
+ * resolves a synthetic back to `""`. Consumers cannot distinguish multiple
+ * empty-string options from each other — and never could.
+ */
+export function useEmptyValueMapping<T extends { value: unknown }>(
+  allOptions: MaybeRefOrGetter<readonly T[]>,
+  prefix: string,
+) {
+  function toInternal(option: T): T['value'] | string {
+    if (option.value !== '') return option.value as T['value']
+    return `${prefix}${toValue(allOptions).indexOf(option)}`
+  }
+
+  function toExternal<V>(internalValue: V): T['value'] | V {
+    return (
+      (toValue(allOptions).find((opt) => toInternal(opt) === internalValue)
+        ?.value as T['value'] | undefined) ?? internalValue
+    )
+  }
+
+  return { toInternal, toExternal }
+}

--- a/src/components/shared/selection/useFilteredGroups.ts
+++ b/src/components/shared/selection/useFilteredGroups.ts
@@ -1,0 +1,40 @@
+import { computed, type ComputedRef, type Ref } from 'vue'
+
+/**
+ * Drives the `filteredGroups` computed shared by MultiSelect and Combobox:
+ *
+ *   - While the popover is closed or the user hasn't typed since opening,
+ *     return groups untouched (so a committed label like "Alex Rivera"
+ *     doesn't filter the list to itself).
+ *   - Otherwise, filter each group's options through `matches(item, query)`
+ *     and drop groups that end up empty.
+ *
+ * The `matches` predicate is supplied by each consumer — MultiSelect uses
+ * a plain label/value substring match; Combobox dispatches on item type
+ * to handle its `custom` rows.
+ */
+export function useFilteredGroups<
+  TItem,
+  TGroup extends { options: TItem[] },
+>(source: {
+  groups: Ref<TGroup[]> | ComputedRef<TGroup[]>
+  open: Ref<boolean>
+  hasTypedSinceOpen: Ref<boolean>
+  query: Ref<string>
+  matches: (item: TItem, query: string) => boolean
+}): ComputedRef<TGroup[]> {
+  return computed(() => {
+    if (!source.open.value || !source.hasTypedSinceOpen.value) {
+      return source.groups.value
+    }
+
+    return source.groups.value
+      .map((group) => ({
+        ...group,
+        options: group.options.filter((item) =>
+          source.matches(item, source.query.value),
+        ),
+      }))
+      .filter((group) => group.options.length > 0) as TGroup[]
+  })
+}

--- a/src/components/shared/selection/utils.ts
+++ b/src/components/shared/selection/utils.ts
@@ -1,0 +1,138 @@
+import type { ItemListSize } from '../../ItemListRow'
+
+/**
+ * Shared helpers for the Select / MultiSelect / Combobox component family.
+ *
+ * Anything genuinely component-specific (types, sentinel prefixes, custom-option
+ * handling) lives in each component's own `utils.ts` — this module holds only
+ * the pieces that were proven duplicates across at least two of those files.
+ */
+
+export type SelectionSize = 'sm' | 'md' | 'lg' | 'xl'
+export type SelectionVariant = 'subtle' | 'outline' | 'ghost'
+
+export function triggerSizeClasses(size: SelectionSize) {
+  return {
+    sm: 'min-h-7 rounded px-2',
+    md: 'min-h-8 rounded px-2.5',
+    lg: 'min-h-10 rounded-md px-3',
+    xl: 'min-h-10 rounded-md px-3',
+  }[size]
+}
+
+export function inputFontSizeClasses(size: SelectionSize) {
+  return {
+    sm: 'text-base',
+    md: 'text-base',
+    lg: 'text-lg',
+    xl: 'text-xl',
+  }[size]
+}
+
+export function itemRootSizeClasses(size: SelectionSize) {
+  return {
+    sm: 'min-h-7',
+    md: 'min-h-8',
+    lg: 'min-h-10',
+    xl: 'min-h-10',
+  }[size]
+}
+
+export function toItemListSize(size: SelectionSize): ItemListSize {
+  return size
+}
+
+export function triggerVariantClasses(
+  variant: SelectionVariant,
+  disabled: boolean,
+) {
+  if (disabled) {
+    return [
+      'cursor-not-allowed border text-ink-gray-4',
+      variant !== 'ghost' ? 'bg-surface-gray-1' : '',
+      variant === 'outline' ? 'border-outline-gray-2' : 'border-transparent',
+    ].join(' ')
+  }
+
+  return {
+    subtle:
+      'border border-[--surface-gray-2] bg-surface-gray-2 hover:border-outline-gray-modals hover:bg-surface-gray-3',
+    outline:
+      'border border-outline-gray-2 bg-surface-white hover:border-outline-gray-3',
+    ghost:
+      'border border-transparent bg-transparent hover:bg-surface-gray-3 focus-within:bg-surface-gray-3',
+  }[variant]
+}
+
+/**
+ * Trigger base classes. Two variants because Combobox has an inner `<input>`
+ * and needs `focus-within`, while Select / MultiSelect rely on `focus-visible`
+ * on the trigger itself.
+ */
+export const triggerBaseClassesFocusVisible =
+  'relative inline-flex items-center gap-2 text-left text-ink-gray-7 outline-none transition-[background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-visible:ring-2 data-[state=open]:ring-2 ring-outline-gray-3'
+
+export const triggerBaseClassesFocusWithin =
+  'relative inline-flex items-center gap-2 text-left text-ink-gray-7 outline-none transition-[background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-within:ring-2 data-[state=open]:ring-2 ring-outline-gray-3'
+
+export const itemClasses =
+  'select-none rounded border-0 text-base text-ink-gray-9 transition-colors duration-100 ease-out data-[disabled]:text-ink-gray-4 data-[highlighted]:bg-surface-gray-2 data-[state=checked]:bg-surface-gray-3 data-[highlighted]:data-[state=checked]:bg-surface-gray-4'
+
+/**
+ * Case-insensitive substring match against an option's label and value.
+ * Used as the default filter predicate by MultiSelect and Combobox.
+ */
+export function matchesByLabelOrValue(
+  item: { label: string; value: string },
+  query: string,
+) {
+  const normalizedQuery = query.toLowerCase()
+  if (!normalizedQuery) return true
+
+  return (
+    item.label.toLowerCase().includes(normalizedQuery) ||
+    item.value.toLowerCase().includes(normalizedQuery)
+  )
+}
+
+/**
+ * Resolve the deprecated `render` alias into a normalized `slots` object.
+ *
+ * - `render` as a function → maps to `slots.item` (full-row takeover).
+ * - `render` as an object  → merged one-to-one into slots.
+ * - `slots` always wins on key conflict.
+ *
+ * In dev, warns when `slots.item` is mixed with `slots.prefix` / `slots.label`
+ * / `slots.suffix` (mutually exclusive — `slots.item` wins).
+ */
+export function resolveItemSlotsFromRaw<TSlots>(
+  raw: { render?: unknown; slots?: TSlots },
+  componentName: string,
+): TSlots {
+  const legacy = raw.render
+  let legacySlots: TSlots | undefined
+
+  if (typeof legacy === 'function') {
+    legacySlots = {
+      item: () => (legacy as () => unknown)(),
+    } as unknown as TSlots
+  } else if (legacy && typeof legacy === 'object') {
+    legacySlots = legacy as TSlots
+  }
+
+  const resolved: TSlots = {
+    ...(legacySlots ?? ({} as TSlots)),
+    ...(raw.slots ?? ({} as TSlots)),
+  } as TSlots
+
+  if (import.meta.env.DEV) {
+    const r = resolved as Record<string, unknown>
+    if (r.item && (r.prefix || r.label || r.suffix)) {
+      console.warn(
+        `[${componentName}] \`slots.item\` is mutually exclusive with \`slots.prefix\` / \`slots.label\` / \`slots.suffix\`. \`slots.item\` wins.`,
+      )
+    }
+  }
+
+  return resolved
+}


### PR DESCRIPTION
## Summary

Consolidates duplicated code across the Select / MultiSelect / Combobox family into `src/components/shared/selection/`. Each component file still has the same public API and rendered output — this PR is about removing internal duplication, not changing behavior.

## Line counts (production code only, excluding `.cy.ts`)

**Overall production: +595 / -727 = net −132 lines**

The headline number understates the win because the 727 deletions all came out of duplicated logic in the consumer components, while the 595 additions are mostly the *single* shared module that replaced 3–7 copies.

**Consumer files alone (`Select.vue`, `MultiSelect*.vue`, `Combobox*.vue`, and their `utils.ts`):**

| File | Δ lines |
|---|---|
| `Select/Select.vue` | −179 |
| `MultiSelect/MultiSelect.vue` | −107 |
| `Combobox/Combobox.vue` | −107 |
| `MultiSelect/utils.ts` | −86 |
| `Combobox/utils.ts` | −98 |
| `MultiSelect/MultiSelectResults.vue` | −27 |
| `Combobox/ComboboxResults.vue` | −32 |
| **Consumer total** | **+158 / −727 = net −569** |

The new shared modules account for the remaining ~437 lines added, in one place rather than 3–7.

## What's in `shared/selection/`

| File | Purpose |
|---|---|
| `utils.ts` | sizing/variant/match helpers (`triggerSizeClasses`, `inputFontSizeClasses`, `itemRootSizeClasses`, `triggerVariantClasses`, `matchesByLabelOrValue`, `resolveItemSlotsFromRaw`, base class strings) |
| `useEmptyValueMapping.ts` | composable wrapping the `value: ''` → synthetic-internal-id workaround that Reka requires |
| `OptionIcon.vue` | the lucide / emoji / component icon cascade, previously copied at 7 call sites |
| `createItemSlotRender.ts` | factory for the parent-supplied slot-fn render wrapper (stable component identity across renders) |
| `useFilteredGroups.ts` | the "filter groups by predicate, drop empty groups, but only when the user has typed" pattern |
| `popoverMotion.css` | the open/close keyframes and `data-motion`-driven animation rules |

## Commits (each is independent and reversible)

1. `79b192a1` extract shared utils for MultiSelect and Combobox
2. `8839de2c` pull Select onto the shared utils
3. `f74183ee` consolidate empty-value mapping into a composable
4. `6a35531c` extract OptionIcon shared component
5. `ab4285c8` share ItemSlotRender factory and useFilteredGroups
6. `1b62478c` share popover motion keyframes via stylesheet
7. `fd98d99a` fix: skip empty item-prefix container when no icon or slot (+ regression tests)

## What's intentionally NOT shared

- **Dropdown** — its icon rendering has extra branches (FeatherIcon, placeholder div) and uses per-item size/color; its motion is shorter, scale-only without translateY, with different easing. Different specs, not duplication.
- **`triggerBaseClasses` focus rule** — exported as two named variants (`triggerBaseClassesFocusVisible` for Select/MultiSelect, `triggerBaseClassesFocusWithin` for Combobox). Combobox needs `focus-within` because its trigger contains an inner `<input>`.
- **Select-specific `triggerVariantClasses` and `triggerBaseClasses`** — Select drives disabled-text via `data-[disabled]:` on the base class instead of in the variant string, and its ghost variant uses `focus:` (not `focus-within:`) because the Select trigger has no focusable descendants. Documented inline in `Select/utils.ts`.
- **transform-origin** — per-component because Select uses `--reka-select-content-transform-origin` (set via Tailwind class on the element) while MultiSelect/Combobox use `--reka-combobox-content-transform-origin` (set via scoped CSS).
- **Combobox chevron reduced-motion rule** — only Combobox has a chevron.

## Bug fix included (last commit)

`Select.vue` rendered an empty `item-prefix` container for every option that had neither an `#item-prefix` slot nor an `option.icon`, producing a stray left gap from the row's `flex gap-2`. Cause: `ItemListRow` filters its prefix slot through `hasRenderableContent`, which treats any component vnode as renderable — so a fallback `<OptionIcon>` left in the slot tree was enough to keep the container even when OptionIcon itself rendered nothing internally. Fixed by switching to a `v-if / v-else-if` chain so neither vnode is emitted when both conditions fail. `MultiSelectResults` and `ComboboxResults` already had this pattern; added matching regression tests in all three spec files (~147 lines of test additions, not counted in the production figures above).

## Test plan

- [ ] `yarn type-check` (vue-tsc — not available in the dev sandbox where this was authored)
- [ ] `yarn test` (vitest) — passes locally (29/29) after each commit
- [ ] `yarn test:cypress` — verify the three new `item-prefix container` describes pass
- [ ] Visually QA Select / MultiSelect / Combobox in the docs site: trigger, options, with/without icon, with/without consumer slots, open/close animation, keyboard open (instant fade), `prefers-reduced-motion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 39.09% (1492/3816) | +0.23%      |
| Statements | 34.11% (1548/4537) | +0.22%      |
| Functions  | 34.20% (288/842) | +0.91%      |
| Branches   | 22.94% (394/1717) | +0.04%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->

