### PR TITLE
docs: add Claude Code skill and llms.txt index

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -54,6 +54,8 @@ export default defineConfig({
   },
   cleanUrls: true,
   head: [
+    // LLM-friendly docs index — https://llmstxt.org
+    ['link', { rel: 'alternate', type: 'text/markdown', href: '/llms.txt' }],
     // newsreader font
     ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
     [

--- a/docs/content/public/llms.txt
+++ b/docs/content/public/llms.txt
@@ -1,0 +1,96 @@
+# frappe-ui
+
+> Vue 3 component library and data-fetching utilities for building UIs on the Frappe Framework. Used by Frappe Cloud, Gameplan, Desk, Drive, and Insights. Components ship with TypeScript, dark mode via `[data-theme="dark"]`, and a semantic Tailwind preset (`ink-*` / `surface-*` / `outline-*` tokens).
+
+Built on Vue 3, TailwindCSS, Headless UI, reka-ui, TipTap, and lucide icons. Distributed as the `frappe-ui` npm package; import everything from `'frappe-ui'`.
+
+Two cross-cutting conventions to know before reading anything else:
+
+- **Color = `variant` + `theme`.** `variant` is visual style (`solid | outline | subtle | ghost`); `theme` is color tone (`gray | blue | red | green | …`). No `intent` / `severity` / `appearance` axis.
+- **Icons are CSS classes.** Render as `<span class="lucide-<name> size-4" aria-hidden="true" />`. Frappe-ui props that accept icons take the namespaced string `"lucide-edit"`.
+
+## Design principles
+
+- [PHILOSOPHY.md](https://raw.githubusercontent.com/frappe/frappe-ui/main/PHILOSOPHY.md): the 13 rules (P1–P13) that govern API shape across the library — naming, prop design, slots, composition, styling, a11y, deprecation policy.
+- [CONTEXT.md](https://raw.githubusercontent.com/frappe/frappe-ui/main/CONTEXT.md): canonical vocabulary (`open`, `variant`, `theme`, `dismissable`, `bare`, `chrome`, `action`, …). Reference for prop and slot names.
+
+## Getting started
+
+- [Introduction](https://ui.frappe.io/docs/introduction): what frappe-ui is, motivation, products using it.
+- [Getting started](https://ui.frappe.io/docs/getting-started): installation, Tailwind preset wiring, `FrappeUIProvider` setup.
+
+## Core components
+
+- [Alert](https://ui.frappe.io/docs/components/alert): inline banner with title, body, theme, variant.
+- [Avatar](https://ui.frappe.io/docs/components/avatar): user/entity avatar with image or label-derived initials.
+- [Badge](https://ui.frappe.io/docs/components/badge): status pill; same `variant` + `theme` axes as Button.
+- [Breadcrumbs](https://ui.frappe.io/docs/components/breadcrumbs): page-header trail; takes `items: { label, route }[]`.
+- [Button](https://ui.frappe.io/docs/components/button): primary trigger element; supports `route`/`link` for nav, `icon`/`iconLeft`/`iconRight`, `loading`, `disabled`.
+- [Calendar](https://ui.frappe.io/docs/components/calendar): month/week calendar view.
+- [Charts](https://ui.frappe.io/docs/components/charts): chart family (line, bar, etc.).
+- [Checkbox](https://ui.frappe.io/docs/components/checkbox): boolean input; standard labeling contract.
+- [CircularProgressBar](https://ui.frappe.io/docs/components/circularprogressbar): radial progress indicator.
+- [Combobox](https://ui.frappe.io/docs/components/combobox): single-select with search; `v-model` value + `v-model:query`.
+- [DatePicker](https://ui.frappe.io/docs/components/datepicker): date input; also DateRangePicker (range is `string[]`).
+- [Dialog](https://ui.frappe.io/docs/components/dialog): modal overlay; `v-model:open`, `title`/`message`/`icon`/`theme`/`actions`/`dismissable`/`bare`. Imperative API: `dialog.confirm`, `dialog.alert`, `dialog.prompt`.
+- [Divider](https://ui.frappe.io/docs/components/divider): horizontal/vertical rule.
+- [Dropdown](https://ui.frappe.io/docs/components/dropdown): action menu anchored to a trigger; takes `options` (flat or grouped).
+- [ErrorMessage](https://ui.frappe.io/docs/components/errormessage): inline error display.
+- [FileUploader](https://ui.frappe.io/docs/components/fileuploader): Frappe-native file upload with progress.
+- [FormControl](https://ui.frappe.io/docs/components/formcontrol): the default labeled-field wrapper; pick `type` to render text/textarea/select/checkbox/autocomplete with the shared `label`/`description`/`error`/`required` contract.
+- [ItemListRow](https://ui.frappe.io/docs/components/itemlistrow): single-row list item primitive.
+- [ListView](https://ui.frappe.io/docs/components/listview): table/grid list with selection, sorting, virtualization.
+- [MonthPicker](https://ui.frappe.io/docs/components/monthpicker): month input.
+- [MultiSelect](https://ui.frappe.io/docs/components/multiselect): multi-value select; value is `string[]`.
+- [Password](https://ui.frappe.io/docs/components/password): masked input with show/hide.
+- [Popover](https://ui.frappe.io/docs/components/popover): anchored floating panel; `v-model:open`, `#target` + `#body` slots.
+- [Progress](https://ui.frappe.io/docs/components/progress): linear progress bar.
+- [Rating](https://ui.frappe.io/docs/components/rating): star-rating input.
+- [Select](https://ui.frappe.io/docs/components/select): fixed-options single-value select.
+- [Sidebar](https://ui.frappe.io/docs/components/sidebar): app-shell sidebar primitive.
+- [Slider](https://ui.frappe.io/docs/components/slider): numeric range input.
+- [Switch](https://ui.frappe.io/docs/components/switch): boolean toggle for settings.
+- [Tabs](https://ui.frappe.io/docs/components/tabs): full content tabs and inline TabButtons.
+- [Textarea](https://ui.frappe.io/docs/components/textarea): multi-line text input.
+- [TextEditor](https://ui.frappe.io/docs/components/texteditor): TipTap-based rich editor (heavy — use only when needed).
+- [TextInput](https://ui.frappe.io/docs/components/textinput): single-line text input.
+- [TimePicker](https://ui.frappe.io/docs/components/timepicker): time input.
+- [Toast](https://ui.frappe.io/docs/components/toast): imperative notifications: `toast.success/error/info`.
+- [Tooltip](https://ui.frappe.io/docs/components/tooltip): hover hint; not for actionable content (use Popover/Dropdown).
+- [Tree](https://ui.frappe.io/docs/components/tree): hierarchical list.
+
+## Design system
+
+- [Background color tokens](https://ui.frappe.io/docs/design-system/background-color): `bg-surface-*` semantic surface tokens.
+- [Text color tokens](https://ui.frappe.io/docs/design-system/text): `text-ink-*` semantic foreground tokens.
+- [Border color tokens](https://ui.frappe.io/docs/design-system/border-color): `border-outline-*` semantic border tokens.
+- [Border radius](https://ui.frappe.io/docs/design-system/border-radius): radius scale.
+- [Drop shadow](https://ui.frappe.io/docs/design-system/drop-shadow): shadow scale.
+
+## Data fetching
+
+Recommended (v3 composables, in the `frappe-ui` exports):
+
+- `useCall` — Vue composable for any whitelisted Frappe method. Options: `url`, `method`, `params` (object or function for reactivity), `immediate`, `refetch`, `cacheKey` (IndexedDB persistence), `transform`, `beforeSubmit`, `onSuccess`, `onError`. Returns a reactive object with `data`, `error`, `loading`, `isFinished`, `promise`, `execute`/`fetch`/`reload`, `submit(params)`, `reset`, `abort`. Use `immediate: false` + `submit()` for writes. Source: https://github.com/frappe/frappe-ui/blob/main/src/data-fetching/useCall/useCall.ts.
+- `useList` — paginated list composable on top of `useCall`. Source: https://github.com/frappe/frappe-ui/tree/main/src/data-fetching/useList.
+- `useDoc` — single doctype document composable. Source: https://github.com/frappe/frappe-ui/tree/main/src/data-fetching/useDoc.
+- `useDoctype` — doctype metadata composable. Source: https://github.com/frappe/frappe-ui/tree/main/src/data-fetching/useDoctype.
+- `useNewDoc` — scaffolding for new-doc forms. Source: https://github.com/frappe/frappe-ui/tree/main/src/data-fetching/useNewDoc.
+
+Legacy (still exported for migration, not recommended for new code):
+
+- [Resource](https://ui.frappe.io/docs/data-fetching/resource): `createResource` — base data fetcher.
+- [List resource](https://ui.frappe.io/docs/data-fetching/list-resource): `createListResource` — paginated list.
+- [Document resource](https://ui.frappe.io/docs/data-fetching/document-resource): `createDocumentResource` — single doc.
+
+## Other
+
+- [Icons](https://ui.frappe.io/docs/other/icons): the lucide icon-class system; how `<span class="lucide-* size-*" aria-hidden="true" />` works.
+- [Directives](https://ui.frappe.io/docs/other/directives): Vue directives shipped with frappe-ui.
+- [Utilities](https://ui.frappe.io/docs/other/utilities): helper functions exported from the package.
+
+## Optional
+
+- [v1-release plan](https://github.com/frappe/frappe-ui/tree/main/v1-release): API-freeze plan, component specs, ADRs. Read when contributing to frappe-ui itself or making decisions about API direction.
+- [GitHub repository](https://github.com/frappe/frappe-ui): source, issues, releases.
+- [Changelog](https://github.com/frappe/frappe-ui/blob/main/v1-release/changelog.md): notable changes per release.

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,18 @@ Now, you can import needed components and start using it:
 </script>
 ```
 
+## Claude Code skill
+
+For AI coding agents (Claude Code, Cursor, Codex, etc.), Frappe UI ships an agent skill that teaches the agent the library's conventions — semantic Tailwind tokens, the `variant` + `theme` color axes, the `useCall` data-fetching composable, common UI recipes, and anti-patterns to avoid.
+
+Install with [Vercel's `skills` CLI](https://github.com/vercel-labs/skills):
+
+```sh
+npx skills add https://github.com/frappe/frappe-ui/tree/main/skills/frappe-ui
+```
+
+The skill lives in [`skills/frappe-ui/`](./skills/frappe-ui/) and is updated alongside the library.
+
 ## Used By
 
 Frappe UI is being used in a lot of products by

--- a/skills/frappe-ui/COMPONENTS.md
+++ b/skills/frappe-ui/COMPONENTS.md
@@ -1,0 +1,284 @@
+# Component catalog
+
+Import everything from `'frappe-ui'`. Below: when to reach for each component, key props, and gotchas.
+
+## Icons
+
+Render any lucide icon as a `<span>` with the icon class — never import a Vue component per icon, never use an `<i>` tag, never inline an `<svg>`.
+
+```vue
+<span class="lucide-edit size-4" aria-hidden="true" />
+<span class="lucide-plus size-5 text-ink-gray-7" aria-hidden="true" />
+```
+
+- Class name is `lucide-<kebab-case-name>` (e.g. `lucide-arrow-right`, `lucide-circle-check`).
+- Size with Tailwind's `size-*` (`size-3`, `size-4`, `size-5` cover most UI).
+- Always `aria-hidden="true"` — icons are decorative; the surrounding label carries meaning. If the icon is the *only* content (icon-only button), give the parent an `aria-label`.
+- Color inherits from `currentColor` — set on the parent or with `text-ink-*`.
+
+For frappe-ui components that take an `icon` prop (Button, Dropdown options, Dialog, Alert, Badge), pass the namespaced **string** `"lucide-edit"` — the component renders the span for you.
+
+## Actions
+
+### `Button`
+Default for any trigger. `<Button :label icon iconLeft iconRight variant theme size loading disabled />`.
+- `variant`: `solid | outline | subtle | ghost` (default `subtle`).
+- `theme`: `gray | blue | red | green` (default `gray`).
+- `size`: `sm | md | lg | xl | 2xl` (default `sm`).
+- Use `Button` for navigation too: pass `route` (Vue Router) or `link` (external URL); it renders the correct element with the right semantics.
+- Icon-only: pass just `icon`. Combine `iconLeft` + `label` for leading-icon buttons.
+- Primary actions: `variant="solid" theme="gray"`. Destructive: `variant="solid" theme="red"` or `subtle theme="red"`.
+
+### `Dropdown`
+Menu of actions anchored to a trigger. `<Dropdown :options="[{ label, icon, onClick, ... }]"><Button ... /></Dropdown>`.
+- The first child is the trigger.
+- Pass actions as `options`; nested groups via `options: [{ group: 'Label', items: [...] }]`.
+
+## Overlays
+
+### `Dialog`
+Modal. Always `v-model:open`. Props: `title`, `message`, `icon`, `theme`, `size`, `actions`, `dismissable`.
+- `actions` is an array of button configs; each `onClick` receives `{ close }`.
+- `bare` to suppress chrome (full-bleed content like command palettes).
+- For confirm/alert/prompt, prefer the **imperative API** below.
+
+### Imperative dialogs
+```ts
+import { dialog, toast } from 'frappe-ui'
+
+dialog.confirm({ title: 'Delete?', theme: 'red', onConfirm: async () => await api.delete() })
+dialog.alert({ title: 'Saved' })
+const { values } = await dialog.prompt({ title: 'Rename', fields: [{ name: 'title', label: 'Title', required: true }] })
+toast.success('Saved'); toast.error('Failed'); toast.info('FYI')
+```
+Mount `<FrappeUIProvider>` once near the app root.
+
+### `Popover` / `Tooltip`
+- `Popover` for arbitrary anchored content. `v-model:open`, slots: `#target` (trigger), `#body` (content).
+- `Tooltip` for hover hints. `<Tooltip text="..."><Button .../></Tooltip>`. Don't use Tooltip for actionable UI — that's `Popover` / `Dropdown`.
+
+## Input controls
+
+All input controls accept the **shared labeling contract**: `label`, `description`, `error`, `required`.
+
+### `FormControl`
+The default wrapper. Pass `type="text" | "textarea" | "select" | "checkbox" | "autocomplete"` etc. Use it instead of raw `TextInput` when you need a labeled field with consistent layout.
+
+### `TextInput` / `Textarea` / `Password`
+Single-line / multi-line / masked input. `v-model="value"`. Use `FormControl :type="..."` if you want the field wrapper.
+
+### `Select`
+Fixed list, single value. `<Select v-model :options="[{ label, value }]" placeholder="..." />`.
+
+### `MultiSelect`
+Fixed list, multiple values. `v-model` is `string[]`.
+
+### `Combobox`
+Single-select with search. `v-model="selected"` + `v-model:query="q"`. For options that filter as user types.
+
+### `Autocomplete`
+Async-fetched options (typically Frappe doctype links). Pass `fetchOptions` or use it inside Frappe Link contexts.
+
+### `Checkbox` / `Switch`
+Boolean. `v-model="checked"` + `:label`. `Switch` for settings-style toggles; `Checkbox` for forms / multi-pick rows.
+
+### `DatePicker` / `MonthPicker` / `TimePicker` / `DateRangePicker`
+`v-model` holds the value. `DateRangePicker` v-model is `string[]` of length 2.
+
+### `Slider` / `Rating`
+`v-model` numeric. Standard labeling props apply.
+
+### `FileUploader`
+Frappe-native file upload. Renders an upload control with progress; emits the uploaded `File` doc.
+
+## Display
+
+### `Badge`
+Status pill. `<Badge :label theme variant size />`. Same color axes as Button.
+
+### `Alert`
+Inline banner. `<Alert :title variant theme>` + slot for body.
+
+### `Avatar`
+`<Avatar :label :image size />`. `label` is used to generate initials when no image.
+
+### `Tooltip` — see Overlays.
+
+### `Progress` / `CircularProgressBar` / `Spinner` / `LoadingIndicator` / `LoadingText`
+- `Spinner` / `LoadingIndicator` for inline loading.
+- `LoadingText` for skeleton-style text placeholder.
+- `Progress` linear; `CircularProgressBar` radial.
+
+### `Divider`
+Horizontal/vertical rule. Prefer over `<hr class="..." />`.
+
+### `Breadcrumbs`
+`<Breadcrumbs :items="[{ label, route }]" />`.
+
+### `Tabs` / `TabButtons`
+- `Tabs` for full content tabs (top-level page sections). `v-model:tab`.
+- `TabButtons` for inline segmented controls (filter switches).
+
+### `KeyboardShortcut`
+Renders a kbd combo. `<KeyboardShortcut keys="cmd+k" />`.
+
+## Lists & data
+
+### `ListView`
+Table/grid list with built-in selection, sorting, virtualization. Configure via `columns`, `rows`, `options`. Prefer this over hand-rolled `<table>` for any data list.
+
+### `ItemListRow`
+Single-row list item (label + prefix/suffix). Compose into custom lists when `ListView` is too heavy.
+
+### `ListFilter`
+Filter builder UI matched to Frappe-style queries.
+
+### `Tree`
+Hierarchical lists.
+
+### `Calendar`
+Month/week calendar view.
+
+### `Charts`
+Chart family (line, bar, etc.) wrapping ECharts/Frappe Charts.
+
+### `TextEditor`
+TipTap-based rich text. Heavy — only when you need real content editing.
+
+### `CommandPalette`
+Cmd-K palette. Compose with `Dialog bare`.
+
+## Layout
+
+### `Sidebar`
+App-shell sidebar primitive. Pair with router views.
+
+### `Divider` — see Display.
+
+> Don't use `Card` — compose surfaces directly with `bg-surface-white rounded border border-outline-gray-1 p-4`.
+
+## Provider
+
+### `FrappeUIProvider`
+Mount once at app root. Provides:
+- Imperative dialog/toast mounts.
+- Theme (light/dark via `[data-theme="dark"]`).
+- Resource provider for `createResource` / v3 data APIs.
+
+## Data & resources
+
+The recommended way to call Frappe APIs is the **`useCall`** composable (with `useList` / `useDoc` / `useDoctype` / `useNewDoc` for higher-level shapes). Don't use `fetch` / `axios` directly, and don't reach for the legacy `createResource` family in new code — `useCall` is the v3 path.
+
+### `useCall` — recommended for any whitelisted Frappe method
+
+```ts
+import { useCall } from 'frappe-ui'
+
+const ping = useCall<string>({
+  url: '/api/v2/method/ping',
+})
+// ping.data, ping.loading, ping.error, ping.execute(), ping.reload(), ping.abort()
+```
+
+**Options** (`UseCallOptions<TResponse, TParams>`):
+- `url: string | Ref<string>` — the API endpoint. Use a `Ref` / `computed` for reactive URLs (e.g. resource ID in the path).
+- `method?: 'GET' | 'POST' | 'PUT' | 'DELETE'` — default `GET`.
+- `params?: TParams | (() => TParams)` — request params. Pass a function for reactive params; refs inside are auto-unwrapped. GET requests serialise to the query string; non-GET sends a JSON body.
+- `immediate?: boolean` — default `true`. Set `false` for write-style calls you'll trigger with `submit` / `execute`.
+- `refetch?: boolean` — re-run automatically when reactive `url` / `params` change.
+- `baseUrl?: string` — prefix for `url`.
+- `initialData?: TResponse` — value of `.data` before the first response.
+- `cacheKey?: string | Array<...>` — when set, the response is persisted in IndexedDB. On next mount, cached data hydrates `.data` while a fresh request runs in the background. Great for "instant" perceived loads.
+- `transform?: (data) => data` — mutate or replace the response shape before it lands in `.data`.
+- `beforeSubmit?: (params) => void | Promise<void>` — async hook before `submit` fires; throw to abort and surface the error on `.error`.
+- `onSuccess?: (data) => void` — fires after a successful response.
+- `onError?: (error) => void` — fires after a failed response.
+
+**Reactive return** (treat as a `reactive` object — no `.value`):
+- `data` — response data (or cached data while loading).
+- `error` — `Error` instance on failure.
+- `loading` / `isFetching` — boolean.
+- `isFinished` — boolean, true after the first response.
+- `canAbort` / `aborted` / `abort()` — request cancellation.
+- `promise` — resolves on the next response (success or error); resets after each call so you can `await` the latest.
+- `execute()` / `fetch()` / `reload()` — re-run the request; returns `Promise<TResponse | null>`.
+- `submit(params?)` — write-style trigger; stores `params` as the current params and runs the request. Typed so calls without a `TParams` generic accept no args.
+- `reset()` — clear `submit`-supplied params.
+- `url` / `params` — the computed URL and params actually sent.
+
+**Read pattern (auto-fetch on mount):**
+
+```ts
+const userResource = useCall<User>({
+  url: computed(() => `/api/v2/document/User/${userId.value}`),
+  refetch: true,
+  cacheKey: ['user', userId],
+})
+```
+```vue
+<LoadingText v-if="userResource.loading && !userResource.data" />
+<ErrorMessage v-else-if="userResource.error" :message="userResource.error.message" />
+<UserCard v-else :user="userResource.data" />
+```
+
+**Write pattern (trigger on action):**
+
+```ts
+const createTask = useCall<Task, { title: string; description?: string }>({
+  url: '/api/v2/method/myapp.api.create_task',
+  method: 'POST',
+  immediate: false,
+  onSuccess: (task) => {
+    toast.success('Task created')
+    router.push(`/tasks/${task.name}`)
+  },
+  onError: (err) => toast.error(err.message),
+})
+
+async function save() {
+  await createTask.submit({ title: form.title, description: form.description })
+}
+```
+
+**Tips:**
+- `immediate: false` + `submit()` is the canonical write shape.
+- For lists, prefer `useList` (paginated, with filters/sort) over composing `useCall` by hand.
+- For a single doctype document, prefer `useDoc`.
+- Pair the loading + error states with the `LoadingIndicator` / `ErrorMessage` components rather than inlining your own.
+
+### Prototyping against a non-Frappe backend
+
+`useCall` is wired to Frappe's response envelope (`{ data: T }`, `{ errors: [...] }`, `X-Frappe-*` headers). Pointing it at a generic REST API (mock server, public API, custom Express/Hono backend) won't work — `.data` will be `undefined` because the response isn't `{ data: ... }`-shaped.
+
+For prototypes and demos, drop to **`useFetch` from `@vueuse/core`** — it's the same composable `useCall` is built on, with no Frappe assumptions:
+
+```ts
+import { useFetch } from '@vueuse/core'
+
+// Read
+const { data: todo, error, isFetching, execute } = useFetch(
+  `https://jsonplaceholder.typicode.com/todos/1`,
+).json<Todo>()
+
+// Write (trigger on action)
+const { data, execute: save, isFetching: saving } = useFetch(
+  '/api/tasks',
+  { immediate: false },
+).post(() => ({ title: form.title })).json<Task>()
+
+async function onSubmit() {
+  await save()
+}
+```
+
+API parallels: `data`, `error`, `isFetching`, `execute`, `abort`, `onFetchResponse`, `onFetchError`. When you move the prototype onto a real Frappe backend, rename `useFetch(url).json()` → `useCall({ url })` and adjust options — most call sites change ~2 lines.
+
+For repeat-the-same-config-across-many-calls, build a project-local wrapper with `createFetch({ baseUrl, options: { beforeFetch, afterFetch, onFetchError } })` — same primitive `useFrappeFetch` itself uses.
+
+### `useList` / `useDoc` / `useDoctype` / `useNewDoc`
+
+Higher-level wrappers around `useCall` for common Frappe shapes (paginated lists, single docs, doctype metadata, new-doc scaffolds). Use them when they fit; drop to `useCall` when you need a custom endpoint.
+
+### Legacy
+
+`createResource` / `createListResource` / `createDocumentResource` still ship for migration but are not recommended for new code. Convert them to `useCall` / `useList` / `useDoc` when touching the surrounding code.

--- a/skills/frappe-ui/PATTERNS.md
+++ b/skills/frappe-ui/PATTERNS.md
@@ -1,0 +1,216 @@
+# UI patterns
+
+Common compositions seen across Frappe Cloud, Gameplan, Desk, Drive, Insights. Reach for these before inventing layouts.
+
+## App shell
+
+```vue
+<script setup>
+import { FrappeUIProvider, Sidebar } from 'frappe-ui'
+</script>
+
+<template>
+  <FrappeUIProvider>
+    <div class="flex h-screen bg-surface-white text-ink-gray-9">
+      <Sidebar />
+      <main class="flex-1 overflow-y-auto">
+        <router-view />
+      </main>
+    </div>
+  </FrappeUIProvider>
+</template>
+```
+
+Mount `FrappeUIProvider` once at the app root so imperative `dialog.*` / `toast.*` work.
+
+## Page header
+
+```vue
+<header class="flex items-center justify-between border-b border-outline-gray-1 px-6 py-4">
+  <div>
+    <Breadcrumbs :items="crumbs" />
+    <h1 class="mt-1 text-xl text-ink-gray-9">{{ title }}</h1>
+  </div>
+  <div class="flex gap-2">
+    <Button icon="lucide-filter" label="Filter" />
+    <Button variant="solid" theme="gray" icon-left="lucide-plus" label="New" @click="create" />
+  </div>
+</header>
+```
+
+Primary action: `variant="solid" theme="gray"`. Secondary actions: default `subtle`.
+
+## Form page
+
+```vue
+<script setup>
+import { FormControl, Button } from 'frappe-ui'
+import { reactive } from 'vue'
+
+const form = reactive({ title: '', description: '', priority: 'medium' })
+const errors = reactive({})
+</script>
+
+<template>
+  <form class="mx-auto max-w-xl space-y-4 p-6" @submit.prevent="save">
+    <FormControl v-model="form.title" label="Title" required :error="errors.title" />
+    <FormControl v-model="form.description" type="textarea" label="Description" description="Markdown supported." />
+    <FormControl
+      v-model="form.priority"
+      type="select"
+      label="Priority"
+      :options="[
+        { label: 'Low', value: 'low' },
+        { label: 'Medium', value: 'medium' },
+        { label: 'High', value: 'high' },
+      ]"
+    />
+    <div class="flex justify-end gap-2 pt-2">
+      <Button label="Cancel" @click="cancel" />
+      <Button variant="solid" theme="gray" type="submit" :loading="saving" label="Save" />
+    </div>
+  </form>
+</template>
+```
+
+Rules:
+- One column. Stack with `space-y-4`.
+- Every field uses `FormControl` (or a direct input control) with `label` + `error`.
+- Submit pair: secondary `Cancel` left, primary `Save` right.
+
+## API calls
+
+Always use `useCall` (or `useList` / `useDoc`) — never raw `fetch` / `axios`.
+
+**Read (auto on mount):**
+```ts
+import { useCall } from 'frappe-ui'
+
+const user = useCall<User>({
+  url: computed(() => `/api/v2/document/User/${userId.value}`),
+  refetch: true,
+  cacheKey: ['user', userId],
+})
+```
+
+**Write (trigger on action):**
+```ts
+import { useCall, toast } from 'frappe-ui'
+
+const saveTask = useCall<Task, { title: string }>({
+  url: '/api/v2/method/myapp.api.create_task',
+  method: 'POST',
+  immediate: false,
+  onSuccess: () => toast.success('Saved'),
+  onError: (err) => toast.error(err.message),
+})
+
+async function onSubmit() {
+  await saveTask.submit({ title: form.title })
+}
+```
+
+Bind `saveTask.loading` to `<Button :loading>`; render `saveTask.error?.message` next to the form.
+
+## Confirmation flow
+
+```ts
+import { dialog, toast } from 'frappe-ui'
+
+async function deleteItem(id) {
+  dialog.confirm({
+    title: 'Delete this item?',
+    message: 'This cannot be undone.',
+    theme: 'red',
+    confirmLabel: 'Delete',
+    onConfirm: async ({ close }) => {
+      await api.delete(id)
+      toast.success('Deleted')
+    },
+  })
+}
+```
+
+Never build your own confirm `<Dialog>` for this.
+
+## List page
+
+```vue
+<script setup>
+import { ListView, Button, useList } from 'frappe-ui'
+
+const tasks = useList<Task>({
+  doctype: 'Task',
+  fields: ['name', 'title', 'status', 'modified'],
+})
+</script>
+
+<template>
+  <div class="flex h-full flex-col">
+    <header class="flex items-center justify-between border-b border-outline-gray-1 px-6 py-3">
+      <h1 class="text-lg text-ink-gray-9">Tasks</h1>
+      <Button variant="solid" theme="gray" icon-left="lucide-plus" label="New Task" />
+    </header>
+    <ListView
+      class="flex-1"
+      :columns="[
+        { label: 'Title', key: 'title' },
+        { label: 'Status', key: 'status' },
+        { label: 'Updated', key: 'modified' },
+      ]"
+      :rows="tasks.data ?? []"
+      :loading="tasks.loading"
+      row-key="name"
+    />
+  </div>
+</template>
+```
+
+## Empty state
+
+```vue
+<div class="flex flex-col items-center justify-center gap-3 py-16 text-center">
+  <div class="rounded-full bg-surface-gray-2 p-3 text-ink-gray-5">
+    <span class="lucide-inbox size-6" aria-hidden="true" />
+  </div>
+  <p class="text-base text-ink-gray-7">No tasks yet</p>
+  <p class="text-sm text-ink-gray-5">Create one to get started.</p>
+  <Button variant="solid" theme="gray" icon-left="lucide-plus" label="New Task" class="mt-2" />
+</div>
+```
+
+## Settings panel
+
+Two-column: nav on the left (`Sidebar` or vertical `Tabs`), form on the right. Each section uses the **form page** pattern. Save action at the bottom of each section, not floating.
+
+## Toast usage
+
+- `toast.success('Saved')` — after writes complete.
+- `toast.error(err.message)` — for transient failures.
+- `toast.info('Heads up')` — neutral notifications.
+
+Don't use toasts for confirmations or anything requiring a decision — that's `dialog.confirm`.
+
+## Status badges
+
+```vue
+<Badge :label="status" :theme="statusTheme(status)" variant="subtle" />
+```
+
+Map statuses to themes in one place:
+```ts
+function statusTheme(s) {
+  return ({ open: 'blue', closed: 'gray', error: 'red', done: 'green' })[s] ?? 'gray'
+}
+```
+
+## Loading states
+
+- Buttons: `<Button :loading="saving" />`.
+- Inline blocks: `<LoadingIndicator />` / `<Spinner />`.
+- Skeleton text: `<LoadingText :lines="3" />`.
+- Whole-page first load: render the page shell + `LoadingText` placeholders inside content slots. Don't blank out the screen.
+
+## Dark-mode check
+
+Before declaring a page done, toggle `[data-theme="dark"]` on `<html>` (or your app's dark-mode switch) and verify nothing looks broken. If you used only semantic tokens, it should just work.

--- a/skills/frappe-ui/SKILL.md
+++ b/skills/frappe-ui/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: frappe-ui
+description: Build consistent Frappe-style user interfaces using the frappe-ui Vue 3 component library and its design tokens. Use when scaffolding pages, forms, dialogs, lists, or any UI inside a Frappe-based app, when the user mentions frappe-ui, Frappe Cloud / Gameplan / Desk / Drive / Insights styling, or asks to "use frappe-ui components".
+---
+
+# frappe-ui
+
+Build UIs that look and feel like Frappe products by composing **frappe-ui** components and styling with the library's **semantic Tailwind tokens**. Never hand-roll buttons, inputs, dialogs, dropdowns, etc. — pick the right component first.
+
+## Quick start
+
+```vue
+<script setup>
+import { Button, Dialog, TextInput, FormControl } from 'frappe-ui'
+import { ref } from 'vue'
+
+const open = ref(false)
+const name = ref('')
+</script>
+
+<template>
+  <div class="p-4 bg-surface-white text-ink-gray-9">
+    <Button variant="solid" theme="gray" @click="open = true">New Task</Button>
+    <Dialog v-model:open="open" title="Create Task">
+      <FormControl v-model="name" label="Title" required />
+    </Dialog>
+  </div>
+</template>
+```
+
+## Workflow
+
+1. **Pick the component, don't build one.** Consult `COMPONENTS.md` — if any entry fits, use it. Only fall back to raw HTML for layout (grids, flex containers).
+2. **Use semantic tokens, not raw colors.** No `bg-gray-100`, `text-gray-900`, `border-gray-300`. Use `bg-surface-*`, `text-ink-*`, `border-outline-*`. See `TOKENS.md`.
+3. **Follow the two-axis color rule.** Component color = `variant` (`solid | outline | subtle | ghost`) + `theme` (`gray | blue | green | red | orange`). Never invent `intent`, `kind`, `severity`, `appearance`.
+4. **Wire two-way state with `v-model`.** Overlays use `v-model:open`. Inputs use `v-model`. Comboboxes use `v-model` + `v-model:query`. Never `:value` + `@change`.
+5. **Use the labeling contract on inputs.** Every input control accepts `label`, `description`, `error`, `required` — use these instead of placeholder hacks or separate `<label>` elements.
+6. **Slot vocabulary is fixed.** `#prefix`, `#suffix`, `#trigger`, `#empty`, `#header`, `#footer`, `#default`. Scoped per-item slots: `#item-prefix`, `#item-suffix`. No `#icon-left` / `#avatar-right`.
+7. **Icons are CSS classes.** Render an icon as `<span class="lucide-<name> size-4" aria-hidden="true" />`. For frappe-ui props that accept an icon (e.g. `Button.icon`, `Dropdown` option `icon`), pass the namespaced string `"lucide-edit"`. Never import per-icon Vue components.
+8. **Imperative for one-shot UI.** Use `dialog.confirm`, `dialog.alert`, `dialog.prompt`, `toast.success/error/info` — don't manually mount `<Dialog>` for confirmations.
+9. **API calls go through `useCall`.** Use the `useCall` composable (or `useList` / `useDoc` for higher-level shapes) for every Frappe API call. Never `fetch` / `axios` directly. `immediate: false` + `submit(params)` for writes; default behavior auto-fetches on mount. See `COMPONENTS.md` → Data & resources.
+
+## Reference files
+
+- [COMPONENTS.md](COMPONENTS.md) — component catalog: when to reach for each one, key props, common pitfalls.
+- [TOKENS.md](TOKENS.md) — semantic color tokens (`ink-*`, `surface-*`, `outline-*`), typography, spacing, radii.
+- [PATTERNS.md](PATTERNS.md) — recipes: form pages, list pages, settings panels, empty states, confirmation flows.
+
+## Authoritative upstream docs
+
+When the bundled refs don't answer a specific API question, fetch the official LLM-friendly index:
+
+- **https://ui.frappe.io/llms.txt** — curated index of every component doc, design-system tokens page, and data-fetching guide. Always current with the published library; follow the links inside for full details on a specific component.
+
+Prefer the upstream `llms.txt` over guessing — it lists every component's docs page and the canonical design-system / data-fetching pages.
+
+## Anti-patterns to flag
+
+- Hand-rolled `<button class="bg-blue-500 ...">` instead of `<Button>`.
+- Raw Tailwind palette colors (`gray-`, `blue-`) outside the semantic tokens.
+- `intent="warning"` / `appearance="primary"` / `kind="success"` props — collapse to `variant` + `theme`.
+- Class-injection props (`triggerClass`, `contentClass`). Use the component's `data-slot` / `data-state` attributes from CSS instead.
+- Manually mounting `<Dialog>` just to ask "are you sure?" — use `dialog.confirm`.
+- Bare `v-model` on `<Dialog>` for visibility — use `v-model:open`.
+- Placeholder-as-label on `TextInput` / `Select` / `DatePicker` — pass `label`.
+- Raw `fetch` / `axios` for API calls — use `useCall` (or `useList` / `useDoc`).
+- `createResource` / `createListResource` / `createDocumentResource` in new code — those are legacy v1 APIs; the v3 composables (`useCall`, `useList`, `useDoc`) are the recommended path.
+
+When in doubt about an API, start at https://ui.frappe.io/llms.txt and follow the link for the component or topic in question. Source lives in the `frappe/frappe-ui` GitHub repo (`src/components/<Name>/`, plus `PHILOSOPHY.md` and `CONTEXT.md` at the repo root).

--- a/skills/frappe-ui/TOKENS.md
+++ b/skills/frappe-ui/TOKENS.md
@@ -1,0 +1,117 @@
+# Design tokens
+
+frappe-ui ships a Tailwind preset with **semantic** color tokens. Use these instead of the raw palette (`gray-500`, `blue-700`, …). Tokens auto-flip in dark mode (`[data-theme="dark"]`).
+
+## Color tokens
+
+Three semantic categories — each takes a color + numeric step. Higher = stronger contrast.
+
+### `text-ink-*` (foreground / text & icons)
+
+`white | gray-1..9 | red-1..4 | green-1..3 | amber-1..3 | blue-1..3 | cyan-1 | pink-1 | violet-1 | blue-link`
+
+- `text-ink-gray-9` — primary text (headings, body).
+- `text-ink-gray-7` — secondary text.
+- `text-ink-gray-5` / `gray-4` — tertiary / placeholder.
+- `text-ink-blue-link` — links.
+- `text-ink-red-3` — destructive / error text.
+- `text-ink-green-3` — success text.
+
+### `bg-surface-*` (backgrounds)
+
+`white | gray-1..7 | red-1..7 | green-1..3 | amber-1..3 | blue-1..3 | orange-1 | violet-1 | cyan-1 | pink-1 | menu-bar | cards | modal | selected`
+
+- `bg-surface-white` — primary page background.
+- `bg-surface-gray-1` / `gray-2` — subtle / hover surface (cards, hovered rows).
+- `bg-surface-gray-3` — pressed state.
+- `bg-surface-menu-bar` — sidebar/toolbar background.
+- `bg-surface-modal` — dialog body background.
+- `bg-surface-selected` — selected row.
+- `bg-surface-red-2` / `green-2` / `amber-2` / `blue-2` — tinted banners.
+
+### `border-outline-*` (borders & rings)
+
+`white | gray-1..5 | red-1..3 | green-1..2 | amber-1..2 | blue-1 | orange-1 | gray-modals`
+
+- `border-outline-gray-1` / `gray-2` — default borders.
+- `border-outline-gray-3` — focus ring on inputs.
+- `border-outline-red-2` / `green-2` — error / success borders.
+
+### Rule of thumb
+
+| Need              | Use                              |
+|-------------------|----------------------------------|
+| Page bg           | `bg-surface-white`               |
+| Card bg           | `bg-surface-white` + border, or `bg-surface-gray-1` |
+| Hovered row       | `bg-surface-gray-2`              |
+| Primary text      | `text-ink-gray-9`                |
+| Muted text        | `text-ink-gray-5`                |
+| Border            | `border-outline-gray-1` (or `gray-2` for stronger) |
+| Destructive text  | `text-ink-red-3`                 |
+| Success text      | `text-ink-green-3`               |
+
+Never reach for `text-gray-900`, `bg-white`, `border-gray-200` — they don't track the theme.
+
+## Typography
+
+`font-family` is `InterVar` by default. The custom font sizes:
+
+| Class       | Size  | Use                           |
+|-------------|-------|-------------------------------|
+| `text-2xs`  | 11px  | Micro-labels, badges          |
+| `text-xs`   | 12px  | Captions, meta                |
+| `text-sm`   | 13px  | Secondary text, dense UI      |
+| `text-base` | 14px  | Body (default)                |
+| `text-lg`   | 16px  | Section subheads              |
+| `text-xl`   | 18px  | Card / panel titles           |
+| `text-2xl`  | 20px  | Page titles                   |
+| `text-3xl`+ | 24px+ | Marketing / hero only         |
+
+All have tuned line-height + letter-spacing — don't override unless you know why.
+
+## Radius
+
+| Class            | px    | Use                            |
+|------------------|-------|--------------------------------|
+| `rounded-none`   | 0     | Flush edges                    |
+| `rounded-sm`     | 4     | Tags, small chips              |
+| `rounded` (default) | 8  | Inputs, buttons, list items    |
+| `rounded-md`     | 10    | Cards                          |
+| `rounded-lg`     | 12    | Dialogs, larger surfaces       |
+| `rounded-xl`     | 16    | Hero panels                    |
+| `rounded-2xl`    | 20    | Marketing surfaces             |
+| `rounded-full`   | pill  | Avatars, status dots, pill badges |
+
+## Shadow
+
+| Class         | Use                                  |
+|---------------|--------------------------------------|
+| `shadow-sm`   | Cards on white                       |
+| `shadow`      | Default (inputs on focus)            |
+| `shadow-md`   | Popovers, dropdowns                  |
+| `shadow-lg`   | Dialogs                              |
+| `shadow-xl`   | Floating panels                      |
+| `shadow-2xl`  | Hero overlays                        |
+
+## Spacing
+
+Use Tailwind's spacing scale. Frappe density tends to be tight:
+- Form field gap: `space-y-3` or `gap-3`.
+- Section gap: `space-y-6` / `gap-6`.
+- Page padding: `p-4` on mobile, `p-6`/`p-8` on desktop.
+- Inline gap inside a row: `gap-2`.
+
+## Dark mode
+
+Toggle by setting `[data-theme="dark"]` on `<html>`. All semantic tokens flip automatically. Test dark mode for every new screen — don't hand-craft `dark:` variants if a semantic token already covers it.
+
+## Custom CSS hooks
+
+When you must style a frappe-ui component beyond its prop surface, target its `data-slot` / `data-state` attributes (not internal classes):
+
+```css
+[data-slot="trigger"][data-state="open"] { box-shadow: ... }
+[data-slot="item"][data-disabled] { opacity: .5 }
+```
+
+Never use class-injection props (`triggerClass`, `contentClass`) — they don't exist on frappe-ui components by design.


### PR DESCRIPTION
Bundles an agent skill at `skills/frappe-ui/` so coding agents (Claude Code, Cursor, Codex, …) generate UI that matches frappe-ui conventions out of the box: semantic Tailwind tokens, variant+theme color axes, useCall for data fetching, and the standard slot/labeling vocabulary.

Adds `docs/content/public/llms.txt` (served at https://ui.frappe.io/llms.txt) as the canonical LLM-friendly index of the docs site, and an `<link rel="alternate" type="text/markdown" href="/llms.txt">` tag in the Vitepress head for auto-discovery.

README documents the one-line install via Vercel's skills CLI:

    npx skills add https://github.com/frappe/frappe-ui/tree/main/skills/frappe-ui

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 44.04% (1889/4289) | ±0.00%      |
| Statements | 38.96% (2001/5135) | +0.02%      |
| Functions  | 39.83% (378/949) | ±0.00%      |
| Branches   | 29.42% (595/2022) | +0.05%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
