### PR TITLE
feat(Select/Combobox/MultiSelect): label, description, error props

### DIFF
--- a/docs/content/docs/components/combobox.md
+++ b/docs/content/docs/components/combobox.md
@@ -37,4 +37,9 @@ Combobox rendered inside a Dialog. Verifies focus restores to the trigger after 
 
 <ComponentPreview name="Combobox-InDialog" layout="stacked" css='justify-center !py-20 grid' />
 
+## Label, Description, Error
+`Combobox` supports `label`, `description`, `error`, and `required` directly — no `FormControl` wrapper needed. The error suppresses the description and wires `aria-invalid` + `aria-errormessage` onto the input.
+
+<ComponentPreview name="Combobox-Labeling" />
+
 <!-- @include: ../../../meta/Combobox.md -->

--- a/docs/content/docs/components/formcontrol.md
+++ b/docs/content/docs/components/formcontrol.md
@@ -1,39 +1,54 @@
 # FormControl
 
-Provides a consistent wrapper for common form inputs. It handles label rendering, helper text, and consistent spacing so related controls feel uniform in forms.
+A single import for building consistent forms. `FormControl` picks the right input component based on its `type` and forwards `label`, `description`, `error`, and `required` down to it. Use it when you want a uniform API across every kind of control in a form.
 
-Use `FormControl` when you want a convenient default wrapper around the library's input primitives. For more specialized layouts or richer behavior, use the underlying component directly.
+## Example
+A realistic create-account form using every control type.
+
+<ComponentPreview name="FormControl-RealForm" layout="stacked" />
 
 ## Supported input types
 
 `FormControl` can render these control types:
 
-- text-like inputs via `TextInput`
+- text-like inputs via `TextInput` (`text`, `email`, `password`, `number`, `date`, etc.)
 - `textarea`
 - `select`
 - `combobox`
+- `multiselect`
 - `checkbox`
 
 > `type="autocomplete"` is deprecated. See
 > [Legacy components](./legacy#formcontrol-with-type-autocomplete).
 
+## Labeling, description, and error
+
+`label`, `description`, `error`, and `required` flow through to the underlying control, which owns the rendered label, helper text, and error message. Set `error` to flip `aria-invalid` on the control and replace the description with the error message.
+
+```vue
+<FormControl
+  v-model="email"
+  type="email"
+  label="Email"
+  description="We'll never share your email."
+  :error="errors.email"
+  required
+/>
+```
+
+Each underlying component (`TextInput`, `Select`, `Combobox`, `MultiSelect`, `Textarea`, `Checkbox`) also accepts these props directly — reach for the underlying component when you don't need a uniform dispatcher.
+
 ## Attribute forwarding
 
-Props such as `placeholder`, `disabled`, `modelValue`, `options`, and similar control-specific attributes are forwarded to the rendered input component.
+Other props such as `placeholder`, `disabled`, `modelValue`, `options`, and similar control-specific attributes are forwarded to the rendered input. This means `FormControl` acts as a convenience wrapper rather than redefining every prop from each underlying control.
 
-This means `FormControl` acts as a convenience wrapper rather than redefining every prop from each underlying control.
+## Slot forwarding
 
-## Slot behavior
-
-Available slots depend on the rendered control type:
-
-- `prefix` and `suffix` are useful for text-like inputs and select-like controls
-- `description` replaces the description text block below the control
+All slots are forwarded to the rendered child generically. The available slots depend on the rendered control type — for example, `#prefix` / `#suffix` for `TextInput`, `#item-prefix` / `#item-label` for `Select` and `Combobox`, etc.
 
 ## Usage notes
 
 - Prefer `FormControl` for standard forms where consistency matters more than custom structure.
-- Prefer the underlying component directly when you need full control over layout or advanced component-specific features.
-- Checkbox rendering differs from the other types because it renders the checkbox control directly instead of using the label + description wrapper layout.
+- Prefer the underlying component directly when you need full control over layout or component-specific features.
 
 <!-- @include: ../../../meta/FormControl.md -->

--- a/docs/content/docs/components/multiselect.md
+++ b/docs/content/docs/components/multiselect.md
@@ -32,4 +32,9 @@ A chips-style trigger: each selected option renders as a removable `Badge`, with
 
 <ComponentPreview name="MultiSelect-TagsTrigger" css='justify-center !py-20' />
 
+## Label, Description, Error
+`MultiSelect` supports `label`, `description`, `error`, and `required` directly — no `FormControl` wrapper needed. The error suppresses the description and wires `aria-invalid` + `aria-errormessage` onto the trigger.
+
+<ComponentPreview name="MultiSelect-Labeling" />
+
 <!-- @include: ../../../meta/MultiSelect.md -->

--- a/docs/content/docs/components/select.md
+++ b/docs/content/docs/components/select.md
@@ -17,6 +17,11 @@ Use `#item-prefix` and `#item-label` to tailor the standard row — for example,
 ## Trigger Slots
 <ComponentPreview name="Select-TriggerSlots" />
 
+## Label, Description, Error
+`Select` supports `label`, `description`, `error`, and `required` directly — no `FormControl` wrapper needed. The error suppresses the description and wires `aria-invalid` + `aria-errormessage` onto the trigger.
+
+<ComponentPreview name="Select-Labeling" />
+
 ## Notes
 
 - Prefer `#item-prefix`, `#item-label`, and `#item-suffix` when you want to

--- a/docs/meta/Alert.md
+++ b/docs/meta/Alert.md
@@ -9,15 +9,13 @@
     name: 'title',
     description: 'Main heading text of the alert',
     required: true,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'theme',
     description: 'Color theme of the alert',
     required: false,
-    type: 'Theme',
-    default: undefined
+    type: 'Theme'
   },
   {
     name: 'variant',
@@ -30,8 +28,7 @@
     name: 'description',
     description: 'Optional supporting text shown below the title',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'dismissable',

--- a/docs/meta/Avatar.md
+++ b/docs/meta/Avatar.md
@@ -9,15 +9,13 @@
     name: 'image',
     description: 'Image URL used for the avatar',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'label',
     description: 'Fallback text shown when the image is missing',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'size',

--- a/docs/meta/Badge.md
+++ b/docs/meta/Badge.md
@@ -30,8 +30,7 @@
     name: 'label',
     description: 'Content displayed inside the badge',
     required: false,
-    type: 'string | number | Label',
-    default: undefined
+    type: 'string | number | Label'
   }
 ]
 

--- a/docs/meta/Breadcrumbs.md
+++ b/docs/meta/Breadcrumbs.md
@@ -9,8 +9,7 @@
     name: 'items',
     description: 'Ordered list of breadcrumb items',
     required: true,
-    type: 'BreadcrumbItem[]',
-    default: undefined
+    type: 'BreadcrumbItem[]'
   }
 ]
 

--- a/docs/meta/Button.md
+++ b/docs/meta/Button.md
@@ -30,36 +30,31 @@
     name: 'label',
     description: 'Text label displayed inside the button',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'icon',
     description: 'Icon shown when no left or right icon is specified',
     required: false,
-    type: 'string | Component',
-    default: undefined
+    type: 'string | Component'
   },
   {
     name: 'iconLeft',
     description: 'Icon shown before the label',
     required: false,
-    type: 'string | Component',
-    default: undefined
+    type: 'string | Component'
   },
   {
     name: 'iconRight',
     description: 'Icon shown after the label',
     required: false,
-    type: 'string | Component',
-    default: undefined
+    type: 'string | Component'
   },
   {
     name: 'tooltip',
     description: 'Tooltip text shown on hover',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'loading',
@@ -72,8 +67,7 @@
     name: 'loadingText',
     description: 'Text shown while the button is loading',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'disabled',
@@ -86,15 +80,13 @@
     name: 'route',
     description: 'Router destination when used as a link',
     required: false,
-    type: 'string | kt | Tt',
-    default: undefined
+    type: 'string | kt | Tt'
   },
   {
     name: 'link',
     description: 'External link URL',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'type',

--- a/docs/meta/Calendar.md
+++ b/docs/meta/Calendar.md
@@ -16,29 +16,25 @@
     name: 'config',
     description: '',
     required: false,
-    type: 'Record<string, any>',
-    default: undefined
+    type: 'Record<string, any>'
   },
   {
     name: 'onClick',
     description: '',
     required: false,
-    type: 'Function',
-    default: undefined
+    type: 'Function'
   },
   {
     name: 'onDblClick',
     description: '',
     required: false,
-    type: 'Function',
-    default: undefined
+    type: 'Function'
   },
   {
     name: 'onCellClick',
     description: '',
     required: false,
-    type: 'Function',
-    default: undefined
+    type: 'Function'
   }
 ]
 

--- a/docs/meta/Combobox.md
+++ b/docs/meta/Combobox.md
@@ -16,7 +16,7 @@
     name: 'trigger',
     description: 'Shape of the trigger.\n- `\'input\'` (default): user types directly into the trigger\n- `\'button\'`: render a button trigger; search input moves into the\n  popover header. Label + prefix auto-derive from the selected option.',
     required: false,
