### PR TITLE
chore(ci): add barista issue-triage workflow

### DIFF
--- a/.claude/commands/barista-triage.md
+++ b/.claude/commands/barista-triage.md
@@ -9,7 +9,7 @@ Inputs from the workflow:
 
 - `REPO`: `${{ github.repository }}`
 - `ISSUE_NUMBER`: `${{ github.event.issue.number }}`
-- `EVENT`: one of `issues` (new issue), `issue_comment` (a maintainer mentioned `@barista`), or `workflow_dispatch` (manual re-triage).
+- `EVENT`: one of `issues` (new issue), `issue_comment` (a maintainer ran a `/barista` command), or `workflow_dispatch` (manual re-triage).
 - `$BARISTA_COMMENT_BODY` and `$BARISTA_COMMENT_AUTHOR` are set when EVENT=issue_comment.
 
 # Tools you can run
@@ -30,7 +30,7 @@ Nothing else is permitted. Do not attempt edits, pushes, or any other gh subcomm
 2. **Read the issue.** Run `./.github/barista/scripts/gh.sh issue view <ISSUE_NUMBER> --comments`.
 3. **Branch on EVENT:**
    - `issues` → first-time triage. Continue to step 4.
-   - `issue_comment` → re-triage prompted by a maintainer. The comment body is in `$BARISTA_COMMENT_BODY`; treat any directives there (e.g. "this is a bug, not a question", "remove the invalid label", "look again") as authoritative. Continue to step 4 with that context.
+   - `issue_comment` → re-triage prompted by a maintainer. The comment body is in `$BARISTA_COMMENT_BODY` and starts with (or contains) `/barista …`. Treat any directives in that comment (e.g. "/barista retriage", "/barista label bug", "/barista this is a question") as authoritative. Continue to step 4 with that context.
    - `workflow_dispatch` → manual re-triage; behave like `issues` but you may overwrite your own prior labels if you now disagree with them.
 4. **Decide labels.** See the rubric below.
 5. **Apply labels.** One call to `edit-issue-labels.sh` with all desired `--add-label`/`--remove-label` flags.
@@ -75,7 +75,7 @@ Post a comment **only** in these cases:
 
 1. EVENT=`issues` and you applied `needs-repro` or `needs-info` — ask politely for the missing info. Keep it short (2–4 sentences). Mention which fields are missing.
 2. EVENT=`issues` and you applied `duplicate` — link the original issue with `#NNN` and explain in one sentence.
-3. EVENT=`issue_comment` — always acknowledge the maintainer's directive with a one-line summary of what you changed (e.g. "Relabeled as `bug` and removed `question`, per @${BARISTA_COMMENT_AUTHOR}.").
+3. EVENT=`issue_comment` — always acknowledge the maintainer's directive with a one-line summary of what you changed (e.g. "Relabeled as `bug` and removed `question`, per @$BARISTA_COMMENT_AUTHOR.").
 
 Do **not** comment when:
 

