### PR TITLE
refactor: Link Control for frappe

### DIFF
--- a/frappe/Link/Link.vue
+++ b/frappe/Link/Link.vue
@@ -1,52 +1,116 @@
 <template>
-  <div class="flex flex-col gap-1.5" :class="attrs.class" :style="attrs.style">
-    <FormLabel v-if="label" :label="label" size="sm" :required="required" />
-    <Combobox
-      v-model="model"
-      :placeholder="placeholder || `Select ${doctype}`"
-      :options="linkOptions"
-      @input="handleInputChange"
-      @focus="() => loadOptions('')"
-      :open-on-focus="true"
-      v-bind="attrsWithoutClassStyle"
-      :variant="props.variant"
+  <Combobox
+    ref="comboboxRef"
+    v-bind="$attrs"
+    v-model="model"
+    v-model:open="open"
+    class="group !gap-1"
+    :options="linkOptions"
+    :disabled="disabled"
+    :loading="options.loading && !options.data"
+    @update:query="handleInputChange"
+    @focus="() => loadOptions('')"
+  >
+    <template
+      v-for="(_, name) in forwardedSlots"
+      #[name]="slotProps"
+      :key="name"
     >
-      <template #create-new="{ searchTerm }">
-        <LucidePlus class="size-4 mr-2" />
-        <span class="font-medium"> Create new {{ doctype }}</span>
-      </template>
-    </Combobox>
-  </div>
+      <slot :name="name" v-bind="slotProps" />
+    </template>
+
+    <template #suffix>
+      <div
+        v-if="!disabled && (showClear || showRedirect)"
+        class="group-hover:inline-flex gap-0.5 hidden items-center"
+      >
+        <button
+          v-if="showClear"
+          type="button"
+          aria-label="Clear"
+          class="grid size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7"
+          @click="clearValue"
+          @pointerdown.stop
+        >
+          <span class="lucide-x size-3.5" />
+        </button>
+        <button
+          v-if="showRedirect"
+          type="button"
+          aria-label="Clear"
+          class="grid size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7"
+          @click="handleRedirect"
+          @pointerdown.stop
+        >
+          <span class="lucide-arrow-right size-3.5" />
+        </button>
+      </div>
+    </template>
+
+    <template #item-create="{ query }">
+      <div class="flex">
+        <span class="truncate">
+          Create
+          <span v-if="query" class="font-medium text-ink-gray-8">
+            {{ query }}
+          </span>
+        </span>
+      </div>
+    </template>
+  </Combobox>
 </template>
 
 <script setup lang="ts">
-import { watch, useAttrs, computed } from 'vue'
-import { Combobox, type ComboboxOption } from '../../src/components/Combobox'
-import FormLabel from '../../src/components/FormLabel.vue'
+import { ref, computed, useSlots, watch } from 'vue'
+import { Combobox } from '../../src/components/Combobox'
+import type {
+  ComboboxCustomOption,
+  ComboboxOption,
+} from '../../src/components/Combobox/types'
 import debounce from '../../src/utils/debounce'
-// @ts-ignore - Vue SFC without explicit types
 import { createResource } from '../../src/resources'
-import { frappeRequest } from '../../src/utils/frappeRequest'
-import type { LinkProps, SelectOption } from './types'
-import LucidePlus from '~icons/lucide/plus'
+import type { LinkProps, LinkOption } from './types'
 
 const props = withDefaults(defineProps<LinkProps>(), {
-  label: '',
   filters: () => ({}),
-  variant: 'subtle',
+  allowCreate: false,
+  allowClear: true,
+  allowRedirect: false,
 })
+
 const model = defineModel<string | null>({ default: '' })
+const open = ref(false)
+const comboboxRef = ref<{ focus: () => void } | null>(null)
+
 const emit = defineEmits<{
-  (e: 'create', searchTerm: string): void
+  (e: 'create', query: string, close: Function): void
+  (e: 'redirect', value: string): void
+  (e: 'clear'): void
 }>()
+
 defineOptions({ inheritAttrs: false })
 
