### PR TITLE
fix(PickerShell): pass MouseEvent in click emit

### DIFF
--- a/src/components/shared/picker/PickerShell.vue
+++ b/src/components/shared/picker/PickerShell.vue
@@ -123,7 +123,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   (e: 'focus'): void
-  (e: 'click'): void
+  (e: 'click', event: MouseEvent): void
   (e: 'blur'): void
   (e: 'enter'): void
   (e: 'open'): void
@@ -199,10 +199,10 @@ function onFocus() {
   emit('focus')
 }
 
-function onClick() {
+function onClick(e: MouseEvent) {
   typing.value = true
   if (props.openOnClick && !open.value) open.value = true
-  emit('click')
+  emit('click', e)
 }
 
 function onBlur(e: FocusEvent) {


### PR DESCRIPTION
Clicking on a DatePicker breaks in Studio. Studio needs to show the editor outline on the clicked component, so it has a click event handler. When PickerShell emits 'click', it doesn't pass the MouseEvent. Since DatePicker doesn't declare click in its emits, `@click="handleClick"` from StudioComponent falls through to PickerShell as a component event listener. When PickerShell's onClick() calls emit('click') without args, handleClick receives undefined instead of a MouseEvent, causing it to break on click

**Before**:

<img width="1005" height="707" alt="image" src="https://github.com/user-attachments/assets/b53ccaf9-64bb-43ab-a229-8f8545e098f3" />

**After**:

<img width="1005" height="707" alt="image" src="https://github.com/user-attachments/assets/a14c9310-5d58-4a39-99ed-41b17e9d67dc" />

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 44.04% (1889/4289) | ±0.00%      |
| Statements | 38.96% (2001/5135) | ±0.00%      |
| Functions  | 39.83% (378/949) | ±0.00%      |
| Branches   | 29.42% (595/2022) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
