### PR TITLE
feat(ci): format tokens in k + tighter barista comments

### DIFF
--- a/.claude/commands/barista-triage.md
+++ b/.claude/commands/barista-triage.md
@@ -119,24 +119,40 @@ Nothing else is permitted.
 
 ## Format & tone:
 
-- Friendly, concise, **investigative**. Lead with what you found, not what you need.
-- Reference specific files with backticks (`src/components/Button.vue:42`) and commits with short SHAs.
-- Be honest about confidence: "Based on a quick read of …" or "I'm not 100% sure, but …" beats false certainty.
-- No emoji. No signature line (the bot identity is the GitHub App actor).
-- Maximum ~8 sentences. If you have more to say, you're over-investing — surface the top 2-3 findings only.
+- **Be short.** Aim for ~4-8 short lines total. If you wouldn't keep reading it on a phone, it's too long.
+- **Use a structured layout, not prose paragraphs.** Default shape:
+  - One opening line stating the finding ("Looks like a CJS/ESM interop bug in `FeatherIcon.vue:3`.").
+  - A bullet list of evidence / candidate fixes.
+  - Optional final line with the ask (e.g. "Can you confirm your Vite version?") only if truly needed.
+- **No filler.** Drop "Thanks for filing!", "Hope this helps!", "Let me know if you need more info." The bot identity is obvious; politeness greetings add bytes without value.
+- Reference files with backticks and `path:line` (`src/components/Button.vue:42`). Commits as short SHAs (`cf227f73`). Issue refs as `#NNN`.
+- Use code fences only for short snippets (≤6 lines). Don't paste long source.
+- Honest confidence markers when warranted: "likely", "probable cause", "couldn't confirm" — but as adjectives, not full sentences.
+- No emoji. No signature line. No closing pleasantry.
 
 # Examples
 
-**Good — hypothesis-style:**
-> I looked into this. `FeatherIcon` lives in `src/components/FeatherIcon.vue` and is re-exported from `src/index.ts`. Installation errors like this usually come from one of: (1) a peer dep mismatch with `lucide-vue-next`, (2) an old version of frappe-ui (please check your `package.json`), or (3) a bundler that doesn't resolve `.vue` imports. The most recent change in this area is `cf227f73` from last week. Could you share your `package.json` and which bundler you're using?
+**Good — terse hypothesis (preferred shape):**
+> Likely a CJS/ESM interop bug in `src/components/FeatherIcon.vue:3`.
+>
+> - `feather-icons` v4 ships only `dist/feather.js` (CJS, no ESM default export).
+> - Vite's pre-bundler usually patches this, but skips transitive deps from libraries.
+> - Fix in lib: `import * as feather from 'feather-icons'` then use `feather.icons`.
+> - Workaround for users: add `feather-icons` to `optimizeDeps.include` in Vite config.
 
-**Good — duplicate found:**
-> This looks like the same issue as #612 (still open) — both involve `MultiSelect` losing focus after a tag is removed. The fix is being tracked there.
+**Good — duplicate found (one-liner):**
+> Likely a duplicate of #612 (open) — same `MultiSelect` focus loss after tag removal.
 
-**Bad — what we want to avoid:**
+**Good — needs more info (only after investigation):**
+> Couldn't reproduce from the description. `useResource` is at `src/data/resources.ts`; nothing obvious matches.
+>
+> - Which call signature did you use?
+> - frappe-ui version + browser?
+
+**Bad — too long, prose-style, full of filler:**
 > Thanks for filing this! Could you share: the version, the component, a repro, and what you expected vs. what happened?
 