-const attrs = useAttrs() as Record<string, any>
-const attrsWithoutClassStyle = computed(() => {
-  return Object.fromEntries(
-    Object.entries(attrs).filter(([key]) => key !== 'class' && key !== 'style'),
-  )
-})
+const slots = useSlots()
+const FORWARDED_SLOT_NAMES = [
+  'label',
+  'description',
+  'prefix',
+  'trigger',
+  'item',
+  'item-prefix',
+  'item-label',
+  'item-suffix',
+  'empty',
+] as const
+
+const forwardedSlots = computed(() =>
+  Object.fromEntries(
+    FORWARDED_SLOT_NAMES.filter((name) => slots[name]).map((name) => [
+      name,
+      slots[name],
+    ]),
+  ),
+)
 
 const options = createResource({
   url: 'frappe.desk.search.search_link',
@@ -56,31 +120,37 @@ const options = createResource({
     filters: props.filters,
   },
   method: 'POST',
-  resourceFetcher: frappeRequest,
-  transform: (data: SelectOption[]) => {
-    return data.map((doc) => ({
+  transform: (data: LinkOption[]): LinkOption[] =>
+    data.map((doc: any) => ({
       label: doc.label || doc.value,
       value: doc.value,
-    }))
-  },
+      description: doc.description,
+    })),
 })
 
-const createNewOption = {
-  type: 'custom' as const,
-  key: 'create_new',
+const createNewOption: ComboboxCustomOption = {
+  type: 'custom',
+  key: 'create',
   label: 'Create New',
-  slotName: 'create-new',
-  condition: () => true,
-  onClick: ({ query }) => emit('create', query),
-} as ComboboxOption
+  slot: 'create',
+  condition: ({ query }: { query: string }) => {
+    const q = query.trim().toLowerCase()
+    if (!q) return false
+    return true
+  },
+  onClick: ({ query }) => emit('create', query, () => (open.value = false)),
+}
 
-const linkOptions = computed(() => {
+const linkOptions = computed<ComboboxOption[]>(() => {
   const _options = options.data || []
   if (props.allowCreate) {
     return [..._options, createNewOption]
   }
   return _options
 })
+
+const showClear = computed(() => props.allowClear && !!model.value)
+const showRedirect = computed(() => props.allowRedirect && !!model.value)
 
 const loadOptions = (txt: string = '') => {
   options.update({
@@ -93,12 +163,27 @@ const loadOptions = (txt: string = '') => {
   options.reload()
 }
 
-const handleInputChange = debounce((inputString: string) => {
-  loadOptions(inputString || '')
+const handleInputChange = debounce((value: string) => {
+  loadOptions(value || '')
 }, 300)
+
+const clearValue = () => {
+  model.value = ''
+  emit('clear')
+  comboboxRef.value?.focus()
+}
+
+const handleRedirect = () => {
+  if (model.value) {
+    open.value = false
+    emit('redirect', model.value)
+  }
+}
 
 watch([() => props.doctype, () => props.filters], () => loadOptions(''), {
   immediate: true,
   deep: true,
 })
+
+defineExpose({ reload: loadOptions })
 </script>

--- a/frappe/Link/Link.vue
+++ b/frappe/Link/Link.vue
@@ -19,11 +19,8 @@
       <slot :name="name" v-bind="slotProps" />
     </template>
 
-    <template #suffix>
-      <div
-        v-if="!disabled && (showClear || showRedirect)"
-        class="group-hover:inline-flex gap-0.5 hidden items-center"
-      >
+    <template v-if="!disabled && (showClear || showRedirect)" #suffix>
+      <div class="group-hover:inline-flex gap-0.5 hidden items-center">
         <button
           v-if="showClear"
           type="button"
@@ -37,7 +34,7 @@
         <button
           v-if="showRedirect"
           type="button"
-          aria-label="Clear"
+          aria-label="Redirect"
           class="grid size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7"
           @click="handleRedirect"
           @pointerdown.stop
@@ -69,6 +66,7 @@ import type {
 } from '../../src/components/Combobox/types'
 import debounce from '../../src/utils/debounce'
 import { createResource } from '../../src/resources'
+import { frappeRequest } from '../../src/utils/frappeRequest'
 import type { LinkProps, LinkOption } from './types'
 
 const props = withDefaults(defineProps<LinkProps>(), {
@@ -120,6 +118,7 @@ const options = createResource({
     filters: props.filters,
   },
   method: 'POST',
+  resourceFetcher: frappeRequest,
   transform: (data: LinkOption[]): LinkOption[] =>
     data.map((doc: any) => ({
       label: doc.label || doc.value,
@@ -168,7 +167,7 @@ const handleInputChange = debounce((value: string) => {
 }, 300)
 
 const clearValue = () => {
-  model.value = ''
+  model.value = null
   emit('clear')
   comboboxRef.value?.focus()
 }

--- a/frappe/Link/types.ts
+++ b/frappe/Link/types.ts
@@ -1,13 +1,14 @@
-import { ComboboxVariant } from '../../src/components/Combobox/types'
-
 export interface LinkProps {
   doctype: string
-  variant?: ComboboxVariant
-  label?: string
-  placeholder?: string
-  filters?: Record<string, string | [string, string] | boolean | number>
-  required?: boolean
+  filters?: Record<string, any> | Array<any> | string
   allowCreate?: boolean
+  allowClear?: boolean
+  allowRedirect?: boolean
+  disabled?: boolean
 }
 
-export type SelectOption = { value: string; label: string }
+export type LinkOption = {
+  label: string
+  value: string
+  description?: string
+}

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -349,6 +349,12 @@ function reset() {
   emit('update:selectedOption', null)
 }
 
+function focus() {
+  const id = isButtonMode.value ? `${inputId.value}-search-input` : inputId.value
+  const el = document.getElementById(id) as HTMLInputElement | null
+  el?.focus()
+}
+
 watch(
   () => props.open,
   (value) => {
@@ -385,7 +391,7 @@ watch(open, (isOpen, wasOpen) => {
   query.value = isButtonMode.value ? '' : displayValue.value
 })
 
-defineExpose<ComboboxExposed>({ reset })
+defineExpose<ComboboxExposed>({ reset, focus })
 defineSlots<ComboboxSlots>()
 </script>
 

--- a/src/components/Combobox/types.ts
+++ b/src/components/Combobox/types.ts
@@ -278,4 +278,5 @@ export interface ComboboxEmits {
 
 export interface ComboboxExposed {
   reset: () => void
+  focus: () => void
 }


### PR DESCRIPTION
Fixes: #701

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 44.04% (1889/4289) | ±0.00%      |
| Statements | 38.96% (2001/5135) | ±0.00%      |
| Functions  | 39.83% (378/949) | ±0.00%      |
| Branches   | 29.42% (595/2022) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->


