### PR TITLE
feat(Combobox, MultiSelect, Select): slot polish for v1 trigger surface

### DIFF
--- a/docs/content/docs/components/combobox.md
+++ b/docs/content/docs/components/combobox.md
@@ -18,9 +18,19 @@ Options split into named groups. `#item-prefix` renders a colored swatch per row
 <ComponentPreview name="Combobox-Grouped" css='justify-center !py-20 grid' />
 
 ## Custom Value
-Provides a creatable option if no results match the current query.
+Free-form acceptance via `allowCustomValue`: the typed query becomes the model value when nothing matches, and unknown external values are preserved. The component renders a built-in "Create X" row as a click affordance. Use this when you want a "text input with autocomplete" feel. For richer create-new UX (custom label, icon, persistence callback), see [Create New](#create-new) below.
 
 <ComponentPreview name="Combobox-CustomValue" css='justify-center !py-20 grid' />
+
+## Clearable
+Uses the `#trigger` slot to compose a custom trigger with an inline clear button. The X clears `v-model` via `@click.stop` so the popover doesn't toggle, and `@pointerdown.stop` keeps the anchor from intercepting the press.
+
+<ComponentPreview name="Combobox-Clearable" css='justify-center !py-20 grid' />
+
+## Create New
+"Create new" is just a `type: 'custom'` option. `condition` hides the row when the query is empty or already matches an existing item, and `onClick` receives the typed `query` so you can persist the new value.
+
+<ComponentPreview name="Combobox-CreateNew" css='justify-center !py-20 grid' />
 
 ## Status Picker
 Dotted indicator aligned to the first line, with supporting description text.

--- a/docs/content/docs/components/multiselect.md
+++ b/docs/content/docs/components/multiselect.md
@@ -12,6 +12,11 @@ Use `#item-prefix` to render avatars, icons, or indicators next to each option l
 
 <ComponentPreview name="MultiSelect-Options" css='justify-center !py-20' />
 
+## Members
+Use `#prefix` to render an aggregate visual across the current selection — here, a stack of avatars capped at three with a "+N" overflow badge. When `#prefix` is provided it owns the entire prefix area regardless of selection count, so the same template handles 0 / 1 / many.
+
+<ComponentPreview name="MultiSelect-Members" css='justify-center !py-20' />
+
 ## Grouped Options
 Options can be split into named groups. Group labels render above each group's items.
 

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -217,10 +217,14 @@ const filteredGroups = useFilteredGroups({
   open,
   hasTypedSinceOpen,
   query,
+  // Selectable rows: query-driven substring match. Custom rows: skip here
+  // and let `alwaysMatch` consult `condition` so the row's visibility is
+  // bespoke (works even before the user types, when the typed-query path
+  // is otherwise bypassed).
   matches: (item, q) =>
-    item.type === 'custom'
-      ? matchesCustomOption(item, q)
-      : matchesSelectableOption(item, q),
+    item.type === 'custom' ? true : matchesSelectableOption(item, q),
+  alwaysMatch: (item) =>
+    item.type !== 'custom' || matchesCustomOption(item, typedQuery.value),
 })
 
 const hasVisibleItems = computed(() => filteredGroups.value.length > 0)
@@ -514,7 +518,17 @@ defineSlots<ComboboxSlots>()
             v-else-if="selectedOption?.icon"
             :icon="selectedOption.icon"
           />
-          <slot v-else-if="!selectedOption && $slots.prefix" name="prefix" />
+          <slot
+            v-else-if="!selectedOption && $slots.prefix"
+            name="prefix"
+            v-bind="{
+              open,
+              disabled: !!disabled,
+              query: typedQuery,
+              selectedOption,
+              displayValue,
+            }"
+          />
 
           <span
             :class="[
@@ -525,12 +539,23 @@ defineSlots<ComboboxSlots>()
             {{ selectedOption?.label ?? placeholder }}
           </span>
 
-          <span
-            :class="[
-              'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
-              open && 'rotate-180',
-            ]"
-          />
+          <slot
+            name="suffix"
+            v-bind="{
+              open,
+              disabled: !!disabled,
+              query: typedQuery,
+              selectedOption,
+              displayValue,
+            }"
+          >
+            <span
+              :class="[
+                'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
+                open && 'rotate-180',
+              ]"
+            />
+          </slot>
         </button>
       </ComboboxAnchor>
     </template>
@@ -567,7 +592,17 @@ defineSlots<ComboboxSlots>()
           v-else-if="selectedOption?.icon"
           :icon="selectedOption.icon"
         />
-        <slot v-else name="prefix" />
+        <slot
+          v-else
+          name="prefix"
+          v-bind="{
+            open,
+            disabled: !!disabled,
+            query: typedQuery,
+            selectedOption,
+            displayValue,
+          }"
+        />
 
         <ComboboxInput
           :id="inputId"
@@ -585,13 +620,24 @@ defineSlots<ComboboxSlots>()
           @keydown.enter="handleInputEnter"
         />
 
-        <ComboboxTrigger
-          :disabled="disabled"
-          data-slot="chevron"
-          class="ml-auto inline-flex shrink-0 items-center justify-center text-ink-gray-4 outline-none transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] data-[state=open]:rotate-180"
+        <slot
+          name="suffix"
+          v-bind="{
+            open,
+            disabled: !!disabled,
+            query: typedQuery,
+            selectedOption,
+            displayValue,
+          }"
         >
-          <span class="lucide-chevron-down size-4 text-ink-gray-6" />
-        </ComboboxTrigger>
+          <ComboboxTrigger
+            :disabled="disabled"
+            data-slot="chevron"
+            class="inline-flex shrink-0 items-center justify-center text-ink-gray-4 outline-none transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] data-[state=open]:rotate-180"
+          >
+            <span class="lucide-chevron-down size-4 text-ink-gray-6" />
+          </ComboboxTrigger>
+        </slot>
       </ComboboxAnchor>
     </template>
 

