### PR TITLE
refactor(Dialog,Alert): rename `dismissable` prop to `dismissible`

### DIFF
--- a/.claude/commands/barista-review.md
+++ b/.claude/commands/barista-review.md
@@ -81,7 +81,7 @@ The "done" components have already converged on these names. A new component or 
 - Form/labeling (`P5`): `label`, `description`, `error`, `required` — via `InputLabelingProps` from `src/composables/useInputLabeling.ts`. Don't redefine.
 - Content: `icon` (`string | Component`, lucide-namespaced strings — `P11`), `placeholder`, `options`.
 - Bounds (any axis — date, number, length, count): `min`, `max`, `step`. Never `minDate`/`maxDate`/`minLength`/`maxLength`/`minValue` — the type already says what's being bounded. Used today by `Slider` and `DatePicker`/`DateTimePicker`/`DateRangePicker`; a new component bounding a numeric or temporal axis must reuse these names.
-- Dismiss/close: `dismissable` (outside click + Esc, default `true`). Not `closable`, `dismissible`, `closeable`, `disableOutsideClickToClose`.
+- Dismiss/close: `dismissible` (outside click + Esc, default `true`). Not `closable`, `dismissible`, `closeable`, `disableOutsideClickToClose`.
 - Picker typing: `typeable` (default `true`). Not `allowCustom`, `readonly`, `allowCustomValue`.
 - Open-after-select: `keepOpen` (default `false`). Not `autoClose`.
 
@@ -100,7 +100,7 @@ The "done" components have already converged on these names. A new component or 
 Any one of these is a `Concerns`-level finding. Suggest the canonical-vocabulary alternative inline.
 
 1. **A new boolean flag that adds a UI affordance.** `allowClear`, `showCloseButton`, `clearable`, `hideSearch`, `withFooter`, `hasIcon`. Almost always a slot (`#suffix`, `#footer`, `#header`) covers it without growing the prop surface. Ask: "could a caller build this with `#suffix` + a Button?" If yes, the prop shouldn't exist.
-2. **A new prop that renames an existing one for this component.** E.g. `closable` instead of `dismissable`, `show` instead of `open`, `title` instead of `label`, `iconLeft`/`iconRight` instead of `#prefix`/`#suffix`. Cite the canonical name and the component(s) already using it.
+2. **A new prop that renames an existing one for this component.** E.g. `closable` instead of `dismissible`, `show` instead of `open`, `title` instead of `label`, `iconLeft`/`iconRight` instead of `#prefix`/`#suffix`. Cite the canonical name and the component(s) already using it.
 3. **A new size/variant/theme enum that doesn't import the shared union.** Inline `'sm' | 'md' | 'lg' | 'xl'` instead of `InputSize`; inline `'subtle' | 'outline' | 'ghost'` instead of `InputVariant`. The shared types live in `src/composables/inputTypes.ts`. Re-declaration is drift, not "explicit".
 4. **A boolean that switches the component's contract** (value type, emitted shape, what kind of options it takes). That's a split (`P8`) — `Select` vs `MultiSelect` vs `Combobox`. Don't add `multi` / `searchable` / `creatable`.
 5. **A config-blob prop** that bundles unrelated fields into one object (`P3`). The Dialog `options` blob is a known wart kept for back-compat — don't propagate it.
