### PR TITLE
fix(barista): repair broken workflows after composite refactor

### DIFF
--- a/.github/actions/barista-setup/action.yml
+++ b/.github/actions/barista-setup/action.yml
@@ -1,43 +1,20 @@
 name: Barista — Setup
-description: Common prelude for every Barista workflow. Mints the barista[bot] app token, checks out the repo, installs Bun, resolves the issue/PR number from the triggering event, and posts an "eyes" reaction on /barista comments.
+description: Common post-checkout setup for every Barista workflow. Installs Bun, resolves the issue/PR number from the triggering event, and posts an "eyes" reaction on /barista comments. The caller is responsible for minting the app token and checking out the repo first (local composites can't be loaded before checkout).
 inputs:
-  app-id:
-    description: GitHub App ID (BARISTA_APP_ID secret)
+  app-token:
+    description: barista[bot] installation token (used to post the reaction)
     required: true
-  private-key:
-    description: GitHub App private key (BARISTA_PRIVATE_KEY secret)
-    required: true
-  fetch-depth:
-    description: git fetch-depth for checkout. Triage/review pass 200 (history for blame); fix passes 0 (full history needed to branch off main).
-    required: false
-    default: '200'
   dispatch-number:
     description: workflow_dispatch input number (issue_number or pr_number). Empty/unset for all other events — the action falls back to the event payload.
     required: false
     default: ''
 outputs:
-  app-token:
-    description: The minted barista[bot] installation token
-    value: ${{ steps.app-token.outputs.token }}
   number:
     description: Issue or PR number resolved from the triggering event (or dispatch input)
     value: ${{ steps.resolve.outputs.number }}
 runs:
   using: composite
   steps:
-    - name: Mint barista app token
-      id: app-token
-      uses: actions/create-github-app-token@v1
-      with:
-        app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.private-key }}
-
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        token: ${{ steps.app-token.outputs.token }}
-        fetch-depth: ${{ inputs.fetch-depth }}
-
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
       with:
@@ -70,7 +47,7 @@ runs:
       if: github.event_name == 'issue_comment'
       shell: bash
       env:
-        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        GH_TOKEN: ${{ inputs.app-token }}
         REPO: ${{ github.repository }}
         COMMENT_ID: ${{ github.event.comment.id }}
       run: |

