### PR TITLE
fix: add position props for Select component

### DIFF
--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -45,6 +45,7 @@ const props = withDefaults(defineProps<SelectProps>(), {
   size: 'sm',
   variant: 'subtle',
   placeholder: 'Select option',
+  position: 'popper',
   options: () => [],
   emptyText: 'No options',
 })
@@ -246,6 +247,8 @@ defineSlots<SelectSlots>()
       <SelectContent
         data-slot="content"
         data-selection
+        :position="position"
+        :side-offset="4"
         class="z-[100] origin-[var(--reka-select-content-transform-origin)]"
       >
         <div

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -43,6 +43,9 @@ export interface SelectProps {
 
   /** Fallback empty-state copy rendered when no options are available. */
   emptyText?: string
+
+  /** Dropdown positioning `popper` anchors the menu below the trigger. */
+  position?: 'item-aligned' | 'popper'
 }
 
 export interface SelectTriggerSlotProps {


### PR DESCRIPTION
Add position props for the Select component.

### why?

The current popover position by default is item-aligned for select.

https://github.com/user-attachments/assets/ca7937e3-ade6-48db-bb53-53bff46cd09f

The user then has to compulsorily select an option to get to the next step or get out of the select option.

### fix:
The fix is to allow the select component to take a position prop and pass the prop popover value with a default offset of 4  for some spacing between the trigger and the popover.

https://github.com/user-attachments/assets/07446ed1-d979-4646-9348-aab12766d927





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Select component now includes a configurable `position` option to control how the dropdown menu is positioned. Choose between `'item-aligned'` for traditional menu item alignment or `'popper'` for viewport-aware floating positioning. The `'popper'` mode is set as the default, providing improved display behavior and greater flexibility when working with constrained layout scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/frappe-ui/pull/651)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->