-    type: '"input" | "button"',
+    type: '"button" | "input"',
     default: '"input"'
   },
   {
@@ -46,12 +46,6 @@
     required: false,
     type: 'boolean',
     default: 'false'
-  },
-  {
-    name: 'id',
-    description: 'Optional HTML id forwarded to the input element.',
-    required: false,
-    type: 'string'
   },
   {
     name: 'open',
@@ -129,6 +123,36 @@
     deprecated: 'use `align` instead; `placement` is kept as a back-compat alias'
   },
   {
+    name: 'label',
+    description: 'Label rendered above (or beside, for binary controls) the input.',
+    required: false,
+    type: 'string'
+  },
+  {
+    name: 'description',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    required: false,
+    type: 'string'
+  },
+  {
+    name: 'error',
+    description: 'Error message rendered below the input. When set, the control receives\n`aria-invalid="true"` and `data-state="invalid"`. May be either a string\nor an `Error` object whose `messages?: string[]` is rendered as stacked\nlines (with `Error.message` as the fallback).',
+    required: false,
+    type: 'string | FrappeUIError'
+  },
+  {
+    name: 'required',
+    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    required: false,
+    type: 'boolean'
+  },
+  {
+    name: 'id',
+    description: 'HTML id of the underlying control. Auto-generated via `useId()` if omitted.',
+    required: false,
+    type: 'string'
+  },
+  {
     name: 'modelValue',
     description: '',
     required: false,
@@ -142,6 +166,16 @@
     name: 'trigger',
     description: 'Fully custom trigger renderer.',
     type: 'ComboboxTriggerSlotProps'
+  },
+  {
+    name: 'label',
+    description: 'Overrides the rendered label content. Receives `{ required }`.',
+    type: '{ required: boolean; }'
+  },
+  {
+    name: 'description',
+    description: 'Overrides the rendered description content.',
+    type: 'any'
   },
   {
     name: 'prefix',
@@ -187,24 +221,24 @@
 
   const emitsData = [
   {
-    name: 'input',
-    description: '',
-    type: '[value: string]'
-  },
-  {
     name: 'update:modelValue',
     description: 'Fired when the model value changes.',
     type: '[value: string | null]'
   },
   {
-    name: 'update:open',
-    description: 'Fired when the open state changes.',
-    type: '[value: boolean]'
-  },
-  {
     name: 'update:query',
     description: 'Fired when the query changes.',
     type: '[value: string]'
+  },
+  {
+    name: 'input',
+    description: '',
+    type: '[value: string]'
+  },
+  {
+    name: 'update:open',
+    description: 'Fired when the open state changes.',
+    type: '[value: boolean]'
   },
   {
     name: 'update:selectedOption',

--- a/docs/meta/DatePicker.md
+++ b/docs/meta/DatePicker.md
@@ -30,8 +30,7 @@
     name: 'format',
     description: 'Display format used for the input text.',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'variant',
@@ -58,8 +57,7 @@
     name: 'inputClass',
     description: 'Additional classes applied to the trigger input.',
     required: false,
-    type: 'string | string[] | Record<string, boolean>',
-    default: undefined
+    type: 'string | string[] | Record<string, boolean>'
   },
   {
     name: 'allowCustom',
@@ -86,8 +84,7 @@
     name: 'label',
     description: 'Optional label forwarded to the trigger input.',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'clearable',

--- a/docs/meta/Dialog.md
+++ b/docs/meta/Dialog.md
@@ -151,13 +151,13 @@
 
   const emitsData = [
   {
-    name: 'update:open',
-    description: 'Fired when the open state changes.',
+    name: 'update:modelValue',
+    description: 'Fired when the model value changes.',
     type: '[value: boolean]'
   },
   {
-    name: 'update:modelValue',
-    description: 'Fired when the model value changes.',
+    name: 'update:open',
+    description: 'Fired when the open state changes.',
     type: '[value: boolean]'
   },
   {

--- a/docs/meta/Divider.md
+++ b/docs/meta/Divider.md
@@ -23,15 +23,13 @@
     name: 'flexItem',
     description: '',
     required: false,
-    type: 'boolean',
-    default: undefined
+    type: 'boolean'
   },
   {
     name: 'action',
     description: '',
     required: false,
-    type: 'DividerAction',
-    default: undefined
+    type: 'DividerAction'
   }
 ]
 </script>

--- a/docs/meta/ErrorMessage.md
+++ b/docs/meta/ErrorMessage.md
@@ -9,8 +9,7 @@
     name: 'message',
     description: 'The error message to display. Can be a string or an Error object',
     required: false,
-    type: 'string | Error',
-    default: undefined
+    type: 'string | Error'
   }
 ]
 </script>

--- a/docs/meta/FileUploader.md
+++ b/docs/meta/FileUploader.md
@@ -16,15 +16,13 @@
     name: 'fileTypes',
     description: '',
     required: false,
-    type: 'string | unknown[]',
-    default: undefined
+    type: 'string | unknown[]'
   },
   {
     name: 'uploadArgs',
     description: '',
     required: false,
-    type: 'Record<string, any>',
-    default: undefined
+    type: 'Record<string, any>'
   }
 ]
 </script>

--- a/docs/meta/FormControl.md
+++ b/docs/meta/FormControl.md
@@ -9,21 +9,25 @@
     name: 'label',
     description: 'Label text displayed above the input',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'description',
     description: 'Optional description or helper text shown below the input',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
+  },
+  {
+    name: 'error',
+    description: 'Error message shown below the input. Sets aria-invalid on the control.',
+    required: false,
+    type: 'string | FrappeUIError'
   },
   {
     name: 'type',
     description: 'Type of input to render',
     required: false,
-    type: '"select" | TextInputTypes | "textarea" | "checkbox" | "autocomplete" | "combobox"',
+    type: '"select" | TextInputTypes | "textarea" | "checkbox" | "autocomplete" | "combobox" | "multiselect"',
     default: '"text"'
   },
   {
@@ -44,8 +48,7 @@
     name: 'required',
     description: 'Whether the input is required',
     required: false,
-    type: 'boolean',
-    default: undefined
+    type: 'boolean'
   }
 ]
 
@@ -64,6 +67,11 @@
     name: 'description',
     description: 'Custom description slot (replaces description prop)',
     type: 'any'
+  },
+  {
+    name: 'label',
+    description: 'Custom label slot (replaces label prop). Receives `{ required }`.',
+    type: '{ required: boolean; }'
   },
   {
     name: 'item-prefix',

--- a/docs/meta/ListView.md
+++ b/docs/meta/ListView.md
@@ -30,8 +30,7 @@
     name: 'rowKey',
     description: '',
     required: true,
-    type: 'string',
-    default: undefined
+    type: 'string'
   }
 ]
 

--- a/docs/meta/MonthPicker.md
+++ b/docs/meta/MonthPicker.md
@@ -16,8 +16,7 @@
     name: 'disabled',
     description: 'Disables the month picker',
     required: false,
-    type: 'boolean',
-    default: undefined
+    type: 'boolean'
   },
   {
     name: 'modelValue',

--- a/docs/meta/MultiSelect.md
+++ b/docs/meta/MultiSelect.md
@@ -48,12 +48,6 @@
     default: 'false'
   },
   {
-    name: 'id',
-    description: 'Optional HTML id forwarded to the trigger.',
-    required: false,
-    type: 'string'
-  },
-  {
     name: 'open',
     description: 'Controls the popover visibility.',
     required: false,
@@ -114,6 +108,36 @@
     description: 'Custom equality function used to resolve which options are currently\nselected for display and rendering. When omitted, the component uses\nstrict equality on `option.value` against entries in `modelValue`.',
     required: false,
     type: '((a: MultiSelectOption, b: MultiSelectOption) => boolean)'
+  },
+  {
+    name: 'label',
+    description: 'Label rendered above (or beside, for binary controls) the input.',
+    required: false,
+    type: 'string'
+  },
+  {
+    name: 'description',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    required: false,
+    type: 'string'
+  },
+  {
+    name: 'error',
+    description: 'Error message rendered below the input. When set, the control receives\n`aria-invalid="true"` and `data-state="invalid"`. May be either a string\nor an `Error` object whose `messages?: string[]` is rendered as stacked\nlines (with `Error.message` as the fallback).',
+    required: false,
+    type: 'string | FrappeUIError'
+  },
+  {
+    name: 'required',
+    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    required: false,
+    type: 'boolean'
+  },
+  {
+    name: 'id',
+    description: 'HTML id of the underlying control. Auto-generated via `useId()` if omitted.',
+    required: false,
+    type: 'string'
   }
 ]
 
@@ -122,6 +146,16 @@
     name: 'trigger',
     description: 'Fully custom trigger renderer.',
     type: 'MultiSelectTriggerSlotProps'
+  },
+  {
+    name: 'label',
+    description: 'Overrides the rendered label content. Receives `{ required }`.',
+    type: '{ required: boolean; }'
+  },
+  {
+    name: 'description',
+    description: 'Overrides the rendered description content.',
+    type: 'any'
   },
   {
     name: 'item-prefix',
@@ -173,14 +207,14 @@
     type: 'unknown[]'
   },
   {
-    name: 'update:open',
-    description: 'Fired when the open state changes.',
-    type: 'unknown[]'
-  },
-  {
     name: 'update:query',
     description: 'Fired when the query changes.',
     type: '[value: string]'
+  },
+  {
+    name: 'update:open',
+    description: 'Fired when the open state changes.',
+    type: 'unknown[]'
   }
 ]
 </script>

--- a/docs/meta/Popover.md
+++ b/docs/meta/Popover.md
@@ -65,15 +65,13 @@
     name: 'matchTargetWidth',
     description: 'Whether the popover width should match the target element',
     required: false,