-(That comment provides no value over the issue template. Don't ship it unless investigation truly turned up nothing.)
+(Filler greeting, no investigation, prose where bullets would work. Don't ship this.)
 
 **Anti-pattern (real case from #637):** the body said
 > `Uncaught SyntaxError: The requested module '/node_modules/feather-icons/dist/feather.js' does not provide an export named 'default' (at FeatherIcon.vue:3:8)`

--- a/.github/barista/scripts/append-stats.sh
+++ b/.github/barista/scripts/append-stats.sh
@@ -34,6 +34,19 @@ DURATION_MS=$(jq 'first(.. | objects | (.duration_ms? // empty))' "$EXECUTION_FI
 
 MODEL=$(jq -r 'first(.. | objects | (.model? // empty)) // "claude"' "$EXECUTION_FILE" 2>/dev/null || echo claude)
 
+# Format token counts as k (1000s): <1000 → as-is, 1000-9999 → X.Xk, ≥10000 → Xk
+fmt_k() {
+  local n="${1:-0}"
+  [[ "$n" =~ ^[0-9]+$ ]] || { echo "0"; return; }
+  if   (( n < 1000 ));  then echo "$n"
+  elif (( n < 10000 )); then awk -v n="$n" 'BEGIN { printf "%.1fk", n/1000 }'
+  else                       awk -v n="$n" 'BEGIN { printf "%dk", int((n + 500) / 1000) }'
+  fi
+}
+INPUT_FMT=$(fmt_k "$INPUT_TOKENS")
+OUTPUT_FMT=$(fmt_k "$OUTPUT_TOKENS")
+CACHE_READ_FMT=$(fmt_k "$CACHE_READ")
+
 # Format duration
 if [[ "$DURATION_MS" =~ ^[0-9]+$ ]] && (( DURATION_MS > 0 )); then
   DURATION_S=$(( DURATION_MS / 1000 ))
@@ -72,7 +85,7 @@ STRIPPED=$(printf '%s' "$STRIPPED" | sed -e 's/[[:space:]]*$//')
 FOOTER=$(cat <<EOF
 
 <!-- barista-stats -->
-<sub><i>barista · ${MODEL} · ${INPUT_TOKENS} in / ${OUTPUT_TOKENS} out · ${CACHE_READ} cached · ${DURATION_FMT} · ${COST_FMT}</i></sub>
+<sub><i>barista · ${MODEL} · ${INPUT_FMT} in / ${OUTPUT_FMT} out · ${CACHE_READ_FMT} cached · ${DURATION_FMT} · ${COST_FMT}</i></sub>
 EOF
 )
 


### PR DESCRIPTION
## Summary
- **Footer:** token counts render as `12k` / `1.2k` / `145k` instead of raw numbers (cleaner skim, same precision).
- **Prompt:** barista now optimises for short, structured comments. Default shape: a one-line finding, a bullet list of evidence/fixes, and only ask for info if truly needed. No filler greetings / closings.

## Before / after example
**Before (verbose prose):**
> The root cause is in `src/components/FeatherIcon.vue:3`. It uses a default import:
> ```js
> import feather from 'feather-icons'
> ```
> `feather-icons` v4 ships a UMD/CommonJS bundle with no native ESM default export. Vite's pre-bundler normally synthesises a default export for CJS packages, but this step is often skipped for transitive deps coming from an installed library like `frappe-ui`. When Vite serves the raw CJS file, the default import fails with exactly the error shown.
>
> Two possible fixes:
>
> 1. **Change the import in `FeatherIcon.vue`** to a namespace import...

**After (terse, structured):**
> Likely a CJS/ESM interop bug in `src/components/FeatherIcon.vue:3`.
>
> - `feather-icons` v4 ships only `dist/feather.js` (CJS, no ESM default export).
> - Vite's pre-bundler usually patches this, but skips transitive deps from libraries.
> - Fix in lib: `import * as feather from 'feather-icons'` then use `feather.icons`.
> - Workaround for users: add `feather-icons` to `optimizeDeps.include` in Vite config.

## Test plan
- [ ] Merge, then dispatch the workflow on a new test issue.
- [ ] Confirm barista's comment uses the bullet-list shape and no filler greetings.
- [ ] Confirm the stats footer renders token counts in `k` (e.g. `12k in / 1.2k out`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated process documentation with stricter formatting requirements for improved consistency and clarity

* **Improvements**
  * Enhanced token statistics display with compact notation formatting

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/frappe-ui/pull/650)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 39.09% (1492/3816) | ±0.00%      |
| Statements | 34.11% (1548/4537) | ±0.00%      |
| Functions  | 34.20% (288/842) | ±0.00%      |
| Branches   | 22.94% (394/1717) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