--- a/src/components/Combobox/stories/Clearable.vue
+++ b/src/components/Combobox/stories/Clearable.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { reactive } from 'vue'
+import { Combobox } from 'frappe-ui'
+
+type FieldOption = string | { label: string; value: string }
+type Field = { key: string; label: string; options: FieldOption[] }
+
+const fields: Field[] = [
+  {
+    key: 'colour',
+    label: 'colour',
+    options: ['gray', 'blue', 'green', 'red'],
+  },
+  { key: 'size', label: 'size', options: ['sm', 'md', 'lg', 'xl'] },
+  { key: 'style', label: 'style', options: ['subtle', 'outline', 'ghost'] },
+  {
+    key: 'fontSize',
+    label: 'font size',
+    options: [
+      { label: '12px', value: '12' },
+      { label: '14px', value: '14' },
+      { label: '16px', value: '16' },
+      { label: '20px', value: '20' },
+      { label: '24px', value: '24' },
+    ],
+  },
+]
+
+const values = reactive<Record<string, string>>({
+  colour: 'gray',
+  size: 'sm',
+  style: 'ghost',
+  fontSize: '14',
+})
+
+const colourSwatch: Record<string, string> = {
+  gray: 'bg-surface-gray-5',
+  blue: 'bg-surface-blue-3',
+  green: 'bg-surface-green-3',
+  red: 'bg-surface-red-5',
+}
+
+const sizeDot: Record<string, string> = {
+  sm: 'size-1.5',
+  md: 'size-2',
+  lg: 'size-2.5',
+  xl: 'size-3',
+}
+
+const styleIcon: Record<string, string> = {
+  subtle: 'lucide-square',
+  outline: 'lucide-square-dashed',
+  ghost: 'lucide-circle-dashed',
+}
+
+const fontSizePx: Record<string, number> = {
+  '12': 8,
+  '14': 10,
+  '16': 12,
+  '20': 14,
+  '24': 16,
+}
+
+function getOptionValue(item: { value?: string; label: string }) {
+  return item.value ?? item.label
+}
+
+function clear(key: string, event: Event) {
+  event.stopPropagation()
+  values[key] = ''
+}
+</script>
+
+<template>
+  <div class="grid w-[420px] gap-2">
+    <div
+      v-for="field in fields"
+      :key="field.key"
+      class="group grid grid-cols-[8rem_1fr] items-center gap-4"
+    >
+      <label class="text-base text-ink-gray-5">{{ field.label }}</label>
+
+      <Combobox
+        v-model="values[field.key]"
+        :options="field.options"
+        variant="outline"
+        :placeholder="`Pick a ${field.label}`"
+        open-on-focus
+      >
+        <template #item-prefix="{ item }">
+          <span class="grid size-4 shrink-0 place-items-center">
+            <span
+              v-if="field.key === 'colour'"
+              :class="[
+                'inline-block size-3 rounded-sm',
+                colourSwatch[getOptionValue(item)] ?? 'bg-surface-gray-3',
+              ]"
+            />
+
+            <span
+              v-else-if="field.key === 'size'"
+              :class="[
+                'inline-block rounded-full bg-surface-gray-4',
+                sizeDot[getOptionValue(item)] ?? 'size-2',
+              ]"
+            />
+
+            <span
+              v-else-if="field.key === 'style'"
+              :class="[
+                'size-4 text-ink-gray-6',
+                styleIcon[getOptionValue(item)] ?? 'lucide-square',
+              ]"
+            />
+
+            <span
+              v-else-if="field.key === 'fontSize'"
+              class="font-semibold leading-none text-ink-gray-7"
+              :style="{
+                fontSize: `${fontSizePx[getOptionValue(item)] ?? 12}px`,
+              }"
+            >
+              A
+            </span>
+          </span>
+        </template>
+
+        <template #suffix="{ open }">
+          <button
+            v-if="values[field.key]"
+            type="button"
+            aria-label="Clear"
+            tabindex="-1"
+            class="grid size-4 place-items-center rounded-sm text-ink-gray-5 opacity-0 hover:bg-surface-gray-3 hover:text-ink-gray-7 group-hover:opacity-100 focus:opacity-100"
+            @click="clear(field.key, $event)"
+            @pointerdown.stop
+          >
+            <span class="lucide-x size-4" />
+          </button>
+          <span
+            v-else
+            :class="[
+              'lucide-chevron-down size-4 text-ink-gray-5 transition-transform duration-200',
+              open && 'rotate-180',
+            ]"
+          />
+        </template>
+      </Combobox>
+    </div>
+  </div>
+</template>

--- a/src/components/Combobox/stories/Clearable.vue
+++ b/src/components/Combobox/stories/Clearable.vue
@@ -47,12 +47,6 @@ const sizeDot: Record<string, string> = {
   xl: 'size-3',
 }
 
-const styleIcon: Record<string, string> = {
-  subtle: 'lucide-square',
-  outline: 'lucide-square-dashed',
-  ghost: 'lucide-circle-dashed',
-}
-
 const fontSizePx: Record<string, number> = {
   '12': 8,
   '14': 10,
@@ -105,13 +99,17 @@ function clear(key: string, event: Event) {
               ]"
             />
 
-            <span
-              v-else-if="field.key === 'style'"
-              :class="[
-                'size-4 text-ink-gray-6',
-                styleIcon[getOptionValue(item)] ?? 'lucide-square',
-              ]"
-            />
+            <template v-else-if="field.key === 'style'">
+              <span
+                v-if="getOptionValue(item) === 'outline'"
+                class="lucide-square-dashed size-4 text-ink-gray-6"
+              />
+              <span
+                v-else-if="getOptionValue(item) === 'ghost'"
+                class="lucide-circle-dashed size-4 text-ink-gray-6"
+              />
+              <span v-else class="lucide-square size-4 text-ink-gray-6" />
+            </template>
 
             <span
               v-else-if="field.key === 'fontSize'"

--- a/src/components/Combobox/stories/CreateNew.vue
+++ b/src/components/Combobox/stories/CreateNew.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Combobox } from 'frappe-ui'
+
+const value = ref<string>('')
+const tags = ref<string[]>(['bug', 'enhancement', 'docs', 'discussion'])
+
+const selectableOptions = computed(() =>
+  tags.value.map((t) => ({ label: t, value: t })),
+)
+
+// "Create new" is just a `type: 'custom'` row. `condition` is authoritative
+// — it runs even before the user types, so the row can decide for itself
+// when to appear based on the typed query and current selection.
+const options = computed(() => [
+  ...selectableOptions.value,
+  {
+    type: 'custom' as const,
+    key: 'create',
+    label: 'Create tag',
+    slot: 'create',
+    keepOpen: false,
+    condition: ({ query }: { query: string }) => {
+      const q = query.trim().toLowerCase()
+      if (!q) return false
+      if (q === value.value?.toLowerCase()) return false
+      return !tags.value.some((t) => t.toLowerCase() === q)
+    },
+    onClick: ({ query }: { query: string }) => {
+      const next = query.trim()
+      if (!next) return
+      tags.value = [...tags.value, next]
+      value.value = next
+    },
+  },
+])
+
+function getBgClass(item: { label: string }) {
+  let options = [
+    'bg-surface-amber-3',
+    'bg-surface-blue-3',
+    'bg-surface-green-3',
+    'bg-surface-gray-3',
+  ]
+  // return a color based on item.label hash
+  const hash = item.label
+    .toLowerCase()
+    .split('')
+    .reduce((a, b) => a + b.charCodeAt(0), 0)
+  return options[hash % options.length]
+}
+</script>
+
+<template>
+  <div class="grid gap-3 shrink-0">
+    <Combobox
+      v-model="value"
+      :options="options"
+      placeholder="Search or create a tag"
+      open-on-focus
+      class="w-64"
+    >
+      <template #item-prefix="{ item }">
+        <span
+          v-if="item.key !== 'create'"
+          :class="getBgClass(item)"
+          class="size-3 rounded-sm"
+        />
+        <span
+          v-if="item.key === 'create'"
+          class="rounded-sm bg-surface-gray-5 lucide-tag"
+        />
+      </template>
+      <template #item-create="{ query }">
+        <div class="flex">
+          <span class="truncate">
+            Create
+            <span v-if="query" class="font-medium text-ink-gray-8">
+              {{ query }}
+            </span>
+          </span>
+        </div>
+      </template>
+    </Combobox>
+
+    <div class="text-sm text-ink-gray-5">
+      Selected: <code class="text-ink-gray-7">{{ value || 'None' }}</code>
+    </div>
+    <div class="text-sm text-ink-gray-5">
+      Tags: <code class="text-ink-gray-7">{{ tags.join(', ') }}</code>
+    </div>
+  </div>
+</template>