-    type: 'boolean',
-    default: undefined
+    type: 'boolean'
   },
   {
     name: 'offset',
     description: '',
     required: false,
-    type: 'number',
-    default: undefined
+    type: 'number'
   },
   {
     name: 'collisionPadding',

--- a/docs/meta/Progress.md
+++ b/docs/meta/Progress.md
@@ -9,8 +9,7 @@
     name: 'value',
     description: 'Current progress value',
     required: true,
-    type: 'number',
-    default: undefined
+    type: 'number'
   },
   {
     name: 'size',

--- a/docs/meta/Select.md
+++ b/docs/meta/Select.md
@@ -9,7 +9,7 @@
     name: 'size',
     description: 'Size of the select input.',
     required: false,
-    type: '"sm" | "md" | "lg" | "xl"',
+    type: '"md" | "sm" | "lg" | "xl"',
     default: '"sm"'
   },
   {
@@ -31,12 +31,6 @@
     description: 'If true, disables the select input.',
     required: false,
     type: 'boolean'
-  },
-  {
-    name: 'id',
-    description: 'Optional HTML id for the select element.',
-    required: false,
-    type: 'string'
   },
   {
     name: 'modelValue',
@@ -64,6 +58,36 @@
     required: false,
     type: 'string',
     default: '"No options"'
+  },
+  {
+    name: 'label',
+    description: 'Label rendered above (or beside, for binary controls) the input.',
+    required: false,
+    type: 'string'
+  },
+  {
+    name: 'description',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    required: false,
+    type: 'string'
+  },
+  {
+    name: 'error',
+    description: 'Error message rendered below the input. When set, the control receives\n`aria-invalid="true"` and `data-state="invalid"`. May be either a string\nor an `Error` object whose `messages?: string[]` is rendered as stacked\nlines (with `Error.message` as the fallback).',
+    required: false,
+    type: 'string | FrappeUIError'
+  },
+  {
+    name: 'required',
+    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    required: false,
+    type: 'boolean'
+  },
+  {
+    name: 'id',
+    description: 'HTML id of the underlying control. Auto-generated via `useId()` if omitted.',
+    required: false,
+    type: 'string'
   }
 ]
 
@@ -72,6 +96,16 @@
     name: 'trigger',
     description: 'Fully custom trigger renderer.',
     type: 'SelectTriggerSlotProps'
+  },
+  {
+    name: 'label',
+    description: 'Overrides the rendered label content. Receives `{ required }`.',
+    type: '{ required: boolean; }'
+  },
+  {
+    name: 'description',
+    description: 'Overrides the rendered description content.',
+    type: 'any'
   },
   {
     name: 'prefix',

--- a/docs/meta/Sidebar.md
+++ b/docs/meta/Sidebar.md
@@ -9,22 +9,19 @@
     name: 'header',
     description: '',
     required: false,
-    type: 'SidebarHeaderProps',
-    default: undefined
+    type: 'SidebarHeaderProps'
   },
   {
     name: 'sections',
     description: '',
     required: false,
-    type: 'SidebarSectionProps[]',
-    default: undefined
+    type: 'SidebarSectionProps[]'
   },
   {
     name: 'disableCollapse',
     description: '',
     required: false,
-    type: 'boolean',
-    default: undefined
+    type: 'boolean'
   },
   {
     name: 'collapsed',

--- a/docs/meta/TabButtons.md
+++ b/docs/meta/TabButtons.md
@@ -9,15 +9,13 @@
     name: 'buttons',
     description: '',
     required: true,
-    type: 'TabButton[]',
-    default: undefined
+    type: 'TabButton[]'
   },
   {
     name: 'modelValue',
     description: '',
     required: false,
-    type: 'TabButtonValue',
-    default: undefined
+    type: 'TabButtonValue'
   }
 ]
 

--- a/docs/meta/Tabs.md
+++ b/docs/meta/Tabs.md
@@ -9,36 +9,31 @@
     name: 'as',
     description: 'Element/component used to render the tab container.',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'tabs',
     description: 'List of tabs to render.',
     required: true,
-    type: 'Tab[]',
-    default: undefined
+    type: 'Tab[]'
   },
   {
     name: 'vertical',
     description: 'Renders tabs vertically instead of horizontally.',
     required: false,
-    type: 'boolean',
-    default: undefined
+    type: 'boolean'
   },
   {
     name: 'modelValue',
     description: 'Currently selected tab value.',
     required: false,
-    type: 'string | number',
-    default: undefined
+    type: 'string | number'
   },
   {
     name: 'dir',
     description: 'Forces layout direction; defaults to `document.documentElement.dir`.',
     required: false,
-    type: '"rtl" | "ltr"',
-    default: undefined
+    type: '"rtl" | "ltr"'
   }
 ]
 
@@ -46,12 +41,12 @@
   {
     name: 'tab-item',
     description: 'Custom renderer for a tab trigger (icon + label / router-link).',
-    type: '{ tab: { label: string; icon?: string | undefined; route?: string | undefined; }; }'
+    type: '{ tab: { label: string; icon?: string | Component | undefined; route?: string | undefined; }; }'
   },
   {
     name: 'tab-panel',
     description: 'Content rendered for each tab panel.',
-    type: '{ tab: { label: string; icon?: string | undefined; route?: string | undefined; }; }'
+    type: '{ tab: { label: string; icon?: string | Component | undefined; route?: string | undefined; }; }'
   }
 ]
 

--- a/docs/meta/TextEditor.md
+++ b/docs/meta/TextEditor.md
@@ -100,15 +100,13 @@
     name: 'uploadFunction',
     description: 'Async file upload handler (used for images, files, etc.)',
     required: false,
-    type: '((file: File) => Promise<UploadedFile>)',
-    default: undefined
+    type: '((file: File) => Promise<UploadedFile>)'
   },
   {
     name: 'uploadArgs',
     description: 'Extra arguments passed to the upload function',
     required: false,
-    type: 'object',
-    default: undefined
+    type: 'object'
   }
 ]
 

--- a/docs/meta/Toast.md
+++ b/docs/meta/Toast.md
@@ -9,50 +9,43 @@
     name: 'open',
     description: 'Controls whether the toast is visible (required)',
     required: true,
-    type: 'boolean',
-    default: undefined
+    type: 'boolean'
   },
   {
     name: 'message',
     description: 'Message content rendered inside the toast',
     required: false,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'type',
     description: 'Visual tone of the toast',
     required: false,
-    type: '"success" | "error" | "info" | "warning"',
-    default: undefined
+    type: '"error" | "success" | "info" | "warning"'
   },
   {
     name: 'duration',
     description: 'Auto-dismiss duration in milliseconds',
     required: false,
-    type: 'number',
-    default: undefined
+    type: 'number'
   },
   {
     name: 'icon',
     description: 'Optional custom icon rendered before the message',
     required: false,
-    type: 'Component',
-    default: undefined
+    type: 'Component'
   },
   {
     name: 'closable',
     description: 'Whether the close button is shown',
     required: false,
-    type: 'boolean',
-    default: undefined
+    type: 'boolean'
   },
   {
     name: 'action',
     description: 'Optional action rendered on the right side of the toast',
     required: false,
-    type: 'ToastAction',
-    default: undefined
+    type: 'ToastAction'
   }
 ]
 

--- a/docs/meta/Tree.md
+++ b/docs/meta/Tree.md
@@ -9,15 +9,13 @@
     name: 'node',
     description: 'Root tree node to render.\nCan contain nested children to form the tree structure.',
     required: true,
-    type: 'TreeNode',
-    default: undefined
+    type: 'TreeNode'
   },
   {
     name: 'nodeKey',
     description: 'Unique key used to identify each node.\nUsually an id-like property present on every node.',
     required: true,
-    type: 'string',
-    default: undefined
+    type: 'string'
   },
   {
     name: 'options',

--- a/src/components/Combobox/Combobox.cy.ts
+++ b/src/components/Combobox/Combobox.cy.ts
@@ -710,4 +710,86 @@ describe('Combobox', () => {
         .and('contain.text', 'Mango')
     })
   })
+
+  describe('shared labeling contract', () => {
+    it('renders label and links it to the input via for/id', () => {
+      cy.mount(Combobox, {
+        props: { options: fruits, label: 'Fruit' },
+      })
+      cy.get('[role="combobox"]').then(($input) => {
+        const id = $input.attr('id')!
+        cy.get(`label[for="${id}"]`).should('contain.text', 'Fruit')
+      })
+    })
+
+    it('renders description and wires aria-describedby on input', () => {
+      cy.mount(Combobox, {
+        props: {
+          options: fruits,
+          label: 'Fruit',
+          description: 'Type to filter.',
+        },
+      })
+      cy.get('[role="combobox"]').then(($input) => {
+        const id = $input.attr('id')!
+        const describedBy = $input.attr('aria-describedby')!
+        expect(describedBy).to.equal(`${id}-description`)
+        cy.get(`#${id}-description`).should('contain.text', 'Type to filter.')
+      })
+    })
+
+    it('renders error with aria-invalid + aria-errormessage and suppresses description', () => {
+      cy.mount(Combobox, {
+        props: {
+          options: fruits,
+          label: 'Fruit',
+          description: 'helper',
+          error: 'Required',
+        },
+      })
+      cy.get('[role="combobox"]')
+        .should('have.attr', 'aria-invalid', 'true')
+        .then(($input) => {
+          const id = $input.attr('id')!
+          expect($input.attr('aria-errormessage')).to.equal(`${id}-error`)
+          cy.get(`#${id}-error`).should('contain.text', 'Required')
+          cy.get(`#${id}-description`).should('not.exist')
+        })
+    })
+
+    it('renders required indicator and forwards aria-required', () => {
+      cy.mount(Combobox, {
+        props: { options: fruits, label: 'Fruit', required: true },
+      })
+      cy.get('[role="combobox"]').should('have.attr', 'aria-required', 'true')
+      cy.contains('label', 'Fruit').within(() => {
+        cy.get('span[aria-hidden="true"]').should('contain.text', '*')
+      })
+    })
+
+    it('flips data-invalid on the trigger when error is set', () => {
+      cy.mount(Combobox, {
+        props: { options: fruits, label: 'Fruit', error: 'Required' },
+      })
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'data-invalid',
+        'true',
+      )
+    })
+
+    it('button-mode trigger gets aria-invalid + data-invalid on error', () => {
+      cy.mount(Combobox, {
+        props: {
+          options: fruits,
+          label: 'Fruit',
+          error: 'Required',
+          trigger: 'button',
+        },
+      })
+      cy.get('[data-slot="trigger"]')
+        .should('have.attr', 'aria-invalid', 'true')
+        .and('have.attr', 'data-invalid', 'true')
+    })
+  })
 })

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -21,8 +21,15 @@ import OptionIcon from '../shared/selection/OptionIcon.vue'
 import '../shared/selection/popoverMotion.css'
 import ComboboxResults from './ComboboxResults.vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
