### PR TITLE
fix(barista): drop gh api /app call from fix-mode git identity

### DIFF
--- a/.github/workflows/barista-fix.yml
+++ b/.github/workflows/barista-fix.yml
@@ -68,11 +68,14 @@ jobs:
 
       - name: Configure git identity for barista[bot]
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # `actions/create-github-app-token` already outputs the slug; pair it
+          # with the App ID secret to derive the bot's noreply email. Don't call
+          # `gh api /app` here — that endpoint needs JWT (app-level) auth, but
+          # the token we have is an installation token, so gh rejects it with
+          # "A JSON web token could not be decoded".
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_ID: ${{ secrets.BARISTA_APP_ID }}
         run: |
-          # App ID needed to derive the bot's noreply email.
-          APP_SLUG=$(gh api /app --jq .slug)
-          APP_ID=$(gh api /app --jq .id)
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
## Summary
- The "Configure git identity for barista[bot]" step in \`barista-fix.yml\` calls \`gh api /app\` to look up the bot's slug and ID. That endpoint needs **JWT (app-level)** auth, but the token from \`actions/create-github-app-token\` is an **installation** token — so \`gh\` rejects it with "A JSON web token could not be decoded (HTTP 401)" and the workflow fails before the agent runs.
- Bug was latent: fix mode was gated behind \`BARISTA_FIX_ENABLED\` (unset until today), so this step had never run in CI.
- Fix uses \`steps.app-token.outputs.app-slug\` (already exposed by the action) plus the existing \`BARISTA_APP_ID\` secret. No API call needed.

## Test plan
- [ ] After merge, comment \`/barista fix\` on a test issue and confirm the workflow gets past "Configure git identity for barista[bot]" without the 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
## Coverage

| Metric     | Coverage         | Δ vs `main` |
| ---------- | ---------------- | ----------- |
| Lines      | 48.92% (5047/10315) | ±0.00%      |
| Statements | 46.18% (5160/11173) | ±0.00%      |
| Functions  | 47.13% (1470/3119) | ±0.00%      |
| Branches   | 40.14% (2359/5876) | ±0.00%      |

_Baseline pulled from the latest successful `main` run._
<!-- coverage-report:end -->
