### PR TITLE
chore(ci): swap show_full_output for display_report

### DIFF
--- a/.github/workflows/barista-triage.yml
+++ b/.github/workflows/barista-triage.yml
@@ -82,7 +82,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           allowed_non_write_users: "*"
-          show_full_output: "true"
+          # Renders a human-readable transcript in the Actions run's Step Summary
+          # (formatted markdown). Avoid show_full_output which dumps raw JSON in logs.
+          display_report: "true"
           prompt: "/barista-triage REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ steps.issue.outputs.number }} EVENT: ${{ github.event_name }}"
 
       - name: Append run-stats footer to barista's comment


### PR DESCRIPTION
## Summary
- `show_full_output: "true"` dumps the raw JSON of every Claude turn into the console logs — hard to skim.
- `display_report: "true"` renders the same content as a formatted markdown transcript in the Actions run's **Step Summary** panel instead.

Same information, readable layout, doesn't clutter the job logs.

## Test plan
- [ ] Merge, then dispatch the workflow on a recent issue (Actions → "Barista — Issue Triage" → Run workflow).
- [ ] On the resulting run page, confirm:
  - Job logs no longer contain a giant JSON blob from the `Run Barista` step.
  - The bottom of the run page has a **Summary** section with a readable transcript (tool calls + Claude's text responses).
  - Barista's stats footer still appends correctly to the comment on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to render human-readable transcripts in workflow step summaries, improving visibility and clarity of automated workflow outputs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/frappe-ui/pull/649)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 39.09% (1492/3816) | ±0.00%      |
| Statements | 34.11% (1548/4537) | ±0.00%      |
| Functions  | 34.20% (288/842) | ±0.00%      |
| Branches   | 22.94% (394/1717) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