--- a/.claude/commands/barista-triage.md
+++ b/.claude/commands/barista-triage.md
@@ -1,0 +1,104 @@
+---
+allowed-tools: Bash(./.github/barista/scripts/gh.sh:*),Bash(./.github/barista/scripts/edit-issue-labels.sh:*),Bash(./.github/barista/scripts/add-comment.sh:*)
+description: Triage a frappe-ui issue — apply labels and (optionally) post one comment.
+---
+
+You are **barista**, the issue-triage assistant for the `frappe/frappe-ui` repository. frappe-ui is a Vue 3 component library used by Frappe-based apps.
+
+Inputs from the workflow:
+
+- `REPO`: `${{ github.repository }}`
+- `ISSUE_NUMBER`: `${{ github.event.issue.number }}`
+- `EVENT`: one of `issues` (new issue), `issue_comment` (a maintainer mentioned `@barista`), or `workflow_dispatch` (manual re-triage).
+- `$BARISTA_COMMENT_BODY` and `$BARISTA_COMMENT_AUTHOR` are set when EVENT=issue_comment.
+
+# Tools you can run
+
+- `./.github/barista/scripts/gh.sh label list` — list available labels (read-only)
+- `./.github/barista/scripts/gh.sh issue view <N>` — read issue title/body/labels
+- `./.github/barista/scripts/gh.sh issue view <N> --comments` — include comments
+- `./.github/barista/scripts/gh.sh search issues "<query>" --limit 10` — find similar issues (no `repo:`/`org:` qualifiers — already scoped)
+- `./.github/barista/scripts/edit-issue-labels.sh --add-label X --add-label Y` — apply labels
+- `./.github/barista/scripts/edit-issue-labels.sh --remove-label X` — remove labels
+- `./.github/barista/scripts/add-comment.sh "body"` — post **one** comment (use `--file path.md` for multi-line)
+
+Nothing else is permitted. Do not attempt edits, pushes, or any other gh subcommand.
+
+# Workflow
+
+1. **List labels.** Run `./.github/barista/scripts/gh.sh label list` once.
+2. **Read the issue.** Run `./.github/barista/scripts/gh.sh issue view <ISSUE_NUMBER> --comments`.
+3. **Branch on EVENT:**
+   - `issues` → first-time triage. Continue to step 4.
+   - `issue_comment` → re-triage prompted by a maintainer. The comment body is in `$BARISTA_COMMENT_BODY`; treat any directives there (e.g. "this is a bug, not a question", "remove the invalid label", "look again") as authoritative. Continue to step 4 with that context.
+   - `workflow_dispatch` → manual re-triage; behave like `issues` but you may overwrite your own prior labels if you now disagree with them.
+4. **Decide labels.** See the rubric below.
+5. **Apply labels.** One call to `edit-issue-labels.sh` with all desired `--add-label`/`--remove-label` flags.
+6. **Decide whether to comment.** See the comment rubric. If commenting, one call to `add-comment.sh`.
+7. **Stop.** Do not loop, re-read, or post more than one comment.
+
+# Label rubric
+
+## Content labels (pick at most ONE primary):
+
+- `bug` — something is broken. Use only if the issue describes observed-vs-expected behavior of an existing component/utility.
+- `enhancement` — feature request or improvement to existing behavior.
+- `documentation` — about docs site, examples, or API reference.
+- `question` — user is asking how to use something; nothing seems broken.
+- `invalid` — spam, not actionable, not about frappe-ui, or clearly wrong premise.
+- `duplicate` — only if `search issues` surfaces an **open** issue that is clearly the same. Reference the duplicate's number in your comment.
+
+`bug` and `enhancement` are mutually exclusive. `invalid` excludes all other content labels.
+
+## Area labels (add when clearly applicable, max 2):
+
+- `ui` — visual/styling/component-rendering issues.
+- `editor` — anything about the rich-text editor component.
+- `javascript` — JS/TS API surface (composables, resources, utilities) rather than visual.
+- `dependencies` — about a dependency upgrade or compatibility.
+
+## Status labels:
+
+- `needs-repro` — looks like a bug but no reproduction is included (no minimal example, no StackBlitz, no steps).
+- `needs-info` — too vague to act on; missing key context (component name, version, what was expected).
+- `triaged` — **always add this** at the end. Lets maintainers filter `is:open -label:triaged` for the human queue.
+
+## Caps and overrides:
+
+- Maximum 3 content/area labels in total, plus status labels. Prefer fewer.
+- **Human override is sacred.** If the issue already has labels you did not place, do not remove them. Only add complementary labels or `triaged`.
+- If you are not confident about a label, omit it. Better to under-label than mis-label.
+
+# Comment rubric
+
+Post a comment **only** in these cases:
+
+1. EVENT=`issues` and you applied `needs-repro` or `needs-info` — ask politely for the missing info. Keep it short (2–4 sentences). Mention which fields are missing.
+2. EVENT=`issues` and you applied `duplicate` — link the original issue with `#NNN` and explain in one sentence.
+3. EVENT=`issue_comment` — always acknowledge the maintainer's directive with a one-line summary of what you changed (e.g. "Relabeled as `bug` and removed `question`, per @${BARISTA_COMMENT_AUTHOR}.").
+
+Do **not** comment when:
+
+- You only applied content/area labels successfully on a well-formed issue. Quiet success is the default.
+- The issue already has a barista comment (avoid duplicate prompts; check the comments thread).
+- EVENT=`workflow_dispatch` unless you changed something material.
+
+Tone: friendly, concise, never preachy. Start with a greeting (e.g. "Thanks for filing this!") only for new-issue comments. No emoji. Sign off with `— barista 🤖` is forbidden; the bot identity is shown by the GitHub App actor.
+
+# Example output for needs-repro
+
+```
+Thanks for filing this! It looks like a bug, but I couldn't find a minimal reproduction.
+
+Could you share:
+- The frappe-ui version (from `package.json`)
+- The component involved (e.g. `Button`, `Dialog`)
+- A short repro — a StackBlitz link or a minimal code snippet — and what you expected vs. what happened?
+```
+
+# Constraints
+
+- Run each tool only when needed. Do not list labels twice. Do not re-read the issue after labeling.
+- If `gh.sh search issues` returns nothing in a single query, do not retry with variations more than once.
+- Never apply a label that does not appear in the output of `gh.sh label list`.
+- Stop after at most: 1 label-list, 1-2 issue-view, 0-2 search calls, 1 edit-labels call, 0-1 comment call.