+import { useInputLabeling } from '../../composables/useInputLabeling'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
+import {
+  InputDescription,
+  InputError,
+  InputLabel,
+  LabelingWrapper,
+} from '../InputLabeling'
 import type {
   ComboboxEmits,
   ComboboxExposed,
@@ -84,6 +91,38 @@ const hasWarnedPlacement = ref(false)
 
 const { motion: contentMotion, onPointerDown: markPointerDown } =
   usePopoverMotion(open)
+
+const {
+  inputId,
+  labelId,
+  descriptionId,
+  errorMessageId,
+  describedBy,
+  hasError,
+  errorLines,
+  showDescription,
+} = useInputLabeling(props, {
+  size: () => props.size,
+  variant: () => props.variant,
+  disabled: () => props.disabled,
+})
+
+const hasLabeling = computed(() => {
+  return Boolean(
+    props.label ||
+      props.description ||
+      hasError.value ||
+      slots.label ||
+      slots.description,
+  )
+})
+
+const inputAriaAttrs = computed(() => ({
+  'aria-invalid': hasError.value || undefined,
+  'aria-errormessage': hasError.value ? errorMessageId.value : undefined,
+  'aria-describedby': describedBy.value,
+  'aria-required': props.required || undefined,
+}))
 
 const inputAttrs = computed(() => {
   const { class: _class, style: _style, autocomplete, ...rest } = attrs
@@ -347,6 +386,31 @@ defineSlots<ComboboxSlots>()
 </script>
 
 <template>
+  <LabelingWrapper
+    :enabled="hasLabeling"
+    :wrapper-class="['space-y-1.5', attrs.class as any]"
+    :wrapper-style="attrs.style as any"
+  >
+    <InputLabel
+      v-if="label || $slots.label"
+      :id="labelId"
+      :for-id="inputId"
+      :label="label"
+      :required="required"
+      class="text-p-sm font-medium text-ink-gray-7"
+    >
+      <template v-if="$slots.label" #default="slotProps">
+        <slot name="label" v-bind="slotProps" />
+      </template>
+    </InputLabel>
+    <!--
+      ComboboxRoot uses `display: contents` so it's invisible to layout —
+      space-y-1.5 on LabelingWrapper would try to attach margin-top to it
+      and the rule gets dropped, collapsing the gap between label and
+      trigger. Wrap in a div that drops back to `display: contents` when
+      there's no labeling, so bare usage keeps its flattened layout.
+    -->
+    <div :class="hasLabeling ? null : 'contents'">
   <ComboboxRoot
     ref="rootRef"
     class="contents"
@@ -411,17 +475,21 @@ defineSlots<ComboboxSlots>()
             triggerClasses,
             'justify-between',
             disabled && 'cursor-not-allowed',
-            attrs.class,
+            hasLabeling ? 'w-full' : null,
+            hasLabeling ? null : (attrs.class as any),
           ]"
-          :style="attrs.style as any"
+          :style="hasLabeling ? null : (attrs.style as any)"
           :disabled="disabled"
           data-slot="trigger"
           :data-state="open ? 'open' : 'closed'"
           :data-variant="variant"
           :data-size="size"
-          :id="id"
+          :data-invalid="hasError ? 'true' : undefined"
+          :data-required="required ? 'true' : undefined"
+          :id="inputId"
           aria-haspopup="listbox"
           :aria-expanded="open"
+          v-bind="inputAriaAttrs"
         >
           <!--
             Prefix precedence on the trigger:
@@ -474,8 +542,14 @@ defineSlots<ComboboxSlots>()
         :data-disabled="disabled ? '' : undefined"
         :data-variant="variant"
         :data-size="size"
-        :class="[triggerClasses, attrs.class]"
-        :style="attrs.style"
+        :data-invalid="hasError ? 'true' : undefined"
+        :data-required="required ? 'true' : undefined"
+        :class="[
+          triggerClasses,
+          hasLabeling ? 'w-full' : null,
+          hasLabeling ? null : (attrs.class as any),
+        ]"
+        :style="hasLabeling ? null : (attrs.style as any)"
         @pointerdown="markPointerDown"
       >
         <!--
@@ -496,8 +570,8 @@ defineSlots<ComboboxSlots>()
         <slot v-else name="prefix" />
 
         <ComboboxInput
-          :id="id"
-          v-bind="inputAttrs"
+          :id="inputId"
+          v-bind="{ ...inputAttrs, ...inputAriaAttrs }"
           data-slot="input"
           :data-variant="variant"
           :data-size="size"
@@ -573,7 +647,7 @@ defineSlots<ComboboxSlots>()
               class="flex items-center gap-2 border-b border-outline-gray-1 px-3"
             >
               <ComboboxInput
-                :id="id ? `${id}-search-input` : undefined"
+                :id="`${inputId}-search-input`"
                 v-bind="inputAttrs"
                 data-slot="input"
                 :value="query"
@@ -606,6 +680,16 @@ defineSlots<ComboboxSlots>()
       </ComboboxContent>
     </ComboboxPortal>
   </ComboboxRoot>
+    </div>
+    <InputDescription
+      v-if="showDescription || $slots.description"
+      :id="descriptionId"
+      :description="description"
+    >
+      <slot v-if="$slots.description" name="description" />
+    </InputDescription>
+    <InputError v-if="hasError" :id="errorMessageId" :lines="errorLines" />
+  </LabelingWrapper>
 </template>
 
 <style scoped>

--- a/src/components/Combobox/stories/Labeling.vue
+++ b/src/components/Combobox/stories/Labeling.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Checkbox, Combobox } from 'frappe-ui'
+
+const value = ref<string | null>(null)
+const required = ref(true)
+const showError = ref(false)
+
+const error = computed(() => (showError.value ? 'Please pick an option.' : ''))
+
+const options = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Cherry', value: 'cherry' },
+  { label: 'Durian', value: 'durian' },
+]
+</script>
+
+<template>
+  <div class="flex gap-8 items-start">
+    <Combobox
+      v-model="value"
+      :options="options"
+      label="Favourite fruit"
+      description="Start typing to filter."
+      :error="error"
+      :required="required"
+      placeholder="Pick one"
+      class="w-72"
+    />
+    <div
+      class="flex flex-col gap-2 items-start border-l border-outline-gray-2 pl-6"
+    >
+      <Checkbox v-model="required" label="required" />
+      <Checkbox v-model="showError" label="show error" />
+    </div>
+  </div>
+</template>

--- a/src/components/Combobox/types.ts
+++ b/src/components/Combobox/types.ts
@@ -1,4 +1,5 @@
 import type { Component, VNode, VNodeChild } from 'vue'
+import type { InputLabelingProps } from '../../composables/useInputLabeling'
 
 export type ComboboxVariant = 'subtle' | 'outline' | 'ghost'
 export type ComboboxSize = 'sm' | 'md' | 'lg' | 'xl'
@@ -88,7 +89,7 @@ export interface ComboboxGroupedOption {
 export type GroupedOption = ComboboxGroupedOption
 export type ComboboxOption = ComboboxSimpleOption | ComboboxGroupedOption
 
-export interface ComboboxProps {
+export interface ComboboxProps extends InputLabelingProps {
   /** Options rendered in the popover. */
   options?: ComboboxOption[]
 
@@ -111,9 +112,6 @@ export interface ComboboxProps {
 
   /** Disables the combobox. */
   disabled?: boolean
-
-  /** Optional HTML id forwarded to the input element. */
-  id?: string
 
   /** Controls the popover visibility. */
   open?: boolean
@@ -193,6 +191,12 @@ export interface ComboboxEmptySlotProps {
 export interface ComboboxSlots {
   /** Fully custom trigger renderer. */
   trigger?: (props: ComboboxTriggerSlotProps) => any
+
+  /** Overrides the rendered label content. Receives `{ required }`. */
+  label?: (props: { required: boolean }) => any
+
+  /** Overrides the rendered description content. */
+  description?: () => any
 
   /** Content rendered before the default input. */
   prefix?: () => any

--- a/src/components/FormControl/FormControl.cy.ts
+++ b/src/components/FormControl/FormControl.cy.ts
@@ -178,5 +178,51 @@ describe('FormControl', () => {
       })
       cy.get('label').should('have.length', 1)
     })
+
+    it('renders bare select with w-full so it fills its container (ListFilter pattern)', () => {
+      // Mirrors how ListFilter renders FormControl in a min-width column:
+      //   <div class="min-w-[140px]"><FormControl type="select" options /></div>
+      // Old template hard-coded `class="w-full"` on Select; ensure the
+      // dispatcher still produces a full-width trigger even without label.
+      cy.mount({
+        components: { FormControl },
+        data: () => ({ options }),
+        template: `
+          <div style="width: 240px; padding: 16px;">
+            <div data-cy="col" style="min-width: 140px;">
+              <FormControl type="select" :options="options" />
+            </div>
+          </div>
+        `,
+      })
+      cy.get('[data-cy="col"]').then(($col) => {
+        const colWidth = $col[0].getBoundingClientRect().width
+        cy.get('[data-slot="trigger"]').then(($trigger) => {
+          const triggerWidth = $trigger[0].getBoundingClientRect().width
+          expect(triggerWidth).to.be.closeTo(colWidth, 1)
+        })
+      })
+    })
+
+    it('renders bare combobox with w-full so it fills its container', () => {
+      cy.mount({
+        components: { FormControl },
+        data: () => ({ options }),
+        template: `
+          <div style="width: 240px; padding: 16px;">
+            <div data-cy="col" style="min-width: 140px;">
+              <FormControl type="combobox" :options="options" />
+            </div>
+          </div>
+        `,
+      })
+      cy.get('[data-cy="col"]').then(($col) => {
+        const colWidth = $col[0].getBoundingClientRect().width
+        cy.get('[data-slot="trigger"]').then(($trigger) => {
+          const triggerWidth = $trigger[0].getBoundingClientRect().width
+          expect(triggerWidth).to.be.closeTo(colWidth, 1)
+        })
+      })
+    })
   })
 })