--- a/src/components/Combobox/stories/CreateNew.vue
+++ b/src/components/Combobox/stories/CreateNew.vue
@@ -36,18 +36,17 @@ const options = computed(() => [
 ])
 
 function getBgClass(item: { label: string }) {
-  let options = [
+  const palette = [
     'bg-surface-amber-3',
     'bg-surface-blue-3',
     'bg-surface-green-3',
     'bg-surface-gray-3',
   ]
-  // return a color based on item.label hash
   const hash = item.label
     .toLowerCase()
     .split('')
     .reduce((a, b) => a + b.charCodeAt(0), 0)
-  return options[hash % options.length]
+  return palette[hash % palette.length]
 }
 </script>
 

--- a/src/components/Combobox/types.ts
+++ b/src/components/Combobox/types.ts
@@ -134,7 +134,16 @@ export interface ComboboxProps extends InputLabelingProps {
   /** Teleport target for the popover content. */
   portalTo?: string | HTMLElement
 
-  /** Accepts the typed query as the value when nothing matches. */
+  /**
+   * Free-form acceptance: the typed query is accepted as the model value
+   * when nothing matches, and external `modelValue` updates with unknown
+   * strings are preserved. The combobox also renders a built-in "Create X"
+   * row as a click affordance.
+   *
+   * For richer create-new UX (custom label / icon / persistence callback),
+   * prefer a `type: 'custom'` option with `condition` instead — see the
+   * Create New story. The two are independent and can be combined.
+   */
   allowCustomValue?: boolean
 
   /** Replaces the results with a loading state. */
@@ -167,6 +176,16 @@ export interface ComboboxTriggerSlotProps {
   displayValue: string
 }
 
+/**
+ * Shared shape for `#trigger`, `#prefix`, and `#suffix`. `selectedOption`
+ * is always `null` in `#prefix` because the prefix only renders before a
+ * selection — the field is still exposed for slot-prop symmetry across
+ * the trio.
+ */
+export type ComboboxSlotProps = ComboboxTriggerSlotProps
+export type ComboboxPrefixSlotProps = ComboboxSlotProps
+export type ComboboxSuffixSlotProps = ComboboxSlotProps
+
 export interface ComboboxItemSlotProps {
   /** Item currently being rendered. */
   item: ComboboxSelectableOption | ComboboxCustomOption
@@ -198,8 +217,18 @@ export interface ComboboxSlots {
   /** Overrides the rendered description content. */
   description?: () => any
 
-  /** Content rendered before the default input. */
-  prefix?: () => any
+  /** Content rendered before the default input. Receives the same shape
+   * as `#trigger` and `#suffix` (`ComboboxSlotProps`). */
+  prefix?: (props: ComboboxPrefixSlotProps) => any
+
+  /**
+   * Content rendered after the input (input mode) or label (button mode).
+   * Providing this slot **replaces the default chevron** — render your
+   * own fallback (e.g. the chevron) when your slot content is conditional.
+   * Common use: an inline clear button. Use `@click.stop` and
+   * `@pointerdown.stop` so the press doesn't toggle the popover.
+   */
+  suffix?: (props: ComboboxSuffixSlotProps) => any
 
   /** Shared content rendered before the standard row label. */
   'item-prefix'?: (props: ComboboxItemSlotProps) => any

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -275,6 +275,7 @@ defineSlots<MultiSelectSlots>()
         v-bind="{
           open,
           disabled: !!disabled,
+          query: typedQuery,
           selectedOptions,
           displayValue,
           clearAll,
@@ -317,12 +318,31 @@ defineSlots<MultiSelectSlots>()
         :aria-required="required || undefined"
       >
         <!--
-          For exactly one selection, reuse `#item-prefix` (or auto-render
-          `option.icon`) so the trigger matches the dropdown row without
-          a separate prefix slot. For 0 or 2+ selected, show placeholder
-          / "N selected" without a prefix.
+          Prefix precedence on the trigger:
+            1. `#prefix` slot, when provided, owns the entire prefix area
+               regardless of selection count. Use it for aggregate
+               visuals like stacked avatars across multiple selections.
+            2. otherwise: exactly one selected + `#item-prefix` → reuse
+               the list's per-item prefix renderer so the trigger
+               matches the dropdown row.
+            3. otherwise: exactly one selected + `option.icon` → auto-render
+               the icon.
+            4. otherwise: nothing.
         -->
-        <template v-if="singleSelectedOption && $slots['item-prefix']">
+        <slot
+          v-if="$slots.prefix"
+          name="prefix"
+          v-bind="{
+            open,
+            disabled: !!disabled,
+            query: typedQuery,
+            selectedOptions,
+            displayValue,
+          }"
+        />
+        <template
+          v-else-if="singleSelectedOption && $slots['item-prefix']"
+        >
           <slot
             name="item-prefix"
             v-bind="{
@@ -344,21 +364,43 @@ defineSlots<MultiSelectSlots>()
               !selectedOptions.length && 'text-ink-gray-4',
             ]"
           >
-            {{ triggerSummary }}
+            <slot
+              name="summary"
+              v-bind="{
+                open,
+                disabled: !!disabled,
+                query: typedQuery,
+                selectedOptions,
+                displayValue,
+                summary: triggerSummary,
+              }"
+            >{{ triggerSummary }}</slot>
           </span>
           <span
+            v-if="!$slots.summary"
             aria-hidden="true"
             class="multi-select-trigger-sizer col-start-1 row-start-1"
             :data-width-text="triggerSizingText"
           />
         </span>
 
-        <span
-          :class="[
-            'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
-            open && 'rotate-180',
-          ]"
-        />
+        <slot
+          name="suffix"
+          v-bind="{
+            open,
+            disabled: !!disabled,
+            query: typedQuery,
+            selectedOptions,
+            displayValue,
+          }"
+        >
+          <span
+            :class="[
+              'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
+              open && 'rotate-180',
+            ]"
+          />
+        </slot>
       </button>
     </ComboboxAnchor>
 

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -338,6 +338,8 @@ defineSlots<MultiSelectSlots>()
             query: typedQuery,
             selectedOptions,
             displayValue,