--- a/.github/barista/SETUP.md
+++ b/.github/barista/SETUP.md
@@ -9,7 +9,7 @@ It posts as **`barista[bot]`** (a custom GitHub App), and bills Claude API calls
 | Trigger | Action |
 | --- | --- |
 | `issues.opened` | Read issue → choose labels → apply them → maybe comment if info is missing |
-| `issue_comment.created` (only if comment contains `@barista` AND author is a maintainer) | Re-triage based on the maintainer's directive |
+| `issue_comment.created` (only if comment contains `/barista` AND author is a maintainer) | Re-triage based on the maintainer's directive |
 | `workflow_dispatch` (manual) | Re-triage a specific issue number for debugging |
 
 ## One-time setup
@@ -82,7 +82,7 @@ The `BARISTA_ENABLED` variable is the kill switch. Set it to anything other than
 ## How maintainers interact with it
 
 - **Disagree with a label?** Just change it. Barista treats human labels as sacred and won't re-apply its choice.
-- **Want it to look again?** Comment `@barista please retriage` (or anything containing `@barista`) on the issue.
+- **Want it to look again?** Comment `/barista retriage` (or anything containing `/barista`) on the issue. Example commands: `/barista retriage`, `/barista label bug`, `/barista this is a question not a bug`.
 - **Want to silence it on one issue?** Add the `triaged` label manually before opening — barista will still run on `issues.opened` but will respect existing labels.
 - **Want to silence it globally?** Set `BARISTA_ENABLED` variable to `false`.
 
@@ -111,4 +111,4 @@ The sandbox scripts intentionally restrict what Claude can do. Even if the promp
 
 ## Phase 2 (not implemented yet)
 
-Auto-opening PRs for narrow issue classes (typos, doc fixes). The current GitHub App already has `pull-requests: write`, so the only missing piece is a separate workflow gated on a maintainer command like `@barista open a PR`. Keep that out of phase 1 until barista's labeling accuracy is proven.
+Auto-opening PRs for narrow issue classes (typos, doc fixes). The current GitHub App already has `pull-requests: write`, so the only missing piece is a separate workflow gated on a maintainer command like `/barista open a PR`. Keep that out of phase 1 until barista's labeling accuracy is proven.