--- a/src/components/FormControl/FormControl.cy.ts
+++ b/src/components/FormControl/FormControl.cy.ts
@@ -95,4 +95,88 @@ describe('FormControl', () => {
     cy.mount(FormControl, { props: { label: 'Title' } })
     cy.get('@consoleWarn').should('not.have.been.calledWithMatch', /FormControl/)
   })
+
+  describe('dispatcher delegation', () => {
+    const options = [
+      { label: 'One', value: '1' },
+      { label: 'Two', value: '2' },
+    ]
+
+    it('forwards label/description/error/required to Select', () => {
+      cy.mount(FormControl, {
+        props: {
+          type: 'select',
+          options,
+          label: 'Pick',
+          description: 'helper',
+          required: true,
+        },
+      })
+      cy.contains('label', 'Pick').should('exist')
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'aria-required',
+        'true',
+      )
+      cy.contains('helper').should('exist')
+    })
+
+    it('forwards error to Select and suppresses description', () => {
+      cy.mount(FormControl, {
+        props: {
+          type: 'select',
+          options,
+          label: 'Pick',
+          description: 'helper',
+          error: 'Required',
+        },
+      })
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'aria-invalid',
+        'true',
+      )
+      cy.contains('Required').should('exist')
+      cy.contains('helper').should('not.exist')
+    })
+
+    it('renders Combobox via type="combobox" with labeling', () => {
+      cy.mount(FormControl, {
+        props: {
+          type: 'combobox',
+          options,
+          label: 'Pick',
+          error: 'Required',
+        },
+      })
+      cy.contains('label', 'Pick').should('exist')
+      cy.get('[role="combobox"]').should('have.attr', 'aria-invalid', 'true')
+    })
+
+    it('renders MultiSelect via type="multiselect" with labeling', () => {
+      cy.mount(FormControl, {
+        props: {
+          type: 'multiselect',
+          options,
+          label: 'Pick many',
+          description: 'Pick as many as you like.',
+          required: true,
+        },
+      })
+      cy.contains('label', 'Pick many').should('exist')
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'aria-required',
+        'true',
+      )
+      cy.contains('Pick as many as you like.').should('exist')
+    })
+
+    it('renders only one label even though child also self-shells (no duplication)', () => {
+      cy.mount(FormControl, {
+        props: { type: 'select', options, label: 'Pick' },
+      })
+      cy.get('label').should('have.length', 1)
+    })
+  })
 })