@@ -123,7 +123,7 @@ The test is: *could three other components plausibly want this?* If yes, push fo
 
 If no caller beyond this component could ever want it (it's truly domain-bound), the new name is fine — but it should still match the **shape** rules (primitive types, named axis, no config blob, no semantic color axis).
 
-**Positive signal**: if the PR *renames* a domain-prefixed prop to the generic name (e.g. `minDate` → `min`, `iconLeft` → `#prefix`, `closable` → `dismissable`), call it out approvingly in the verdict. That's the direction the library should be moving.
+**Positive signal**: if the PR *renames* a domain-prefixed prop to the generic name (e.g. `minDate` → `min`, `iconLeft` → `#prefix`, `closable` → `dismissible`), call it out approvingly in the verdict. That's the direction the library should be moving.
 
 ## What to cite
 
@@ -182,7 +182,7 @@ Then post a fresh verdict + bullets.
 **Good — concerns (API drift):**
 > **Concerns** — public surface grows where existing vocabulary covers it.
 >
-> - `src/components/Toast/types.ts:31` — new `closable` prop. Alert and Dialog already spell this `dismissable` (`Alert/types.ts:33`, `Dialog/types.ts:87`). Rename to `dismissable` to keep the v1 vocabulary tight (`P13` + canonical-vocab list).
+> - `src/components/Toast/types.ts:31` — new `closable` prop. Alert and Dialog already spell this `dismissible` (`Alert/types.ts:33`, `Dialog/types.ts:87`). Rename to `dismissible` to keep the v1 vocabulary tight (`P13` + canonical-vocab list).
 > - `src/components/Combobox/types.ts:147` — `allowClear: boolean`. A clear button is `#suffix` + a `<Button icon="lucide-x">`; the prop hard-codes a UI affordance the slot already supports (`P6`, smell #1). Drop the prop, document the `#suffix` recipe in stories.
 > - `src/components/Combobox/types.ts:5` — inline `'sm' | 'md' | 'lg' | 'xl'` redeclares `InputSize` from `src/composables/inputTypes.ts`. Import the shared type so the four picker sizes stay locked together.
 >

--- a/.claude/commands/barista-review.md
+++ b/.claude/commands/barista-review.md
@@ -81,7 +81,7 @@ The "done" components have already converged on these names. A new component or 
 - Form/labeling (`P5`): `label`, `description`, `error`, `required` — via `InputLabelingProps` from `src/composables/useInputLabeling.ts`. Don't redefine.
 - Content: `icon` (`string | Component`, lucide-namespaced strings — `P11`), `placeholder`, `options`.
 - Bounds (any axis — date, number, length, count): `min`, `max`, `step`. Never `minDate`/`maxDate`/`minLength`/`maxLength`/`minValue` — the type already says what's being bounded. Used today by `Slider` and `DatePicker`/`DateTimePicker`/`DateRangePicker`; a new component bounding a numeric or temporal axis must reuse these names.
-- Dismiss/close: `dismissible` (outside click + Esc, default `true`). Not `closable`, `dismissible`, `closeable`, `disableOutsideClickToClose`.
+- Dismiss/close: `dismissible` (outside click + Esc, default `true`). Not `closable`, `closeable`, `disableOutsideClickToClose`.
 - Picker typing: `typeable` (default `true`). Not `allowCustom`, `readonly`, `allowCustomValue`.
 - Open-after-select: `keepOpen` (default `false`). Not `autoClose`.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,7 +18,7 @@ _Avoid_: visible, show, isOpen (as a public API; internal refs are fine)
 Reserved for the **primary value** a component represents (selected option, text content, etc.). For overlay components, `modelValue` is *not* the visibility — visibility is `open`.
 _Avoid_: using `v-model` (bare) for visibility on overlay components
 
-**dismissable**:
+**dismissible**:
 Whether the overlay closes via user-initiated dismiss channels — outside click and Escape. Default `true`. When `false`, the overlay can only be closed programmatically or via an explicit close control (e.g. a close button or an action). The name is chosen with cross-overlay reuse in mind (Popover, Dropdown), but in v1 it ships **only on Dialog**. Replaces `disableOutsideClickToClose`, which remains a deprecated alias on Dialog with a one-time warning.
 _Avoid_: `disableOutsideClickToClose`, `closeOnOutsideClick` (in new code)
 
@@ -37,10 +37,10 @@ The single modal overlay component. Traps focus, blocks interaction with the pag
 - `aria-labelledby` ← `title` (or the custom `#body-title` slot's container, when used)
 - `aria-describedby` ← `message`
 
-A non-dismissable Dialog is still `role="dialog"` — "must respond" is expressed by `dismissable: false` and explicit actions, not by a different role.
+A non-dismissible Dialog is still `role="dialog"` — "must respond" is expressed by `dismissible: false` and explicit actions, not by a different role.
 
 **Imperative dialog API**:
-A `dialog` namespace exporting Promise-based helpers: `dialog.confirm()`, `dialog.alert()`, `dialog.prompt()`. Each helper mounts a `<Dialog>` with `dismissable: false` and resolves on the user's chosen action. Replaces the legacy `confirmDialog()` helper.
+A `dialog` namespace exporting Promise-based helpers: `dialog.confirm()`, `dialog.alert()`, `dialog.prompt()`. Each helper mounts a `<Dialog>` with `dismissible: false` and resolves on the user's chosen action. Replaces the legacy `confirmDialog()` helper.
 
 Mounting is handled by `<FrappeUIProvider>`, which renders a hidden `<Dialogs />` next to `<Toasts />` so imperative dialogs inherit `provide/inject` (router, Pinia, theme, etc.) from the host app. The `<Dialogs />` component remains exported for callers who don't use the provider and want to mount it manually.
 

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -10,7 +10,7 @@ This is the rulebook that governs API design across `frappe-ui`. Every principle
 - When a principle stops being generative — when it forces a clearly wrong answer in a real case — propose an edit, don't carve a quiet exception.
 
 **Relationship to other docs:**
-- **`CONTEXT.md`** is the *vocabulary*: what `open`, `variant`, `theme`, `dismissable` mean. PHILOSOPHY is the *rules* that use the vocabulary.
+- **`CONTEXT.md`** is the *vocabulary*: what `open`, `variant`, `theme`, `dismissible` mean. PHILOSOPHY is the *rules* that use the vocabulary.
 - **`v1-release/adr/`** are *decisions* — specific applications of principles to specific design questions. ADRs cite principles; principles don't cite ADRs.
 - **`v1-release/*-spec.md`** are *component-family specs* that implement principles for a family (Dialog, inputs, selection).
 
@@ -434,20 +434,20 @@ When in doubt, deprecate. The carve-out is for things you'd otherwise spend the 
 ```ts
 // Bad — outright rename, breaks every existing call site
 - props: ['disableOutsideClickToClose']
-+ props: ['dismissable']
++ props: ['dismissible']
 
 // Good — add the new prop, deprecate the old, keep both working
 const props = defineProps<{
-  dismissable?: boolean
-  /** @deprecated use `dismissable` */
+  dismissible?: boolean
+  /** @deprecated use `dismissible` */
   disableOutsideClickToClose?: boolean
 }>()
 
-const isDismissable = computed(() => {
+const isDismissible = computed(() => {
   if (props.disableOutsideClickToClose !== undefined) {
-    warnDeprecated('Dialog', 'disableOutsideClickToClose', 'dismissable')
+    warnDeprecated('Dialog', 'disableOutsideClickToClose', 'dismissible')
     return !props.disableOutsideClickToClose
   }
-  return props.dismissable ?? true
+  return props.dismissible ?? true
 })
 ```

--- a/skills/frappe-ui/COMPONENTS.md
+++ b/skills/frappe-ui/COMPONENTS.md
@@ -37,7 +37,7 @@ Menu of actions anchored to a trigger. `<Dropdown :options="[{ label, icon, onCl
 ## Overlays
 
 ### `Dialog`
-Modal. Always `v-model:open`. Props: `title`, `message`, `icon`, `theme`, `size`, `actions`, `dismissable`.
+Modal. Always `v-model:open`. Props: `title`, `message`, `icon`, `theme`, `size`, `actions`, `dismissible`.
 - `actions` is an array of button configs; each `onClick` receives `{ close }`.
 - `bare` to suppress chrome (full-bleed content like command palettes).
 - For confirm/alert/prompt, prefer the **imperative API** below.

--- a/src/components/Alert/Alert.api.md
+++ b/src/components/Alert/Alert.api.md
@@ -31,7 +31,7 @@
     type: 'string'
   },
   {
-    name: 'dismissable',
+    name: 'dismissible',
     description: 'Whether the alert can be closed by the user',
     required: false,
     type: 'boolean',

--- a/src/components/Alert/Alert.cy.ts
+++ b/src/components/Alert/Alert.cy.ts
@@ -42,8 +42,8 @@ describe('Alert', () => {
     cy.get(el).should('not.exist')
   })
 
-  it('Non Dismissable', () => {
-    cy.mount(Alert, { props: { dismissable: false } })
+  it('Non Dismissible', () => {
+    cy.mount(Alert, { props: { dismissible: false } })
     cy.get(`${el} button`).should('not.exist')
   })
 

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -38,7 +38,7 @@ const icon = computed(() => {
 
 const props = withDefaults(defineProps<AlertProps>(), {
   variant: "subtle",
-  dismissable: true,
+  dismissible: true,
 });
 
 defineSlots<{
@@ -79,7 +79,7 @@ defineSlots<{
     </div>
 
     <button
-      v-if="props.dismissable"
+      v-if="props.dismissible"
       type="button"
       aria-label="Dismiss"
       @click="dismissAlert"

--- a/src/components/Alert/types.ts
+++ b/src/components/Alert/types.ts
@@ -30,5 +30,5 @@ export interface AlertProps {
    * Whether the alert can be closed by the user
    * @default false
    */
-  dismissable?: boolean
+  dismissible?: boolean
 }

--- a/src/components/Dialog/Dialog.api.md
+++ b/src/components/Dialog/Dialog.api.md
@@ -64,7 +64,7 @@
     type: 'DialogAction[]'
   },
   {
-    name: 'dismissable',
+    name: 'dismissible',
     description: 'Allow outside-click and Escape to close. Default `true`.',
     required: false,
     type: 'boolean',
@@ -90,7 +90,7 @@
     required: false,
     type: 'boolean',
     default: 'undefined',
-    deprecated: 'Use `dismissable` (inverted) instead.'
+    deprecated: 'Use `dismissible` (inverted) instead.'
   },
   {
     name: 'options',

--- a/src/components/Dialog/Dialog.cy.ts
+++ b/src/components/Dialog/Dialog.cy.ts
@@ -86,13 +86,13 @@ describe('Dialog', () => {
 
   // ---- New behavior props ----------------------------------------------------
 
-  it('dismissable=false blocks outside click and Escape from closing', () => {
+  it('dismissible=false blocks outside click and Escape from closing', () => {
     cy.mount(Dialog, {
       props: {
         open: true,
         title: 'Locked',
         message: 'Cannot dismiss',
-        dismissable: false,
+        dismissible: false,
       },
     })
 
@@ -273,7 +273,7 @@ describe('Dialog', () => {
     cy.get('[role=dialog] [aria-label=Close]').should('not.exist')
   })
 
-  it('inverts `disableOutsideClickToClose` into `dismissable`', () => {
+  it('inverts `disableOutsideClickToClose` into `dismissible`', () => {
     cy.mount(Dialog, {
       props: {
         open: true,

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -19,12 +19,12 @@
             @open-auto-focus="handleOpenAutoFocus"
             @escape-key-down="
               (e: Event) => {
-                if (!isDismissable) e.preventDefault()
+                if (!isDismissible) e.preventDefault()
               }
             "
             @interact-outside="
               (e: Event) => {
-                if (!isDismissable) e.preventDefault()
+                if (!isDismissible) e.preventDefault()
               }
             "
           >
@@ -201,7 +201,7 @@ const props = withDefaults(defineProps<DialogProps>(), {
   // Defaults are applied inside `resolved`.
   size: undefined,
   position: undefined,
-  dismissable: true,
+  dismissible: true,
   showCloseButton: true,
   bare: false,
 })
@@ -218,7 +218,7 @@ watchEffect(() => {
   if (props.disableOutsideClickToClose !== undefined) {
     warnDeprecated(
       'Dialog `disableOutsideClickToClose` prop',
-      '`dismissable` (inverted)',
+      '`dismissible` (inverted)',
     )
   }
 })
@@ -261,9 +261,9 @@ const resolved = computed(() => {
   }
 })
 
-const isDismissable = computed(() => {
+const isDismissible = computed(() => {
   if (props.disableOutsideClickToClose) return false
-  return props.dismissable !== false
+  return props.dismissible !== false
 })
 
 const sizeClass = computed(() => {

--- a/src/components/Dialog/stories/Confirm.vue
+++ b/src/components/Dialog/stories/Confirm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 // Adapted from gameplan/SpaceOptions.vue — "Delete space" confirm.
 // Uses declarative `actions` with a `{ close }` context, `theme: 'red'`,
-// `dismissable: false` so the user must pick an action, and a loading
+// `dismissible: false` so the user must pick an action, and a loading
 // flag wired to the in-flight delete.
 import { ref } from 'vue'
 import { Button, Dialog } from 'frappe-ui'
@@ -28,7 +28,7 @@ async function deleteSpace({ close }: { close: () => void }) {
     title="Delete space"
     message="This will permanently delete the space along with 12 discussions and 4 tasks. This action cannot be undone."
     :icon="{ name: 'lucide-alert-triangle', theme: 'red' }"
-    :dismissable="false"
+    :dismissible="false"
     :show-close-button="false"
     :actions="[
       { label: 'Cancel' },

--- a/src/components/Dialog/stories/Interactive.vue
+++ b/src/components/Dialog/stories/Interactive.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 // Adapted from gameplan/NewTaskDialog.vue — a "new task" form with a
 // single full-width primary action that owns the submit. Demonstrates
-// using `dismissable` from a dirty-form flag, the canonical `#default`
+// using `dismissible` from a dirty-form flag, the canonical `#default`
 // slot for the form, and an `#actions` slot that's a single CTA.
 import { computed, ref } from 'vue'
 import { Button, Dialog, FormControl, KeyboardShortcut } from 'frappe-ui'
@@ -26,7 +26,7 @@ async function createTask(close: () => void) {
   <Dialog
     v-model:open="open"
     title="New task"
-    :dismissable="!isDirty"
+    :dismissible="!isDirty"
   >
     <div class="space-y-4">
       <FormControl

--- a/src/components/Dialog/stories/Modal.vue
+++ b/src/components/Dialog/stories/Modal.vue
@@ -2,7 +2,7 @@
 // Adapted from insights/ConnectPostgreSQLDialog.vue — a multi-state form
 // dialog where the primary action's label/theme transitions as the
 // connection is tested. Demonstrates state-driven action buttons inside
-// a non-dismissable dialog.
+// a non-dismissible dialog.
 import { computed, reactive, ref } from 'vue'
 import { Button, Dialog, FormControl } from 'frappe-ui'
 
@@ -34,7 +34,7 @@ const testButton = computed(() => {
   <Dialog
     v-model:open="open"
     title="Connect to PostgreSQL"
-    :dismissable="false"
+    :dismissible="false"
   >
     <div class="flex flex-col gap-4">
       <FormControl label="Host" v-model="db.host" />

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -84,7 +84,7 @@ export interface DialogProps {
 
   // Behavior.
   /** Allow outside-click and Escape to close. Default `true`. */
-  dismissable?: boolean
+  dismissible?: boolean
 
   /** Show the top-right close button. Default `true`. */
   showCloseButton?: boolean
@@ -93,7 +93,7 @@ export interface DialogProps {
   bare?: boolean
 
   // Deprecated.
-  /** @deprecated Use `dismissable` (inverted) instead. */
+  /** @deprecated Use `dismissible` (inverted) instead. */
   disableOutsideClickToClose?: boolean
 
   /** @deprecated Use flat top-level props instead. */

--- a/src/utils/dialog.cy.ts
+++ b/src/utils/dialog.cy.ts
@@ -178,21 +178,21 @@ describe('dialog.ts — imperative API', () => {
     cy.get('[role=dialog]').should('not.exist')
   })
 
-  it('dismissable=false blocks Esc from closing', () => {
+  it('dismissible=false blocks Esc from closing', () => {
     const onCancel = cy.spy().as('onCancel')
     cy.mount(DialogManager)
     cy.then(() => {
-      confirm({ title: 'Locked', dismissable: false, onCancel })
+      confirm({ title: 'Locked', dismissible: false, onCancel })
     })
     cy.get('body').type('{esc}')
     cy.get('[role=dialog]').should('exist')
     cy.get('@onCancel').should('not.have.been.called')
   })
 
-  it('dismissable=false hides the close (X) button', () => {
+  it('dismissible=false hides the close (X) button', () => {
     cy.mount(DialogManager)
     cy.then(() => {
-      confirm({ title: 'Locked', dismissable: false })
+      confirm({ title: 'Locked', dismissible: false })
     })
     cy.get('[role=dialog] [aria-label=Close]').should('not.exist')
   })

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -67,7 +67,7 @@ export interface ConfirmArgs {
    * Whether the dialog can be dismissed via Esc / outside-click / close button.
    * @default true
    */
-  dismissable?: boolean
+  dismissible?: boolean
   /**
    * Invoked when the user clicks the confirm button. Loading state is held
    * for as long as the returned promise is pending. Resolving auto-closes;
@@ -163,7 +163,7 @@ export interface PromptArgs {
    * Whether the dialog can be dismissed via Esc / outside-click / close button.
    * @default true
    */
-  dismissable?: boolean
+  dismissible?: boolean
   /**
    * Invoked when the user submits and required fields pass validation.
    * Promise behavior matches `confirm.onConfirm`.
@@ -346,7 +346,7 @@ export function confirm(args: ConfirmArgs): DialogHandle {
     args.onCancel?.()
   }
 
-  const dismissable = args.dismissable !== false
+  const dismissible = args.dismissible !== false
 
   const resolvedIcon = resolveIcon(args.theme, args.icon)
   const buttonTheme = themeToButtonTheme(args.theme)
@@ -409,8 +409,8 @@ export function confirm(args: ConfirmArgs): DialogHandle {
             title: args.title,
             icon: resolvedIcon,
             size: args.size || 'md',
-            dismissable,
-            showCloseButton: dismissable,
+            dismissible,
+            showCloseButton: dismissible,
             onAfterLeave: () => remove(assignedId),
           },
           {
@@ -530,7 +530,7 @@ export function prompt(args: PromptArgs): DialogHandle {
     args.onCancel?.()
   }
 
-  const dismissable = args.dismissable !== false
+  const dismissible = args.dismissible !== false
 
   const resolvedIcon = resolveIcon(args.theme, args.icon)
   const buttonTheme = themeToButtonTheme(args.theme)
@@ -586,8 +586,8 @@ export function prompt(args: PromptArgs): DialogHandle {
             title: args.title,
             icon: resolvedIcon,
             size: args.size || 'md',
-            dismissable,
-            showCloseButton: dismissable,
+            dismissible,
+            showCloseButton: dismissible,
             onAfterLeave: () => remove(assignedId),
           },
           {
@@ -642,7 +642,7 @@ export type DangerArgs = Omit<ConfirmArgs, 'theme' | 'icon'>
  * `lucide-alert-triangle`, and defaults `confirmLabel` to `'Delete'`. Use
  * for irreversible actions like deleting, revoking, or discarding data.
  *
- * Everything else (actions[], dismissable, onCancel, …) works identically
+ * Everything else (actions[], dismissible, onCancel, …) works identically
  * to `confirm`.
  */
 export function danger(args: DangerArgs): DialogHandle {

--- a/v1-release/08f-dialog-spec.md
+++ b/v1-release/08f-dialog-spec.md
@@ -24,7 +24,7 @@ Apps reach for the imperative `dialog.*` helpers when they need a one-off confir
 | ARIA role | `role="dialog"` always |
 | Visibility model | `v-model:open` (canonical) **and** `v-model` (also supported) |
 | Prop surface | Flat top-level props; `options` blob retained as deprecated alias |
-| Dismiss control | `dismissable: boolean` (default `true`); replaces `disableOutsideClickToClose` |
+| Dismiss control | `dismissible: boolean` (default `true`); replaces `disableOutsideClickToClose` |
 | Chrome control | `bare: boolean` (default `false`); replaces the legacy `#body` slot |
 | Close button | `showCloseButton: boolean` (default `true`); independent of header |
 | Size scale | All 11 sizes kept (`xs` → `7xl`); maps to Tailwind `max-w-*` |
@@ -92,7 +92,7 @@ interface DialogProps {
   actions?: DialogAction[]
 
   // Behavior.
-  dismissable?: boolean             // default true
+  dismissible?: boolean             // default true
   showCloseButton?: boolean         // default true
   bare?: boolean                    // default false
 
@@ -105,7 +105,7 @@ interface DialogProps {
 #### Prop semantics
 
 - **`open` / `modelValue`** — same boolean state. `v-model:open` is canonical and aligns with `Popover`/`Dropdown`. `v-model` (bound to `modelValue`) is also supported indefinitely for back-compat; no warning. If both are bound, `open` wins.
-- **`dismissable`** — when `false`, both outside-click and Escape are suppressed. Replaces `disableOutsideClickToClose`. Default `true`.
+- **`dismissible`** — when `false`, both outside-click and Escape are suppressed. Replaces `disableOutsideClickToClose`. Default `true`.
 - **`bare`** — when `true`, drops the chrome: no padded card, no auto-header, no auto-actions container. `#default` fills the modal shell directly. `title`/`actions` props become no-ops with a dev warning; `#title`/`#actions` slots are not rendered. Used for command palettes, full-screen settings, etc.
 - **`showCloseButton`** — controls the absolute-positioned top-right close button. Independent of the auto-header. Default `true`.
 - **`paddingTop`** — overrides the position-based top padding (escape hatch; kept for the single in-the-wild use case).
@@ -217,7 +217,7 @@ interface ConfirmArgs {
   theme?: DialogTheme            // colors the confirm button + picks default icon
   icon?: string | DialogIcon     // overrides theme-derived default icon
   size?: DialogSize              // default 'md'
-  dismissable?: boolean          // default true
+  dismissible?: boolean          // default true
   onConfirm?: (ctx: DialogControl) => void | Promise<void>
   onCancel?: () => void | Promise<void>
   /**
@@ -231,7 +231,7 @@ interface ConfirmArgs {
 /**
  * Destructive preset for `dialog.danger`. Forces `theme: 'red'`, defaults
  * `confirmLabel` to 'Delete', defaults the icon to `lucide-alert-triangle`.
- * Everything else (actions[], dismissable, onCancel, …) works as in confirm.
+ * Everything else (actions[], dismissible, onCancel, …) works as in confirm.
  */
 type DangerArgs = Omit<ConfirmArgs, 'theme' | 'icon'>
 
@@ -244,7 +244,7 @@ interface PromptArgs {
   theme?: DialogTheme
   icon?: string | DialogIcon
   size?: DialogSize              // default 'md'
-  dismissable?: boolean          // default true
+  dismissible?: boolean          // default true
   onConfirm: (ctx: PromptControl) => void | Promise<void>
   onCancel?: () => void | Promise<void>
 }
@@ -296,7 +296,7 @@ declare const dialog: {
 
 The confirm/submit button shows a loading spinner for as long as the `onConfirm` promise is pending. When `actions[]` is supplied, each action tracks its own loading state — the clicked button spins; every other button disables until it settles.
 
-`onCancel` fires on Cancel click, Escape, outside-click, or close-button click (whenever the dialog's `open` flag flips to `false` via dismissal). Set `dismissable: false` to disable Escape / outside-click / close-button.
+`onCancel` fires on Cancel click, Escape, outside-click, or close-button click (whenever the dialog's `open` flag flips to `false` via dismissal). Set `dismissible: false` to disable Escape / outside-click / close-button.
 
 Each helper returns `{ close }` synchronously, so callers can dismiss the dialog from outside the callback chain — e.g., from a socket event or route change.
 
@@ -394,7 +394,7 @@ dialog.prompt({
 // Programmatic dismissal via the returned handle.
 const handle = dialog.confirm({
   title: 'Waiting for upload…',
-  dismissable: false,
+  dismissible: false,
 })
 socket.once('upload:done', () => handle.close())
 ```
@@ -406,7 +406,7 @@ Each deprecated surface keeps working in v1, emits a one-time dev-mode console w
 | Deprecated | Replacement |
 |---|---|
 | `options` blob prop | Flat top-level props |
-| `disableOutsideClickToClose` | `dismissable` (inverted) |
+| `disableOutsideClickToClose` | `dismissible` (inverted) |
 | `icon: { appearance: 'warning' \| 'info' \| 'danger' \| 'success' }` | `icon: { theme: 'yellow' \| 'blue' \| 'red' \| 'green' }` |
 | `#body-content`, `#body-main` slots | `#default` |
 | `#body-title` slot | `#title` |
@@ -481,7 +481,7 @@ For non-destructive flows, use `dialog.confirm` with the same `onConfirm` shape.
 
 These are intentionally not in this spec; revisit in `1.x`:
 
-- Cross-component rollout of `dismissable` to Popover, Dropdown, Tooltip.
+- Cross-component rollout of `dismissible` to Popover, Dropdown, Tooltip.
 - Additional `PromptField` types beyond `text` / `textarea` / `select` / `checkbox` / `combobox` (`date`, `number`, `autocomplete`, multi-step wizards, etc.).
 - A `dialog.alert()` helper. The same affordance is achieved today with `dialog.confirm({ actions: [{ label: 'OK', variant: 'solid' }] })` or by passing only `cancelLabel`; not worth a dedicated entry point in v1.
 - `dialog.message()` or other named imperative helpers beyond `confirm` / `danger` / `prompt`.

--- a/v1-release/README.md
+++ b/v1-release/README.md
@@ -16,7 +16,7 @@ This directory contains the active planning docs for `frappe-ui` v1.
 - [`08-selection-and-menu-api-spec.md`](./08-selection-and-menu-api-spec.md)
   - Accepted API direction for Dropdown, Select, Combobox, MultiSelect, and ItemListRow.
 - [`08f-dialog-spec.md`](./08f-dialog-spec.md)
-  - Accepted API direction for `Dialog` and the imperative `dialog.confirm/alert/prompt` namespace. Covers flat-prop migration, slot rename, the `bare` chrome toggle, `dismissable`, and the caller-controlled-close lifecycle for imperative helpers.
+  - Accepted API direction for `Dialog` and the imperative `dialog.confirm/alert/prompt` namespace. Covers flat-prop migration, slot rename, the `bare` chrome toggle, `dismissible`, and the caller-controlled-close lifecycle for imperative helpers.
 - [`09-input-components-spec.md`](./09-input-components-spec.md)
   - Accepted API direction for the input family: TextInput, Textarea, Password, Checkbox, Switch, Rating, Slider, and ErrorMessage. Covers the shared labeling contract, size/variant scales, `defineModel` pattern, and deprecation warnings. FileUploader is out of scope and addressed in a separate spec.
 

--- a/v1-release/adr/0001-single-dialog-component.md
+++ b/v1-release/adr/0001-single-dialog-component.md
@@ -13,19 +13,19 @@ When designing the v1 Dialog API and the imperative `dialog.confirm/alert/prompt
 
 ## Decision
 
-Ship **one** public component, `<Dialog>`, with `role="dialog"` always. There is no `<AlertDialog>` component in the public surface. Forced-response semantics are expressed via `dismissable: false` + explicit actions, not via a different ARIA role.
+Ship **one** public component, `<Dialog>`, with `role="dialog"` always. There is no `<AlertDialog>` component in the public surface. Forced-response semantics are expressed via `dismissible: false` + explicit actions, not via a different ARIA role.
 
-The imperative `dialog.*` helpers internally mount the same `<Dialog>` with `dismissable: false`.
+The imperative `dialog.*` helpers internally mount the same `<Dialog>` with `dismissible: false`.
 
 ## Rationale
 
-- A separate `<AlertDialog>` would mostly be a thin wrapper of `<Dialog>` with `dismissable: false` + focused cancel button. The duplication adds API surface (a second component to document, story, test, and freeze for v1) for a small semantic gain.
-- An attempted heuristic to auto-derive `role="alertdialog"` (e.g. "set role when `dismissable: false`") gives the wrong role for legitimate non-dismissable modals like multi-step wizards or mandatory-completion forms. The signal "must respond" isn't structurally distinguishable from "must complete this step."
+- A separate `<AlertDialog>` would mostly be a thin wrapper of `<Dialog>` with `dismissible: false` + focused cancel button. The duplication adds API surface (a second component to document, story, test, and freeze for v1) for a small semantic gain.
+- An attempted heuristic to auto-derive `role="alertdialog"` (e.g. "set role when `dismissible: false`") gives the wrong role for legitimate non-dismissible modals like multi-step wizards or mandatory-completion forms. The signal "must respond" isn't structurally distinguishable from "must complete this step."
 - Screen readers in practice surface `dialog` and `alertdialog` very similarly. The accessibility win is marginal.
 - "One Dialog" is consistent with the plan's principle of keeping component boundaries narrow and avoiding API breadth before freeze.
 
 ## Consequences
 
-- App authors reaching for a destructive-confirm pattern set `dismissable: false` and label their actions clearly. They do not get `role="alertdialog"`.
+- App authors reaching for a destructive-confirm pattern set `dismissible: false` and label their actions clearly. They do not get `role="alertdialog"`.
 - Imperative helpers (`dialog.confirm/alert/prompt`) always render `role="dialog"`. This is a deliberate accessibility trade-off.
 - If we later need `role="alertdialog"` semantics — e.g. for compliance with a specific audit — we can add a `role` prop additively without breaking callers. Reversal is non-destructive.

--- a/v1-release/changelog.md
+++ b/v1-release/changelog.md
@@ -14,7 +14,7 @@ one-time dev-mode warning (unless noted). Removal is post-v1.
 - Flat top-level props (`title`, `message`, `icon`, `size`, `position`,
   `paddingTop`, `actions`) are canonical; legacy `options` blob warns.
 - `v-model:open` is canonical; `v-model` (modelValue) still works silently.
-- New props: `dismissable` (default `true`, replaces
+- New props: `dismissible` (default `true`, replaces
   `disableOutsideClickToClose`), `bare`, `showCloseButton` (default `true`,
   independent of the auto-header).
 - Canonical slots `#default`, `#title`, `#actions` (scoped with

--- a/v1-release/migration/dialog.md
+++ b/v1-release/migration/dialog.md
@@ -16,7 +16,7 @@ spec. This document is the practical checklist.
 | `:options="{ title: 'X' }"`                | `title="X"`                                 | Flatten every key in `options` to a top-level prop.    |
 | `:options="{ size: 'sm' }"`                | `size="sm"`                                 | Same scale (`xs` → `7xl`).                             |
 | `:options="{ actions: [...] }"`            | `:actions="[...]"`                          | Array-of-`{label, variant, theme, onClick}` unchanged. |
-| `disableOutsideClickToClose`               | `:dismissable="false"`                      | Inverted boolean. Default is `true`.                   |
+| `disableOutsideClickToClose`               | `:dismissible="false"`                      | Inverted boolean. Default is `true`.                   |
 | `<template #body-content>…</template>`     | `…` (default slot)                          | Drop the wrapper — content goes in the default slot.   |
 | `<template #body-title>…</template>`       | `<template #title>…</template>`             | Renamed.                                               |
 | `<template #body>…</template>`             | `bare` prop + default slot                  | `bare` opts out of the chrome (no padded card, no auto-header, no auto-actions). |
@@ -185,10 +185,10 @@ into the wrapper to find the first focusable descendant.
 <Dialog :disableOutsideClickToClose="isSubmitting" v-model="show">…</Dialog>
 
 <!-- After -->
-<Dialog :dismissable="!isSubmitting" v-model:open="show">…</Dialog>
+<Dialog :dismissible="!isSubmitting" v-model:open="show">…</Dialog>
 ```
 
-`dismissable` covers both outside-click and Escape; the default is `true`.
+`dismissible` covers both outside-click and Escape; the default is `true`.
 Set it to `false` while a form is submitting or whenever you want to trap
 the user until they pick an action.
 
@@ -257,7 +257,7 @@ Three helpers in the `dialog` namespace:
 All three return a synchronous `DialogHandle` (`{ close }`) so callers can dismiss the dialog programmatically — e.g., from a socket event:
 
 ```ts
-const handle = dialog.confirm({ title: 'Waiting…', dismissable: false })
+const handle = dialog.confirm({ title: 'Waiting…', dismissible: false })
 socket.once('done', () => handle.close())
 ```
 


### PR DESCRIPTION
## Summary
- Rename the canonical v1 prop `dismissable` → `dismissible` (correct English spelling) on `<Dialog>` and `<Alert>`, plus the imperative `dialog.confirm/alert/prompt` helpers.
- Update all stories, Cypress tests, `.api.md` files, and v1-release docs (`08f-dialog-spec.md`, `adr/0001-single-dialog-component.md`, `migration/dialog.md`, `changelog.md`, `README.md`, `CONTEXT.md`, `PHILOSOPHY.md`).
- Update `barista-review.md` canonical-vocab list and the `frappe-ui` skill `COMPONENTS.md` reference.

Pre-v1 rename: no deprecation shim added, since the old name only existed on the unreleased v1 surface. The `disableOutsideClickToClose` legacy shim continues to map to the new `dismissible` (inverted).

## Test plan
- [ ] `pnpm cypress run` (Dialog + Alert + `dialog.*` helper specs)
- [ ] Storybook: Dialog Modal / Interactive / Confirm stories open and dismiss as expected
- [ ] Grep for `dismissable` in app code post-merge — should return zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 44.04% (1889/4289) | ±0.00%      |
| Statements | 38.96% (2001/5135) | ±0.00%      |
| Functions  | 39.83% (378/949) | ±0.00%      |
| Branches   | 29.42% (595/2022) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->

