### PR TITLE
fix(TextInput): set autocomplete=off by default

### DIFF
--- a/src/components/TextInput/TextInput.cy.ts
+++ b/src/components/TextInput/TextInput.cy.ts
@@ -73,6 +73,16 @@ describe('Textinput', () => {
     }
   })
 
+  it('sets autocomplete=off by default and allows override via attrs', () => {
+    cy.mount(TextInput)
+    cy.get('input').should('have.attr', 'autocomplete', 'off')
+
+    cy.mount(TextInput, {
+      attrs: { autocomplete: 'email' },
+    })
+    cy.get('input').should('have.attr', 'autocomplete', 'email')
+  })
+
   it('v-model', () => {
     cy.mount(TextInput, {
       props: {

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -45,6 +45,7 @@
         :aria-errormessage="hasError ? errorMessageId : undefined"
         :aria-describedby="describedBy"
         data-slot="control"
+        autocomplete="off"
         v-bind="{ ...dataAttrs, ...attrsWithoutClassStyle }"
         @input="handleChange"
         @change="handleChange"


### PR DESCRIPTION
## Summary
- Adds `autocomplete="off"` as a static default on the `<input>` element in `TextInput.vue`
- Callers can still override via attrs passthrough (e.g. `autocomplete="email"`)

Closes #660

## Test plan
- [ ] Verify default TextInput renders with `autocomplete="off"`
- [ ] Verify passing `autocomplete="email"` overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 41.53% (1658/3992) | ±0.00%      |
| Statements | 36.55% (1734/4743) | ±0.00%      |
| Functions  | 37.52% (334/890) | ±0.00%      |
| Branches   | 26.08% (474/1817) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->

