### PR TITLE
fix(FormControl): conditional slots not rendering

### DIFF
--- a/src/components/FormControl/FormControl.vue
+++ b/src/components/FormControl/FormControl.vue
@@ -6,14 +6,14 @@
     :class="[fillWidth ? 'w-full' : null, attrs.class]"
     :style="attrs.style"
   >
-    <template v-for="name in slotNames" :key="name" #[name]="slotProps">
+    <template v-for="name in Object.keys($slots)" :key="name" #[name]="slotProps">
       <!-- @vue-ignore -->
       <slot :name="name" v-bind="slotProps" />
     </template>
   </component>
 </template>
 <script setup lang="ts">
-import { useAttrs, computed, provide, watchEffect, useSlots } from 'vue'
+import { useAttrs, computed, provide, watchEffect } from 'vue'
 import { useId } from '../../utils/useId'
 import { TextInput } from '../TextInput'
 import { Select } from '../Select'
@@ -48,9 +48,6 @@ watchEffect(() => {
 })
 
 const attrs = useAttrs()
-const slots = useSlots()
-
-const slotNames = computed(() => Object.keys(slots))
 
 // FormControl represents "form context = full width" — the legacy template
 // hard-coded `class="w-full"` on Select/Combobox. Preserve that contract for


### PR DESCRIPTION
If I pass slots like this:

```vue
<FormControl
	v-else
	:type="type"
	:modelValue="data"
	@change="triggerUpdate"
	@input="($event: Event) => emit('input', ($event.target as HTMLInputElement).value)"
	autocomplete="off"
	:autofocus="autofocus"
	v-bind="attrs"
>
	<template #suffix v-if="$slots.suffix">
		<slot name="suffix" />
	</template>
	<template #suffix v-else-if="!['select', 'checkbox'].includes(type) && !hideClearButton && data">
		<button
			class="cursor-pointer text-ink-gray-4 hover:text-ink-gray-5"
			tabindex="-1"
			@click="clearValue"
		>
			<CrossIcon />
		</button>
	</template>
</FormControl>
```

the cross icon doesn't show up

<img width="292" height="52" alt="image" src="https://github.com/user-attachments/assets/468e1178-584e-47be-917d-e2176e79aa45" />

After:

<img width="292" height="52" alt="image" src="https://github.com/user-attachments/assets/c4c8b7cc-7a0b-4fef-a7fe-8746461c32cf" />

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 44.04% (1889/4289) | ±0.00%      |
| Statements | 38.96% (2001/5135) | ±0.00%      |
| Functions  | 39.83% (378/949) | ±0.00%      |
| Branches   | 29.42% (595/2022) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