--- a/.github/barista/SETUP.md
+++ b/.github/barista/SETUP.md
@@ -1,0 +1,114 @@
+# Barista — Issue Triage Bot Setup
+
+Barista is a GitHub Actions workflow that uses Claude (via the official `anthropics/claude-code-action`) to triage incoming issues on `frappe/frappe-ui`. It applies labels, occasionally asks the reporter for missing info, and never overrides human-set labels.
+
+It posts as **`barista[bot]`** (a custom GitHub App), and bills Claude API calls against a maintainer's Claude Max subscription.
+
+## What gets created on each trigger
+
+| Trigger | Action |
+| --- | --- |
+| `issues.opened` | Read issue → choose labels → apply them → maybe comment if info is missing |
+| `issue_comment.created` (only if comment contains `@barista` AND author is a maintainer) | Re-triage based on the maintainer's directive |
+| `workflow_dispatch` (manual) | Re-triage a specific issue number for debugging |
+
+## One-time setup
+
+### 1. Create the `barista` GitHub App
+
+1. Go to **<https://github.com/organizations/frappe/settings/apps/new>** (must be a frappe org admin).
+2. Fill in:
+   - **Name:** `barista`
+   - **Homepage URL:** `https://github.com/frappe/frappe-ui`
+   - **Webhook:** **uncheck** "Active" (we don't need webhooks; the workflow handles events).
+3. **Permissions (Repository):**
+   - Issues: **Read & write**
+   - Pull requests: **Read & write** (reserved for phase 2; safe to grant now)
+   - Contents: **Read-only**
+   - Metadata: **Read-only** (auto-selected)
+4. **Where can this app be installed?** Only on this account.
+5. Click **Create**.
+6. On the app page:
+   - Note the **App ID** (top of the page).
+   - **Generate a private key** (bottom) — downloads a `.pem` file. Keep it safe; you'll paste its contents into a secret.
+   - Upload an avatar if you like (this is what shows next to the bot's name on issues).
+7. Click **Install App** in the left sidebar → install on **frappe/frappe-ui** (or all frappe-ui-related repos).
+
+### 2. Add labels barista uses
+
+Barista already uses your existing labels (`bug`, `enhancement`, `documentation`, `question`, `invalid`, `duplicate`, `ui`, `editor`, `javascript`, `dependencies`). It also expects three new labels — create them once:
+
+```sh
+gh label create needs-repro --description "Bug report missing a minimal reproduction" --color FBCA04 --repo frappe/frappe-ui
+gh label create needs-info  --description "Needs more context to be actionable"        --color FBCA04 --repo frappe/frappe-ui
+gh label create triaged     --description "Seen by barista"                            --color C2E0C6 --repo frappe/frappe-ui
+```
+
+### 3. Mint a Claude Max OAuth token
+
+On a machine where you're logged into Claude with the Max subscription you want billed:
+
+```sh
+claude setup-token
+```
+
+Copy the printed token.
+
+### 4. Add repository secrets and variables
+
+In **<https://github.com/frappe/frappe-ui/settings/secrets/actions>**, add:
+
+| Type | Name | Value |
+| --- | --- | --- |
+| Secret | `BARISTA_APP_ID` | The numeric App ID from step 1.6 |
+| Secret | `BARISTA_PRIVATE_KEY` | **Full contents** of the `.pem` file, including the `-----BEGIN…-----` and `-----END…-----` lines |
+| Secret | `CLAUDE_CODE_OAUTH_TOKEN` | The token from `claude setup-token` |
+
+In **Settings → Secrets and variables → Actions → Variables**, add:
+
+| Type | Name | Value |
+| --- | --- | --- |
+| Variable | `BARISTA_ENABLED` | `true` |
+
+The `BARISTA_ENABLED` variable is the kill switch. Set it to anything other than `true` (or delete it) to instantly disable barista without redeploying.
+
+### 5. Verify
+
+1. Open a throwaway test issue on the repo titled e.g. "Test: barista triage" with a clear bug description.
+2. Within ~60 seconds you should see `barista[bot]` apply labels (and possibly comment).
+3. If nothing happens, check **Actions → Barista — Issue Triage** for run logs.
+4. To re-run on an existing issue manually: **Actions → Barista — Issue Triage → Run workflow → enter issue number**.
+
+## How maintainers interact with it
+
+- **Disagree with a label?** Just change it. Barista treats human labels as sacred and won't re-apply its choice.
+- **Want it to look again?** Comment `@barista please retriage` (or anything containing `@barista`) on the issue.
+- **Want to silence it on one issue?** Add the `triaged` label manually before opening — barista will still run on `issues.opened` but will respect existing labels.
+- **Want to silence it globally?** Set `BARISTA_ENABLED` variable to `false`.
+
+## Files in this setup
+
+```
+.github/
+  workflows/barista-triage.yml         # workflow definition
+  barista/
+    SETUP.md                            # this file
+    scripts/
+      gh.sh                             # read-only gh wrapper (sandbox)
+      edit-issue-labels.sh              # write-only label editor (sandbox)
+      add-comment.sh                    # write-only comment poster (sandbox)
+.claude/
+  commands/barista-triage.md            # the prompt + allowed-tools manifest
+```
+
+The sandbox scripts intentionally restrict what Claude can do. Even if the prompt is jailbroken, Claude can only call subcommands and flags these scripts allow.
+
+## Cost & rate limits
+
+- Each triage run = one Claude conversation (typically a few tool calls, ~10–30 seconds of model time).
+- Billed to the Max subscription tied to `CLAUDE_CODE_OAUTH_TOKEN`. Max's 5-hour rolling rate limit is far above expected issue volume on this repo.
+- If you switch off Max (or want to bill the org), regenerate against an Anthropic API key: replace `claude_code_oauth_token` with `anthropic_api_key` in the workflow and set `ANTHROPIC_API_KEY` instead.
+
+## Phase 2 (not implemented yet)
+
+Auto-opening PRs for narrow issue classes (typos, doc fixes). The current GitHub App already has `pull-requests: write`, so the only missing piece is a separate workflow gated on a maintainer command like `@barista open a PR`. Keep that out of phase 1 until barista's labeling accuracy is proven.

--- a/.github/barista/scripts/add-comment.sh
+++ b/.github/barista/scripts/add-comment.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Posts a single comment on the current issue. Issue number is sourced from
+# $BARISTA_ISSUE with a fallback to the event payload.
+#
+# Usage:
+#   ./add-comment.sh "Body text, multi-line OK"
+#   ./add-comment.sh --file body.md
+
+set -euo pipefail
+
+ISSUE="${BARISTA_ISSUE:-}"
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  ISSUE=$(jq -r '.issue.number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
+fi
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "Error: no issue number resolved" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "--file" ]]; then
+  FILE="${2:?--file requires a path}"
+  if [[ ! -f "$FILE" ]]; then
+    echo "Error: file not found: $FILE" >&2
+    exit 1
+  fi
+  gh issue comment "$ISSUE" --body-file "$FILE"
+else
+  BODY="${1:?body required}"
+  gh issue comment "$ISSUE" --body "$BODY"
+fi
+
+echo "Commented on #$ISSUE"

--- a/.github/barista/scripts/edit-issue-labels.sh
+++ b/.github/barista/scripts/edit-issue-labels.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Adds/removes labels on an issue. Issue number is sourced from
+# $BARISTA_ISSUE (set by the workflow) with a fallback to the event payload
+# so this also works under workflow_dispatch where the payload lacks .issue.
+#
+# Usage:
+#   ./edit-issue-labels.sh --add-label bug --add-label needs-repro
+#   ./edit-issue-labels.sh --remove-label invalid
+
+set -euo pipefail
+
+ISSUE="${BARISTA_ISSUE:-}"
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  ISSUE=$(jq -r '.issue.number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
+fi
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "Error: no issue number resolved (set BARISTA_ISSUE or use an event with .issue)" >&2
+  exit 1
+fi
+
+ADD_LABELS=()
+REMOVE_LABELS=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --add-label)
+      ADD_LABELS+=("$2")
+      shift 2
+      ;;
+    --remove-label)
+      REMOVE_LABELS+=("$2")
+      shift 2
+      ;;
+    *)
+      echo "Error: unknown argument (only --add-label and --remove-label are accepted)" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then
+  echo "Error: no labels supplied" >&2
+  exit 1
+fi
+
+VALID_LABELS=$(gh label list --limit 500 --json name --jq '.[].name')
+
+FILTERED_ADD=()
+for label in "${ADD_LABELS[@]}"; do
+  if echo "$VALID_LABELS" | grep -qxF "$label"; then
+    FILTERED_ADD+=("$label")
+  else
+    echo "Skipping unknown label (does not exist in repo): $label" >&2
+  fi
+done
+
+FILTERED_REMOVE=()
+for label in "${REMOVE_LABELS[@]}"; do
+  if echo "$VALID_LABELS" | grep -qxF "$label"; then
+    FILTERED_REMOVE+=("$label")
+  fi
+done
+
+if [[ ${#FILTERED_ADD[@]} -eq 0 && ${#FILTERED_REMOVE[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+GH_ARGS=("issue" "edit" "$ISSUE")
+for label in "${FILTERED_ADD[@]}"; do
+  GH_ARGS+=("--add-label" "$label")
+done
+for label in "${FILTERED_REMOVE[@]}"; do
+  GH_ARGS+=("--remove-label" "$label")
+done
+
+gh "${GH_ARGS[@]}"
+
+[[ ${#FILTERED_ADD[@]} -gt 0 ]] && echo "Added: ${FILTERED_ADD[*]}"
+[[ ${#FILTERED_REMOVE[@]} -gt 0 ]] && echo "Removed: ${FILTERED_REMOVE[*]}"
+exit 0

--- a/.github/barista/scripts/gh.sh
+++ b/.github/barista/scripts/gh.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Read-only `gh` wrapper. Restricts subcommands and flags so the agent
+# cannot mutate state via this script. Write operations live in
+# sibling scripts (edit-issue-labels.sh, add-comment.sh) with their own
+# allowlists.
+#
+# Usage:
+#   ./gh.sh issue view 123
+#   ./gh.sh issue view 123 --comments
+#   ./gh.sh issue list --state open --limit 20
+#   ./gh.sh search issues "query" --limit 10
+#   ./gh.sh label list --limit 100
+
+set -euo pipefail
+
+export GH_HOST=github.com
+
+REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+if [[ -z "$REPO" || "$REPO" == */*/* || "$REPO" != */* ]]; then
+  echo "Error: GH_REPO or GITHUB_REPOSITORY must be set to owner/repo format" >&2
+  exit 1
+fi
+export GH_REPO="$REPO"
+
+ALLOWED_FLAGS=(--comments --state --limit --label)
+FLAGS_WITH_VALUES=(--state --limit --label)
+
+SUB1="${1:-}"
+SUB2="${2:-}"
+CMD="$SUB1 $SUB2"
+case "$CMD" in
+  "issue view"|"issue list"|"search issues"|"label list")
+    ;;
+  *)
+    echo "Error: only 'issue view', 'issue list', 'search issues', 'label list' are allowed" >&2
+    exit 1
+    ;;
+esac
+
+shift 2
+
+POSITIONAL=()
+FLAGS=()
+skip_next=false
+for arg in "$@"; do
+  if [[ "$skip_next" == true ]]; then
+    FLAGS+=("$arg")
+    skip_next=false
+  elif [[ "$arg" == -* ]]; then
+    flag="${arg%%=*}"
+    matched=false
+    for allowed in "${ALLOWED_FLAGS[@]}"; do
+      if [[ "$flag" == "$allowed" ]]; then
+        matched=true
+        break
+      fi
+    done
+    if [[ "$matched" == false ]]; then
+      echo "Error: only --comments, --state, --limit, --label flags are allowed" >&2
+      exit 1
+    fi
+    FLAGS+=("$arg")
+    if [[ "$arg" != *=* ]]; then
+      for vflag in "${FLAGS_WITH_VALUES[@]}"; do
+        if [[ "$flag" == "$vflag" ]]; then
+          skip_next=true
+          break
+        fi
+      done
+    fi
+  else
+    POSITIONAL+=("$arg")
+  fi
+done
+
+if [[ "$CMD" == "search issues" ]]; then
+  QUERY="${POSITIONAL[0]:-}"
+  QUERY_LOWER=$(echo "$QUERY" | tr '[:upper:]' '[:lower:]')
+  if [[ "$QUERY_LOWER" == *"repo:"* || "$QUERY_LOWER" == *"org:"* || "$QUERY_LOWER" == *"user:"* ]]; then
+    echo "Error: search query must not contain repo:, org:, or user: qualifiers" >&2
+    exit 1
+  fi
+  gh "$SUB1" "$SUB2" "$QUERY" --repo "$REPO" "${FLAGS[@]}"
+elif [[ "$CMD" == "issue view" ]]; then
+  if [[ ${#POSITIONAL[@]} -ne 1 ]] || ! [[ "${POSITIONAL[0]}" =~ ^[0-9]+$ ]]; then
+    echo "Error: issue view requires exactly one numeric issue number" >&2
+    exit 1
+  fi
+  gh "$SUB1" "$SUB2" "${POSITIONAL[0]}" "${FLAGS[@]}"
+else
+  if [[ ${#POSITIONAL[@]} -ne 0 ]]; then
+    echo "Error: this subcommand does not accept positional arguments" >&2
+    exit 1
+  fi
+  gh "$SUB1" "$SUB2" "${FLAGS[@]}"
+fi

--- a/.github/workflows/barista-triage.yml
+++ b/.github/workflows/barista-triage.yml
@@ -1,0 +1,83 @@
+name: Barista — Issue Triage
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to (re)triage
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: barista-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    # Kill switch: set repo variable BARISTA_ENABLED=true to enable.
+    # Comment-trigger gating: only run on @barista mentions from maintainers, on issues (not PRs).
+    if: >-
+      vars.BARISTA_ENABLED == 'true' && (
+        github.event_name == 'issues' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          !github.event.issue.pull_request &&
+          contains(github.event.comment.body, '@barista') &&
+          (
+            github.event.comment.author_association == 'OWNER' ||
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'COLLABORATOR'
+          )
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Mint barista app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BARISTA_APP_ID }}
+          private-key: ${{ secrets.BARISTA_PRIVATE_KEY }}
+
+      - name: Resolve issue number
+        id: issue
+        run: |
+          case "${{ github.event_name }}" in
+            issues|issue_comment)
+              echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+              ;;
+            workflow_dispatch)
+              echo "number=${{ inputs.issue_number }}" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Run Barista
+        uses: anthropics/claude-code-action@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          BARISTA_ISSUE: ${{ steps.issue.outputs.number }}
+          BARISTA_EVENT: ${{ github.event_name }}
+          BARISTA_COMMENT_BODY: ${{ github.event.comment.body }}
+          BARISTA_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          allowed_non_write_users: "*"
+          prompt: "/barista-triage REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ steps.issue.outputs.number }} EVENT: ${{ github.event_name }}"

--- a/.github/workflows/barista-triage.yml
+++ b/.github/workflows/barista-triage.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   triage:
     # Kill switch: set repo variable BARISTA_ENABLED=true to enable.
-    # Comment-trigger gating: only run on @barista mentions from maintainers, on issues (not PRs).
+    # Comment-trigger gating: only run on /barista commands from maintainers, on issues (not PRs).
     if: >-
       vars.BARISTA_ENABLED == 'true' && (
         github.event_name == 'issues' ||
@@ -31,7 +31,7 @@ jobs:
         (
           github.event_name == 'issue_comment' &&
           !github.event.issue.pull_request &&
-          contains(github.event.comment.body, '@barista') &&
+          contains(github.event.comment.body, '/barista') &&
           (
             github.event.comment.author_association == 'OWNER' ||
             github.event.comment.author_association == 'MEMBER' ||


### PR DESCRIPTION
Adds a Claude-powered triage bot ("barista") that runs on issues.opened, mentions from maintainers, and workflow_dispatch. Posts as a custom GitHub App; bills the Anthropic call against a Max OAuth token.

Sandbox: Claude can only call three allow-listed scripts (read-only gh wrapper, label editor, single-comment poster). Kill switch via the BARISTA_ENABLED repo variable. See .github/barista/SETUP.md for the one-time install steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated issue triage bot that labels and processes issues when created or when triggered via mention
  * Maintainers can control triage behavior through repository label changes and direct bot mentions
  * Added repository kill switch configuration to enable or disable the triage system

* **Documentation**
  * Setup and configuration guides added for the issue triage system

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/frappe-ui/pull/646)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 38.86% (1480/3808) | ±0.00%      |
| Statements | 33.89% (1536/4531) | ±0.00%      |
| Functions  | 33.29% (277/832) | ±0.00%      |
| Branches   | 22.90% (396/1729) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->