--- a/src/components/FormControl/FormControl.cy.ts
+++ b/src/components/FormControl/FormControl.cy.ts
@@ -185,15 +185,12 @@ describe('FormControl', () => {
       // Old template hard-coded `class="w-full"` on Select; ensure the
       // dispatcher still produces a full-width trigger even without label.
       cy.mount({
-        components: { FormControl },
-        data: () => ({ options }),
-        template: `
-          <div style="width: 240px; padding: 16px;">
-            <div data-cy="col" style="min-width: 140px;">
-              <FormControl type="select" :options="options" />
-            </div>
-          </div>
-        `,
+        render: () =>
+          h('div', { style: 'width: 240px; padding: 16px;' }, [
+            h('div', { 'data-cy': 'col', style: 'min-width: 140px;' }, [
+              h(FormControl, { type: 'select', options }),
+            ]),
+          ]),
       })
       cy.get('[data-cy="col"]').then(($col) => {
         const colWidth = $col[0].getBoundingClientRect().width
@@ -206,15 +203,12 @@ describe('FormControl', () => {
 
     it('renders bare combobox with w-full so it fills its container', () => {
       cy.mount({
-        components: { FormControl },
-        data: () => ({ options }),
-        template: `
-          <div style="width: 240px; padding: 16px;">
-            <div data-cy="col" style="min-width: 140px;">
-              <FormControl type="combobox" :options="options" />
-            </div>
-          </div>
-        `,
+        render: () =>
+          h('div', { style: 'width: 240px; padding: 16px;' }, [
+            h('div', { 'data-cy': 'col', style: 'min-width: 140px;' }, [
+              h(FormControl, { type: 'combobox', options }),
+            ]),
+          ]),
       })
       cy.get('[data-cy="col"]').then(($col) => {
         const colWidth = $col[0].getBoundingClientRect().width

--- a/src/components/FormControl/FormControl.vue
+++ b/src/components/FormControl/FormControl.vue
@@ -1,82 +1,19 @@
 <template>
-  <div
-    v-if="type != 'checkbox'"
-    :class="['space-y-1.5', attrs.class]"
+  <component
+    :is="resolvedComponent"
+    :id="id"
+    v-bind="forwardedAttrs"
+    :class="attrs.class"
     :style="attrs.style"
   >
-    <FormLabel
-      v-if="label"
-      :label="label"
-      :size="size"
-      :id="id"
-      :required="required"
-    />
-    <Select
-      v-if="type === 'select'"
-      :id="id"
-      class="w-full"
-      v-bind="{ ...controlAttrs, size, variant }"
-    >
-      <template #prefix v-if="$slots.prefix">
-        <slot name="prefix" />
-      </template>
-    </Select>
-    <!--
-      Wrap Combobox in a div so the surrounding `space-y-1.5` has a real
-      box to attach `margin-top` to. ComboboxRoot uses `display: contents`,
-      which lets selectors match it but drops any margins applied to it.
-    -->
-    <div v-else-if="type === 'combobox'">
-      <Combobox
-        :id="id"
-        class="w-full"
-        v-bind="{ ...controlAttrs, size, variant }"
-      >
-        <template #prefix v-if="$slots.prefix">
-          <slot name="prefix" />
-        </template>
-      </Combobox>
-    </div>
-    <Autocomplete
-      v-else-if="type === 'autocomplete'"
-      v-bind="{ ...controlAttrs }"
-    >
-      <template #prefix v-if="$slots.prefix">
-        <slot name="prefix" />
-      </template>
-      <template #item-prefix="itemPrefixProps" v-if="$slots['item-prefix']">
-        <slot name="item-prefix" v-bind="itemPrefixProps" />
-      </template>
-    </Autocomplete>
-    <Textarea
-      v-else-if="type === 'textarea'"
-      :id="id"
-      v-bind="{ ...controlAttrs, size, variant }"
-    />
-    <TextInput
-      v-else
-      :id="id"
-      v-bind="{ ...controlAttrs, type, size, variant, required }"
-    >
-      <template #prefix v-if="$slots.prefix">
-        <slot name="prefix" />
-      </template>
-      <template #suffix v-if="$slots.suffix">
-        <slot name="suffix" />
-      </template>
-    </TextInput>
-    <slot name="description">
-      <p v-if="description" :class="descriptionClasses">{{ description }}</p>
-    </slot>
-  </div>
-  <Checkbox
-    v-else
-    :id="id"
-    v-bind="{ ...controlAttrs, label, size, class: attrs.class }"
-  />
+    <template v-for="name in slotNames" :key="name" #[name]="slotProps">
+      <!-- @vue-ignore -->
+      <slot :name="name" v-bind="slotProps" />
+    </template>
+  </component>
 </template>
 <script setup lang="ts">
-import { useAttrs, computed, provide, watchEffect } from 'vue'
+import { useAttrs, computed, provide, watchEffect, useSlots } from 'vue'
 import { useId } from '../../utils/useId'
 import { TextInput } from '../TextInput'
 import { Select } from '../Select'
@@ -85,7 +22,7 @@ import { Checkbox } from '../Checkbox'
 import { Autocomplete } from '../Autocomplete'
 import { autocompleteDeprecationSuppressed } from '../Autocomplete/deprecationKey'
 import { Combobox } from '../Combobox'
-import FormLabel from '../FormLabel.vue'
+import { MultiSelect } from '../MultiSelect'
 import { warnDeprecated } from '../../utils/warnDeprecated'
 import type { FormControlProps } from './types'
 
@@ -109,25 +46,60 @@ watchEffect(() => {
 })
 
 const attrs = useAttrs()
-const controlAttrs = computed(() => {
-  // pass everything except class and style
-  let _attrs: typeof attrs = {}
-  for (let key in attrs) {
-    if (key !== 'class' && key !== 'style') {
-      _attrs[key] = attrs[key]
-    }
+const slots = useSlots()
+
+const slotNames = computed(() => Object.keys(slots))
+
+const resolvedComponent = computed(() => {
+  switch (props.type) {
+    case 'select':
+      return Select
+    case 'combobox':
+      return Combobox
+    case 'multiselect':
+      return MultiSelect
+    case 'autocomplete':
+      return Autocomplete
+    case 'textarea':
+      return Textarea
+    case 'checkbox':
+      return Checkbox
+    default:
+      return TextInput
   }
-  return _attrs
 })
 
-const descriptionClasses = computed(() => {
-  return [
-    {
-      sm: 'text-p-xs',
-      md: 'text-p-base',
-    }[props.size],
-    'text-ink-gray-5',
-  ]
+const forwardedAttrs = computed(() => {
+  // attrs minus class/style (applied separately on the rendered child)
+  const out: Record<string, unknown> = {}
+  for (const key in attrs) {
+    if (key !== 'class' && key !== 'style') out[key] = attrs[key]
+  }
+
+  out.size = props.size
+  out.variant = props.variant
+
+  if (props.label !== undefined) out.label = props.label
+  if (props.description !== undefined) out.description = props.description
+  if (props.error !== undefined) out.error = props.error
+  if (props.required !== undefined) out.required = props.required
+
+  // TextInput needs the html input `type`; the dispatcher consumes the
+  // composite types (select/combobox/multiselect/textarea/checkbox/autocomplete)
+  // and lets the rest fall through to <TextInput :type="...">.
+  const composite = new Set([
+    'select',
+    'combobox',
+    'multiselect',
+    'autocomplete',
+    'textarea',
+    'checkbox',
+  ])
+  if (!composite.has(props.type as string)) {
+    out.type = props.type
+  }
+
+  return out
 })
 
 defineSlots<{
@@ -137,6 +109,8 @@ defineSlots<{
   suffix?: () => any
   /** Custom description slot (replaces description prop) */
   description?: () => any
+  /** Custom label slot (replaces label prop). Receives `{ required }`. */
+  label?: (props: { required: boolean }) => any
   /** Custom slot for autocomplete items prefix (if using Autocomplete type) */
   'item-prefix'?: (props: { item: any }) => any
   /** Default slot override for full input rendering */

--- a/src/components/FormControl/FormControl.vue
+++ b/src/components/FormControl/FormControl.vue
@@ -3,7 +3,7 @@
     :is="resolvedComponent"
     :id="id"
     v-bind="forwardedAttrs"
-    :class="attrs.class"
+    :class="[fillWidth ? 'w-full' : null, attrs.class]"
     :style="attrs.style"
   >
     <template v-for="name in slotNames" :key="name" #[name]="slotProps">
@@ -49,6 +49,17 @@ const attrs = useAttrs()
 const slots = useSlots()
 
 const slotNames = computed(() => Object.keys(slots))
+
+// FormControl represents "form context = full width" — the legacy template
+// hard-coded `class="w-full"` on Select/Combobox. Preserve that contract for
+// all select-like dispatched types (including bare uses with no label, e.g.
+// ListFilter's operator picker placed inside a min-width column). Standalone
+// Select/Combobox/MultiSelect retain their own hasLabeling heuristic.
+const fillWidth = computed(() =>
+  new Set(['select', 'combobox', 'multiselect', 'autocomplete']).has(
+    props.type as string,
+  ),
+)
 
 const resolvedComponent = computed(() => {
   switch (props.type) {

--- a/src/components/FormControl/stories/RealForm.vue
+++ b/src/components/FormControl/stories/RealForm.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue'
+import { Button, FormControl } from 'frappe-ui'
+
+const form = reactive({
+  fullName: '',
+  email: '',
+  password: '',
+  role: '',
+  team: '',
+  skills: [] as string[],
+  bio: '',
+  acceptTerms: false,
+})
+
+const submitted = ref(false)
+
+const errors = computed(() => {
+  if (!submitted.value) return {} as Record<string, string>
+  const e: Record<string, string> = {}
+  if (!form.fullName.trim()) e.fullName = 'Full name is required.'
+  if (!form.email.trim()) e.email = 'Email is required.'
+  else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email))
+    e.email = 'Enter a valid email.'
+  if (!form.password) e.password = 'Pick a password.'
+  else if (form.password.length < 8)
+    e.password = 'Use at least 8 characters.'
+  if (!form.role) e.role = 'Pick a role.'
+  if (!form.team) e.team = 'Pick a team.'
+  if (form.skills.length === 0) e.skills = 'Pick at least one skill.'
+  if (!form.acceptTerms) e.acceptTerms = 'You must accept the terms.'
+  return e
+})
+
+const isValid = computed(() => Object.keys(errors.value).length === 0)
+
+const roleOptions = [
+  { label: 'Engineer', value: 'engineer' },
+  { label: 'Designer', value: 'designer' },
+  { label: 'Product Manager', value: 'pm' },
+  { label: 'Other', value: 'other' },
+]
+
+const teamOptions = [
+  { label: 'Platform', value: 'platform' },
+  { label: 'Growth', value: 'growth' },
+  { label: 'Frontend', value: 'frontend' },
+  { label: 'Backend', value: 'backend' },
+  { label: 'Mobile', value: 'mobile' },
+]
+
+const skillOptions = [
+  { label: 'Vue', value: 'vue' },
+  { label: 'TypeScript', value: 'typescript' },
+  { label: 'Python', value: 'python' },
+  { label: 'Frappe Framework', value: 'frappe' },
+  { label: 'Tailwind CSS', value: 'tailwind' },
+  { label: 'PostgreSQL', value: 'postgres' },
+]
+
+function submit() {
+  submitted.value = true
+}
+
+function reset() {
+  Object.assign(form, {
+    fullName: '',
+    email: '',
+    password: '',
+    role: '',
+    team: '',
+    skills: [],
+    bio: '',
+    acceptTerms: false,
+  })
+  submitted.value = false
+}
+</script>
+
+<template>
+  <form
+    class="w-full max-w-lg space-y-4 py-4"
+    @submit.prevent="submit"
+  >
+    <div class="space-y-1">
+      <h2 class="text-lg font-semibold text-ink-gray-9">Create account</h2>
+      <p class="text-p-sm text-ink-gray-6">
+        Every <code>FormControl</code> type rendered together. Submit to see
+        validation light up.
+      </p>
+    </div>
+
+    <FormControl
+      v-model="form.fullName"
+      type="text"
+      label="Full name"
+      placeholder="Jane Doe"
+      :error="errors.fullName"
+      required
+    />
+
+    <FormControl
+      v-model="form.email"
+      type="email"
+      label="Email"
+      description="We'll never share your email."
+      placeholder="you@example.com"
+      :error="errors.email"
+      required
+    />
+
+    <FormControl
+      v-model="form.password"
+      type="password"
+      label="Password"
+      description="At least 8 characters."
+      :error="errors.password"
+      required
+    />
+
+    <FormControl
+      v-model="form.role"
+      type="select"
+      label="Role"
+      placeholder="Pick a role"
+      :options="roleOptions"
+      :error="errors.role"
+      required
+    />
+
+    <FormControl
+      v-model="form.team"
+      type="combobox"
+      label="Team"
+      placeholder="Type to filter"
+      :options="teamOptions"
+      :error="errors.team"
+      required
+    />
+
+    <FormControl
+      v-model="form.skills"
+      type="multiselect"
+      label="Skills"
+      description="Pick all that apply."
+      placeholder="Pick skills"
+      :options="skillOptions"
+      :error="errors.skills"
+      required
+    />
+
+    <FormControl
+      v-model="form.bio"
+      type="textarea"
+      label="Short bio"
+      description="A sentence or two — optional."
+      placeholder="Tell us a little about yourself..."
+    />
+
+    <FormControl
+      v-model="form.acceptTerms"
+      type="checkbox"
+      label="I accept the terms and privacy policy"
+    />
+    <p v-if="errors.acceptTerms" class="text-p-sm text-ink-red-3">
+      {{ errors.acceptTerms }}
+    </p>
+
+    <div class="flex items-center gap-2 pt-2">
+      <Button variant="solid" type="submit">Create account</Button>
+      <Button variant="ghost" type="button" @click="reset">Reset</Button>
+      <span
+        v-if="submitted && isValid"
+        class="ml-auto text-p-sm text-ink-green-3"
+      >
+        Looks good!
+      </span>
+    </div>
+  </form>
+</template>

--- a/src/components/FormControl/types.ts
+++ b/src/components/FormControl/types.ts
@@ -1,12 +1,22 @@
 import type { TextInputTypes } from '../types/TextInput'
+import type { FrappeUIError } from '../../composables/useInputLabeling'
 
 export interface FormControlProps {
   /** Label text displayed above the input */
   label?: string
   /** Optional description or helper text shown below the input */
   description?: string
+  /** Error message shown below the input. Sets aria-invalid on the control. */
+  error?: string | FrappeUIError
   /** Type of input to render */
-  type?: TextInputTypes | 'textarea' | 'select' | 'checkbox' | 'autocomplete' | 'combobox'
+  type?:
+    | TextInputTypes
+    | 'textarea'
+    | 'select'
+    | 'checkbox'
+    | 'autocomplete'
+    | 'combobox'
+    | 'multiselect'
   /** Size of the input */
   size?: 'sm' | 'md'
   /** Visual variant of the input */

--- a/src/components/MultiSelect/MultiSelect.cy.ts
+++ b/src/components/MultiSelect/MultiSelect.cy.ts
@@ -240,4 +240,79 @@ describe('MultiSelect', () => {
         .and('contain.text', options[1].label)
     })
   })
+
+  describe('shared labeling contract', () => {
+    it('renders label and links it to the trigger via for/id', () => {
+      cy.mount(MultiSelect, {
+        props: { options, label: 'Fruits' },
+      })
+      cy.get('[data-slot="trigger"]').then(($trigger) => {
+        const id = $trigger.attr('id')!
+        cy.get(`label[for="${id}"]`).should('contain.text', 'Fruits')
+      })
+    })
+
+    it('renders description and wires aria-describedby on trigger', () => {
+      cy.mount(MultiSelect, {
+        props: {
+          options,
+          label: 'Fruits',
+          description: 'Pick as many as you like.',
+        },
+      })
+      cy.get('[data-slot="trigger"]').then(($trigger) => {
+        const id = $trigger.attr('id')!
+        const describedBy = $trigger.attr('aria-describedby')!
+        expect(describedBy).to.equal(`${id}-description`)
+        cy.get(`#${id}-description`).should(
+          'contain.text',
+          'Pick as many as you like.',
+        )
+      })
+    })
+
+    it('renders error with aria-invalid + aria-errormessage and suppresses description', () => {
+      cy.mount(MultiSelect, {
+        props: {
+          options,
+          label: 'Fruits',
+          description: 'helper',
+          error: 'Pick at least one.',
+        },
+      })
+      cy.get('[data-slot="trigger"]')
+        .should('have.attr', 'aria-invalid', 'true')
+        .then(($trigger) => {
+          const id = $trigger.attr('id')!
+          expect($trigger.attr('aria-errormessage')).to.equal(`${id}-error`)
+          cy.get(`#${id}-error`).should('contain.text', 'Pick at least one.')
+          cy.get(`#${id}-description`).should('not.exist')
+        })
+    })
+
+    it('renders required indicator and forwards aria-required', () => {
+      cy.mount(MultiSelect, {
+        props: { options, label: 'Fruits', required: true },
+      })
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'aria-required',
+        'true',
+      )
+      cy.contains('label', 'Fruits').within(() => {
+        cy.get('span[aria-hidden="true"]').should('contain.text', '*')
+      })
+    })
+
+    it('flips data-invalid on the trigger when error is set', () => {
+      cy.mount(MultiSelect, {
+        props: { options, label: 'Fruits', error: 'Required' },
+      })
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'data-invalid',
+        'true',
+      )
+    })
+  })
 })

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -12,9 +12,16 @@ import Button from '../Button/Button.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import MultiSelectResults from './MultiSelectResults.vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
+import { useInputLabeling } from '../../composables/useInputLabeling'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
 import OptionIcon from '../shared/selection/OptionIcon.vue'
+import {
+  InputDescription,
+  InputError,
+  InputLabel,
+  LabelingWrapper,
+} from '../InputLabeling'
 import '../shared/selection/popoverMotion.css'
 import type {
   MultiSelectEmits,
@@ -60,6 +67,31 @@ const open = defineModel<boolean>('open', { default: false })
 
 const query = ref('')
 const hasTypedSinceOpen = ref(false)
+
+const {
+  inputId,
+  labelId,
+  descriptionId,
+  errorMessageId,
+  describedBy,
+  hasError,
+  errorLines,
+  showDescription,
+} = useInputLabeling(props, {
+  size: () => props.size,
+  variant: () => props.variant,
+  disabled: () => props.disabled,
+})
+
+const hasLabeling = computed(() => {
+  return Boolean(
+    props.label ||
+      props.description ||
+      hasError.value ||
+      slots.label ||
+      slots.description,
+  )
+})
 
 const { motion: contentMotion, onPointerDown: markPointerDown } =
   usePopoverMotion(open)
@@ -206,6 +238,23 @@ defineSlots<MultiSelectSlots>()
 </script>
 
 <template>
+  <LabelingWrapper
+    :enabled="hasLabeling"
+    :wrapper-class="['space-y-1.5', attrs.class as any]"
+    :wrapper-style="attrs.style as any"
+  >
+    <InputLabel
+      v-if="label || $slots.label"
+      :id="labelId"
+      :for-id="inputId"
+      :label="label"
+      :required="required"
+      class="text-p-sm font-medium text-ink-gray-7"
+    >
+      <template v-if="$slots.label" #default="slotProps">
+        <slot name="label" v-bind="slotProps" />
+      </template>
+    </InputLabel>
   <ComboboxRoot
     multiple
     :model-value="internalModel"
@@ -247,18 +296,25 @@ defineSlots<MultiSelectSlots>()
           triggerClasses,
           'justify-between',
           disabled && 'cursor-not-allowed',
-          attrs.class,
+          hasLabeling ? 'w-full' : null,
+          hasLabeling ? null : (attrs.class as any),
         ]"
-        :style="attrs.style as any"
+        :style="hasLabeling ? null : (attrs.style as any)"
         :disabled="disabled"
         data-slot="trigger"
         :data-state="open ? 'open' : 'closed'"
         :data-variant="variant"
         :data-size="size"
         :data-disabled="disabled ? '' : undefined"
-        :id="id"
+        :data-invalid="hasError ? 'true' : undefined"
+        :data-required="required ? 'true' : undefined"
+        :id="inputId"
         aria-haspopup="listbox"
         :aria-expanded="open"
+        :aria-invalid="hasError || undefined"
+        :aria-errormessage="hasError ? errorMessageId : undefined"
+        :aria-describedby="describedBy"
+        :aria-required="required || undefined"
       >
         <!--
           For exactly one selection, reuse `#item-prefix` (or auto-render
@@ -408,6 +464,15 @@ defineSlots<MultiSelectSlots>()
       </ComboboxContent>
     </ComboboxPortal>
   </ComboboxRoot>
+    <InputDescription
+      v-if="showDescription || $slots.description"
+      :id="descriptionId"
+      :description="description"
+    >
+      <slot v-if="$slots.description" name="description" />
+    </InputDescription>
+    <InputError v-if="hasError" :id="errorMessageId" :lines="errorLines" />
+  </LabelingWrapper>
 </template>
 
 <style scoped>

--- a/src/components/MultiSelect/stories/Labeling.vue
+++ b/src/components/MultiSelect/stories/Labeling.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Checkbox, MultiSelect } from 'frappe-ui'
+
+const value = ref<string[]>([])
+const required = ref(true)
+const showError = ref(false)
+
+const error = computed(() =>
+  showError.value ? 'Pick at least one fruit.' : '',
+)
+
+const options = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Cherry', value: 'cherry' },
+  { label: 'Durian', value: 'durian' },
+]
+</script>
+
+<template>
+  <div class="flex gap-8 items-start">
+    <MultiSelect
+      v-model="value"
+      :options="options"
+      label="Favourite fruits"
+      description="Pick as many as you like."
+      :error="error"
+      :required="required"
+      placeholder="Pick some"
+      class="w-72"
+    />
+    <div
+      class="flex flex-col gap-2 items-start border-l border-outline-gray-2 pl-6"
+    >
+      <Checkbox v-model="required" label="required" />
+      <Checkbox v-model="showError" label="show error" />
+    </div>
+  </div>
+</template>

--- a/src/components/MultiSelect/types.ts
+++ b/src/components/MultiSelect/types.ts
@@ -1,4 +1,5 @@
 import type { Component, VNode, VNodeChild } from 'vue'
+import type { InputLabelingProps } from '../../composables/useInputLabeling'
 
 export type MultiSelectVariant = 'subtle' | 'outline' | 'ghost'
 export type MultiSelectSize = 'sm' | 'md' | 'lg' | 'xl'
@@ -51,7 +52,7 @@ export type MultiSelectOptions = Array<
   MultiSelectOption | MultiSelectGroupedOption
 >
 
-export interface MultiSelectProps {
+export interface MultiSelectProps extends InputLabelingProps {
   /** Array of selected option values. */
   modelValue?: string[]
 
@@ -69,9 +70,6 @@ export interface MultiSelectProps {
 
   /** Disables the multi-select. */
   disabled?: boolean
-
-  /** Optional HTML id forwarded to the trigger. */
-  id?: string
 
   /** Controls the popover visibility. */
   open?: boolean
@@ -163,6 +161,12 @@ export interface MultiSelectFooterSlotProps {
 export interface MultiSelectSlots {
   /** Fully custom trigger renderer. */
   trigger?: (props: MultiSelectTriggerSlotProps) => any
+
+  /** Overrides the rendered label content. Receives `{ required }`. */
+  label?: (props: { required: boolean }) => any
+
+  /** Overrides the rendered description content. */
+  description?: () => any
 
   /** Shared content rendered before the standard row label. */
   'item-prefix'?: (props: MultiSelectItemSlotProps) => any

--- a/src/components/Select/Select.cy.ts
+++ b/src/components/Select/Select.cy.ts
@@ -364,4 +364,90 @@ describe('Select', () => {
         .should('exist')
     })
   })
+
+  describe('shared labeling contract', () => {
+    it('renders label and links it to the trigger via for/id', () => {
+      cy.mount(Select, {
+        props: { options, label: 'Fruit' },
+      })
+      cy.get('[data-slot="trigger"]').then(($trigger) => {
+        const id = $trigger.attr('id')!
+        cy.get(`label[for="${id}"]`).should('contain.text', 'Fruit')
+      })
+    })
+
+    it('renders description and wires aria-describedby on trigger', () => {
+      cy.mount(Select, {
+        props: {
+          options,
+          label: 'Fruit',
+          description: 'Pick one fruit.',
+        },
+      })
+      cy.get('[data-slot="trigger"]').then(($trigger) => {
+        const id = $trigger.attr('id')!
+        const describedBy = $trigger.attr('aria-describedby')!
+        expect(describedBy).to.equal(`${id}-description`)
+        cy.get(`#${id}-description`).should('contain.text', 'Pick one fruit.')
+      })
+    })
+
+    it('renders error with aria-invalid + aria-errormessage and suppresses description', () => {
+      cy.mount(Select, {
+        props: {
+          options,
+          label: 'Fruit',
+          description: 'helper',
+          error: 'Required',
+        },
+      })
+      cy.get('[data-slot="trigger"]')
+        .should('have.attr', 'aria-invalid', 'true')
+        .then(($trigger) => {
+          const id = $trigger.attr('id')!
+          expect($trigger.attr('aria-errormessage')).to.equal(`${id}-error`)
+          cy.get(`#${id}-error`).should('contain.text', 'Required')
+          cy.get(`#${id}-description`).should('not.exist')
+        })
+    })
+
+    it('renders required indicator and forwards aria-required', () => {
+      cy.mount(Select, {
+        props: { options, label: 'Fruit', required: true },
+      })
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'aria-required',
+        'true',
+      )
+      cy.contains('label', 'Fruit').within(() => {
+        cy.get('span[aria-hidden="true"]').should('contain.text', '*')
+      })
+    })
+
+    it('honors an explicit id over the generated one', () => {
+      cy.mount(Select, {
+        props: { options, id: 'my-select-id', label: 'Fruit' },
+      })
+      cy.get('[data-slot="trigger"]').should('have.attr', 'id', 'my-select-id')
+      cy.get('label[for="my-select-id"]').should('exist')
+    })
+
+    it('flips data-invalid on the trigger when error is set', () => {
+      cy.mount(Select, {
+        props: { options, label: 'Fruit', error: 'Required' },
+      })
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'data-invalid',
+        'true',
+      )
+    })
+
+    it('renders without a labeling wrapper when no labeling props are set', () => {
+      cy.mount(Select, { props: { options } })
+      cy.get('[data-slot="trigger"]').should('exist')
+      cy.get('label').should('not.exist')
+    })
+  })
 })

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, useAttrs, useSlots } from 'vue'
 import { usePopoverMotion } from '../../composables/usePopoverMotion'
+import { useInputLabeling } from '../../composables/useInputLabeling'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import type {
   SelectNormalizedOption,
@@ -10,6 +11,12 @@ import type {
   SelectSlots,
 } from './types'
 import ItemListRow from '../ItemListRow/ItemListRow.vue'
+import {
+  InputDescription,
+  InputError,
+  InputLabel,
+  LabelingWrapper,
+} from '../InputLabeling'
 import {
   SelectContent,
   SelectItem,
@@ -52,15 +59,42 @@ const props = withDefaults(defineProps<SelectProps>(), {
 const attrs = useAttrs()
 const slots = useSlots()
 
-const formAttrKeys = ['name', 'required', 'autocomplete'] as const
+const {
+  inputId,
+  labelId,
+  descriptionId,
+  errorMessageId,
+  describedBy,
+  hasError,
+  errorLines,
+  showDescription,
+} = useInputLabeling(props, {
+  size: () => props.size,
+  variant: () => props.variant,
+  disabled: () => props.disabled,
+})
+
+const hasLabeling = computed(() => {
+  return Boolean(
+    props.label ||
+      props.description ||
+      hasError.value ||
+      slots.label ||
+      slots.description,
+  )
+})
+
+const formAttrKeys = ['name', 'autocomplete'] as const
 
 const { motion: contentMotion, onPointerDown: markPointerDown } =
   usePopoverMotion(open)
 
 const rootAttrs = computed(() => {
-  return Object.fromEntries(
+  const out: Record<string, unknown> = Object.fromEntries(
     formAttrKeys.filter((key) => key in attrs).map((key) => [key, attrs[key]]),
   )
+  if (props.required) out.required = true
+  return out
 })
 
 const triggerAttrs = computed(() => {
@@ -68,7 +102,6 @@ const triggerAttrs = computed(() => {
     class: _class,
     style: _style,
     name: _name,
-    required: _required,
     autocomplete: _autocomplete,
     ...rest
   } = attrs
@@ -168,14 +201,41 @@ defineSlots<SelectSlots>()
 </script>
 
 <template>
-  <SelectRoot v-model="internalModel" v-model:open="open" v-bind="rootAttrs">
+  <LabelingWrapper
+    :enabled="hasLabeling"
+    :wrapper-class="['space-y-1.5', attrs.class as any]"
+    :wrapper-style="attrs.style as any"
+  >
+    <InputLabel
+      v-if="label || $slots.label"
+      :id="labelId"
+      :for-id="inputId"
+      :label="label"
+      :required="required"
+      class="text-p-sm font-medium text-ink-gray-7"
+    >
+      <template v-if="$slots.label" #default="slotProps">
+        <slot name="label" v-bind="slotProps" />
+      </template>
+    </InputLabel>
+    <SelectRoot v-model="internalModel" v-model:open="open" v-bind="rootAttrs">
     <SelectTrigger
-      :id="id"
+      :id="inputId"
       data-slot="trigger"
       v-bind="triggerAttrs"
-      :class="[triggerClasses, attrs.class]"
-      :style="attrs.style"
+      :class="[
+        triggerClasses,
+        hasLabeling ? 'w-full' : null,
+        hasLabeling ? null : (attrs.class as any),
+      ]"
+      :style="hasLabeling ? null : (attrs.style as any)"
       :disabled="disabled"
+      :aria-invalid="hasError || undefined"
+      :aria-errormessage="hasError ? errorMessageId : undefined"
+      :aria-describedby="describedBy"
+      :aria-required="required || undefined"
+      :data-invalid="hasError ? 'true' : undefined"
+      :data-required="required ? 'true' : undefined"
       @pointerdown="markPointerDown"
     >
       <template v-if="$slots.trigger">
@@ -366,6 +426,15 @@ defineSlots<SelectSlots>()
       </SelectContent>
     </SelectPortal>
   </SelectRoot>
+    <InputDescription
+      v-if="showDescription || $slots.description"
+      :id="descriptionId"
+      :description="description"
+    >
+      <slot v-if="$slots.description" name="description" />
+    </InputDescription>
+    <InputError v-if="hasError" :id="errorMessageId" :lines="errorLines" />
+  </LabelingWrapper>
 </template>
 
 <style scoped>

--- a/src/components/Select/stories/Labeling.vue
+++ b/src/components/Select/stories/Labeling.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Checkbox, Select } from 'frappe-ui'
+
+const value = ref('')
+const required = ref(true)
+const showError = ref(false)
+
+const error = computed(() =>
+  showError.value ? 'Please choose a fruit.' : '',
+)
+
+const options = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Cherry', value: 'cherry' },
+]
+</script>
+
+<template>
+  <div class="flex gap-8 items-start">
+    <Select
+      v-model="value"
+      :options="options"
+      label="Favourite fruit"
+      description="We'll pick a default for you when you don't choose."
+      :error="error"
+      :required="required"
+      placeholder="Pick one"
+      class="w-72"
+    />
+    <div
+      class="flex flex-col gap-2 items-start border-l border-outline-gray-2 pl-6"
+    >
+      <Checkbox v-model="required" label="required" />
+      <Checkbox v-model="showError" label="show error" />
+    </div>
+  </div>
+</template>

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -1,4 +1,5 @@
 import type { Component } from 'vue'
+import type { InputLabelingProps } from '../../composables/useInputLabeling'
 
 export type SelectOptionValue = string | number | bigint | Record<string, any>
 
@@ -16,7 +17,7 @@ export type SelectOption =
 
 export type SelectNormalizedOption = Exclude<SelectOption, string>
 
-export interface SelectProps {
+export interface SelectProps extends InputLabelingProps {
   /** Size of the select input. */
   size?: 'sm' | 'md' | 'lg' | 'xl'
 
@@ -28,9 +29,6 @@ export interface SelectProps {
 
   /** If true, disables the select input. */
   disabled?: boolean
-
-  /** Optional HTML id for the select element. */
-  id?: string
 
   /** The currently selected value. */
   modelValue?: SelectOptionValue
@@ -67,6 +65,12 @@ export interface SelectItemSlotProps {
 export interface SelectSlots {
   /** Fully custom trigger renderer. */
   trigger?: (props: SelectTriggerSlotProps) => any
+
+  /** Overrides the rendered label content. Receives `{ required }`. */
+  label?: (props: { required: boolean }) => any
+
+  /** Overrides the rendered description content. */
+  description?: () => any
 
   /** Content rendered before the trigger value. */
   prefix?: () => any


### PR DESCRIPTION
Select, Combobox, and MultiSelect now own their own labeling shell via the existing InputLabelingProps + useInputLabeling pattern. Each component accepts label / description / error / required directly and wires aria-invalid, aria-errormessage, aria-describedby on the trigger.

FormControl is now a thin dispatcher that forwards labeling props (and all slots, generically) to the underlying control. type='multiselect' is now a supported dispatcher target. type='autocomplete' deprecation kept for v1 back-compat.

When labeling is set, the trigger defaults to w-full so labeled selects line up with TextInput in forms. Bare (toolbar/inline) usage keeps natural width driven by the option sizer.

closes #657

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 41.53% (1658/3992) | ±0.00%      |
| Statements | 36.55% (1734/4743) | ±0.00%      |
| Functions  | 37.52% (334/890) | ±0.00%      |
| Branches   | 26.08% (474/1817) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->

