### PR TITLE
docs(MultiSelect): add async options example

### DIFF
--- a/src/components/MultiSelect/MultiSelect.md
+++ b/src/components/MultiSelect/MultiSelect.md
@@ -22,6 +22,11 @@ Options can be split into named groups. Group labels render above each group's i
 
 <ComponentPreview name="MultiSelect-Grouped" />
 
+## Async Options
+Fetch options from a server as the user types. Listen to `@update:query`, debounce the request, and feed the results back into `:options`. The `:loading` prop swaps the result body for a loading state. Two things to watch for: drop stale responses with a request id so a slower earlier query can't overwrite the latest results, and merge currently-selected items into the options array so chips stay resolvable after the query narrows the list.
+
+<ComponentPreview name="MultiSelect-AsyncOptions" />
+
 ## Custom Footer
 Replace the default Clear All / Select All footer with a custom one. The slot receives `clearAll`, `selectAll`, `selectedOptions`, and `query`.
 

--- a/src/components/MultiSelect/stories/AsyncOptions.vue
+++ b/src/components/MultiSelect/stories/AsyncOptions.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
+import { Avatar, MultiSelect } from 'frappe-ui'
+
+type Member = {
+  label: string
+  value: string
+  image: string
+  role: string
+}
+
+const ALL_MEMBERS: Member[] = [
+  { label: 'Alex Rivera', value: 'alex@frappe.io', image: 'https://i.pravatar.cc/80?u=alex@frappe.io', role: 'Engineering' },
+  { label: 'Alexandra Chen', value: 'alexandra@frappe.io', image: 'https://i.pravatar.cc/80?u=alexandra@frappe.io', role: 'Design' },
+  { label: 'Alexei Volkov', value: 'alexei@frappe.io', image: 'https://i.pravatar.cc/80?u=alexei@frappe.io', role: 'Engineering' },
+  { label: 'Priya Shah', value: 'priya@frappe.io', image: 'https://i.pravatar.cc/80?u=priya@frappe.io', role: 'Design' },
+  { label: 'Priyanka Mehta', value: 'priyanka@frappe.io', image: 'https://i.pravatar.cc/80?u=priyanka@frappe.io', role: 'Product' },
+  { label: 'Marcus Lee', value: 'marcus@frappe.io', image: 'https://i.pravatar.cc/80?u=marcus@frappe.io', role: 'Product' },
+  { label: 'Marco Silva', value: 'marco@frappe.io', image: 'https://i.pravatar.cc/80?u=marco@frappe.io', role: 'Engineering' },
+  { label: 'Maria Garcia', value: 'maria@frappe.io', image: 'https://i.pravatar.cc/80?u=maria@frappe.io', role: 'Marketing' },
+  { label: 'Sofia Hartmann', value: 'sofia@frappe.io', image: 'https://i.pravatar.cc/80?u=sofia@frappe.io', role: 'Engineering' },
+  { label: 'Sophie Laurent', value: 'sophie@frappe.io', image: 'https://i.pravatar.cc/80?u=sophie@frappe.io', role: 'Sales' },
+  { label: 'Kenji Tanaka', value: 'kenji@frappe.io', image: 'https://i.pravatar.cc/80?u=kenji@frappe.io', role: 'Design' },
+  { label: 'Kenta Mori', value: 'kenta@frappe.io', image: 'https://i.pravatar.cc/80?u=kenta@frappe.io', role: 'Engineering' },
+  { label: 'Nadia Okafor', value: 'nadia@frappe.io', image: 'https://i.pravatar.cc/80?u=nadia@frappe.io', role: 'Product' },
+  { label: 'Diego Alvarez', value: 'diego@frappe.io', image: 'https://i.pravatar.cc/80?u=diego@frappe.io', role: 'Engineering' },
+  { label: 'Lina Petrova', value: 'lina@frappe.io', image: 'https://i.pravatar.cc/80?u=lina@frappe.io', role: 'Marketing' },
+  { label: 'Liam Connor', value: 'liam@frappe.io', image: 'https://i.pravatar.cc/80?u=liam@frappe.io', role: 'Product' },
+  { label: 'Hassan Iqbal', value: 'hassan@frappe.io', image: 'https://i.pravatar.cc/80?u=hassan@frappe.io', role: 'Sales' },
+  { label: 'Ava Nguyen', value: 'ava@frappe.io', image: 'https://i.pravatar.cc/80?u=ava@frappe.io', role: 'Engineering' },
+]
+
+// Mocks a server endpoint: 400ms latency + substring match on label/value.
+function searchMembersApi(query: string): Promise<Member[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const q = query.trim().toLowerCase()
+      const matches = q
+        ? ALL_MEMBERS.filter(
+            (m) =>
+              m.label.toLowerCase().includes(q) ||
+              m.value.toLowerCase().includes(q),
+          )
+        : ALL_MEMBERS
+      resolve(matches.slice(0, 6))
+    }, 400)
+  })
+}
+
+const value = ref<string[]>([])
+const results = ref<Member[]>([])
+const loading = ref(false)
+const knownById = ref(new Map<string, Member>())
+
+let requestId = 0
+async function fetchMembers(query: string) {
+  const id = ++requestId
+  loading.value = true
+  const members = await searchMembersApi(query)
+  // Drop stale responses so an earlier-but-slower request can't overwrite
+  // the latest results.
+  if (id !== requestId) return
+  results.value = members
+  for (const m of members) knownById.value.set(m.value, m)
+  loading.value = false
+}
+
+const onQueryChange = useDebounceFn(fetchMembers, 250)
+
+// Merge currently-selected members into the options so chips stay
+// resolvable after the query narrows the result set.
+const options = computed<Member[]>(() => {
+  const byId = new Map<string, Member>()
+  for (const m of results.value) byId.set(m.value, m)
+  for (const id of value.value) {
+    if (!byId.has(id)) {
+      const existing = knownById.value.get(id)
+      if (existing) byId.set(id, existing)
+    }
+  }
+  return Array.from(byId.values())
+})
+
+function onOpen(isOpen: boolean) {
+  if (isOpen && results.value.length === 0) fetchMembers('')
+}
+</script>
+
+<template>
+  <div class="w-full flex flex-wrap gap-3 items-center justify-center !py-20">
+    <MultiSelect
+      v-model="value"
+      :options="options"
+      :loading="loading"
+      placeholder="Search members…"
+      empty-text="No members found"
+      class="w-80"
+      @update:query="onQueryChange"
+      @update:open="onOpen"
+    >
+      <template #item-prefix="{ item }">
+        <Avatar :image="(item as Member).image" :label="item.label" size="sm" />
+      </template>
+
+      <template #item-label="{ item }">
+        <div class="min-w-0 flex justify-between">
+          <div class="truncate">{{ item.label }}</div>
+          <div class="truncate text-p-sm text-ink-gray-5">
+            {{ (item as Member).role }}
+          </div>
+        </div>
+      </template>
+    </MultiSelect>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Adds an **Async Options** docs example demonstrating dynamically-fetched options as the user types, addressing the use case in #702.
- No component API changes — uses the existing `update:query` event + `loading` prop + reactive `:options`.

The story (`stories/AsyncOptions.vue`) mocks a 400 ms member-search endpoint and demonstrates the patterns consumers need:
- debounce `@update:query` (250 ms via `useDebounceFn`)
- request-id race guard so a slower earlier query can't overwrite later results
- merge currently-selected items into `:options` so chips stay resolvable after the query narrows the list
- avatars + role suffix via `#item-prefix` / `#item-label`

## Test plan
- [ ] `yarn docs:dev` → MultiSelect page → **Async Options** section
- [ ] Open the popover with no query → initial 6 results load
- [ ] Type `"alex"` → multiple matches (Alex Rivera, Alexandra Chen, Alexei Volkov)
- [ ] Select one, then change the query → trigger still shows the selected name (selection preserved across query changes)
- [ ] Loading indicator appears in the search row while fetching

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 44.04% (1889/4289) | ±0.00%      |
| Statements | 38.96% (2001/5135) | ±0.00%      |
| Functions  | 39.83% (378/949) | ±0.00%      |
| Branches   | 29.42% (595/2022) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
