### PR TITLE
fix(toast): icon vertical alignment

### DIFF
--- a/src/components/Toast/Toast.vue
+++ b/src/components/Toast/Toast.vue
@@ -4,11 +4,12 @@
     :duration="closable ? duration : 0"
     :class="[
       'toast-root-animatable',
-      'bg-surface-gray-6 border-none rounded-md px-4 py-1.5 shadow-lg flex items-center justify-between gap-3 min-w-[280px] max-w-[400px] pointer-events-auto list-none',
+      'bg-surface-gray-6 border-none rounded-md px-4 shadow-lg flex items-center justify-between gap-3 min-w-[280px] max-w-[400px] pointer-events-auto list-none',
+       message && message.length > 60 ? 'py-3' : 'py-1.5',
     ]"
   >
     <div class="flex items-center gap-2 flex-grow overflow-hidden">
-      <div>
+      <div class="mb-auto mt-0.5">
         <component v-if="icon" :is="icon" class="flex-shrink-0 size-4" />
         <CircleCheck
           v-else-if="type == 'success'"


### PR DESCRIPTION
## Before: 

<img width="940" height="220" alt="image" src="https://github.com/user-attachments/assets/7a44f4b3-fb9a-474d-a62f-ad2ec21b504c" />


## After: 


<img width="876" height="250" alt="image" src="https://github.com/user-attachments/assets/08ea1b5e-eff1-4ed5-bb0e-6200c2247e10" />

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 41.53% (1658/3992) | ±0.00%      |
| Statements | 36.55% (1734/4743) | ±0.00%      |
| Functions  | 37.52% (334/890) | ±0.00%      |
| Branches   | 26.08% (474/1817) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->

