### PR TITLE
fix(coverage): include .vue files in nyc report output

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -3,11 +3,13 @@
   "report-dir": "coverage/cypress",
   "temp-dir": ".nyc_output/cypress",
   "reporter": ["json", "lcov", "text-summary"],
+  "extension": [".js", ".cjs", ".mjs", ".ts", ".tsx", ".jsx", ".vue"],
   "include": ["src/**/*.{ts,vue}"],
   "exclude": [
     "src/**/*.cy.ts",
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
+    "src/**/*.story.vue",
     "src/**/stories/**",
     "src/**/types.ts",
     "src/**/types/**",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         'src/**/*.cy.ts',
         'src/**/*.spec.ts',
         'src/**/*.test.ts',
+        'src/**/*.story.vue',
         'src/**/stories/**',
         'src/**/types.ts',
         'src/**/types/**',


### PR DESCRIPTION
## Summary
- `nyc`'s default extension list excludes `.vue`, so `nyc report` was silently dropping every Vue SFC from the merged coverage report — components with passing Cypress tests (Button, Combobox, Dialog, Calendar, etc.) showed up as missing rather than covered.
- Add `.vue` to the `extension` array in `.nycrc.json` so `nyc report` keeps Vue entries when generating lcov/summary output.
- Exclude `*.story.vue` (Storybook fixtures) from both `.nycrc.json` and `vitest.config.ts` so they stop showing as ghost 0% files.

## Impact
Before the fix, the merged report contained **0 `.vue` files** and totaled 4,289 lines — the headline coverage number was measured against less than half the real source tree.

After the fix, the report covers 8,927 lines across all 212 source files (123 `.vue` + 89 `.ts`):

```
Lines      : 44.59% (3981/8927)
Statements : 41.69% (4247/10185)
Functions  : 42.74% (1019/2384)
Branches   : 37.61% (2171/5771)
```

This is the same set of tests — only the report aggregation was broken.

## Test plan
- [ ] `yarn coverage` completes and `coverage/final/coverage-summary.json` includes `.vue` files
- [ ] `coverage/final/lcov-report/index.html` lists Vue components (Button, Combobox, Dialog, …) with per-file coverage
- [ ] `*.story.vue` files no longer appear as 0% entries
- [ ] CI's PR-coverage-comment workflow posts a delta against `main` (will be the first run that establishes the new, accurate baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 44.59% (3981/8927) | +0.55%      |
| Statements | 41.70% (4248/10185) | +2.74%      |
| Functions  | 42.74% (1019/2384) | +2.91%      |
| Branches   | 37.68% (2175/5771) | +8.26%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
