### PR TITLE
feat(ci): append model/token/cost footer to barista's comment

### DIFF
--- a/.github/barista/scripts/append-stats.sh
+++ b/.github/barista/scripts/append-stats.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Reads the claude-code-action execution file and appends a one-line
+# stats footer to barista's most recent comment on the issue.
+#
+# Expected env:
+#   EXECUTION_FILE  — path to action's JSON output
+#   ISSUE_NUMBER    — issue we're triaging
+#   REPO            — owner/repo
+#   GH_TOKEN        — barista app token (must be able to PATCH the bot's own comment)
+#
+# Idempotent: re-running won't double-append because we check for the
+# <!-- barista-stats --> marker and replace it.
+
+set -euo pipefail
+
+: "${EXECUTION_FILE:?EXECUTION_FILE not set}"
+: "${ISSUE_NUMBER:?ISSUE_NUMBER not set}"
+: "${REPO:?REPO not set}"
+
+if [[ ! -f "$EXECUTION_FILE" ]]; then
+  echo "No execution file at $EXECUTION_FILE — skipping stats footer." >&2
+  exit 0
+fi
+
+# Sum usage across all turns + grab final-turn totals defensively.
+INPUT_TOKENS=$(jq '[.. | objects | .usage? | .input_tokens? // 0] | add' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+OUTPUT_TOKENS=$(jq '[.. | objects | .usage? | .output_tokens? // 0] | add' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+CACHE_READ=$(jq '[.. | objects | .usage? | .cache_read_input_tokens? // 0] | add' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+CACHE_CREATE=$(jq '[.. | objects | .usage? | .cache_creation_input_tokens? // 0] | add' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+
+# Final-turn-style totals (action's result turn)
+TOTAL_COST=$(jq 'first(.. | objects | (.total_cost_usd? // empty))' "$EXECUTION_FILE" 2>/dev/null || echo null)
+DURATION_MS=$(jq 'first(.. | objects | (.duration_ms? // empty))' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+
+MODEL=$(jq -r 'first(.. | objects | (.model? // empty)) // "claude"' "$EXECUTION_FILE" 2>/dev/null || echo claude)
+
+# Format duration
+if [[ "$DURATION_MS" =~ ^[0-9]+$ ]] && (( DURATION_MS > 0 )); then
+  DURATION_S=$(( DURATION_MS / 1000 ))
+  DURATION_FMT="${DURATION_S}s"
+else
+  DURATION_FMT="?"
+fi
+
+# Format cost
+if [[ "$TOTAL_COST" != "null" && -n "$TOTAL_COST" ]]; then
+  COST_FMT=$(printf '$%.3f' "$TOTAL_COST" 2>/dev/null || echo "?")
+else
+  COST_FMT="—"
+fi
+
+# Find barista's most recent comment on this issue
+COMMENT_ID=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
+  --jq '[.[] | select(.user.type == "Bot" and (.user.login | startswith("barista")))] | sort_by(.created_at) | last | .id // empty')
+
+if [[ -z "$COMMENT_ID" ]]; then
+  echo "No barista comment found on #$ISSUE_NUMBER — nothing to append stats to."
+  exit 0
+fi
+
+CURRENT_BODY=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq '.body')
+
+# Strip any pre-existing barista stats footer so re-runs replace rather than stack.
+STRIPPED=$(printf '%s' "$CURRENT_BODY" | awk '
+  /<!-- barista-stats -->/ { found=1 }
+  !found { print }
+')
+
+# Trim trailing whitespace
+STRIPPED=$(printf '%s' "$STRIPPED" | sed -e 's/[[:space:]]*$//')
+
+FOOTER=$(cat <<EOF
+
+<!-- barista-stats -->
+<sub><i>barista · ${MODEL} · ${INPUT_TOKENS} in / ${OUTPUT_TOKENS} out · ${CACHE_READ} cached · ${DURATION_FMT} · ${COST_FMT}</i></sub>
+EOF
+)
+
+NEW_BODY="${STRIPPED}
+${FOOTER}"
+
+# PATCH the comment via JSON input on stdin (handles newlines / special chars safely)
+jq -n --arg body "$NEW_BODY" '{body: $body}' \
+  | gh api -X PATCH "repos/$REPO/issues/comments/$COMMENT_ID" --input - > /dev/null
+
+echo "Appended stats footer to comment $COMMENT_ID on #$ISSUE_NUMBER"

--- a/.github/workflows/barista-triage.yml
+++ b/.github/workflows/barista-triage.yml
@@ -68,6 +68,7 @@ jobs:
           esac
 
       - name: Run Barista
+        id: run-barista
         uses: anthropics/claude-code-action@v1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -82,3 +83,12 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           allowed_non_write_users: "*"
           prompt: "/barista-triage REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ steps.issue.outputs.number }} EVENT: ${{ github.event_name }}"
+
+      - name: Append run-stats footer to barista's comment
+        if: always() && steps.run-barista.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          EXECUTION_FILE: ${{ steps.run-barista.outputs.execution_file }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: ./.github/barista/scripts/append-stats.sh


### PR DESCRIPTION
Adds a post-step that reads the claude-code-action execution file, totals input/output/cache tokens, picks up model + duration + cost, and PATCHes barista's most recent comment to append a one-line stats footer. Idempotent (replaces existing footer marked with HTML comment).

Footer format:
  barista · claude-… · 12k in / 1.2k out · 8k cached · 45s · $0.034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Barista bot comments now automatically append execution statistics, including token usage, model information, cost, and execution duration metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/frappe-ui/pull/648)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 38.86% (1480/3808) | ±0.00%      |
| Statements | 33.89% (1536/4531) | ±0.00%      |
| Functions  | 33.29% (277/832) | ±0.00%      |
| Branches   | 22.90% (396/1729) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