+            clearAll,
+            toggleOpen,
           }"
         />
         <template
@@ -372,6 +374,8 @@ defineSlots<MultiSelectSlots>()
                 query: typedQuery,
                 selectedOptions,
                 displayValue,
+                clearAll,
+                toggleOpen,
                 summary: triggerSummary,
               }"
             >{{ triggerSummary }}</slot>
@@ -392,6 +396,8 @@ defineSlots<MultiSelectSlots>()
             query: typedQuery,
             selectedOptions,
             displayValue,
+            clearAll,
+            toggleOpen,
           }"
         >
           <span

--- a/src/components/MultiSelect/index.ts
+++ b/src/components/MultiSelect/index.ts
@@ -9,9 +9,13 @@ export type {
   MultiSelectItemSlots,
   MultiSelectOption,
   MultiSelectOptions,
+  MultiSelectPrefixSlotProps,
   MultiSelectProps,
   MultiSelectSize,
+  MultiSelectSlotProps,
   MultiSelectSlots,
+  MultiSelectSuffixSlotProps,
+  MultiSelectSummarySlotProps,
   MultiSelectTriggerSlotProps,
   MultiSelectVariant,
 } from './types'

--- a/src/components/MultiSelect/stories/Members.vue
+++ b/src/components/MultiSelect/stories/Members.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Avatar, MultiSelect } from 'frappe-ui'
+
+type Member = {
+  label: string
+  value: string
+  image: string
+  role: string
+}
+
+const members: Member[] = [
+  {
+    label: 'Alex Rivera',
+    value: 'alex@frappe.io',
+    image: 'https://i.pravatar.cc/80?u=alex@frappe.io',
+    role: 'Engineering',
+  },
+  {
+    label: 'Priya Shah',
+    value: 'priya@frappe.io',
+    image: 'https://i.pravatar.cc/80?u=priya@frappe.io',
+    role: 'Design',
+  },
+  {
+    label: 'Marcus Lee',
+    value: 'marcus@frappe.io',
+    image: 'https://i.pravatar.cc/80?u=marcus@frappe.io',
+    role: 'Product',
+  },
+  {
+    label: 'Sofia Hartmann',
+    value: 'sofia@frappe.io',
+    image: 'https://i.pravatar.cc/80?u=sofia@frappe.io',
+    role: 'Engineering',
+  },
+  {
+    label: 'Kenji Tanaka',
+    value: 'kenji@frappe.io',
+    image: 'https://i.pravatar.cc/80?u=kenji@frappe.io',
+    role: 'Design',
+  },
+  {
+    label: 'Nadia Okafor',
+    value: 'nadia@frappe.io',
+    image: 'https://i.pravatar.cc/80?u=nadia@frappe.io',
+    role: 'Product',
+  },
+]
+
+const value = ref<string[]>(['alex@frappe.io', 'priya@frappe.io'])
+
+const MAX_AVATARS = 3
+
+const visibleSelected = computed(() =>
+  (
+    value.value
+      .map((v) => members.find((m) => m.value === v))
+      .filter(Boolean) as Member[]
+  ).slice(0, MAX_AVATARS),
+)
+
+const overflowCount = computed(() =>
+  Math.max(0, value.value.length - MAX_AVATARS),
+)
+</script>
+
+<template>
+  <MultiSelect
+    v-model="value"
+    :options="members"
+    placeholder="Assign reviewers…"
+    class="w-80"
+  >
+    <template #prefix>
+      <div v-if="visibleSelected.length" class="flex -space-x-1.5">
+        <Avatar
+          v-for="m in visibleSelected"
+          :key="m.value"
+          :image="m.image"
+          :label="m.label"
+          size="sm"
+        />
+        <span
+          v-if="overflowCount > 0"
+          class="z-10 grid size-5 place-items-center rounded-full bg-surface-gray-3 text-p-xs font-medium text-ink-gray-7"
+        >
+          +{{ overflowCount }}
+        </span>
+      </div>
+      <span v-else class="lucide-users size-4 text-ink-gray-5" />
+    </template>
+
+    <template #summary="{ selectedOptions, summary }">
+      <template v-if="selectedOptions.length">
+        {{ selectedOptions.map((o) => o.label).join(', ') }}
+      </template>
+      <template v-else>{{ summary }}</template>
+    </template>
+
+    <template #item-prefix="{ item }">
+      <Avatar :image="(item as Member).image" :label="item.label" size="sm" />
+    </template>
+
+    <template #item-label="{ item }">
+      <div class="min-w-0 flex justify-between">
+        <div class="truncate">{{ item.label }}</div>
+        <div class="truncate text-p-sm text-ink-gray-5">
+          {{ (item as Member).role }}
+        </div>
+      </div>
+    </template>
+  </MultiSelect>
+</template>

--- a/src/components/MultiSelect/types.ts
+++ b/src/components/MultiSelect/types.ts
@@ -103,24 +103,42 @@ export interface MultiSelectProps extends InputLabelingProps {
   compareFn?: (a: MultiSelectOption, b: MultiSelectOption) => boolean
 }
 
