### PR TITLE
fix: add type declaration for `useTelemetry` to avoid TS warning

### DIFF
--- a/frappe/index.d.ts
+++ b/frappe/index.d.ts
@@ -50,6 +50,16 @@ declare module 'frappe-ui/frappe' {
   //   Components
   export const Link: Component
   export type { LinkProps } from './Link/types'
+
+  // Telemetry
+  export function useTelemetry(): {
+    isEnabled: { readonly value: boolean }
+    disable: () => void
+    capture: (event_name: string, data?: Record<string, any>) => void
+  }
+  export const telemetryPlugin: {
+    install: (app: import('vue').App, options: { app_name: string }) => Promise<void>
+  }
 }
 
 // Data Import


### PR DESCRIPTION
Resolves following Typescript warning while using `useTelemetry`

<img width="873" height="305" alt="Screenshot 2026-05-16 at 5 06 24 PM" src="https://github.com/user-attachments/assets/296c1370-f28c-4efd-a3b3-fa34afbb833b" />

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 41.53% (1658/3992) | ±0.00%      |
| Statements | 36.55% (1734/4743) | ±0.00%      |
| Functions  | 37.52% (334/890) | ±0.00%      |
| Branches   | 26.08% (474/1817) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