--- a/.github/workflows/barista-fix.yml
+++ b/.github/workflows/barista-fix.yml
@@ -45,19 +45,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
+      - name: Mint barista app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BARISTA_APP_ID }}
+          private-key: ${{ secrets.BARISTA_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          # Full history so barista can create a branch off main and push.
+          fetch-depth: 0
+
       - name: Setup Barista
         id: setup
         uses: ./.github/actions/barista-setup
         with:
-          app-id: ${{ secrets.BARISTA_APP_ID }}
-          private-key: ${{ secrets.BARISTA_PRIVATE_KEY }}
-          # Full history so barista can create a branch off main and push.
-          fetch-depth: '0'
+          app-token: ${{ steps.app-token.outputs.token }}
           dispatch-number: ${{ inputs.issue_number }}
 
       - name: Configure git identity for barista[bot]
         env:
-          GH_TOKEN: ${{ steps.setup.outputs.app-token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # App ID needed to derive the bot's noreply email.
           APP_SLUG=$(gh api /app --jq .slug)
@@ -83,7 +94,7 @@ jobs:
         uses: ./.github/actions/barista-run
         with:
           oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          app-token: ${{ steps.setup.outputs.app-token }}
+          app-token: ${{ steps.app-token.outputs.token }}
           repo: ${{ github.repository }}
           issue-number: ${{ steps.setup.outputs.number }}
           event: ${{ github.event_name }}
@@ -98,7 +109,7 @@ jobs:
         if: always() && steps.run-barista.outcome == 'success'
         uses: ./.github/actions/barista-append-stats
         with:
-          token: ${{ steps.setup.outputs.app-token }}
+          token: ${{ steps.app-token.outputs.token }}
           repo: ${{ github.repository }}
           issue-number: ${{ steps.setup.outputs.number }}
           execution-file: ${{ steps.run-barista.outputs.execution-file }}

--- a/.github/workflows/barista-review.yml
+++ b/.github/workflows/barista-review.yml
@@ -60,14 +60,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Mint barista app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BARISTA_APP_ID }}
+          private-key: ${{ secrets.BARISTA_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          # History so barista can inspect recent commits near changed files.
+          fetch-depth: 200
+
       - name: Setup Barista
         id: setup
         uses: ./.github/actions/barista-setup
         with:
-          app-id: ${{ secrets.BARISTA_APP_ID }}
-          private-key: ${{ secrets.BARISTA_PRIVATE_KEY }}
-          # History so barista can inspect recent commits near changed files.
-          fetch-depth: '200'
+          app-token: ${{ steps.app-token.outputs.token }}
           dispatch-number: ${{ inputs.pr_number }}
 
       - name: Run Barista
@@ -75,7 +86,7 @@ jobs:
         uses: ./.github/actions/barista-run
         with:
           oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          app-token: ${{ steps.setup.outputs.app-token }}
+          app-token: ${{ steps.app-token.outputs.token }}
           repo: ${{ github.repository }}
           issue-number: ${{ steps.setup.outputs.number }}
           event: ${{ github.event_name }}
@@ -88,7 +99,7 @@ jobs:
         if: always() && steps.run-barista.outcome == 'success'
         uses: ./.github/actions/barista-append-stats
         with:
-          token: ${{ steps.setup.outputs.app-token }}
+          token: ${{ steps.app-token.outputs.token }}
           repo: ${{ github.repository }}
           issue-number: ${{ steps.setup.outputs.number }}
           execution-file: ${{ steps.run-barista.outputs.execution-file }}

--- a/.github/workflows/barista-triage.yml
+++ b/.github/workflows/barista-triage.yml
@@ -45,14 +45,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Mint barista app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BARISTA_APP_ID }}
+          private-key: ${{ secrets.BARISTA_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          # History so barista can inspect recent commits near suspected files.
+          fetch-depth: 200
+
       - name: Setup Barista
         id: setup
         uses: ./.github/actions/barista-setup
         with:
-          app-id: ${{ secrets.BARISTA_APP_ID }}
-          private-key: ${{ secrets.BARISTA_PRIVATE_KEY }}
-          # History so barista can inspect recent commits near suspected files.
-          fetch-depth: '200'
+          app-token: ${{ steps.app-token.outputs.token }}
           dispatch-number: ${{ inputs.issue_number }}
 
       - name: Run Barista
@@ -60,7 +71,7 @@ jobs:
         uses: ./.github/actions/barista-run
         with:
           oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          app-token: ${{ steps.setup.outputs.app-token }}
+          app-token: ${{ steps.app-token.outputs.token }}
           repo: ${{ github.repository }}
           issue-number: ${{ steps.setup.outputs.number }}
           event: ${{ github.event_name }}
@@ -73,7 +84,7 @@ jobs:
         if: always() && steps.run-barista.outcome == 'success'
         uses: ./.github/actions/barista-append-stats
         with:
-          token: ${{ steps.setup.outputs.app-token }}
+          token: ${{ steps.app-token.outputs.token }}
           repo: ${{ github.repository }}
           issue-number: ${{ steps.setup.outputs.number }}
           execution-file: ${{ steps.run-barista.outputs.execution-file }}


### PR DESCRIPTION
## Summary
- The previous refactor (#721) moved `actions/checkout` *inside* `barista-setup`, which is a local composite action.
- Local composites can't be loaded before the repo is checked out, so every Barista workflow run since the merge fails with: `Can't find 'action.yml' under '.github/actions/barista-setup'`.
- This PR hoists `actions/create-github-app-token` and `actions/checkout` back into each workflow file. `barista-setup` keeps the post-checkout work (Bun + number resolution + `/barista` comment ack) and now receives the app token as an input.

## Test plan
- [ ] After merge, run **Actions → Barista — Issue Triage → Run workflow** against any existing issue and confirm it completes without the "Can't find action.yml" error.
- [ ] (Optional) Comment `/barista` on a test issue to confirm the natural `issue_comment` trigger path also works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 48.92% (5047/10315) | ±0.00%      |
| Statements | 46.18% (5160/11173) | ±0.00%      |
| Functions  | 47.13% (1470/3119) | ±0.00%      |
| Branches   | 40.14% (2359/5876) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
