### PR TITLE
fix(ci): use pull_request_target so Claude review works on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,13 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  # pull_request_target (rather than pull_request) is required so that fork PRs
+  # have access to repository secrets and an OIDC token. The workflow file used
+  # is the one from the base branch, and the default checkout below pulls the
+  # base ref — the PR's code is NEVER checked out or executed here, which is
+  # what keeps this safe. Do not add a `ref: refs/pull/...` to the checkout
+  # step, and do not run install/build scripts from the PR.
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:


### PR DESCRIPTION
## Summary

- The `Claude Code Review` workflow fails on PRs from external forks (e.g. #666) because GitHub's `pull_request` event withholds secrets and the OIDC token from fork-PR runs. The action exits with `Could not fetch an OIDC token...` after 3 retries.
- Switching to `pull_request_target` runs the workflow in the base-repo context, so `secrets.CLAUDE_CODE_OAUTH_TOKEN` and the OIDC token are available.

## Security

`pull_request_target` is the GitHub-recommended pattern for this case, but only safe if the PR's code is never executed:

- The workflow file used is from the **base branch**, not the PR — a malicious fork can't modify the workflow itself.
- The existing `actions/checkout@v4` step has no `ref:`, so it checks out the base ref (default), not the PR head. PR code is never on disk.
- No install or build step runs PR-supplied scripts.

An inline comment was added explaining these constraints so they aren't accidentally broken later.

## Test plan

- [ ] After merge, push a new commit to a fork PR (e.g. #666) and confirm the `claude-review` check runs and succeeds.
- [ ] Confirm the action no longer logs `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 41.53% (1658/3992) | ±0.00%      |
| Statements | 36.55% (1734/4743) | ±0.00%      |
| Functions  | 37.52% (334/890) | ±0.00%      |
| Branches   | 26.12% (475/1818) | +0.04%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