-export interface MultiSelectTriggerSlotProps {
+/**
+ * Shared shape for `#trigger` and `#suffix`. `#trigger` extends this with
+ * imperative `clearAll` / `toggleOpen` helpers (see `MultiSelectTriggerSlotProps`).
+ */
+export interface MultiSelectSlotProps {
   /** Whether the popover is open. */
   open: boolean
 
   /** Whether the multi-select is disabled. */
   disabled: boolean
 
+  /** Current search query — empty when the user hasn't typed since opening. */
+  query: string
+
   /** Resolved option objects for the selected values, in `modelValue` order. */
   selectedOptions: MultiSelectOption[]
 
   /** Comma-joined labels of the selected options, or `''` when nothing is selected. */
   displayValue: string
+}
 
+export interface MultiSelectTriggerSlotProps extends MultiSelectSlotProps {
   /** Clears all selected values. */
   clearAll: () => void
 
   /** Toggles the popover open state. */
   toggleOpen: () => void
+}
+
+export type MultiSelectPrefixSlotProps = MultiSelectSlotProps
+export type MultiSelectSuffixSlotProps = MultiSelectSlotProps
+
+export interface MultiSelectSummarySlotProps extends MultiSelectSlotProps {
+  /** Default label text the trigger would render (e.g. placeholder,
+   * single selected label, or `"N selected"`). Use it as a fallback. */
+  summary: string
 }
 
 export interface MultiSelectItemSlotProps {
@@ -161,6 +179,31 @@ export interface MultiSelectFooterSlotProps {
 export interface MultiSelectSlots {
   /** Fully custom trigger renderer. */
   trigger?: (props: MultiSelectTriggerSlotProps) => any
+
+  /**
+   * Content rendered before the trigger label. When provided, this slot
+   * owns the entire prefix area regardless of selection count — useful
+   * for aggregate visuals like stacked avatars. If omitted, the trigger
+   * auto-renders the selected option's `#item-prefix` / `icon` when
+   * exactly one is selected, and nothing otherwise.
+   */
+  prefix?: (props: MultiSelectPrefixSlotProps) => any
+
+  /**
+   * Overrides the trigger label region. Receives the default summary
+   * text as `summary` — use it as a fallback. Useful when you want to
+   * show comma-separated labels (or any other format) instead of the
+   * default `"N selected"` for multi-selection states.
+   */
+  summary?: (props: MultiSelectSummarySlotProps) => any
+
+  /**
+   * Content rendered after the trigger label. Providing this slot
+   * **replaces the default chevron** — render your own fallback when
+   * your slot content is conditional. Use `@click.stop` and
+   * `@pointerdown.stop` so the press doesn't toggle the popover.
+   */
+  suffix?: (props: MultiSelectSuffixSlotProps) => any
 
   /** Overrides the rendered label content. Receives `{ required }`. */
   label?: (props: { required: boolean }) => any

--- a/src/components/MultiSelect/types.ts
+++ b/src/components/MultiSelect/types.ts
@@ -104,8 +104,10 @@ export interface MultiSelectProps extends InputLabelingProps {
 }
 
 /**
- * Shared shape for `#trigger` and `#suffix`. `#trigger` extends this with
- * imperative `clearAll` / `toggleOpen` helpers (see `MultiSelectTriggerSlotProps`).
+ * Shared shape for `#trigger`, `#prefix`, `#suffix`, and (with an added
+ * `summary` field) `#summary`. The imperative helpers `clearAll` and
+ * `toggleOpen` are exposed on every slot so consumers don't need to hoist
+ * into `#trigger` just to clear the selection.
  */
 export interface MultiSelectSlotProps {
   /** Whether the popover is open. */
@@ -122,9 +124,7 @@ export interface MultiSelectSlotProps {
 
   /** Comma-joined labels of the selected options, or `''` when nothing is selected. */
   displayValue: string
-}
 
-export interface MultiSelectTriggerSlotProps extends MultiSelectSlotProps {
   /** Clears all selected values. */
   clearAll: () => void
 
@@ -132,6 +132,7 @@ export interface MultiSelectTriggerSlotProps extends MultiSelectSlotProps {
   toggleOpen: () => void
 }
 
+export type MultiSelectTriggerSlotProps = MultiSelectSlotProps
 export type MultiSelectPrefixSlotProps = MultiSelectSlotProps
 export type MultiSelectSuffixSlotProps = MultiSelectSlotProps
 

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -281,7 +281,16 @@ defineSlots<SelectSlots>()
           v-else-if="selectedOption?.icon"
           :icon="selectedOption.icon"
         />
-        <slot v-else name="prefix" />
+        <slot
+          v-else
+          name="prefix"
+          v-bind="{
+            open,
+            disabled: !!disabled,
+            selectedOption,
+            displayValue,
+          }"
+        />
 
         <div class="grid min-w-0 text-left">
           <SelectValue
@@ -299,7 +308,15 @@ defineSlots<SelectSlots>()
           />
         </div>
 
-        <slot name="suffix">
+        <slot
+          name="suffix"
+          v-bind="{
+            open,
+            disabled: !!disabled,
+            selectedOption,
+            displayValue,
+          }"
+        >
           <span class="lucide-chevron-down ml-auto size-4 shrink-0 text-ink-gray-4" />
         </slot>
       </template>

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -57,6 +57,16 @@ export interface SelectTriggerSlotProps {
   displayValue: string
 }
 
+/**
+ * Shared shape for `#trigger`, `#prefix`, and `#suffix`. `selectedOption`
+ * is always `null` in `#prefix` because the prefix only renders before a
+ * selection — the field is still exposed for slot-prop symmetry across
+ * the trio.
+ */
+export type SelectSlotProps = SelectTriggerSlotProps
+export type SelectPrefixSlotProps = SelectSlotProps
+export type SelectSuffixSlotProps = SelectSlotProps
+
 export interface SelectItemSlotProps {
   /** Item currently being rendered. */
   item: SelectNormalizedOption
@@ -78,11 +88,16 @@ export interface SelectSlots {
   /** Overrides the rendered description content. */
   description?: () => any
 
-  /** Content rendered before the trigger value. */
-  prefix?: () => any
+  /** Content rendered before the trigger value. Receives the same shape
+   * as `#trigger` and `#suffix` (`SelectSlotProps`). */
+  prefix?: (props: SelectPrefixSlotProps) => any
 
-  /** Content rendered after the trigger value. */
-  suffix?: () => any
+  /**
+   * Content rendered after the trigger value. Providing this slot
+   * **replaces the default chevron** — render your own fallback when
+   * your slot content is conditional.
+   */
+  suffix?: (props: SelectSuffixSlotProps) => any
 
   /**
    * Shared renderer for option labels.

--- a/src/components/shared/selection/useFilteredGroups.ts
+++ b/src/components/shared/selection/useFilteredGroups.ts
@@ -4,14 +4,17 @@ import { computed, type ComputedRef, type Ref } from 'vue'
  * Drives the `filteredGroups` computed shared by MultiSelect and Combobox:
  *
  *   - While the popover is closed or the user hasn't typed since opening,
- *     return groups untouched (so a committed label like "Alex Rivera"
- *     doesn't filter the list to itself).
- *   - Otherwise, filter each group's options through `matches(item, query)`
- *     and drop groups that end up empty.
+ *     skip the query-based `matches` filter (so a committed label like
+ *     "Alex Rivera" doesn't filter the list to itself).
+ *   - `alwaysMatch` runs on both paths — it's for items whose visibility
+ *     is bespoke (e.g. Combobox's `type: 'custom'` action rows, whose
+ *     `condition` callback must be authoritative even before the user
+ *     types). Default: include every item.
+ *   - On the typing path, items must pass BOTH `alwaysMatch` AND `matches`.
  *
  * The `matches` predicate is supplied by each consumer — MultiSelect uses
- * a plain label/value substring match; Combobox dispatches on item type
- * to handle its `custom` rows.
+ * a plain label/value substring match; Combobox uses it for selectable
+ * rows only and defers custom rows to `alwaysMatch`.
  */
 export function useFilteredGroups<
   TItem,
@@ -22,18 +25,21 @@ export function useFilteredGroups<
   hasTypedSinceOpen: Ref<boolean>
   query: Ref<string>
   matches: (item: TItem, query: string) => boolean
+  alwaysMatch?: (item: TItem) => boolean
 }): ComputedRef<TGroup[]> {
   return computed(() => {
-    if (!source.open.value || !source.hasTypedSinceOpen.value) {
-      return source.groups.value
-    }
+    const alwaysMatch = source.alwaysMatch ?? (() => true)
+    const filterByTypedQuery =
+      source.open.value && source.hasTypedSinceOpen.value
 
     return source.groups.value
       .map((group) => ({
         ...group,
-        options: group.options.filter((item) =>
-          source.matches(item, source.query.value),
-        ),
+        options: group.options.filter((item) => {
+          if (!alwaysMatch(item)) return false
+          if (!filterByTypedQuery) return true
+          return source.matches(item, source.query.value)
+        }),
       }))
       .filter((group) => group.options.length > 0) as TGroup[]
   })

--- a/v1-release/08c-select-spec.md
+++ b/v1-release/08c-select-spec.md
@@ -121,6 +121,11 @@ type SelectTriggerSlotProps = {
   displayValue: string
 }
 
+// `#trigger`, `#prefix`, and `#suffix` all receive the same shape.
+type SelectSlotProps = SelectTriggerSlotProps
+type SelectPrefixSlotProps = SelectSlotProps
+type SelectSuffixSlotProps = SelectSlotProps
+
 type SelectOptionSlotProps = {
   option: Exclude<SelectOption, string>
 }
@@ -130,10 +135,13 @@ Supported slots:
 
 - `#trigger="{ open, disabled, selectedOption, displayValue }"`
   - advanced trigger customization
-- `#prefix`
-  - convenience slot inside the default trigger shell
-- `#suffix`
-  - convenience slot inside the default trigger shell
+- `#prefix="{ open, disabled, selectedOption, displayValue }"`
+  - convenience slot inside the default trigger shell. `selectedOption`
+    is always `null` here (prefix renders pre-selection)
+- `#suffix="{ open, disabled, selectedOption, displayValue }"`
+  - convenience slot inside the default trigger shell. **Replaces the
+    default chevron** — render an explicit chevron fallback when your
+    slot content is conditional
 - `#item-prefix="{ option }"`
 - `#item-label="{ option }"`
 - `#item-suffix="{ option }"`

--- a/v1-release/08d-combobox-spec.md
+++ b/v1-release/08d-combobox-spec.md
@@ -248,6 +248,13 @@ type ComboboxTriggerSlotProps = {
   displayValue: string
 }
 
+// `#trigger`, `#prefix`, and `#suffix` all receive the same shape. `selectedOption`
+// is always `null` inside `#prefix` since the prefix slot only renders before
+// a selection — the field is still exposed for symmetry.
+type ComboboxSlotProps = ComboboxTriggerSlotProps
+type ComboboxPrefixSlotProps = ComboboxSlotProps
+type ComboboxSuffixSlotProps = ComboboxSlotProps
+
 type ComboboxItemSlotProps = {
   item: ComboboxSelectableOption | ComboboxCustomOption
   query: string
@@ -271,8 +278,17 @@ Supported slots:
     popover header** instead of using the trigger as the input. Use this
     for assignee pickers, status pills, emoji reactions, and any other
     button-initiated search flow.
-- `#prefix`
-  - convenience slot rendered inside the default input shell, before the input
+- `#prefix="{ open, disabled, query, selectedOption, displayValue }"`
+  - convenience slot rendered inside the default input shell, before the input.
+    Receives the same shape as `#trigger` and `#suffix`. `selectedOption` is
+    always `null` here because the prefix only renders pre-selection
+- `#suffix="{ open, disabled, query, selectedOption, displayValue }"`
+  - convenience slot rendered after the input (input mode) or after the
+    label (button mode). **Replaces the default chevron** when provided —
+    render an explicit chevron fallback when your slot content is
+    conditional. Typical use: an inline clear button. The slot's button
+    should call `@click.stop` and `@pointerdown.stop` so the press does
+    not toggle the popover
 - `#item-prefix="{ item, query, selected }"`
   - custom leading content for the standard option row shell
 - `#item-label="{ item, query, selected }"`
@@ -334,8 +350,13 @@ Filtering rules:
 - for custom options, `condition({ query })` is evaluated when present and
   controls visibility; if `condition` is absent, custom options match the same
   case-insensitive rule against `label`
-- filtering is not applied when the popover just opened and the user has not
-  yet typed, so the full list is shown with the current selection focused
+- `condition` is **authoritative**: it is consulted even before the user
+  has typed since opening, so a `type: 'custom'` row can fully gate its
+  own visibility (e.g. "show only when the typed query is non-empty and
+  doesn't already match an existing option"). The `query` passed in is
+  the typed-since-open query — empty when the user hasn't typed yet
+- the "show the full list before the user has typed" bypass applies only
+  to selectable options; custom options always go through `condition`
 
 Selection behavior:
 
@@ -354,11 +375,24 @@ Selection behavior:
 
 `allowCustomValue` behavior:
 
+`allowCustomValue` is the **free-form acceptance** flag — it lets the combobox
+behave like a text input with autocomplete, where any typed-or-programmatically-set
+string is a valid model value.
+
 - when `true` and no option matches the current query on commit, the free-form
   query itself is accepted as the value
 - `update:modelValue` fires with the raw query string in that case
+- external `modelValue` updates with unknown strings are preserved; without
+  `allowCustomValue`, an unmatched external value is dropped
+- the combobox also renders a built-in "Create X" row as a click affordance
+  when typing has no matches
 - custom options still take precedence over free-form acceptance when they
   match and are chosen explicitly
+
+For **richer create-new UX** — custom label, icon, persistence callback, or
+"create only when the query isn't already a known value" — prefer a
+`type: 'custom'` option with `condition` (see the Create New story). The two
+mechanisms are independent and can be combined.
 
 Display rules:
 
@@ -775,6 +809,52 @@ object-form `render` is aliased one-to-one to `slots`, so existing code
 continues to work unchanged through `v1.x`.
 
 ## Changelog
+
+### 2026-05-17
+
+- **Added `#suffix` slot.** Rendered after the input (input mode) or label
+  (button mode). Providing the slot replaces the default chevron — consumers
+  render their own fallback for the unselected/closed state. Canonical use
+  is an inline clear button; the slot's button must `stopPropagation` on
+  `click` and `pointerdown` so the press does not toggle the popover.
+
+- **`condition` is now authoritative for custom rows.** A `type: 'custom'`
+  row's `condition({ query })` is consulted even before the user types
+  since opening, so it can fully gate its own visibility based on selection
+  state and the typed query. Selectable rows are unchanged — they still
+  skip query filtering until the user types.
+
+- **Decided against a dedicated `clearable` prop (#658).** The `#suffix`
+  slot plus `v-model` already cover the clear-button pattern with no
+  loss of expressiveness. The story at `stories/Clearable.vue` is the
+  canonical example.
+
+- **Decided against a dedicated `createOption` prop (#661).** The
+  existing `type: 'custom'` option shape, combined with the authoritative
+  `condition`, expresses the "create new" pattern in ~15 lines of consumer
+  code. A `createOption` prop would be pure sugar over the same primitive.
+  The story at `stories/CreateNew.vue` is the canonical example.
+
+- **`#659` deferred.** Suppressing the popover-header search input when
+  `#trigger` already contains an input still requires a Combobox-level
+  change (a `hideSearchInput` prop or similar). Will revisit when a
+  concrete consumer needs it.
+
+- **Slot-prop symmetry across `#trigger` / `#prefix` / `#suffix`.** All
+  three slots now receive the same shape (`ComboboxSlotProps`). `#prefix`
+  previously received no props; it now gets `{ open, disabled, query,
+  selectedOption, displayValue }` for parity. `selectedOption` is always
+  `null` inside `#prefix` because the prefix only renders pre-selection,
+  but the field is exposed for symmetry. The matching change was made on
+  `MultiSelect` (added `query` to `#trigger`; aligned `#suffix`) and
+  `Select` (added the shared shape to `#prefix` / `#suffix`).
+
+- **`allowCustomValue` reframed as the free-form-acceptance flag.** The
+  prop docs and spec now lead with its distinctive behavior — accepting
+  arbitrary typed-or-set strings into the model — rather than the
+  "creatable option" framing. For richer create-new UX, prefer
+  `type: 'custom'` with `condition` (Create New story). The two are
+  independent.
 
 ### 2026-04-24
 

--- a/v1-release/08e-multiselect-spec.md
+++ b/v1-release/08e-multiselect-spec.md
@@ -144,21 +144,22 @@ Emit rules:
 Guaranteed slot props:
 
 ```ts
-// Shared shape for `#trigger` and `#suffix`. `#trigger` extends this with
-// imperative `clearAll` / `toggleOpen` helpers.
+// Shared shape for `#trigger`, `#prefix`, `#suffix`, and `#summary`
+// (the latter adds `summary`). `clearAll` / `toggleOpen` are exposed
+// on every slot so consumers don't need to hoist into `#trigger` just
+// to clear the selection or toggle the popover.
 type MultiSelectSlotProps = {
   open: boolean
   disabled: boolean
   query: string
   selectedOptions: MultiSelectOption[]
   displayValue: string
-}
-
-type MultiSelectTriggerSlotProps = MultiSelectSlotProps & {
   clearAll: () => void
   toggleOpen: () => void
 }
 
+type MultiSelectTriggerSlotProps = MultiSelectSlotProps
+type MultiSelectPrefixSlotProps = MultiSelectSlotProps
 type MultiSelectSuffixSlotProps = MultiSelectSlotProps
 
 type MultiSelectSummarySlotProps = MultiSelectSlotProps & {
@@ -192,13 +193,13 @@ Supported slots:
 
 - `#trigger="{ open, disabled, query, selectedOptions, displayValue, clearAll, toggleOpen }"`
   - preferred advanced trigger slot; replaces the default button trigger
-- `#prefix="{ open, disabled, query, selectedOptions, displayValue }"`
+- `#prefix="{ open, disabled, query, selectedOptions, displayValue, clearAll, toggleOpen }"`
   - convenience slot rendered before the trigger label. When provided,
     it owns the entire prefix area regardless of selection count — use
     it for aggregate visuals like stacked avatars across multiple
     selections. If omitted, the trigger auto-renders the selected
     option's `#item-prefix` / `icon` when exactly one is selected
-- `#summary="{ open, disabled, query, selectedOptions, displayValue, summary }"`
+- `#summary="{ open, disabled, query, selectedOptions, displayValue, clearAll, toggleOpen, summary }"`
   - overrides the trigger's label region. Receives the default summary
     text as `summary` — placeholder, single label, or `"N selected"` —
     so the consumer can fall back to it or replace entirely (e.g. with
@@ -206,11 +207,12 @@ Supported slots:
     default phantom-sizer (which only knows the default summary's
     worst-case width), so the trigger is content-sized — pin a width
     on the trigger (or wrap with one) if you need a stable layout
-- `#suffix="{ open, disabled, query, selectedOptions, displayValue }"`
+- `#suffix="{ open, disabled, query, selectedOptions, displayValue, clearAll, toggleOpen }"`
   - convenience slot rendered after the trigger label. **Replaces the
     default chevron** — render an explicit chevron fallback when your
     slot content is conditional. Use `@click.stop` / `@pointerdown.stop`
-    so the press doesn't toggle the popover
+    so the press doesn't toggle the popover. Canonical home for a
+    clear-all button — call `clearAll` from the slot prop
 - `#item-prefix="{ item, query, selected }"`
 - `#item-label="{ item, query, selected }"`
 - `#item-suffix="{ item, query, selected }"`

--- a/v1-release/08e-multiselect-spec.md
+++ b/v1-release/08e-multiselect-spec.md
@@ -144,13 +144,26 @@ Emit rules:
 Guaranteed slot props:
 
 ```ts
-type MultiSelectTriggerSlotProps = {
+// Shared shape for `#trigger` and `#suffix`. `#trigger` extends this with
+// imperative `clearAll` / `toggleOpen` helpers.
+type MultiSelectSlotProps = {
   open: boolean
   disabled: boolean
+  query: string
   selectedOptions: MultiSelectOption[]
   displayValue: string
+}
+
+type MultiSelectTriggerSlotProps = MultiSelectSlotProps & {
   clearAll: () => void
   toggleOpen: () => void
+}
+
+type MultiSelectSuffixSlotProps = MultiSelectSlotProps
+
+type MultiSelectSummarySlotProps = MultiSelectSlotProps & {
+  // default summary text — placeholder, single label, or `"N selected"`
+  summary: string
 }
 
 type MultiSelectItemSlotProps = {
@@ -177,8 +190,27 @@ type MultiSelectEmptySlotProps = {
 
 Supported slots:
 
-- `#trigger="{ open, disabled, selectedOptions, displayValue, clearAll, toggleOpen }"`
+- `#trigger="{ open, disabled, query, selectedOptions, displayValue, clearAll, toggleOpen }"`
   - preferred advanced trigger slot; replaces the default button trigger
+- `#prefix="{ open, disabled, query, selectedOptions, displayValue }"`
+  - convenience slot rendered before the trigger label. When provided,
+    it owns the entire prefix area regardless of selection count — use
+    it for aggregate visuals like stacked avatars across multiple
+    selections. If omitted, the trigger auto-renders the selected
+    option's `#item-prefix` / `icon` when exactly one is selected
+- `#summary="{ open, disabled, query, selectedOptions, displayValue, summary }"`
+  - overrides the trigger's label region. Receives the default summary
+    text as `summary` — placeholder, single label, or `"N selected"` —
+    so the consumer can fall back to it or replace entirely (e.g. with
+    a comma-separated label list). Providing this slot suppresses the
+    default phantom-sizer (which only knows the default summary's
+    worst-case width), so the trigger is content-sized — pin a width
+    on the trigger (or wrap with one) if you need a stable layout
+- `#suffix="{ open, disabled, query, selectedOptions, displayValue }"`
+  - convenience slot rendered after the trigger label. **Replaces the
+    default chevron** — render an explicit chevron fallback when your
+    slot content is conditional. Use `@click.stop` / `@pointerdown.stop`
+    so the press doesn't toggle the popover
 - `#item-prefix="{ item, query, selected }"`
 - `#item-label="{ item, query, selected }"`
 - `#item-suffix="{ item, query, selected }"`

--- a/v1-release/changelog.md
+++ b/v1-release/changelog.md
@@ -276,6 +276,30 @@ so editors hint at the rename. The legacy `#option` slot still passes
 Root renders as a transparent layout box so the trigger sizes like
 `Select` in flex/grid containers. Query decoupled from model in button mode.
 
+### Combobox / MultiSelect — `#suffix` slot replaces the chevron
+
+New `#suffix` slot on `Combobox` (input and button modes) and `MultiSelect`,
+mirroring the existing slot on `Select`. Providing the slot replaces the
+default chevron — render an explicit chevron fallback when your content is
+conditional. Canonical use is an inline clear button. See
+`Combobox/stories/Clearable.vue`.
+
+### Combobox — `condition` authoritative for `type: 'custom'` rows
+
+A custom row's `condition({ query })` is now consulted even before the user
+types since opening, so it can fully gate its own visibility based on
+selection state and the typed query. Selectable rows are unchanged. This
+makes "create new" patterns expressible directly via `condition`, with no
+need for a dedicated `createOption` prop. See `Combobox/stories/CreateNew.vue`.
+
+### MultiSelect — `#summary` suppresses the phantom sizer
+
+The trigger's default behavior pins a minimum width derived from the
+worst-case default summary (`placeholder` vs `"N selected"`) so the
+trigger doesn't jitter as the count changes. That sizer can't predict
+custom text, so it's now skipped when `#summary` is provided — the
+trigger becomes content-sized and the consumer owns the width.
+
 ### InputLabel — slot polish
 
 The default required indicator is not rendered when `#label` is used


### PR DESCRIPTION
## Summary

Polish pass on the v1 trigger surface for `Combobox`, `MultiSelect`, and `Select`. Three concrete additions plus the slot-prop symmetry that ties them together.

- **`#suffix` slot on Combobox and MultiSelect.** Mirrors the existing slot on Select. Providing the slot replaces the default chevron — consumers render their own fallback. Canonical use: an inline clear button. See `src/components/Combobox/stories/Clearable.vue`.
- **`condition` is authoritative for Combobox `type: 'custom'` rows.** A custom row's `condition({ query })` now runs even before the user types since opening, so the row can fully gate its own visibility against the typed query and current selection. Selectable rows are unchanged. See `src/components/Combobox/stories/CreateNew.vue`.
- **MultiSelect `#prefix` and `#summary` slots.** `#prefix` owns the entire prefix area regardless of selection count (good for stacked avatars / aggregate visuals). `#summary` overrides the label region with a `summary` fallback prop. When `#summary` is provided, the phantom width-sizer is suppressed since the consumer owns the trigger width. See `src/components/MultiSelect/stories/Members.vue`.
- **Slot-prop symmetry.** `#trigger` / `#prefix` / `#suffix` all receive the same shape on Combobox and Select. MultiSelect's `#trigger` now also gets `query` for parity.
- **`allowCustomValue` docs reframed** as the free-form-acceptance flag (vs the prior "creatable option" framing).

## Closes

- Closes #658 — clear button in Combobox: use the new `#suffix` slot with a clear button that calls `@click.stop` / `@pointerdown.stop` (see `Clearable.vue`); no dedicated `clearable` prop needed.
- Closes #661 — canonical "create new" API: a `type: 'custom'` option with the now-authoritative `condition({ query })` callback expresses the pattern in ~15 lines of consumer code (see `CreateNew.vue`); no dedicated `createOption` prop needed.

## Related

- #659 — suppress popover-header search input when `#trigger` already contains an input. **Deferred**, not closed by this PR: still requires a Combobox-level prop (e.g. `hideSearchInput`). Will revisit when a concrete consumer needs it.

## Test plan

- [ ] Storybook / docs: open the three new stories (`Combobox-Clearable`, `Combobox-CreateNew`, `MultiSelect-Members`) and exercise selection, clearing, and create flows.
- [ ] Combobox: confirm `type: 'custom'` rows whose `condition` returns `false` are hidden on first open (before any typing).
- [ ] MultiSelect: with `#summary` overriding the label, confirm the trigger no longer reserves a min-width from the default summary; without `#summary`, confirm the trigger stays stable as the count grows.
- [ ] Visual: chevron rotation on open still works when no `#suffix` slot is provided (Combobox input + button modes, MultiSelect).

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 43.28% (1807/4175) | +0.05%      |
| Statements | 38.43% (1911/4972) | +0.08%      |
| Functions  | 39.91% (370/927) | +0.07%      |
| Branches   | 29.34% (577/1966) | +0.10%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->



