### PR TITLE
chore(coderabbit): add changelog check, semgrep rules, linked repos

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,6 +12,13 @@ knowledge_base:
       - "v1-release/changelog.md"
   learnings:
     scope: local
+  linked_repositories:
+    - repository: "frappe/gameplan"
+    - repository: "frappe/crm"
+    - repository: "frappe/lms"
+    - repository: "frappe/builder"
+    - repository: "frappe/drive"
+    - repository: "frappe/insights"
 
 reviews:
   profile: chill
@@ -140,7 +147,38 @@ reviews:
       mode: off
     issue_assessment:
       mode: off
+    custom_checks:
+      - name: changelog
+        mode: error
+        instructions: |
+          The PR description must include a `## Changelog` section.
 
-tools:
-  languagetool:
-    enabled: false
+          The section must contain one of:
+          - A short (one or two sentences) description of the user-facing change,
+            written so it could be pasted into v1-release/changelog.md under the
+            Unreleased heading. Phrase it for consumers of the library, not
+            contributors. Mention the component or API surface affected.
+          - The literal text `None — <reason>` where `<reason>` briefly states
+            why the PR has no user-facing impact (examples: "internal refactor",
+            "test only", "docs only", "build config only").
+
+          Fail the check when:
+          - The `## Changelog` heading is missing entirely.
+          - The section is empty or contains only placeholder text
+            (e.g. "TBD", "TODO", "n/a", the HTML comment from the PR template).
+          - The section says "None" but lacks a reason.
+
+          Pass the check when the section contains either a real consumer-facing
+          entry or an explicit `None — <reason>` declaration.
+
+          Reference v1-release/changelog.md for the existing entry style. The
+          changelog's own guidance says NOT to log internal refactors, tests, or
+          planning/doc maintenance unless they affect consumers — so `None — ...`
+          is the correct choice for those PRs, not a fabricated entry.
+
+  tools:
+    semgrep:
+      enabled: true
+      config_file: ".semgrep.yml"
+    languagetool:
+      enabled: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- One or two sentences describing what this PR changes and why. -->
+
+## Changelog
+
+<!--
+Pick one. The CodeRabbit `changelog` check enforces this section.
+
+If this PR has user-facing impact — a new prop / emit / slot, a removed or
+renamed export, a changed default, a behavior change, a deprecation, an
+accessibility fix that consumers will notice — write a one- or two-sentence
+entry phrased for library consumers. This is the entry that will eventually
+land under "Unreleased" in v1-release/changelog.md.
+
+Example:
+  Slider now emits `value-commit` when the user finishes dragging.
+
+Otherwise, replace this block with one of:
+  None — internal refactor
+  None — test only
+  None — docs only
+  None — build config only
+-->
+
+## Test plan
+
+<!--
+How was this verified? Examples:
+- Manual: opened the FormControl story, toggled X, confirmed Y
+- Cypress: added `Component.cy.ts` covering the new prop
+- Type-check: `pnpm typecheck` clean
+-->

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,57 @@
+rules:
+  - id: no-resources-import-outside-resources
+    message: |
+      Importing from `src/resources/` pulls in legacy resource-layer code.
+      Prefer composables under `src/data-fetching/` for new work. If this
+      import is intentional (e.g. fixing a bug in the legacy layer), ignore
+      this warning.
+    severity: WARNING
+    languages: [ts, js]
+    paths:
+      exclude:
+        - "src/resources/**"
+    pattern-regex: 'from\s+[''"][^''"]*\/resources[\/''"]'
+
+  - id: no-console-log-in-source
+    message: |
+      `console.log` left in source. Use `console.warn` / `console.error` for
+      real diagnostics, or remove before merge. Story and Cypress files are
+      excluded from this rule.
+    severity: WARNING
+    languages: [ts, js]
+    paths:
+      include:
+        - "src/**/*.ts"
+        - "src/**/*.js"
+        - "frappe/**/*.ts"
+        - "frappe/**/*.js"
+      exclude:
+        - "**/*.cy.ts"
+        - "**/*.story.ts"
+        - "**/*.spec.ts"
+        - "**/*.test.ts"
+        - "src/stories/**"
+        - "src/mocks/**"
+    pattern: console.log(...)
+
+  - id: prefer-lucide-over-feather-icon
+    message: |
+      `FeatherIcon` is being migrated out of frappe-ui. New code should use
+      `lucide-*` icon strings via the shared Tailwind plugin (see Rating,
+      Switch, Slider for examples). Existing usages can stay until the
+      migration reaches that component.
+    severity: INFO
+    languages: [generic]
+    paths:
+      include:
+        - "src/**/*.vue"
+        - "src/**/*.ts"
+        - "src/**/*.js"
+        - "frappe/**/*.vue"
+        - "frappe/**/*.ts"
+        - "frappe/**/*.js"
+      exclude:
+        - "src/components/FeatherIcon.vue"
+        - "src/utils/iconString.ts"
+        - "src/index.ts"
+    pattern-regex: 'FeatherIcon'


### PR DESCRIPTION
- Add custom pre-merge check requiring a `## Changelog` section in PR bodies (real entry or explicit `None — <reason>`), aligned with the existing v1-release/changelog.md policy.
- Seed `.github/PULL_REQUEST_TEMPLATE.md` so the convention is discoverable before contributors hit the check.
- Wire semgrep via `.semgrep.yml` with three repo-specific rules: no new src/resources imports (WARNING), no `console.log` in source excluding stories/cy tests (WARNING), and a FeatherIcon migration nudge (INFO).
- Link six consumer apps (gameplan, crm, lms, builder, drive, insights) so reviews can reason about downstream impact.
- Move `languagetool` under `reviews.tools` to match the schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced code review workflow with automated changelog verification for pull requests.
  * Added Semgrep linting rules to enforce code quality standards and guide developers away from deprecated patterns.
  * Integrated knowledge base linking for related repositories.

* **Documentation**
  * Introduced standardized pull request template with clear changelog submission guidelines.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/frappe-ui/pull/653)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 39.09% (1492/3816) | ±0.00%      |
| Statements | 34.11% (1548/4537) | ±0.00%      |
| Functions  | 34.20% (288/842) | ±0.00%      |
| Branches   | 22.94% (394/1717) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
