### PR TITLE
fix: add truncation to last textual item of breadcrumb

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -22,12 +22,12 @@
           class="flex items-center rounded px-0.5 py-1 text-lg font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
           :class="[
             i == crumbs.length - 1
-              ? 'text-ink-gray-9'
+              ? 'min-w-0 text-ink-gray-9'
               : 'text-ink-gray-5 hover:text-ink-gray-7',
           ]"
         >
           <slot name="prefix" :item="item" />
-          <span>
+          <span :class="i == crumbs.length - 1 && 'truncate'">
             {{ item.label }}
           </span>
           <slot name="suffix" :item="item" />
@@ -39,12 +39,12 @@
           class="flex items-center rounded px-0.5 py-1 text-lg font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
           :class="[
             i == crumbs.length - 1
-              ? 'text-ink-gray-9'
+              ? 'min-w-0 text-ink-gray-9'
               : 'text-ink-gray-5 hover:text-ink-gray-7',
           ]"
         >
           <slot name="prefix" :item="item" />
-          <span>
+          <span :class="i == crumbs.length - 1 && 'truncate'">
             {{ item.label }}
           </span>
           <slot name="suffix" :item="item" />
@@ -55,12 +55,12 @@
           class="flex items-center rounded px-0.5 py-1 text-lg font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
           :class="[
             i == crumbs.length - 1
-              ? 'text-ink-gray-9'
+              ? 'min-w-0 text-ink-gray-9'
               : 'text-ink-gray-5 hover:text-ink-gray-7',
           ]"
         >
           <slot name="prefix" :item="item" />
-          <span>
+          <span :class="i == crumbs.length - 1 && 'truncate'">
             {{ item.label }}
           </span>
           <slot name="suffix" :item="item" />

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -27,7 +27,10 @@
           ]"
         >
           <slot name="prefix" :item="item" />
-          <span :class="i == crumbs.length - 1 && 'truncate'">
+          <span
+            :class="i == crumbs.length - 1 && 'min-w-0 truncate'"
+            :title="i == crumbs.length - 1 ? item.label : undefined"
+          >
             {{ item.label }}
           </span>
           <slot name="suffix" :item="item" />
@@ -44,7 +47,10 @@
           ]"
         >
           <slot name="prefix" :item="item" />
-          <span :class="i == crumbs.length - 1 && 'truncate'">
+          <span
+            :class="i == crumbs.length - 1 && 'min-w-0 truncate'"
+            :title="i == crumbs.length - 1 ? item.label : undefined"
+          >
             {{ item.label }}
           </span>
           <slot name="suffix" :item="item" />
@@ -60,7 +66,10 @@
           ]"
         >
           <slot name="prefix" :item="item" />
-          <span :class="i == crumbs.length - 1 && 'truncate'">
+          <span
+            :class="i == crumbs.length - 1 && 'min-w-0 truncate'"
+            :title="i == crumbs.length - 1 ? item.label : undefined"
+          >
             {{ item.label }}
           </span>
           <slot name="suffix" :item="item" />


### PR DESCRIPTION
  
  ## Summary
  The last breadcrumb item now truncates with an ellipsis when its label is wider than the available space, instead of overflowing the container. Currently  

before:
<img width="1218" height="47" alt="image" src="https://github.com/user-attachments/assets/bee1c2ec-c53f-433b-9701-29a02b227e43" />


after:
<img width="1214" height="49" alt="image" src="https://github.com/user-attachments/assets/7cb2d2ff-37cd-417b-9a4b-9d705bd08f5b" />
  
  ## Changelog
  
  `Breadcrumbs` now truncates the label of the last (current page) item with an ellipsis when space is constrained.
  
  ## Test plan  
   Manual: opened a page with a long final breadcrumb label (e.g. Knowledge Base article title) in a narrow container — confirmed the label ellipsizes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation and layout styling for the final breadcrumb item in navigation paths, ensuring better display of long breadcrumb labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/frappe-ui/pull/666)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 41.53% (1658/3992) | ±0.00%      |
| Statements | 36.55% (1734/4743) | ±0.00%      |
| Functions  | 37.52% (334/890) | ±0.00%      |
| Branches   | 26.08% (474/1817) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->

