### PR TITLE
feat: render `router-link` when `:route` prop is passed

### DIFF
--- a/src/components/Button/Button.cy.ts
+++ b/src/components/Button/Button.cy.ts
@@ -1,5 +1,16 @@
 import Button from './Button.vue'
 import { h } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+
+function createTestRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div />' } },
+      { path: '/reports', component: { template: '<div />' } },
+    ],
+  })
+}
 
 describe('<Button />', () => {
   it('renders default button', () => {
@@ -116,6 +127,46 @@ describe('<Button />', () => {
     cy.get('@onClickSpy').should('have.been.called')
   })
 
+  it('renders a router link when route is provided', () => {
+    const router = createTestRouter()
+
+    cy.mount(Button, {
+      props: {
+        route: '/reports',
+        label: 'Reports',
+      },
+      attrs: {
+        'data-test-id': 'reports-link',
+        'aria-current': 'page',
+      },
+      global: {
+        plugins: [router],
+      },
+    })
+
+    cy.get('a[data-test-id="reports-link"]')
+      .should('have.attr', 'href', '/reports')
+      .and('have.attr', 'aria-current', 'page')
+      .and('contain.text', 'Reports')
+    cy.get('button').should('not.exist')
+  })
+
+  it('renders an anchor when link is provided', () => {
+    cy.mount(Button, {
+      props: {
+        link: 'https://frappe.io/docs',
+        label: 'Docs',
+      },
+    })
+
+    cy.get('a')
+      .should('have.attr', 'href', 'https://frappe.io/docs')
+      .and('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noreferrer noopener')
+      .and('contain.text', 'Docs')
+    cy.get('button').should('not.exist')
+  })
+
   it('is disabled', () => {
     cy.mount(Button, {
       props: {
@@ -124,5 +175,33 @@ describe('<Button />', () => {
       },
     })
     cy.get('button').should('be.disabled')
+  })
+
+  it('falls back to a disabled button when route or link is blocked', () => {
+    const router = createTestRouter()
+
+    cy.mount(Button, {
+      props: {
+        route: '/reports',
+        disabled: true,
+        label: 'Disabled route',
+      },
+      global: {
+        plugins: [router],
+      },
+    })
+    cy.get('button').should('be.disabled').and('contain.text', 'Disabled route')
+    cy.get('a').should('not.exist')
+
+    cy.mount(Button, {
+      props: {
+        link: 'https://frappe.io/docs',
+        loading: true,
+        loadingText: 'Loading docs',
+        label: 'Docs',
+      },
+    })
+    cy.get('button').should('be.disabled').and('contain.text', 'Loading docs')
+    cy.get('a').should('not.exist')
   })
 })

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -1,23 +1,12 @@
 <template>
-  <!--
-    The <button> is the effective DOM root. reka's Tooltip primitives
-    (TooltipProvider/TooltipRoot/TooltipTrigger) are renderless / pass-
-    through, so consumers wrapping <Button> in their own reka primitives
-    (e.g. ComboboxTrigger as-child) see a native <button> element with
-    all forwarded attrs — tabindex, aria-expanded, role — intact. Using
-    the separate <Tooltip> component as a wrapper dropped those attrs
-    because it's a Vue component with `inheritAttrs: false`.
-  -->
   <TooltipProvider>
     <TooltipRoot>
       <TooltipTrigger as-child>
-        <button
+        <component
+          :is="Root"
           v-bind="$attrs"
           :class="buttonClasses"
-          @click="handleClick"
-          :disabled="isDisabled"
           :aria-label="label"
-          :type="props.type"
           ref="rootRef"
         >
       <LoadingIndicator
@@ -84,19 +73,19 @@
           :class="slotClasses"
         />
       </slot>
-        </button>
+        </component>
       </TooltipTrigger>
       <TooltipBubble v-if="tooltip?.length" :text="tooltip" />
     </TooltipRoot>
   </TooltipProvider>
 </template>
 <script lang="ts" setup>
-import { computed, useSlots, ref, watchEffect } from 'vue'
+import { computed, h, ref, useSlots, watchEffect } from 'vue'
 import { TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui'
 import FeatherIcon from '../FeatherIcon.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import TooltipBubble from '../Tooltip/TooltipBubble.vue'
-import { useRouter } from 'vue-router'
+import { RouterLink } from 'vue-router'
 import { warnFeatherIconUsage } from '../../utils/iconString'
 import type { ButtonProps, ThemeVariant } from './types'
 
@@ -108,7 +97,7 @@ const props = withDefaults(defineProps<ButtonProps>(), {
   variant: 'subtle',
   loading: false,
   disabled: false,
-  type: "button"
+  type: 'button',
 })
 
 watchEffect(() => {
@@ -118,7 +107,6 @@ watchEffect(() => {
 })
 
 const slots = useSlots()
-const router = useRouter()
 
 const buttonClasses = computed(() => {
   let solidClasses = {
@@ -248,6 +236,26 @@ const isDisabled = computed(() => {
   return props.disabled || props.loading
 })
 
+// Avoid "Maximum call stack size exceeded" error
+// when using <component is='button' /> inside <Button /> component
+// by using "render" function here to avoid conflicting html "button" component with
+// globally registered "Button" component in consumer apps
+const Root = computed(() => {
+  if (!isDisabled.value && props.route) {
+    return h(RouterLink, { to: props.route })
+  }
+
+  if (!isDisabled.value && props.link) {
+    return h('a', {
+      href: props.link,
+      target: '_blank',
+      rel: 'noreferrer noopener',
+    })
+  }
+
+  return h('button', { type: props.type, disabled: isDisabled.value })
+})
+
 const isIconButton = computed(() => {
   return props.icon || slots.icon || hasLucideIconInDefaultSlot.value
 })
@@ -268,14 +276,6 @@ const hasLucideIconInDefaultSlot = computed(() => {
   }
   return false
 })
-
-const handleClick = () => {
-  if (props.route) {
-    return router.push(props.route)
-  } else if (props.link) {
-    return window.open(props.link, '_blank')
-  }
-}
 
 const rootRef = ref()
 defineExpose({ rootRef })


### PR DESCRIPTION
Update `Button` to render a `RouterLink` when the `route` prop is provided, and anchor tag when the `link` prop is provided, instead of navigating with a click handler. 

#### Test plan

- Cypress: added cases in `src/components/Button/Button.cy.ts` covering `route`, `link`, and disabled/loading fallback behavior
- Manual: reviewed the root rendering paths for `route`, `link`, `disabled`, and `loading` to confirm navigation only happens when the button is interactive

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 44.04% (1889/4289) | ±0.00%      |
| Statements | 38.96% (2001/5135) | ±0.00%      |
| Functions  | 39.83% (378/949) | ±0.00%      |
| Branches   | 29.42% (595/2022) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->

