### PR TITLE
docs(spec): extract API contracts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,462 +1,55 @@
 ---
-description: 'frappe-ui library development standards and best practices'
-applyTo: 'src/**, docs/**, vite/**, tailwind/**, icons/**, frappe/**, v1-release/**'
+description: 'frappe-ui library development guidance'
+applyTo: 'src/**, docs/**, vite/**, tailwind/**, icons/**, frappe/**, spec/**, v1-release/**'
 ---
 
-# Project Name: frappe-ui
+# frappe-ui Copilot instructions
 
-**frappe-ui** is a Vue 3 component library and utilities package designed for
-rapid development of modern Frappe-based web applications.
+`frappe-ui` is a Vue 3 component library and utilities package for Frappe-based apps. Treat it as a reusable library, not an app codebase.
 
-## Overview
+## Read order
 
-frappe-ui provides a broad set of Vue 3 components, utility layers,
-Frappe-oriented integrations, docs tooling, and styling primitives used across
-multiple Frappe products.
+1. [`CONTEXT.md`](../CONTEXT.md) — repo map and shared vocabulary.
+2. [`PHILOSOPHY.md`](../PHILOSOPHY.md) — API design rules.
+3. [`spec/README.md`](../spec/README.md) — current specs and ADR index.
+4. The relevant `spec/*.md` file before changing public component APIs.
+5. [`v1-release/README.md`](../v1-release/README.md) for release execution, migration, changelog, and research.
 
-This file defines the **general development guidance for the repository**.
+If docs conflict, prefer:
 
-## How to use v1-release docs
-
-The docs in `v1-release/` are important **planning and direction documents**.
-They should **inform** implementation decisions in areas they cover, but they
-should not replace this file as the general repo-wide guidance.
-
-Use them primarily when working on:
-
-- core component stabilization
-- component API consistency
-- selection/menu family APIs
-- deprecation and migration decisions
-- TextEditor narrowing and stabilization
-- release-facing docs and changelog updates
-
-Especially relevant files:
-
-- `v1-release/plan.md`
-- `v1-release/04-components-audit.md`
-- `v1-release/08-selection-and-menu-api-spec.md`
-- `v1-release/changelog.md`
-
-If you are working outside those topics, follow the normal repo guidance in this
-file.
-
-## Tech Stack & Architecture
-
-- **Frontend Framework**: Vue 3 with Composition API and `<script setup>` syntax
-- **Language**: TypeScript-first authoring for public APIs and modern components
-- **Build Tool**: Vite
-- **Styling**: TailwindCSS v3 with semantic color tokens
-- **UI Primitives**: Reka UI / accessible headless primitives
-- **Rich Text**: TipTap v3
-- **Date Utilities**: dayjs
-- **Testing**: Vitest
-- **Documentation**: VitePress
-
-## Project Structure
-
-```bash
-frappe-ui/
-├── src/
-│   ├── components/               # Main library source code
-│   ├── data-fetching/            # Vue 3 composables for Frappe API access
-│   ├── resources/                # Older resource APIs kept for compatibility
-│   ├── mocks/                    # Mock service worker handlers and test helpers
-│   ├── composables/              # Reusable Vue composables
-│   ├── directives/               # Vue directives
-│   ├── utils/                    # Shared utilities
-│   └── index.ts                  # Main export surface
-├── docs/                         # VitePress docs site
-├── icons/                        # Custom icon components
-├── tailwind/                     # Tailwind preset/plugin/colors
-├── vite/                         # Vite plugins and helpers
-├── frappe/                       # Frappe-specific components and utilities
-└── v1-release/                   # Planning docs for v1 stabilization work
+```txt
+spec/*.md > accepted ADRs > PHILOSOPHY.md > CONTEXT.md > v1-release research/plan
 ```
 
-## Development Standards
-
-### General engineering principles
-
-- Treat frappe-ui as a **reusable library**, not an app codebase
-- Prefer stable, high-signal public APIs over clever internal abstractions
-- Optimize for maintainability, consistency, and migration safety
-- Keep component responsibilities narrow and composable
-- Avoid growing components into do-everything abstractions
-- Prefer small, requirement-driven changes over speculative rewrites
-- When a behavior is public, preserve backwards compatibility unless the task
-  explicitly involves a planned breaking change or deprecation path
-
-## Component Authoring Guidelines
-
-### Component structure and API design
-
-When creating or modernizing a component, prefer this structure:
-
-```bash
-src/components/ComponentName/
-├── ComponentName.vue
-├── types.ts
-├── utils.ts           # optional
-├── stories/           # optional but preferred for public components
-└── index.ts
-```
-
-For small legacy components that do not yet match this structure, prefer moving
-incrementally toward it instead of forcing a large rewrite unless the task calls
-for one.
-
-### TypeScript requirements
-
-For public component APIs, use consistent naming:
-
-- `ComponentNameProps`
-- `ComponentNameEmits`
-- `ComponentNameSlots`
-- `ComponentNameExposed`
-- `ComponentNameSize`, `ComponentNameVariant`, `ComponentNameTheme`, etc.
-
-These names matter because public types and JSDoc are used to generate
-component documentation metadata.
-
-### JSDoc expectations
-
-Every public prop, emit, and slot should have a JSDoc description.
-
-Use JSDoc for:
-
-- generated docs
-- IntelliSense quality
-- clear API contracts for consumers
-
-### Vue authoring conventions
-
-Prefer:
-
-- `<script setup lang="ts">`
-- `defineProps<Props>()`
-- `defineEmits<Emits>()`
-- `defineSlots<Slots>()`
-- `defineExpose<Exposed>()` when truly needed
-- `withDefaults()` for sensible defaults
-- `computed` instead of `watch` when deriving state
-- small, focused composables for reusable logic
-
-Avoid:
-
-- Options API for new component work unless there is a compelling migration reason
-- runtime prop validation when TypeScript is enough
-- broad watchers when a narrower reactive dependency would do
-- imperative DOM access unless necessary
-
-### Public API design rules
-
-Prefer:
-
-- narrow and predictable component boundaries
-- props and slots as the default customization mechanism
-- `v-model` / `modelValue` for the primary value state
-- `v-model:open` for visibility state where relevant
-- semantic event names like `change`, `open`, `close`, `submit`
-- slots over render functions for normal customization
-- limited, requirement-driven escape hatches
-
-Avoid:
-
-- giant multi-mode components with too many flags
-- exposing low-level composition as the default user story
-- breaking or renaming public APIs casually
-- proliferating one-off event and slot names across similar components
-
-### Component consistency
-
-Consistency matters a lot in a UI library.
-
-When working across related components, try to align:
-
-- prop names
-- event names
-- slot vocabulary
-- size / variant naming
-- controlled / uncontrolled behavior
-- visibility APIs (`open`, `v-model:open`)
-- positioning vocabulary (`side`, `align`, `placement`, `offset`)
-
-## Strategic direction currently influencing the repo
-
-These are **important directional signals**, not hard rules for every file.
-
-### 1. Core component quality bar is rising
-
-Many public components are being pushed toward a stronger baseline:
-
-- TypeScript
-- `<script setup>`
-- `types.ts`
-- docs
-- stories
-- tests
-
-When touching a public component that is still legacy, prefer nudging it toward
-that baseline if the change is local and safe.
-
-### 2. Selection/menu family needs consistent APIs
-
-When working on:
-
-- `Dropdown`
-- `Select`
-- `Combobox`
-- `MultiSelect`
-- related shells and shared list primitives
-
-use `v1-release/08-selection-and-menu-api-spec.md` as guidance.
-
-Broad preferred direction:
-
-- keep each component narrowly scoped
-- do not turn `Dropdown` into a generic value picker
-- prefer shared item slot vocabulary like:
-  - `#trigger`
-  - `#item-prefix`
-  - `#item-label`
-  - `#item-suffix`
-  - `#empty`
-  - `#footer`
-- prefer shell-owned row structure over forcing consumers to rebuild rows
-- support `v-model:open` where appropriate
-- prefer `@update:query` for searchable components when relevant
-
-### 3. Some APIs are compatibility layers, not the preferred path
-
-These areas still matter and should be maintained carefully, but should not be
-presented as the ideal API for new work unless the task is specifically about
-legacy compatibility:
-
-- `src/resources/*`
-- older resource-style APIs
-- older compatibility components like `Resource.vue`, `Input.vue`,
-  `Autocomplete`, and `FeatherIcon`
-
-If you touch them:
-
-- preserve compatibility unless the task is explicitly a migration/deprecation task
-- prefer conservative bug fixes and migration-safe improvements
-- avoid expanding their scope unnecessarily
-
-### 4. TextEditor should be stabilized thoughtfully
-
-When touching `TextEditor`, prioritize:
-
-- internal simplification
-- public API stability
-- safe defaults
-- docs / stories / tests alignment
-
-Use `v1-release/plan.md` for the current planning direction in that area.
-
-## Icons
-
-### Lucide icons
-
-Prefer Lucide icons for new work.
-
-```vue
-<template>
-  <LucideCheck class="size-4" />
-</template>
-```
-
-```ts
-import LucideCheck from '~icons/lucide/check'
-```
-
-### FeatherIcon
-
-`FeatherIcon` still exists and is used in parts of the repo, so do not break it
-casually. But for new component work, prefer Lucide.
-
-If you are already modifying a small area that uses `FeatherIcon`, it is usually
-reasonable to migrate it if the change stays low-risk.
-
-## Styling Standards
-
-### Semantic color system
-
-Always prefer semantic design tokens over hardcoded colors.
-
-Examples:
-
-- `bg-surface-*`
-- `text-ink-*`
-- `border-outline-*`
-- `fill-ink-*`
-- `placeholder-ink-*`
-
-### Layout and spacing
-
-Prefer Tailwind utility classes for layout and spacing.
-
-Use:
-
-- `size-*` for square elements
-- flex and grid utilities for layout
-- responsive utilities when needed
-
-### Stable styling hooks
-
-When a component owns its shell, prefer stable styling and testing hooks such as:
-
-- `data-slot`
-- `data-state`
-- `data-size`
-- `data-variant`
-- `data-disabled`
-
-These reduce the need for fragile DOM assumptions and full markup replacement.
-
-### Scoped styles
-
-Use `<style scoped>` only when utility classes and stable hooks are not enough.
-
-## Data Fetching Guidance
-
-frappe-ui currently contains multiple generations of data APIs.
-
-### `src/resources/`
-
-This is an older compatibility layer. Treat it as mature and compatibility
-sensitive.
-
-When working here:
-
-- favor conservative fixes
-- preserve existing behavior when possible
-- avoid broad redesigns unless explicitly asked
-
-### `src/data-fetching/`
-
-This contains newer composable-based data APIs.
-
-When working here, focus on:
-
-- reactive correctness
-- cache behavior
-- loading and error state handling
-- API contract clarity
-- mutation ergonomics
-- type safety
-
-Avoid opportunistic migration work unless the task is explicitly about data API
-migration or modernization.
-
-## Documentation
-
-### Docs philosophy
-
-Public components should be documented in a way that matches how consumers are
-expected to use them, not just how the internals currently happen to work.
-
-Docs should prioritize:
-
-- intended API shape
-- examples of normal usage
-- slots and customization points
-- accessibility guidance where relevant
-- migration notes when behavior changes matter to consumers
-
-### Generated metadata
-
-`docs/meta/` is generated output.
-
-Do not treat it as the source of truth. If docs metadata looks wrong, fix the
-underlying component types, JSDoc, or docs generation inputs.
-
-### Stories
-
-Stories should be:
-
-- focused
-- representative
-- easy to scan
-- based on public APIs
-
-Common story types:
-
-- `Sizes.vue`
-- `Variants.vue`
-- `States.vue`
-- `WithIcons.vue`
-- `Interactive.vue`
-
-## Testing Guidance
-
-For public components, tests should focus on behavior that consumers rely on:
-
-- rendering states
-- keyboard interaction
-- focus behavior
-- ARIA semantics
-- emitted events
-- controlled and uncontrolled usage
-- slot behavior when it affects output
-
-Avoid shallow tests that only assert implementation trivia.
-
-## Accessibility
-
-Accessibility is part of component quality, not a later polish pass.
-
-Prioritize:
-
-- semantic structure
-- keyboard navigation
-- focus management
-- accessible labels and relationships
-- overlay trigger/content semantics
-- disabled state behavior
-
-## Code Quality
-
-### Comments
-
-- explain **why**, not **what**
-- use JSDoc/TSDoc for public APIs and non-obvious logic
-- avoid noisy inline comments
-
-### Review priorities
-
-When reviewing or implementing changes in this repo, prioritize:
-
-- real bugs and regressions
-- API consistency
-- backwards compatibility risks
-- TypeScript correctness
-- accessibility
-- docs/story/test drift
-- maintainability of public library code
-
-Avoid over-indexing on:
-
-- formatting-only feedback
-- Tailwind class ordering nits
-- speculative refactors with unclear user value
-- app-level architectural advice that does not fit a reusable library
-
-## Release-facing docs in `v1-release/`
-
-The files in `v1-release/` are planning and release-support docs.
-
-When editing them:
-
-- keep `plan.md` focused on scope, blockers, and direction
-- keep `changelog.md` consumer-facing
-- keep audits concrete and evidence-based
-- do not mix speculative ideas into accepted-direction docs without making that
-  status clear
-
-## Miscellaneous
-
-- ignore newline-only errors
-- prefer small, focused edits over repository-wide churn
-- preserve migration safety in legacy areas unless explicitly asked to change it
+## Working rules
+
+- Preserve backwards compatibility unless a spec explicitly calls for a breaking v1 change or deprecation path.
+- Prefer small, focused changes over broad rewrites.
+- New or modernized Vue components should use TypeScript and `<script setup lang="ts">`.
+- Public component APIs need typed props/emits/slots/exposed surfaces and useful JSDoc.
+- Use semantic Tailwind tokens (`surface-*`, `ink-*`, `outline-*`) instead of hardcoded colors.
+- Prefer stable styling hooks (`data-slot`, `data-state`, `data-size`, `data-variant`, `data-disabled`) over DOM/class assumptions.
+- Accessibility, keyboard behavior, focus management, and ARIA semantics are part of done.
+- Update docs, stories, tests, and changelog/migration notes when public behavior changes.
+
+## Component API rules
+
+Follow [`PHILOSOPHY.md`](../PHILOSOPHY.md) and the relevant spec.
+
+## Area-specific pointers
+
+- Selection/menu: [`spec/selection.md`](../spec/selection.md)
+- Dialog: [`spec/dialog.md`](../spec/dialog.md)
+- Inputs: [`spec/inputs.md`](../spec/inputs.md)
+- Date/time pickers: [`spec/date-picker.md`](../spec/date-picker.md)
+- Toast: [`spec/toast.md`](../spec/toast.md)
+- ADR status: [`spec/adr/README.md`](../spec/adr/README.md)
+- v1 release execution: [`v1-release/`](../v1-release/)
+
+## Do not
+
+- Invent new public API vocabulary without checking `PHILOSOPHY.md` and `spec/`.
+- Treat `v1-release/research/` as the current contract.
+- Expand legacy compatibility APIs casually.
+- Make broad repo-wide refactors unless explicitly requested.
+- Optimize for app-local convenience at the expense of reusable-library stability.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,7 +4,7 @@ A Vue 3 component library for Frappe-based apps. This document captures the voca
 
 The cross-cutting **design rules** that govern API shape live in [`PHILOSOPHY.md`](./PHILOSOPHY.md) (cite as `P1`–`P13`). This doc is the vocabulary the rules use.
 
-Planning artifacts live under [`v1-release/`](./v1-release/) — specs in `v1-release/*.md` and architecture decision records in [`v1-release/adr/`](./v1-release/adr/). The user-facing documentation in `docs/` is the published vitepress site and intentionally does not host ADRs or specs.
+Current API contracts live in [`spec/`](./spec/). Release execution, migration notes, changelog, and temporary research live in [`v1-release/`](./v1-release/). The user-facing documentation in `docs/` is the published vitepress site and intentionally does not host specs or ADRs.
 
 ## Language
 
@@ -18,7 +18,7 @@ _Avoid_: visible, show, isOpen (as a public API; internal refs are fine)
 Reserved for the **primary value** a component represents (selected option, text content, etc.). For overlay components, `modelValue` is *not* the visibility — visibility is `open`.
 _Avoid_: using `v-model` (bare) for visibility on overlay components
 
-**dismissible**:
+**dismissable**:
 Whether the overlay closes via user-initiated dismiss channels — outside click and Escape. Default `true`. When `false`, the overlay can only be closed programmatically or via an explicit close control (e.g. a close button or an action). The name is chosen with cross-overlay reuse in mind (Popover, Dropdown), but in v1 it ships **only on Dialog**. Replaces `disableOutsideClickToClose`, which remains a deprecated alias on Dialog with a one-time warning.
 _Avoid_: `disableOutsideClickToClose`, `closeOnOutsideClick` (in new code)
 
@@ -37,18 +37,14 @@ The single modal overlay component. Traps focus, blocks interaction with the pag
 - `aria-labelledby` ← `title` (or the custom `#body-title` slot's container, when used)
 - `aria-describedby` ← `message`
 
-A non-dismissible Dialog is still `role="dialog"` — "must respond" is expressed by `dismissible: false` and explicit actions, not by a different role.
+A non-dismissable Dialog is still `role="dialog"` — "must respond" is expressed by `dismissable: false` and explicit actions, not by a different role.
 
 **Imperative dialog API**:
-A `dialog` namespace exporting Promise-based helpers: `dialog.confirm()`, `dialog.alert()`, `dialog.prompt()`. Each helper mounts a `<Dialog>` with `dismissible: false` and resolves on the user's chosen action. Replaces the legacy `confirmDialog()` helper.
+A `dialog` namespace exporting callback-based helpers: `dialog.confirm()`, `dialog.danger()`, `dialog.prompt()`. Each helper mounts a `<Dialog>` for one-shot confirms/prompts outside normal component templates. Replaces the legacy `confirmDialog()` helper.
 
 Mounting is handled by `<FrappeUIProvider>`, which renders a hidden `<Dialogs />` next to `<Toasts />` so imperative dialogs inherit `provide/inject` (router, Pinia, theme, etc.) from the host app. The `<Dialogs />` component remains exported for callers who don't use the provider and want to mount it manually.
 
-- `dialog.confirm({...})` → `Promise<{ ok: boolean, close: () => void }>`
-- `dialog.alert({...})` → `Promise<{ close: () => void }>`
-- `dialog.prompt({...})` → `Promise<{ values: Record<string, any> | null, close: () => void }>` *(values is null on cancel)*
-
-**Lifecycle contract**: imperative helpers do **not** auto-close on confirm. The promise resolves the moment the user picks an action; the caller calls `close()` when ready (typically after async work). The confirm/submit button auto-shows a loading state from click until `close()` is called. On cancel, the dialog auto-closes and the promise resolves with `ok: false` / `values: null`.
+**Lifecycle contract**: `onConfirm` resolving auto-closes the dialog; throwing keeps it open and renders the thrown message inline. Each helper returns a synchronous handle with `close()` for programmatic dismissal. See [`spec/dialog.md`](./spec/dialog.md) and [`spec/adr/0003-imperative-dialog-onconfirm.md`](./spec/adr/0003-imperative-dialog-onconfirm.md).
 
 **PromptField** (the schema for `dialog.prompt`'s `fields` array):
 ```ts
@@ -87,4 +83,4 @@ A button rendered in the Dialog's footer area, declared via the `actions` prop. 
 
 ## Flagged ambiguities
 
-- **`v-model` vs `v-model:open` on Dialog**: both are supported indefinitely. `v-model:open` is canonical and aligns with Popover/Dropdown; `v-model` (bound to `modelValue`) remains supported with no deprecation warning. If both are bound, `open` wins. See [`v1-release/08f-dialog-spec.md`](./v1-release/08f-dialog-spec.md).
+- **`v-model` vs `v-model:open` on Dialog**: both are supported indefinitely. `v-model:open` is canonical and aligns with Popover/Dropdown; `v-model` (bound to `modelValue`) remains supported with no deprecation warning. If both are bound, `open` wins. See [`spec/dialog.md`](./spec/dialog.md).

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,29 @@
+# Specs
+
+Current API contracts and durable design decisions for `frappe-ui`.
+
+## Source of truth order
+
+1. Specs in this directory — current public API contracts.
+2. Accepted ADRs in [`adr/`](./adr/) — rationale and decision history.
+3. [`CONTEXT.md`](../CONTEXT.md) — short repo map and shared vocabulary.
+4. Research and release notes in [`v1-release/`](../v1-release/) — evidence, migration, and execution history.
+
+If these disagree, update the lower-authority document or mark it historical.
+
+## Component specs
+
+- [`dialog.md`](./dialog.md)
+- [`toast.md`](./toast.md)
+- [`inputs.md`](./inputs.md)
+- [`date-picker.md`](./date-picker.md)
+- [`selection.md`](./selection.md)
+  - [`item-list-row.md`](./item-list-row.md)
+  - [`dropdown.md`](./dropdown.md)
+  - [`select.md`](./select.md)
+  - [`combobox.md`](./combobox.md)
+  - [`multiselect.md`](./multiselect.md)
+
+## ADRs
+
+See [`adr/README.md`](./adr/README.md).

--- a/spec/adr/0001-single-dialog-component.md
+++ b/spec/adr/0001-single-dialog-component.md
@@ -1,0 +1,31 @@
+# Single `Dialog` component (no separate `AlertDialog`)
+
+**Status**: accepted
+
+## Context
+
+The `frappe-ui` library wraps `reka-ui`, which ships `Dialog` and `AlertDialog` as two distinct components — matching the Radix/ARIA convention where `role="alertdialog"` denotes a dialog that interrupts the user with a message requiring response (e.g. destructive confirms), while `role="dialog"` is the generic modal.
+
+When designing the v1 Dialog API and the imperative `dialog.confirm/alert/prompt` helpers, we had to choose whether to expose this split:
+
+- **Two public components**: `<Dialog>` for generic modals + `<AlertDialog>` for forced-response confirms. Imperative helpers mount `<AlertDialog>`.
+- **One public component**: `<Dialog>` handles everything; ARIA semantics are derived from props.
+
+## Decision
+
+Ship **one** public component, `<Dialog>`, with `role="dialog"` always. There is no `<AlertDialog>` component in the public surface. Forced-response semantics are expressed via `dismissable: false` + explicit actions, not via a different ARIA role.
+
+The imperative `dialog.*` helpers internally mount the same `<Dialog>` with `dismissable: false`.
+
+## Rationale
+
+- A separate `<AlertDialog>` would mostly be a thin wrapper of `<Dialog>` with `dismissable: false` + focused cancel button. The duplication adds API surface (a second component to document, story, test, and freeze for v1) for a small semantic gain.
+- An attempted heuristic to auto-derive `role="alertdialog"` (e.g. "set role when `dismissable: false`") gives the wrong role for legitimate non-dismissable modals like multi-step wizards or mandatory-completion forms. The signal "must respond" isn't structurally distinguishable from "must complete this step."
+- Screen readers in practice surface `dialog` and `alertdialog` very similarly. The accessibility win is marginal.
+- "One Dialog" is consistent with the plan's principle of keeping component boundaries narrow and avoiding API breadth before freeze.
+
+## Consequences
+
+- App authors reaching for a destructive-confirm pattern set `dismissable: false` and label their actions clearly. They do not get `role="alertdialog"`.
+- Imperative helpers (`dialog.confirm/alert/prompt`) always render `role="dialog"`. This is a deliberate accessibility trade-off.
+- If we later need `role="alertdialog"` semantics — e.g. for compliance with a specific audit — we can add a `role` prop additively without breaking callers. Reversal is non-destructive.

--- a/spec/adr/0002-imperative-dialog-caller-closes.md
+++ b/spec/adr/0002-imperative-dialog-caller-closes.md
@@ -1,0 +1,40 @@
+# Imperative dialog API resolves on click; caller calls `close()`
+
+**Status**: superseded by [ADR-0003](./0003-imperative-dialog-onconfirm.md). The decision below was the planned design; implementation reversed it in favor of an `onConfirm` callback with auto-close. This ADR is preserved for historical context.
+
+## Context
+
+The v1 imperative dialog API exposes Promise-based helpers: `dialog.confirm()`, `dialog.alert()`, `dialog.prompt()`. Most libraries in this space (SweetAlert, Element Plus's `MessageBox`, Naive UI's `dialog.warning`, etc.) auto-close the dialog when the user picks an action and resolve the Promise once it's closed.
+
+We considered three lifecycle contracts:
+
+1. **Auto-close on click, Promise resolves to a boolean** (industry default).
+2. **Auto-close after an optional `onConfirm` callback resolves**, with throw-to-keep-open (Naive UI's pattern).
+3. **Resolve on click, dialog stays open until the caller calls `close()`** (custom).
+
+## Decision
+
+The imperative helpers resolve **on click**, with a `close()` callback in the resolved object. The dialog stays open until the caller calls `close()` themselves. The confirm/submit button auto-shows a loading state from the moment of click until `close()` is called.
+
+```ts
+const { ok, close } = await dialog.confirm({ title: 'Delete?' })
+if (ok) {
+  await api.deleteFile()
+}
+close()
+```
+
+On cancel, the dialog auto-closes and the Promise resolves with `ok: false` / `values: null`. Calling `close()` after cancel is a no-op.
+
+## Rationale
+
+- The async-confirm pattern is common in real apps (gameplan, insights both have confirm-then-API-call flows). Auto-closing the dialog before async work runs leaves the user looking at the underlying page with no feedback while a network call is in flight — bad UX.
+- Promise-with-`onConfirm`-callback works, but reintroduces the callback-context pattern we're explicitly migrating away from in the declarative `actions` API. We want one mental model for both.
+- Caller-controlled close gives the caller full lifecycle control without callbacks: any error handling, retries, or follow-up UI happens between the `await` and the `close()`.
+- Auto-loading on the action button (provided by the helper, not the caller) covers the one thing the caller can't easily do from outside the dialog. This compromise keeps the caller's code simple while still showing in-flight state.
+
+## Consequences
+
+- This contract is **unusual** — callers coming from other libraries will be surprised that `await dialog.confirm()` returns while the dialog is still on screen. Documentation must lead with the contract, not bury it.
+- A forgotten `close()` call leaves the dialog open forever. This is the caller's bug; we accept it as the cost of explicit control.
+- Reversing this decision later (switching to auto-close) is a breaking change for every caller. The cost of getting it wrong is high — recorded here so future contributors understand the trade-off.

--- a/spec/adr/0003-imperative-dialog-onconfirm.md
+++ b/spec/adr/0003-imperative-dialog-onconfirm.md
@@ -1,0 +1,58 @@
+# Imperative dialog API uses `onConfirm` with auto-close
+
+**Status**: accepted. Supersedes [ADR-0002](./0002-imperative-dialog-caller-closes.md).
+
+## Context
+
+[ADR-0002](./0002-imperative-dialog-caller-closes.md) evaluated three lifecycle contracts for the imperative dialog API and chose option #3: "Resolve on click, dialog stays open until the caller calls `close()`". During implementation and codebase rollout, this contract was reversed in favour of option #2: "Auto-close after an optional `onConfirm` callback resolves, with throw-to-keep-open" — the pattern used by Naive UI.
+
+This ADR records the reversal so future contributors understand why the shipping implementation in `src/utils/dialog.ts` diverges from ADR-0002's stated decision.
+
+## Decision
+
+The imperative helpers (`dialog.confirm`, `dialog.danger`, `dialog.prompt`) take an `onConfirm` callback that receives `{ close, setError }` (and `values` for prompt). The lifecycle:
+
+- `onConfirm` **resolves** → dialog **auto-closes**.
+- `onConfirm` **throws / rejects** → dialog **stays open**, thrown message rendered inline as an error, buttons re-enabled.
+- `onConfirm` calls `ctx.close()` early → dialog closes immediately; the trailing auto-close is an idempotent no-op.
+
+```ts
+dialog.confirm({
+  title: 'Delete?',
+  onConfirm: async () => {
+    await api.deleteFile()
+    // auto-closes here
+  },
+})
+```
+
+Each helper returns a synchronous `DialogHandle` (`{ close }`) so callers can dismiss the dialog programmatically — e.g., from a socket event — without depending on Promise resolution.
+
+## Rationale for reversing ADR-0002
+
+ADR-0002 rejected option #2 with two concerns. Implementation experience reversed both:
+
+1. **"Callback-context pattern reintroduces what we're moving away from in `actions[]`."**
+   The shipping declarative `actions[]` API uses `(ctx: DialogControl) => void | Promise<void>` — the **same shape** as `onConfirm`. So `onConfirm` is consistent with `actions[i].onClick`, not divergent from it. One mental model, not two.
+
+2. **"Caller-controlled close is more explicit and safer."**
+   In practice every confirm/delete call site ended up writing the same two-line `await api.x(); close()` boilerplate. Migrating gameplan alone (16 destructive call sites — see `commit acc50047` and the surrounding refactor) removed dozens of lines of plumbing because auto-close became the default. The "explicit `close()`" path optimised for a flexibility that callers didn't actually use.
+
+Additional considerations the implementation surfaced:
+
+- **Throw-to-stay-open routes server-side validation errors cleanly.** Server says "username taken"? Throw `new Error('...')`. The thrown message flows through `extractErrorMessage` (which handles Frappe's `{ messages: [...] }` envelope, plain `Error.message`, and string rejections) and renders inline. The dialog re-enables for retry. ADR-0002 only used inline rendering for the post-cancel path; the new contract makes it the canonical pattern for all in-handler failures.
+- **Programmatic close is preserved.** The synchronous `DialogHandle` return covers the "close from outside the callback" case ADR-0002 emphasised — e.g., a socket event that should dismiss an upload dialog. Callers haven't lost lifecycle control; they've lost only the forced ceremony.
+- **Forgotten close calls are no longer a class of bug.** ADR-0002 accepted "forgotten `close()` leaves the dialog open forever" as the cost of explicit control. That class of bug doesn't exist under the new contract — `close()` runs whenever `onConfirm` resolves.
+
+## Consequences
+
+- ADR-0002's "this contract is unusual" warning no longer applies. The shipping API matches Naive UI's `dialog.warning` pattern, which most frontend developers already recognise.
+- **`setError` is the lone vestige of the ADR-0002 design.** It's still passed to `onConfirm` via the `ctx` arg for niche uses (clearing a stale error from outside the immediate flow), but calling it from inside `onConfirm` without throwing does **not** prevent the auto-close. Throw to stay open. The `src/components/Dialog/stories/Imperative.vue` story documents this matrix explicitly because it surprised early users.
+- **The new failure mode**: forgetting to throw on a validation failure. The dialog closes when the developer expected an error to keep it open. The migration guide (Section 7) and the `Imperative.vue` story both call this out.
+- **`dialog.alert` was never implemented.** ADR-0002 listed it as a planned helper; the actual `dialog` namespace exports only `confirm`, `danger`, and `prompt`. Use `dialog.confirm({ actions: [{ label: 'OK', variant: 'solid' }] })` for one-button acknowledgements until/unless a dedicated `alert` is added in a future minor.
+
+## Related code
+
+- Implementation: `src/utils/dialog.ts` — `makeClose`, `makeSetError`, the `try { await onConfirm(...); close() } catch { setError(...) }` shape in `confirm()`, `prompt()`, and `makeActionRunner()`.
+- Story: `src/components/Dialog/stories/Imperative.vue` — covers auto-close, optimistic close, throw-to-stay-open, custom `actions[]`, `danger` preset, and the close-behaviour matrix in a single comment block.
+- User-facing docs: `v1-release/migration/dialog.md` Section 7, `spec/dialog.md` "Imperative API".

--- a/spec/adr/README.md
+++ b/spec/adr/README.md
@@ -1,0 +1,11 @@
+# ADRs
+
+Architecture decision records for durable `frappe-ui` API/design choices.
+
+Specs describe the current contract. ADRs explain why decisions were made. Superseded ADRs are historical and are not current guidance.
+
+| ADR | Status | Notes |
+| --- | --- | --- |
+| [0001 — Single `Dialog` component](./0001-single-dialog-component.md) | Accepted | One modal component; no separate `AlertDialog`. |
+| [0002 — Imperative dialog resolves on click](./0002-imperative-dialog-caller-closes.md) | Superseded | Replaced by ADR-0003. Historical only. |
+| [0003 — Imperative dialog uses `onConfirm`](./0003-imperative-dialog-onconfirm.md) | Accepted | Current imperative dialog lifecycle. |

--- a/spec/combobox.md
+++ b/spec/combobox.md
@@ -1,0 +1,874 @@
+# Combobox Spec
+
+Status: accepted direction for `frappe-ui` v1 planning.
+
+This document defines the exact public API for `Combobox`. It is a sub-spec of
+[`selection.md`](./selection.md) and
+inherits the shared design rules from that document.
+
+## Role
+
+`Combobox` is the canonical searchable single-choice picker.
+
+It should become the recommended path for new searchable single-select work.
+Use `Combobox` when the UI needs:
+
+- free-form typing combined with a filtered option list
+- create-new actions driven by the current query
+- single-select picking from a non-trivial list where scanning alone is not
+  enough
+
+If the UI is a small static value picker, use `Select`. If the UI is a menu of
+actions, use `Dropdown`. If the UI needs multiple selected values, use
+`MultiSelect`.
+
+## Exact public API for v1
+
+### Types
+
+```ts
+type ComboboxVariant = 'subtle' | 'outline' | 'ghost'
+type ComboboxSize = 'sm' | 'md' | 'lg' | 'xl'
+
+type PopoverSide = 'top' | 'right' | 'bottom' | 'left'
+type PopoverAlign = 'start' | 'center' | 'end'
+
+/** @deprecated alias for `align` */
+type ComboboxPlacement = PopoverAlign
+
+type SlotFn<TProps> = (props: TProps) => VNodeChild
+
+interface ItemSlots<TProps> {
+  prefix?: SlotFn<TProps>
+  label?: SlotFn<TProps>
+  suffix?: SlotFn<TProps>
+  /** Full-row replacement; mutually exclusive with prefix/label/suffix */
+  item?: SlotFn<TProps>
+}
+
+interface ComboboxSelectableOption {
+  type?: 'option'
+  label: string
+  value: string
+  icon?: string | Component
+  description?: string
+  disabled?: boolean
+  slot?: string
+  slots?: ItemSlots<ComboboxItemSlotProps>
+  [key: string]: any
+}
+
+interface ComboboxCustomOption {
+  type: 'custom'
+  key: string
+  label: string
+  icon?: string | Component
+  description?: string
+  disabled?: boolean
+  slot?: string
+  slots?: ItemSlots<ComboboxItemSlotProps>
+  onClick: (context: { query: string }) => void
+  keepOpen?: boolean
+  condition?: (context: { query: string }) => boolean
+  /** @deprecated use `slots` — function → `slots.item`; object → `slots` */
+  render?: (() => VNode) | ItemSlots<ComboboxItemSlotProps>
+}
+
+type ComboboxSimpleOption =
+  | string
+  | ComboboxSelectableOption
+  | ComboboxCustomOption
+
+interface ComboboxGroupedOption {
+  key?: string | number
+  group: string
+  hideLabel?: boolean
+  options: ComboboxSimpleOption[]
+}
+
+type ComboboxOption = ComboboxSimpleOption | ComboboxGroupedOption
+```
+
+Notes:
+
+- `type: 'option'` is the default for selectable items and may be omitted
+- `type: 'custom'` items are action-style rows driven by the current query
+- app-defined extra fields on selectable options are allowed and passed through
+  unchanged to slot props
+
+### Props
+
+```ts
+interface ComboboxProps {
+  modelValue?: string | null
+  options?: ComboboxOption[]
+  trigger?: 'input' | 'button'
+  variant?: ComboboxVariant
+  size?: ComboboxSize
+  placeholder?: string
+  disabled?: boolean
+  id?: string
+  open?: boolean
+  openOnFocus?: boolean
+  openOnClick?: boolean
+  side?: PopoverSide
+  align?: PopoverAlign
+  offset?: number
+  portalTo?: string | HTMLElement
+  allowCustomValue?: boolean
+  loading?: boolean
+  emptyText?: string
+  /** @deprecated alias for `align` */
+  placement?: ComboboxPlacement
+}
+```
+
+Defaults:
+
+- `options = []`
+- `trigger = 'input'`
+- `variant = 'subtle'`
+- `size = 'sm'`
+- `placeholder = 'Select option'`
+- `disabled = false`
+- `open = false`
+- `openOnFocus = false`
+- `openOnClick = false`
+- `side = 'bottom'`
+- `align = 'start'`
+- `offset = 4`
+- `portalTo = 'body'`
+- `allowCustomValue = false`
+- `loading = false`
+- `emptyText = 'No results'`
+
+`id`, when provided, is forwarded to the focusable input element so a
+`<label for="...">` associates correctly.
+
+Loading behavior:
+
+- when `loading` is `true`, the popover shows a loading indicator in place
+  of the empty/result list, suspends `#empty`, and disables the create-new
+  path for `allowCustomValue`
+
+Trigger modes:
+
+- `trigger = 'input'` (default): the trigger IS the search input. User
+  types directly into it.
+- `trigger = 'button'`: the trigger is a Button. The search input moves
+  into the popover header and auto-focuses on open. The button's label
+  is the selected option's `label` or the `placeholder`. The button's
+  prefix resolves by priority:
+    1. selected + consumer's `#item-prefix` slot → reused with the
+       selected option, so the same slot that renders each row's prefix
+       also renders the selected-state prefix
+    2. selected + `selectedOption.icon` → rendered as a `<component>`
+    3. no selection + consumer's `#prefix` slot → used as the
+       placeholder prefix (e.g. a generic icon shown before anything is
+       picked)
+    4. nothing
+  For richer custom triggers, use the `#trigger` slot directly.
+
+Providing a `#trigger` slot implicitly activates button mode regardless
+of the `trigger` prop value, since the caller is replacing the trigger
+shell wholesale.
+
+Positioning follows the shared popover positioning conventions in
+[`selection.md`](./selection.md).
+
+Compatibility rules for `placement`:
+
+- `placement` remains supported through `v1.x`
+- if `placement` is provided without `align`, it is silently mapped
+  one-to-one: `'start'` / `'center'` / `'end'` → same value on `align`
+- if both `placement` and `align` are provided, `align` wins and a dev warning
+  is emitted
+- docs should show `align` in primary examples
+
+State conventions:
+
+- selected value uses `v-model` / `modelValue`
+- menu visibility uses `v-model:open`
+- query state stays internal; searchable components emit `update:query` but do
+  not accept a `v-model:query` in v1
+- `Combobox` does not accept a value prop for the input query directly
+
+### Emits
+
+```ts
+interface ComboboxEmits {
+  'update:modelValue': [value: string | null]
+  'update:open': [value: boolean]
+  'update:query': [value: string]
+  'update:selectedOption': [
+    option: ComboboxSelectableOption | ComboboxCustomOption | null,
+  ]
+  focus: [event: FocusEvent]
+  blur: [event: FocusEvent]
+  input: [value: string]
+}
+```
+
+Custom-option context:
+
+- `onClick` and `condition` on a `type: 'custom'` option receive an object
+  context. In v1 the canonical field is `query`
+- for backward compatibility, the context object also carries `searchTerm`
+  with the same value through `v1.x`, so existing handlers destructuring
+  `({ searchTerm })` continue to work unchanged
+- `searchTerm` is marked deprecated in types; apps should migrate to
+  `query`
+- the two fields are always kept in sync; apps must not rely on only one of
+  them being present
+
+Emit rules:
+
+- `update:modelValue` fires only when a regular selectable option is chosen, or
+  when `allowCustomValue` is true and the free-form query becomes the value
+- `update:open` fires on open/close transitions driven by user interaction or
+  selection
+- `update:query` fires on every user-driven change to the input query
+- `input` is kept as a compatibility alias of `update:query` and should emit
+  the same value; `update:query` is the preferred event
+- `update:selectedOption` fires alongside `update:modelValue` with the resolved
+  option object, or `null` when the selection is cleared
+- custom options do **not** emit `update:modelValue`; they call their own
+  `onClick({ query })` handler
+
+### Slots
+
+Guaranteed slot props:
+
+```ts
+type ComboboxTriggerSlotProps = {
+  open: boolean
+  disabled: boolean
+  query: string
+  selectedOption: ComboboxSelectableOption | null
+  displayValue: string
+}
+
+// `#trigger`, `#prefix`, and `#suffix` all receive the same shape. `selectedOption`
+// is always `null` inside `#prefix` since the prefix slot only renders before
+// a selection — the field is still exposed for symmetry.
+type ComboboxSlotProps = ComboboxTriggerSlotProps
+type ComboboxPrefixSlotProps = ComboboxSlotProps
+type ComboboxSuffixSlotProps = ComboboxSlotProps
+
+type ComboboxItemSlotProps = {
+  item: ComboboxSelectableOption | ComboboxCustomOption
+  query: string
+  selected: boolean
+}
+
+type ComboboxGroupLabelSlotProps = {
+  group: ComboboxGroupedOption
+}
+
+type ComboboxEmptySlotProps = {
+  query: string
+}
+```
+
+Supported slots:
+
+- `#trigger="{ open, disabled, query, selectedOption, displayValue }"`
+  - renders a custom button-like trigger in place of the default input
+    shell. When present, `Combobox` moves the search input **into the
+    popover header** instead of using the trigger as the input. Use this
+    for assignee pickers, status pills, emoji reactions, and any other
+    button-initiated search flow.
+- `#prefix="{ open, disabled, query, selectedOption, displayValue }"`
+  - convenience slot rendered inside the default input shell, before the input.
+    Receives the same shape as `#trigger` and `#suffix`. `selectedOption` is
+    always `null` here because the prefix only renders pre-selection
+- `#suffix="{ open, disabled, query, selectedOption, displayValue }"`
+  - convenience slot rendered after the input (input mode) or after the
+    label (button mode). **Replaces the default chevron** when provided —
+    render an explicit chevron fallback when your slot content is
+    conditional. Typical use: an inline clear button. The slot's button
+    should call `@click.stop` and `@pointerdown.stop` so the press does
+    not toggle the popover
+- `#item-prefix="{ item, query, selected }"`
+  - custom leading content for the standard option row shell
+- `#item-label="{ item, query, selected }"`
+  - custom label region for the standard option row shell
+- `#item-suffix="{ item, query, selected }"`
+  - custom trailing content for the standard option row shell
+- `#item="{ item, query, selected }"`
+  - full-row escape hatch for a single item; replaces the standard row shell
+- `#item-<slot>="{ item, query, selected }"`
+  - dynamic named label slot selected via `item.slot`
+- `#group-label="{ group }"`
+  - optional custom group label rendering
+- `#empty="{ query }"`
+  - empty state rendered when the filtered result set is empty
+- `#footer`
+  - rendered once after the option list, inside the popover
+
+Exact slot rules:
+
+- `#trigger` wins over the default input shell; when `#trigger` is used:
+  - the caller-provided content is wrapped in the underlying primitive's
+    trigger element, so it behaves as a real button (click / Enter /
+    Space toggles the popover, `aria-expanded` is managed)
+  - `#prefix` is ignored (it only applies inside the default input shell)
+  - the search input is rendered at the top of the popover content and
+    receives auto-focus on open so the user can start typing immediately
+  - the popover does not constrain itself to the trigger's width
+- if `item.slot` is set, it maps to `#item-<slot>` and overrides the label
+  region only
+- `#item-label` is the preferred label-region slot and is used as the fallback
+  when no matching `#item-<slot>` exists
+- `#item-prefix` and `#item-suffix` customize only those regions of the standard
+  option row shell
+- `#item-suffix` renders before the built-in selected checkmark indicator
+- `#item` is a per-row escape hatch and, when used, fully replaces the standard
+  row shell for that row
+- `#empty` receives the current query so create-new prompts can be rendered in
+  the empty state if desired
+- custom options may provide a `slots.item` function on the option itself as
+  an alternative to slots; template slots take precedence when both are
+  present
+
+## Option normalization and behavior
+
+Normalization rules:
+
+- string options normalize to `{ type: 'option', label: option, value: option }`
+- nullish entries in `options` are ignored
+- selectable options with missing or `undefined` `value` are omitted
+- grouped entries with empty `options` after filtering are omitted
+- each custom option keeps its original `key`; each selectable option is keyed
+  by its `value`
+
+Filtering rules:
+
+- filtering is internal to `Combobox` and is based on the current query
+- for selectable options, a case-insensitive substring match against `label`
+  (and `value`) is used by default
+- for custom options, `condition({ query })` is evaluated when present and
+  controls visibility; if `condition` is absent, custom options match the same
+  case-insensitive rule against `label`
+- `condition` is **authoritative**: it is consulted even before the user
+  has typed since opening, so a `type: 'custom'` row can fully gate its
+  own visibility (e.g. "show only when the typed query is non-empty and
+  doesn't already match an existing option"). The `query` passed in is
+  the typed-since-open query — empty when the user hasn't typed yet
+- the "show the full list before the user has typed" bypass applies only
+  to selectable options; custom options always go through `condition`
+
+Selection behavior:
+
+- selecting an enabled selectable option:
+  - updates `modelValue` to the option's `value`
+  - emits `update:modelValue` and `update:selectedOption`
+  - closes the popover via select semantics
+- selecting a custom option:
+  - calls `onClick({ query })` with the last user-typed query
+  - does **not** emit `update:modelValue`
+  - keeps the popover open if `keepOpen` is true; otherwise closes it
+- disabled options (selectable or custom) are not selectable and are skipped by
+  keyboard navigation
+- when the query is cleared to empty by the user, the current selection is
+  cleared and `update:modelValue` fires with `null`
+
+`allowCustomValue` behavior:
+
+`allowCustomValue` is the **free-form acceptance** flag — it lets the combobox
+behave like a text input with autocomplete, where any typed-or-programmatically-set
+string is a valid model value.
+
+- when `true` and no option matches the current query on commit, the free-form
+  query itself is accepted as the value
+- `update:modelValue` fires with the raw query string in that case
+- external `modelValue` updates with unknown strings are preserved; without
+  `allowCustomValue`, an unmatched external value is dropped
+- the combobox also renders a built-in "Create X" row as a click affordance
+  when typing has no matches
+- custom options still take precedence over free-form acceptance when they
+  match and are chosen explicitly
+
+For **richer create-new UX** — custom label, icon, persistence callback, or
+"create only when the query isn't already a known value" — prefer a
+`type: 'custom'` option with `condition` (see the Create New story). The two
+mechanisms are independent and can be combined.
+
+Display rules:
+
+- when an option matches `modelValue`, the input shows its `label` by default
+- when no option matches but a raw value is set (via `allowCustomValue`), the
+  input shows the raw value
+- otherwise the input shows the placeholder
+- `displayValue` exposed to `#trigger` is the resolved display string or `''`
+- `selectedOption` exposed to `#trigger` is the resolved selectable option or
+  `null`; custom options never appear as `selectedOption`
+
+Row behavior:
+
+- option rows should use the shared `ItemListRow` shell
+- selectable option rows render a built-in trailing checkmark indicator when
+  their `value === modelValue`
+- custom option rows do not render a checkmark
+- `item.icon` is auto-rendered in the prefix region when no consumer
+  slot (`#item-prefix` or `item.slots.prefix`) overrides it:
+  - strings starting with `lucide-` render through the shared Lucide
+    Tailwind plugin (see the main RFC) — e.g. `icon: 'lucide-edit'`
+  - Vue `Component` values render directly as `<component :is>`
+  - other strings are ignored (back-compat with FeatherIcon strings
+    is not provided here — consumers that need FeatherIcon should use
+    the prefix slot explicitly)
+- default label rendering is `label` plus optional `description`
+
+## Disabled handling
+
+Follows the shared disabled-option rule (shared design rule 8 in the main
+RFC):
+
+- disabled selectable options are skipped by keyboard navigation and
+  typeahead
+- disabled custom options are skipped too, even if their `condition`
+  returns `true`
+- disabled options cannot be selected by click or keyboard
+- disabled options never emit `update:modelValue` or
+  `update:selectedOption`, and disabled custom options never invoke
+  `onClick`
+- a disabled option is never used as the `allowCustomValue` target
+- disabled options apply `ItemListRow` disabled styling and `data-disabled`
+
+## Rendering precedence
+
+Rows follow the per-region precedence from shared design rule 9. For each
+visible item:
+
+Full row (if any of these provide a full-row renderer, per-region rendering
+below is skipped):
+
+1. `#item` slot
+2. `item.slots.item` (or function-form legacy `item.render`)
+
+Prefix region:
+
+1. `#item-prefix` slot
+2. `item.slots.prefix`
+3. `item.icon` auto-rendered (`lucide-*` string → Tailwind plugin,
+   Component → rendered directly)
+4. default: empty
+
+Label region:
+
+1. `#item-<slot>` slot matching `item.slot`
+2. `#item-label` slot
+3. `item.slots.label`
+4. default: `label` plus optional `description`
+
+Suffix region:
+
+1. `#item-suffix` slot
+2. `item.slots.suffix`
+3. default: built-in selected checkmark indicator for selectable options;
+   empty for custom options
+
+Back-compat note:
+
+- the old semantic where `type: 'custom'` options with a `render()` function
+  replaced the row is preserved: a function-form `render` is aliased to
+  `slots.item`, and an object-form `render` is aliased to `slots`
+- existing code like `render: () => h(...)` continues to produce a full-row
+  takeover
+
+## Imperative API
+
+`Combobox` should continue to expose:
+
+```ts
+interface ComboboxExposed {
+  reset: () => void
+}
+```
+
+Rules:
+
+- `reset()` clears the query, clears the selected value, and emits
+  `update:modelValue(null)` and `update:selectedOption(null)`
+- `reset()` does not open or close the popover on its own
+
+## Styling hooks
+
+Stable hooks for `Combobox` should include:
+
+- `data-slot="trigger"`
+- `data-slot="input"`
+- `data-slot="content"`
+- `data-slot="group"`
+- `data-slot="group-label"`
+- `data-slot="item"`
+- `data-slot="empty"`
+- `data-slot="footer"`
+- `data-variant`
+- `data-size`
+
+Combobox rows should use `ItemListRow`, which provides:
+
+- `data-slot="item-list-row"`
+- `data-slot="item-prefix"`
+- `data-slot="item-label"`
+- `data-slot="item-suffix"`
+
+State hooks should include, where relevant:
+
+- `data-state="open|closed"` on trigger/content via the combobox primitive
+- `data-state="checked|unchecked"` on selectable option rows
+- `data-disabled`
+- row-level selected styling inherited from `ItemListRow`
+
+## Motion
+
+`Combobox` follows the shared popover motion conventions (shared design
+rule 10 in the main RFC):
+
+- content scales in from the trigger via
+  `transform-origin: var(--reka-combobox-content-transform-origin)` on the
+  animated element (the inner content-body, not the outer positioned wrapper)
+- enter `180ms` / exit `140ms` with `cubic-bezier(0.23, 1, 0.32, 1)`, from
+  `scale(0.97)` + `translateY(2px)` + `opacity: 0`
+- keyboard-driven opens — typing, Enter, Space, ArrowUp, ArrowDown on the
+  trigger, or tab-focus with `openOnFocus` — skip the animation entirely
+- pointer-driven opens (click / tap) play the full animation
+- classification is pointer-recency based: the component records the
+  timestamp of each `pointerdown` on the trigger, and an open transition
+  counts as pointer-driven only if a `pointerdown` fired within ~300ms
+  before it; everything else (including tab-focus) defaults to keyboard.
+  The resolved mode is exposed as `data-motion="animated" | "instant"` on
+  the content-body
+- `prefers-reduced-motion: reduce` disables the content animation and the
+  chevron rotation
+
+## Accessibility and semantics
+
+`Combobox` should follow the ARIA combobox pattern (single-select, with
+listbox popup).
+
+That means:
+
+- the input has `role="combobox"` with appropriate `aria-expanded`,
+  `aria-controls`, and `aria-activedescendant` attributes
+- the listbox exposes `role="listbox"` and items expose `role="option"`
+- keyboard navigation (arrow keys, home/end, typeahead), escape handling, and
+  active-descendant management are delegated to the underlying combobox
+  primitive
+- escape closes the popover without clearing the current value
+- the query and the committed value are distinct: typing updates the query,
+  only explicit selection (or `allowCustomValue` acceptance) updates the value
+
+## Keep supported in v1.x
+
+Current API stays supported:
+
+- `v-model`
+- `variant`
+- `options`
+- `placeholder`
+- `disabled`
+- `openOnFocus`
+- `openOnClick`
+- `placement` (as an alias for `align`)
+- `allowCustomValue`
+- `update:selectedOption`
+- `focus`
+- `blur`
+- `input`
+- `slotName`
+- `render`
+- `type: 'custom'`
+- `#prefix`
+- current dynamic slot behavior for custom items
+- imperative `reset()`
+
+## Add / prefer
+
+### Advanced state
+
+- `v-model:open`
+
+### Query event
+
+- `@update:query` is the preferred event
+- keep `@input` working as a compatibility alias in v1.x
+
+### Preferred trigger API
+
+- `#trigger`
+- keep `#prefix` as a convenience slot
+
+### Preferred item slots
+
+- `#item-prefix`
+- `#item-label`
+- `#item-suffix`
+- `#empty`
+- `#footer`
+- `#item` as the full takeover escape hatch
+
+### Preferred item schema
+
+Simple selectable items can keep their current shape, but richer object items
+should converge on:
+
+```ts
+{
+  label: string
+  value: string
+  icon?: string | Component
+  description?: string
+  disabled?: boolean
+  slot?: string
+}
+```
+
+For custom action-style rows, keep the current capability and preserve the
+existing naming convention:
+
+```ts
+{
+  type: 'custom'
+  key: string
+  label: string
+  icon?: string | Component
+  disabled?: boolean
+  slot?: string
+  onClick?: (context: { query: string }) => void
+  keepOpen?: boolean
+  condition?: (context: { query: string }) => boolean
+  slots?: ItemSlots<ComboboxItemSlotProps>
+}
+```
+
+Preferred change here should be limited to:
+
+- `slot` over `slotName`
+- `query` over `searchTerm` in the custom option context
+
+Keep these existing names as canonical because they already match broader
+library convention:
+
+- `onClick`
+- `condition`
+
+Dynamic custom item slots should be namespaced as:
+
+- `#item-<slot>`
+
+## Deprecate
+
+Keep working, but deprecate in favor of the new names only where the change is
+clearly worth it:
+
+- `slotName` on custom options, in favor of `slot`
+- `searchTerm` in custom-option context, in favor of `query`
+- `input` event for query updates, in favor of `update:query`
+- `render` on options, in favor of `slots` —
+  - function-form `render` (full-row takeover) maps to `slots.item`
+  - object-form `render` (`{ prefix, label, suffix, item }`) maps one-to-one
+    to `slots`
+- `placement` prop, in favor of `align`
+
+Do not deprecate:
+
+- `onClick`
+- `condition`
+- `type: 'custom'`
+- imperative `reset()`
+
+## Migration path
+
+### Custom option: old
+
+```ts
+{
+  type: 'custom',
+  key: 'create-new',
+  label: 'Create new',
+  slotName: 'create-new',
+  onClick: ({ searchTerm }) => createItem(searchTerm),
+  condition: ({ searchTerm }) => Boolean(searchTerm),
+}
+```
+
+```vue
+<Combobox v-model="value" :options="options">
+  <template #create-new="{ option, searchTerm }">
+    Create "{{ searchTerm }}"
+  </template>
+</Combobox>
+```
+
+### Custom option: new
+
+```ts
+{
+  type: 'custom',
+  key: 'create-new',
+  label: 'Create new',
+  slot: 'create-new',
+  onClick: ({ query }) => createItem(query),
+  condition: ({ query }) => Boolean(query),
+}
+```
+
+```vue
+<Combobox
+  v-model="value"
+  :options="options"
+  @update:query="query = $event"
+>
+  <template #item-create-new="{ item, query }">
+    Create "{{ query }}"
+  </template>
+</Combobox>
+```
+
+### Query event migration
+
+Old:
+
+```vue
+<Combobox @input="onQueryChange" />
+```
+
+New:
+
+```vue
+<Combobox @update:query="onQueryChange" />
+```
+
+### Standard item customization migration
+
+Old (function-form `render` takes over the entire row, skipping the shell):
+
+```ts
+{
+  label: 'John Doe',
+  value: 'john',
+  render: () => h('div', { class: 'flex items-center gap-2' }, [
+    h(Avatar, { image: '/john.png' }),
+    h('span', 'John Doe'),
+  ]),
+}
+```
+
+New, template-first (shell-owned rows with focused slots):
+
+```vue
+<Combobox v-model="user" :options="users">
+  <template #item-prefix="{ item }">
+    <Avatar :image="item.image" class="size-4" />
+  </template>
+
+  <template #item-label="{ item }">
+    {{ item.label }}
+  </template>
+</Combobox>
+```
+
+New, JS-authored (shell-owned rows with per-region `slots`, for cases
+where no template is available):
+
+```ts
+import { h } from 'vue'
+import Avatar from '@/components/Avatar.vue'
+
+const users = fetchedUsers.map((user) => ({
+  label: user.name,
+  value: user.id,
+  slots: {
+    prefix: ({ item }) =>
+      h(Avatar, { image: item.image, class: 'size-4' }),
+  },
+}))
+```
+
+Full-row takeover still available via `slots.item` when the shell is not
+wanted:
+
+```ts
+{
+  label: 'John Doe',
+  value: 'john',
+  slots: {
+    item: () => h('div', { class: 'flex items-center gap-2' }, [
+      h(Avatar, { image: '/john.png' }),
+      h('span', 'John Doe'),
+    ]),
+  },
+}
+```
+
+The old function-form `render` is aliased to `slots.item` and the old
+object-form `render` is aliased one-to-one to `slots`, so existing code
+continues to work unchanged through `v1.x`.
+
+## Changelog
+
+### 2026-05-17
+
+- **Added `#suffix` slot.** Rendered after the input (input mode) or label
+  (button mode). Providing the slot replaces the default chevron — consumers
+  render their own fallback for the unselected/closed state. Canonical use
+  is an inline clear button; the slot's button must `stopPropagation` on
+  `click` and `pointerdown` so the press does not toggle the popover.
+
+- **`condition` is now authoritative for custom rows.** A `type: 'custom'`
+  row's `condition({ query })` is consulted even before the user types
+  since opening, so it can fully gate its own visibility based on selection
+  state and the typed query. Selectable rows are unchanged — they still
+  skip query filtering until the user types.
+
+- **Decided against a dedicated `clearable` prop (#658).** The `#suffix`
+  slot plus `v-model` already cover the clear-button pattern with no
+  loss of expressiveness. The story at `stories/Clearable.vue` is the
+  canonical example.
+
+- **Decided against a dedicated `createOption` prop (#661).** The
+  existing `type: 'custom'` option shape, combined with the authoritative
+  `condition`, expresses the "create new" pattern in ~15 lines of consumer
+  code. A `createOption` prop would be pure sugar over the same primitive.
+  The story at `stories/CreateNew.vue` is the canonical example.
+
+- **`#659` deferred.** Suppressing the popover-header search input when
+  `#trigger` already contains an input still requires a Combobox-level
+  change (a `hideSearchInput` prop or similar). Will revisit when a
+  concrete consumer needs it.
+
+- **Slot-prop symmetry across `#trigger` / `#prefix` / `#suffix`.** All
+  three slots now receive the same shape (`ComboboxSlotProps`). `#prefix`
+  previously received no props; it now gets `{ open, disabled, query,
+  selectedOption, displayValue }` for parity. `selectedOption` is always
+  `null` inside `#prefix` because the prefix only renders pre-selection,
+  but the field is exposed for symmetry. The matching change was made on
+  `MultiSelect` (added `query` to `#trigger`; aligned `#suffix`) and
+  `Select` (added the shared shape to `#prefix` / `#suffix`).
+
+- **`allowCustomValue` reframed as the free-form-acceptance flag.** The
+  prop docs and spec now lead with its distinctive behavior — accepting
+  arbitrary typed-or-set strings into the model — rather than the
+  "creatable option" framing. For richer create-new UX, prefer
+  `type: 'custom'` with `condition` (Create New story). The two are
+  independent.
+
+### 2026-04-24
+
+- **Added `trigger="button"` mode.** When `trigger="button"`, the combobox
+  renders a Button-shaped trigger instead of a bare input. The closed state
+  shows the selected label (or placeholder); opening swaps the face for an
+  input. Keyboard focus and native tab order work as expected. Useful for
+  pickers that should not look like a text field when closed.
+
+- **`item.icon` is auto-rendered in the prefix region.** Setting `icon` on an
+  option now shows that icon automatically — no `#item-prefix` slot needed for
+  the common case. Precedence: `#item-prefix` slot → `item.slots.prefix` →
+  `item.icon` → empty. Existing prefix slots are unaffected.
+
+- **`item.icon` accepts `lucide-*` strings.** Pass `icon: 'lucide-user-plus'`
+  directly in an item definition — rendered via the Tailwind CSS-mask plugin,
+  no import needed. Component values also work.

--- a/spec/date-picker.md
+++ b/spec/date-picker.md
@@ -1,0 +1,692 @@
+# DatePicker & TimePicker Family Spec
+
+Status: accepted direction for `frappe-ui` v1 planning, with audit notes preserved.
+
+This document covers the three picker components shipped from the `DatePicker` directory plus the standalone `TimePicker`:
+
+- `DatePicker` — single date selection
+- `DateRangePicker` — start/end date range
+- `DateTimePicker` — date + time combined
+- `TimePicker` — standalone time selection (also embedded by `DateTimePicker`)
+
+The vocabulary-alignment rules in this document apply to **all four** components. The first three share an internal composables module (`DatePicker/composables.ts`); `TimePicker` inlines equivalent logic so it stays decoupled from the DatePicker tree.
+
+---
+
+## Current state summary
+
+All three pickers are already on TypeScript and `<script setup>`, have `types.ts`, stories, tests, and docs. The audit matrix marks them as "Good baseline". This document focuses on what still needs to change before the API can be frozen at v1.
+
+---
+
+## Vocabulary alignment with the selection family
+
+These three issues are about making DatePicker props consistent with what `Combobox`, `Dropdown`, and `Select` already use.
+
+### `placement` → `side` + `align` + `offset`
+
+DatePicker currently takes a single compound `placement` string (`'bottom-start'`, `'top-end'`, etc.). `Combobox` and `Dropdown` settled on the decomposed vocabulary: `side` (`top | bottom | left | right`) + `align` (`start | center | end`) + `offset` (number). `placement` is kept on Combobox only as a `@deprecated` back-compat alias.
+
+DatePicker should do the same: introduce `side`, `align`, and `offset`, deprecate `placement`, and map the old values internally.
+
+```ts
+// Current (deprecated)
+placement?: 'bottom-start' | 'bottom-end' | 'top-start' | ...
+
+// v1
+side?: 'top' | 'right' | 'bottom' | 'left'   // default: 'bottom'
+align?: 'start' | 'center' | 'end'            // default: 'start'
+offset?: number                                // default: 4
+/** @deprecated use side + align */
+placement?: DatePickerPlacement
+```
+
+---
+
+### `autoClose` → `keepOpen`
+
+DatePicker has `autoClose: boolean` (default `true`). The selection family uses `keepOpen` on individual items as the escape hatch. At the component level there is no direct equivalent — but the naming `keepOpen` is the established direction. These are inverse booleans of each other:
+
+| Current | v1 equivalent |
+|---|---|
+| `autoClose: true` (default) | `keepOpen: false` (default) |
+| `autoClose: false` | `keepOpen: true` |
+
+**Fix:** Rename `autoClose` to `keepOpen` with default `false`. Deprecate `autoClose` with a mapping.
+
+---
+
+### `allowCustom` → drop it (use `readonly`)
+
+DatePicker has two props that both make the text input non-editable:
+
+- `readonly` — standard HTML concept, prevents typing, popover still opens
+- `allowCustom: false` — also prevents typing, popover still opens
+
+They produce identical behavior: `:readonly="props.readonly || !props.allowCustom"`. `allowCustom` is fully redundant. The "force calendar-only, no freeform typing" use case is already covered by `readonly`.
+
+**Fix:** Deprecate `allowCustom`. Document that `readonly` is the correct way to disable freeform input while keeping the picker interactive.
+
+---
+
+### `inputClass` → drop it
+
+`inputClass` applies extra classes to the inner `TextInput` element. The only practical use case is controlling width. Since the Popover root has `class="inline-block"` and the inner TextInput has `w-full`, users can size the picker by putting a class on the component element itself:
+
+```html
+<!-- instead of inputClass="w-48" -->
+<DatePicker class="w-48" ... />
+```
+
+There is no case where `inputClass` is needed that `class` on the component cannot cover. The prop leaks internal structure.
+
+**Fix:** Deprecate `inputClass`. Document the `class` pattern as the width control.
+
+---
+
+## Issues to fix before v1
+
+### 1. FeatherIcon in all three pickers
+
+All three components import and render `FeatherIcon` for the chevron-down suffix in the default trigger slot:
+
+```ts
+// @ts-ignore - Vue SFC without explicit types
+import FeatherIcon from '../FeatherIcon.vue'
+```
+
+```html
+<FeatherIcon
+  name="chevron-down"
+  class="h-4 w-4 cursor-pointer"
+  @mousedown.prevent="togglePopover"
+/>
+```
+
+This is a v1 blocker — the plan requires removing all internal `FeatherIcon` usage from core components.
+
+**Fix:** Replace with `LucideChevronDown` imported via `~icons/lucide/chevron-down`, matching the pattern already used by `Select` and `Combobox`.
+
+---
+
+### 2. Deprecated `value` prop — keep but warn
+
+All three pickers accept both `value` and `modelValue` with an `||` fallback:
+
+```ts
+interface DatePickerProps extends CommonDatePickerProps {
+  value?: string      // uncontrolled
+  modelValue?: string // controlled
+}
+```
+
+The v1 plan says: "use `v-model` / `modelValue` for the primary value state."
+
+The `value` prop is a legacy uncontrolled pattern that should be deprecated. Keep exporting it for migration but add a dev-mode warning when `value` is used without `modelValue`.
+
+---
+
+### 3. `DateTimePickerProps` is not exported
+
+`DateTimePicker.vue` defines its extra props inline and does not export a public type:
+
+```ts
+// inside DateTimePicker.vue — not in types.ts
+interface ExtraDateTimeProps {
+  minDateTime?: string
+  maxDateTime?: string
+  allowCustomTime?: boolean
+}
+```
+
+`DateTimePickerProps` does not exist in `types.ts` or anywhere in the public surface.
+
+**Fix:** Define and export `DateTimePickerProps` from `types.ts`:
+
+```ts
+export interface DateTimePickerProps extends DatePickerProps {
+  minDateTime?: string
+  maxDateTime?: string
+  allowCustomTime?: boolean
+}
+```
+
+---
+
+### 4. `DateRangePicker` emits the wrong type shape
+
+`DateRangePicker` reuses `DatePickerEmits`:
+
+```ts
+export type DatePickerEmits = {
+  (event: 'update:modelValue', value: string): void
+  (event: 'change', value: string): void
+}
+```
+
+But the actual emitted value is a comma-separated string like `"2025-01-01,2025-01-31"`, not a plain date string. Users who `v-model` bind a range picker receive a comma-separated string and must split it themselves — this is not documented in the types.
+
+**Fix:** Define a separate `DateRangePickerEmits` that makes the format explicit, and document the output format. Consider whether the emitted value should be `string[]` instead of a comma-joined string for a cleaner v1 API.
+
+Option A (keep string, document it):
+```ts
+export type DateRangePickerEmits = {
+  /** Emits a comma-separated "YYYY-MM-DD,YYYY-MM-DD" string, or "" when cleared. */
+  (event: 'update:modelValue', value: string): void
+  (event: 'change', value: string): void
+}
+```
+
+Option B (emit array — breaking change from current):
+```ts
+export type DateRangePickerEmits = {
+  /** Emits [fromDate, toDate] in YYYY-MM-DD format, or [] when cleared. */
+  (event: 'update:modelValue', value: [string, string] | []): void
+  (event: 'change', value: [string, string] | []): void
+}
+```
+
+The `modelValue` prop already accepts `string | string[]`, which suggests Option B aligns better with the input shape. **Recommended: choose one and freeze it.**
+
+---
+
+### 5. `clearable` prop ignored by `DateRangePicker`
+
+`clearable` is defined in `CommonDatePickerProps` but `DateRangePicker` never applies it. The Clear footer is always rendered — only the Clear button is disabled when no range is selected.
+
+`DatePicker` wraps its entire footer in `v-if="props.clearable"`. `DateRangePicker` has no such guard.
+
+**Fix:** Add `clearable` to `DateRangePicker`'s `withDefaults` and apply `v-if="props.clearable"` to its footer section, matching `DatePicker`'s behavior.
+
+---
+
+### 6. `useDatePicker` composable is stale and should be deprecated
+
+`useDatePicker.ts` is exported publicly but is not used by any of the three picker components. It uses a 1-based month index and raw `Date` objects — a completely different internal model from the `dayjs`-based approach used by the actual pickers.
+
+The legacy utility functions it depends on (`getDate`, `getDatesAfter`, `getDaysInMonth`, `isLeapYear`) are also exported from `utils.ts` but are only used by this composable.
+
+**Fix:**
+- Mark `useDatePicker` as `@deprecated` in its JSDoc and add a dev-mode warning.
+- Mark the legacy util exports (`getDate`, `getDatesAfter`, `getDaysInMonth`, `isLeapYear`) as `@deprecated`.
+- Keep them exported for the v1 migration window, consistent with the broader deprecation policy.
+
+---
+
+### 7. `defineSlots` missing in `DateTimePicker`
+
+`DatePicker` and `DateRangePicker` both call `defineSlots<{...}>()` with typed slot descriptors. `DateTimePicker` does not call `defineSlots` at all.
+
+**Fix:** Add `defineSlots<{...}>()` to `DateTimePicker` matching the other two pickers.
+
+---
+
+### 8. Missing accessible label on `DateTimePicker` cycle-view button
+
+`DatePicker` and `DateRangePicker` both pass `label="cycle-calendar-view"` to the month/year cycle button, which produces an `aria-label` for screen readers. `DateTimePicker` omits this:
+
+```html
+<!-- DateTimePicker.vue — missing label -->
+<Button variant="ghost" size="sm" @click="cycleView">
+```
+
+**Fix:** Add `label="cycle-calendar-view"` to the cycle-view button in `DateTimePicker`.
+
+---
+
+### 9. `defineExpose` only on `DateRangePicker`
+
+`DateRangePicker` exposes `open()` so callers can open it programmatically:
+
+```ts
+defineExpose({
+  open: () => popoverRef.value?.open(),
+})
+```
+
+`DatePicker` and `DateTimePicker` expose nothing. If programmatic opening is a supported use case, all three should be consistent.
+
+**Fix:** Either add `defineExpose({ open })` to `DatePicker` and `DateTimePicker` as well, or remove it from `DateRangePicker` and document an alternative pattern. Recommend exposing it on all three for consistency.
+
+---
+
+## API issues to decide before freeze
+
+### Emit format for `DateRangePicker` (comma-string vs array)
+
+**Resolved:** Option B (array). `update:modelValue` and `change` emit `[from, to]` or `[]` (`DateRangeValue`). Internal serializer keeps a comma-joined string for change-tracking only; the public payload is the array.
+
+---
+
+## Code quality note (not a v1 blocker)
+
+All three pickers duplicate approximately 70% of their implementation: navigation (`prev`, `next`, `cycleView`), week grid generation, view state, input handling (`onBlur`, `onEnter`, `activateInput`, `commitInput`), and popover coordination.
+
+This is a maintenance risk. A shared internal composable or a `DatePickerPanel` base component would reduce the surface. This does not need to happen before v1, but should be in the immediate post-v1 roadmap.
+
+---
+
+## v1 target public API
+
+### Shared `CommonDatePickerProps`
+
+```ts
+type PopoverSide = 'top' | 'right' | 'bottom' | 'left'
+type PopoverAlign = 'start' | 'center' | 'end'
+
+interface CommonDatePickerProps {
+  // Positioning — aligned with Combobox/Dropdown/Select vocabulary
+  side?: PopoverSide             // default: 'bottom'
+  align?: PopoverAlign           // default: 'start'
+  offset?: number                // default: 4
+  /** @deprecated use side + align */
+  placement?: DatePickerPlacement
+
+  // Display
+  format?: string
+  variant?: 'subtle' | 'ghost' | 'outline'
+  placeholder?: string
+  label?: string
+
+  // Interaction
+  readonly?: boolean             // prevents typing; popover still opens
+  disabled?: boolean             // prevents all interaction
+  clearable?: boolean
+  keepOpen?: boolean             // default: false (closes after selection)
+  /** @deprecated use keepOpen: true */
+  autoClose?: boolean
+
+  // Constraints
+  min?: string                   // YYYY-MM-DD — earliest selectable date
+  max?: string                   // YYYY-MM-DD — latest selectable date
+  isDateUnavailable?: (date: Dayjs) => boolean  // return true to block a date
+
+  // Deprecated
+  /** @deprecated use readonly instead */
+  allowCustom?: boolean
+  /** @deprecated apply class directly to the component element */
+  inputClass?: string | string[] | Record<string, boolean>
+}
+```
+
+---
+
+### `DatePicker`
+
+```ts
+interface DatePickerProps extends CommonDatePickerProps {
+  modelValue?: string
+  /** @deprecated use modelValue */
+  value?: string
+}
+
+type DatePickerEmits = {
+  (event: 'update:modelValue', value: string): void
+  (event: 'change', value: string): void
+}
+```
+
+Slots: `target`, `prefix`, `suffix` (all with `{ togglePopover, isOpen, displayLabel, inputValue }`).
+
+Exposed: `open(): void`
+
+---
+
+### `DateRangePicker`
+
+```ts
+interface DateRangePickerProps extends CommonDatePickerProps {
+  /** Controlled range value as `[from, to]` in `YYYY-MM-DD` format, or `[]` for no selection. */
+  modelValue?: string[]
+  /** @deprecated use modelValue */
+  value?: string[]
+
+  /** Render two calendar panels side by side (current month + next month). Default: false. */
+  dualPane?: boolean
+}
+
+/** Emitted range value: a `[from, to]` tuple in `YYYY-MM-DD` format, or `[]` when cleared. */
+type DateRangeValue = [string, string] | []
+
+type DateRangePickerEmits = {
+  (event: 'update:modelValue', value: DateRangeValue): void
+  (event: 'change', value: DateRangeValue): void
+}
+```
+
+Slots: `target`, `prefix`, `suffix` (same shape as DatePicker).
+
+Exposed: `open(): void`
+
+**`dualPane` rendering rules:**
+- Only renders the second panel when `view === 'date'` — cycling to month/year falls back to a single panel to avoid duplicate selectors.
+- Right panel always shows the month following `currentMonth` and hides its own prev/Today nav (left panel hides its next nav, so chrome isn't duplicated).
+
+---
+
+### `DateTimePicker`
+
+```ts
+interface DateTimePickerProps extends CommonDatePickerProps {
+  modelValue?: string
+  /** @deprecated use modelValue */
+  value?: string
+  // min/max/isDateUnavailable are inherited from CommonDatePickerProps.
+  // `min`/`max` accept either YYYY-MM-DD or YYYY-MM-DD HH:mm:ss; date-only
+  // values get day-level granularity, datetime values second-level.
+  /** @deprecated use `min` */
+  minDateTime?: string
+  /** @deprecated use `max` */
+  maxDateTime?: string
+  allowCustomTime?: boolean
+}
+```
+
+Emits: same shape as `DatePickerEmits` (emitted value is `YYYY-MM-DD HH:mm:ss`).
+
+Slots: `target`, `prefix`, `suffix` (same shape as DatePicker).
+
+Exposed: `open(): void`
+
+---
+
+## TimePicker
+
+`TimePicker` was not included in the original DatePicker audit but follows the same popover-trigger pattern and ships the same vocab debt. The fixes mirror the DatePicker family one-for-one.
+
+### Vocab alignment
+
+Same four issues as the DatePicker family:
+
+| Current | v1 |
+|---|---|
+| `placement: 'bottom-start' \| ...` | `side` + `align` + `offset` (deprecate `placement`) |
+| `autoClose: boolean` (default `true`) | `keepOpen: boolean` (default `false`); deprecate `autoClose` |
+| `allowCustom: boolean` (default `true`) | `readonly: boolean` (default `false`); deprecate `allowCustom` |
+| `value?: string` (uncontrolled) | use `modelValue` / `v-model`; deprecate `value` |
+
+`TimePicker` has no `inputClass` prop, so that fix is N/A.
+
+### Hardcoded chevron icon — already fixed
+
+`TimePicker.vue` previously hardcoded `FeatherIcon[name=chevron-down]` in the suffix slot. This is now a `<span class="lucide-chevron-down">` via the shared Tailwind icon plugin. No further action.
+
+### `readonly` is a new prop
+
+Unlike the DatePicker family, `TimePicker` did not previously expose `readonly`. The default trigger already wires `:readonly="!props.allowCustom"`. v1 adds a proper `readonly` prop and computes the underlying readonly state as `props.readonly || props.allowCustom === false` so existing call sites keep working under the deprecation window.
+
+### Composables stay inlined (for now)
+
+The DatePicker family extracted `usePopoverPositioning`, `useKeepOpen`, and `useDeprecationWarnings` into `DatePicker/composables.ts`. For v1, `TimePicker` inlines the same small bits of logic rather than importing across component boundaries. Post-v1, these should move to a shared `src/composables/` module that both families consume — same refactor as the "shared CalendarPanel" item, just for the popover-trigger plumbing.
+
+### v1 target public API
+
+```ts
+type PopoverSide = 'top' | 'right' | 'bottom' | 'left'
+type PopoverAlign = 'start' | 'center' | 'end'
+
+interface TimePickerProps {
+  // Value
+  modelValue?: string
+  /** @deprecated use modelValue */
+  value?: string
+
+  // Positioning
+  side?: PopoverSide       // default: 'bottom'
+  align?: PopoverAlign     // default: 'start'
+  offset?: number          // default: 4
+  /** @deprecated use side + align */
+  placement?: TimePickerPlacement
+
+  // Display
+  placeholder?: string
+  variant?: 'outline' | 'subtle'
+  use12Hour?: boolean
+
+  // Interaction
+  readonly?: boolean       // default: false — prevents typing; popover still opens
+  disabled?: boolean
+  keepOpen?: boolean       // default: false (closes after selection)
+  /** @deprecated use keepOpen (inverse) */
+  autoClose?: boolean
+
+  // Options / constraints
+  interval?: number
+  options?: Array<{ value: string; label?: string }>
+  min?: string             // HH:mm[:ss] — minimum selectable time
+  max?: string             // HH:mm[:ss] — maximum selectable time
+  scrollMode?: 'center' | 'start' | 'nearest'
+
+  // Deprecated
+  /** @deprecated use readonly */
+  allowCustom?: boolean
+  /** @deprecated use `min` */
+  minTime?: string
+  /** @deprecated use `max` */
+  maxTime?: string
+}
+
+type TimePickerEmits = {
+  (e: 'update:modelValue', value: string): void
+  (e: 'change', value: string): void
+  (e: 'input-invalid', input: string): void
+  (e: 'invalid-change', invalid: boolean): void
+  (e: 'open'): void
+  (e: 'close'): void
+}
+```
+
+Slots: `prefix`, `suffix` (suffix exposes `{ togglePopover, isOpen }`).
+
+---
+
+## shadcn/ui comparison
+
+shadcn (both React and Vue versions) treats the date picker as a **composition pattern** — users wire together `Popover` + `Calendar` primitives themselves rather than reaching for a single `<DatePicker>` component. The Vue version (`shadcn-vue`) is built on top of `@internationalized/date` and Reka UI.
+
+### Where frappe-ui is ahead
+
+**Monolithic high-level API.** shadcn's composition approach is flexible but puts integration burden on the caller every time. frappe-ui's single `<DatePicker>` component is the right call for this library's audience. The v1 plan explicitly says "keep app-facing public APIs high-level where possible."
+
+**`clearable` with quick-action buttons.** Neither shadcn version documents or ships a clearable/quick-action pattern. frappe-ui's Today/Tomorrow/Clear footer is a practical differentiator — keep it.
+
+**`allowCustom` text input.** shadcn shows typed input as a composition example requiring extra setup. frappe-ui has it built-in.
+
+**`DateTimePicker` as a first-class component.** shadcn shows date+time as a composition example. frappe-ui ships it as a standalone component with proper min/max datetime constraints.
+
+### Where frappe-ui is behind
+
+**`DatePicker` has no `minDate`/`maxDate` props.**
+`DateTimePicker` has `minDateTime`/`maxDateTime`, but the plain `DatePicker` has no equivalent. Users cannot restrict the selectable range to future dates, past dates, or a specific window. shadcn-vue exposes `min-value`/`max-value` on `Calendar`.
+
+This is a notable gap. Apps commonly need "no past dates" or "within the next 30 days" constraints. The logic already exists in `DateTimePicker` (the `dateDisabled` function) and just needs to be lifted to `DatePicker`.
+
+**No `isDateUnavailable` callback for arbitrary date disabling.**
+shadcn-vue allows disabling specific individual dates. frappe-ui has no mechanism for this — once `minDate`/`maxDate` don't cover the case (e.g., disable weekends, holidays), there is no escape hatch. An `isDateUnavailable?: (date: Dayjs) => boolean` callback would cover all cases including min/max (which can be built on top of it).
+
+**No standalone `Calendar` / inline panel.**
+shadcn's `Calendar` component can be used inline without a popover. frappe-ui always wraps the calendar in a `Popover`. There is no way for an app to render the calendar grid directly (e.g., in a card or sidebar filter). This is a post-v1 item, but worth noting.
+
+**No locale or calendar system support.**
+shadcn-vue supports 13 calendar systems (Persian, Hebrew, Japanese, etc.) and RTL direction. frappe-ui is hardcoded to Gregorian. This is a post-v1 item.
+
+### Decisions this comparison reaffirms
+
+- Keep the monolithic `<DatePicker>` API (do not decompose into primitives for v1)
+- Keep `clearable` as a first-class prop — it's a differentiator
+- Keep `DateTimePicker` as a standalone component
+- Drop `allowCustom` — `readonly` already covers this
+
+### What to add for v1
+
+**`min` / `max` on `DatePicker` and `DateRangePicker`.** This is a common enough need that it should be in the v1 frozen API. Naming aligns with `Rating` and numeric `TextInput`, which already use `min`/`max`. Add to `CommonDatePickerProps`:
+
+```ts
+/** Earliest selectable date (YYYY-MM-DD, or YYYY-MM-DD HH:mm:ss for DateTimePicker). */
+min?: string
+
+/** Latest selectable date (YYYY-MM-DD, or YYYY-MM-DD HH:mm:ss for DateTimePicker). */
+max?: string
+```
+
+Internally, derive a `dateDisabled` function from these (same pattern as `DateTimePicker`). On `DateTimePicker`, `min`/`max` subsume the legacy `minDateTime`/`maxDateTime`, which remain as deprecated aliases. Likewise on `TimePicker`, `min`/`max` replace `minTime`/`maxTime`.
+
+**`isDateUnavailable` callback on all three pickers.** A single predicate is more composable than min/max alone and covers cases they cannot (weekends, holidays, custom business logic):
+
+```ts
+/** Return true to prevent a date from being selected. */
+isDateUnavailable?: (date: Dayjs) => boolean
+```
+
+If both `min`/`max` and `isDateUnavailable` are provided, the internal disabled check combines them (`min`/`max` constraints OR `isDateUnavailable(date)`).
+
+### What is explicitly post-v1
+
+- Standalone `Calendar` panel component (inline usage)
+- Locale / calendar system / RTL support
+
+---
+
+## `#actions` slot — sidebar of shortcuts
+
+The current `#actions` slot renders as a ~40px footer at the bottom of the popover. In practice it fits one button and a label, which is not enough for the real shortcut lists callers want to build ("Today", "Last 7 days", "Last 12 months"). The dominant industry pattern (Linear, Notion, GitHub, Asana) puts these in a left sidebar with ~6–8 rows of vertical room.
+
+The current footer `#actions` was added during the v1 refactor and has no published consumers, so it can be repurposed without a deprecation window.
+
+### Decisions
+
+| Decision | Direction |
+|---|---|
+| Slot name | `#actions` — kept, matches `Dialog` |
+| Location | Left sidebar inside the popover, divided from the calendar by `divide-x divide-outline-gray-2` |
+| Visibility | Rendered only when the slot is provided. Calendar layout unchanged otherwise. |
+| Styling | Unstyled. Consumer renders their own button list inside `<aside class="flex flex-col p-2 gap-0.5">`. |
+| Popover width | Fixed widths (`w-56` on `DatePicker`) switch to `w-fit` when the sidebar is present. |
+| Footer block | **Removed** from all three components. |
+| Auto Clear button | **Removed.** Consumers who want an in-popover Clear write it inside `#actions` using the `clear` slot prop. |
+| `clearable` prop | Survives. Reduced to an input-level affordance — controls the trigger input's clear `×`, not a popover button. |
+| Migration | None. Behavior-change changelog entry only. |
+
+### Slot props
+
+`DatePicker` and `DateTimePicker` reuse their existing slot-prop shapes. `DateRangePickerActionsSlotProps` gains a `setRange` method.
+
+```ts
+interface DatePickerActionsSlotProps {
+  selected: string                                     // 'YYYY-MM-DD' or ''
+  setDate: (date: string | Date | Dayjs) => void
+  clear: () => void
+  close: () => void
+}
+
+interface DateRangePickerActionsSlotProps {
+  fromDate: string
+  toDate: string
+
+  /** Mirrors a cell click — sets one endpoint at a time. */
+  setDate: (date: string | Date | Dayjs) => void
+
+  /** Commits both endpoints atomically; normalizes order. */
+  setRange: (
+    range: [string | Date | Dayjs, string | Date | Dayjs],
+  ) => void
+
+  clear: () => void
+  close: () => void
+}
+
+interface DateTimePickerActionsSlotProps extends DatePickerActionsSlotProps {
+  time: string                                         // 'HH:mm:ss' or ''
+}
+```
+
+`setRange` is the only new internal helper. Implementation: parse both inputs through `coerceToDayjs`, validate against `checkUnavailable`, write `fromDate.value` / `toDate.value`, call `ensureOrder()`, then `emitIfChanged()`. Without it, fixed-window presets ("Last 7 days") would have to call `setDate` twice and rely on internal state ordering.
+
+### Behavior
+
+- `setDate` / `setRange` respect `min` / `max` / `isDateUnavailable` — calls with unavailable dates silently no-op.
+- `close()` closes the popover unconditionally (ignores `keepOpen`). A consumer calling `close()` is making an explicit choice.
+- No internal arrow-key navigation inside the sidebar. Consumer-rendered `<button>`s sit in normal Tab order, before the calendar grid. The grid keeps its own arrow-key navigation.
+- `data-slot="actions"` set on the `<aside>` for styling hooks (P10).
+
+### Example
+
+```vue
+<DateRangePicker v-model="range">
+  <template #actions="{ fromDate, toDate, setRange, clear, close }">
+    <button @click="setRange([dayjs(), dayjs()]); close()">Today</button>
+    <button @click="setRange([dayjs().subtract(7, 'day'), dayjs()]); close()">
+      Last 7 days
+    </button>
+    <button @click="setRange([dayjs().subtract(28, 'day'), dayjs()]); close()">
+      Last 4 weeks
+    </button>
+    <button @click="setRange([dayjs().subtract(3, 'month'), dayjs()]); close()">
+      Last 3 months
+    </button>
+    <button @click="setRange([dayjs().subtract(12, 'month'), dayjs()]); close()">
+      Last 12 months
+    </button>
+    <hr class="my-1 border-outline-gray-2" />
+    <button v-if="fromDate || toDate" @click="clear(); close()">Clear</button>
+  </template>
+</DateRangePicker>
+```
+
+### Open / deferred
+
+- Sidebar a11y as a roving-focus menu — add behind a future opt-in if a real consumer needs it.
+- `<ShortcutButton>` helper component — extract post-v1 if consumer patterns converge.
+- `#footer` slot for non-shortcut affordances (Apply / Cancel) — purely additive, ship when asked.
+
+---
+
+## Execution checklist
+
+**Vocab alignment**
+- [ ] Replace `placement` with `side` + `align` + `offset`; deprecate `placement` with internal mapping
+- [ ] Rename `autoClose` → `keepOpen` (default `false`); deprecate `autoClose`
+- [ ] Deprecate `allowCustom`; document `readonly` as the replacement
+- [ ] Deprecate `inputClass`; document `class` on the component element as the replacement
+
+**Constraints**
+- [x] Add `min` / `max` to `CommonDatePickerProps` (all three pickers). On `DateTimePicker`, deprecate `minDateTime`/`maxDateTime` as aliases.
+- [x] Add `isDateUnavailable?: (date: Dayjs) => boolean` to `CommonDatePickerProps`
+- [x] Lift date-disabling logic from `DateTimePicker` into a shared util; wire it into `DatePicker` and `DateRangePicker`
+
+**Structural fixes**
+- [ ] Replace `FeatherIcon` with `LucideChevronDown` in all three pickers
+- [ ] Add `DateTimePickerProps` to `types.ts` and export it
+- [ ] Define and export `DateRangePickerEmits`; decide comma-string vs `string[]` before freeze
+- [ ] Fix `clearable` in `DateRangePicker` (add default `true`, apply `v-if` guard to footer)
+- [ ] Add `defineSlots` to `DateTimePicker`
+- [ ] Add `label="cycle-calendar-view"` to `DateTimePicker` cycle-view button
+- [ ] Add `defineExpose({ open })` to `DatePicker` and `DateTimePicker`
+
+**Deprecations**
+- [ ] Add `@deprecated` warning for `value` prop (dev-mode warn, all three pickers)
+- [ ] Deprecate `useDatePicker` composable (JSDoc + dev-mode warning)
+- [ ] Deprecate legacy util exports: `getDate`, `getDatesAfter`, `getDaysInMonth`, `isLeapYear`
+
+**TimePicker**
+- [ ] Add `side` / `align` / `offset` to `TimePickerProps`; deprecate `placement` with internal mapping
+- [ ] Add `keepOpen` (default `false`); deprecate `autoClose` with inverse mapping
+- [ ] Add `readonly` prop; deprecate `allowCustom`; internal trigger reads `props.readonly || props.allowCustom === false`
+- [ ] Add `@deprecated` warning for `value` prop (dev-mode warn)
+- [ ] Update `DateTimePicker`'s internal `TimePicker` call site to use `side`/`align`/`readonly` instead of `placement`/`allowCustom`
+- [x] Add `min`/`max` props; deprecate `minTime`/`maxTime` with internal fallback
+
+**`#actions` slot relocation**
+- [ ] Move `#actions` rendering from footer to left sidebar in `DatePicker`, `DateRangePicker`, `DateTimePicker`
+- [ ] Delete the footer `<div v-if="$slots.actions || (clearable && …)">` block from all three components
+- [ ] Switch fixed-width popovers to `w-fit` when `$slots.actions` is present
+- [ ] Add `setRange(range)` to `DateRangePicker`; expose via the `#actions` slot props
+- [ ] Add `data-slot="actions"` to the sidebar `<aside>`
+- [ ] Reduce `clearable` to an input-level affordance (no popover Clear button)
+- [ ] Update / replace `WithActions` story per picker to show the canonical shortcut list pattern
+- [ ] Cypress: slot renders to the left of calendar; click commits via `setDate` / `setRange` + `close`; `setRange` normalizes reversed input; no auto Clear in footer
+- [ ] Changelog entry: behavior change — `#actions` moved to sidebar, footer removed, in-popover auto Clear removed
+
+**Docs**
+- [ ] Regenerate `docs/meta/DatePicker.md` after API changes
+- [ ] Regenerate `docs/meta/TimePicker.md` after API changes

--- a/spec/dialog.md
+++ b/spec/dialog.md
@@ -1,0 +1,489 @@
+# Dialog Spec
+
+Status: accepted direction for `frappe-ui` v1.
+
+This document defines the exact public API for `Dialog` and the imperative `dialog` namespace (`dialog.confirm`, `dialog.danger`, `dialog.prompt`). It is part of the overlay/floating stabilization workstream listed in [`v1-release/plan.md`](../v1-release/plan.md).
+
+Architectural calls in this spec are recorded as ADRs:
+
+- [`adr/0001-single-dialog-component.md`](./adr/0001-single-dialog-component.md) — why we ship one `<Dialog>` and not `<Dialog>` + `<AlertDialog>`.
+- [`adr/0002-imperative-dialog-caller-closes.md`](./adr/0002-imperative-dialog-caller-closes.md) — *superseded.* Original plan: imperative API resolves on click, caller calls `close()`.
+- [`adr/0003-imperative-dialog-onconfirm.md`](./adr/0003-imperative-dialog-onconfirm.md) — why the imperative API ended up callback-based (`onConfirm` with auto-close, throw to stay open), reversing ADR-0002.
+
+## Role
+
+`Dialog` is the single modal overlay component in `frappe-ui`. Used for forms, confirms, alerts, command palettes, multi-step flows, full-screen settings — anything that traps focus and blocks the page until dismissed.
+
+Apps reach for the imperative `dialog.*` helpers when they need a one-off confirm/alert/prompt from non-component code (stores, utilities, route guards).
+
+## Decisions at a glance
+
+| Decision | Direction |
+|---|---|
+| Component count | One `<Dialog>` only — no `<AlertDialog>` |
+| ARIA role | `role="dialog"` always |
+| Visibility model | `v-model:open` (canonical) **and** `v-model` (also supported) |
+| Prop surface | Flat top-level props; `options` blob retained as deprecated alias |
+| Dismiss control | `dismissable: boolean` (default `true`); replaces `disableOutsideClickToClose` |
+| Chrome control | `bare: boolean` (default `false`); replaces the legacy `#body` slot |
+| Close button | `showCloseButton: boolean` (default `true`); independent of header |
+| Size scale | All 11 sizes kept (`xs` → `7xl`); maps to Tailwind `max-w-*` |
+| Color vocabulary | `theme` with color names (`'yellow' \| 'blue' \| 'red' \| 'green'`), matching `Alert.theme`. No semantic axis. |
+| Slots | Canonical: `#default`, `#title`, `#actions`. Legacy slots deprecated with internal forwarding. |
+| Imperative API | Callback-based `dialog.confirm`, `dialog.danger`, `dialog.prompt`. `onConfirm` resolving auto-closes; throwing keeps the dialog open with the thrown message rendered inline. Each helper returns a synchronous `DialogHandle` for programmatic dismissal. |
+| Mount mechanism | `<FrappeUIProvider>` renders `<Dialogs />` next to `<Toasts />`. `<Dialogs />` is still exported for callers who don't use the provider. |
+
+## Exact public API for v1
+
+### Types
+
+```ts
+type DialogSize =
+  | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '7xl'
+
+type DialogTheme = 'yellow' | 'blue' | 'red' | 'green'
+
+type DialogPosition = 'center' | 'top'
+
+interface DialogIcon {
+  name: string
+  /** Color tone. Replaces deprecated `appearance`. */
+  theme?: DialogTheme
+}
+
+type DialogActionContext = { close: () => void }
+
+interface DialogAction extends ButtonProps {
+  onClick?: (context: DialogActionContext) => void | Promise<void>
+}
+
+/** Legacy blob — accepted for back-compat, warns once. */
+interface DialogOptions {
+  title?: string
+  message?: string
+  size?: DialogSize
+  icon?: string | DialogIcon
+  actions?: DialogAction[]
+  position?: DialogPosition
+  paddingTop?: string | number
+}
+```
+
+### Props
+
+```ts
+interface DialogProps {
+  // Visibility — both supported, document `open` as canonical.
+  open?: boolean
+  modelValue?: boolean
+
+  // Content.
+  title?: string
+  message?: string
+  icon?: string | DialogIcon
+
+  // Layout.
+  size?: DialogSize                 // default 'lg'
+  position?: DialogPosition         // default 'center'
+  paddingTop?: string | number
+
+  // Actions.
+  actions?: DialogAction[]
+
+  // Behavior.
+  dismissable?: boolean             // default true
+  showCloseButton?: boolean         // default true
+  bare?: boolean                    // default false
+
+  // Deprecated (still supported, warn once).
+  disableOutsideClickToClose?: boolean
+  options?: DialogOptions
+}
+```
+
+#### Prop semantics
+
+- **`open` / `modelValue`** — same boolean state. `v-model:open` is canonical and aligns with `Popover`/`Dropdown`. `v-model` (bound to `modelValue`) is also supported indefinitely for back-compat; no warning. If both are bound, `open` wins.
+- **`dismissable`** — when `false`, both outside-click and Escape are suppressed. Replaces `disableOutsideClickToClose`. Default `true`.
+- **`bare`** — when `true`, drops the chrome: no padded card, no auto-header, no auto-actions container. `#default` fills the modal shell directly. `title`/`actions` props become no-ops with a dev warning; `#title`/`#actions` slots are not rendered. Used for command palettes, full-screen settings, etc.
+- **`showCloseButton`** — controls the absolute-positioned top-right close button. Independent of the auto-header. Default `true`.
+- **`paddingTop`** — overrides the position-based top padding (escape hatch; kept for the single in-the-wild use case).
+- **`options`** — accepted for back-compat. Setting it triggers a one-time dev warning per Dialog instance. Flat props **override** any matching key in `options`. Internally flattened before rendering.
+
+### Slots
+
+| Slot | Scope | Purpose |
+|---|---|---|
+| `#default` | — | Main content, rendered inside the padded card. |
+| `#title` | — | Title area; accepts arbitrary content (extra buttons next to title, etc.). |
+| `#actions` | `{ close, actions }` | Footer override; `actions` is the reactive action list (with `loading`) so callers can re-lay-out the auto-rendered buttons. |
+
+**Slot precedence rules:**
+
+- `#actions` slot wins when both `actions` prop and slot are provided.
+- `#title` slot wins when both `title` prop and slot are provided.
+- When neither `title` prop nor `#title` slot is set, the auto-header **does not render** (no "Untitled" fallback).
+- When `bare`, all auto-chrome (padded card, auto-header, auto-actions container) is suppressed.
+
+**Deprecated slots** (warn once, internally forwarded to the canonical slot):
+
+| Legacy slot | Forwards to | Notes |
+|---|---|---|
+| `#body-content` | `#default` | Most-common legacy slot (~85% of legacy usage). |
+| `#body-main` | `#default` | Auto-header conditional on title makes these equivalent. |
+| `#body-title` | `#title` | Direct rename. |
+| `#body-header` | — | No replacement — extras go in `#title`. Warns + renders nothing. |
+| `#body` | `#default` + `bare` | Apps using `#body` for full layout control migrate to `bare` + `#default`. Codemod-able. |
+
+### Events
+
+| Event | Payload | Notes |
+|---|---|---|
+| `update:open` | `boolean` | Fires for `v-model:open`. |
+| `update:modelValue` | `boolean` | Fires for `v-model` (bare). Same value as `update:open`. |
+| `close` | — | Fires when the dialog transitions to closed. |
+| `after-leave` | — | Fires after the close animation finishes. Used heavily in apps for form-reset patterns. |
+
+### ARIA
+
+- `role="dialog"` always — no `alertdialog` variant. See ADR-0001.
+- `aria-labelledby` ← the `DialogTitle` element (whether populated by `title` prop or `#title` slot).
+- `aria-describedby` ← the description element when `message` is set.
+- When `bare`, the caller is responsible for `aria-labelledby` / `aria-describedby`.
+
+### Styling hooks
+
+- `data-state="open" | "closed"` on overlay and content (already provided by reka-ui).
+- `data-dialog="{title}"` on overlay (kept from current API for test selection).
+- `data-position="center" | "top"` on the centering wrapper.
+
+## Imperative API
+
+The `dialog` namespace exports three callback-based helpers: `dialog.confirm`, `dialog.danger`, and `dialog.prompt`. Each mounts a `<Dialog>` from non-component code (stores, route guards, utilities) and returns a synchronous `DialogHandle` so the caller can dismiss programmatically.
+
+The lifecycle is driven by `onConfirm` / `onCancel` callbacks. `onConfirm` resolving auto-closes the dialog; throwing keeps it open with the thrown message rendered inline. See [ADR-0003](./adr/0003-imperative-dialog-onconfirm.md) for the rationale (which supersedes ADR-0002).
+
+### Mount
+
+Wrap the app once with `<FrappeUIProvider>` — it already hosts the toast
+viewport and now also renders `<Dialogs />` for the imperative API:
+
+```vue
+<!-- App.vue -->
+<FrappeUIProvider>
+  <RouterView />
+</FrappeUIProvider>
+```
+
+That's the entire setup. Imperative `dialog.*` calls work from anywhere
+in the app and inherit `provide/inject` (router, Pinia, theme) from the
+host app — no separate Vue instance, no internal-API touches.
+
+Apps that don't use `FrappeUIProvider` can mount `<Dialogs />` directly
+in their root template instead. There is no `DialogsPlugin` — keeping
+mounts in the component tree avoids the `createApp` + `_context` shim
+pattern used by some other libraries.
+
+### Types
+
+```ts
+interface DialogControl {
+  /** Manually dismiss the dialog. Idempotent. */
+  close: () => void
+  /**
+   * Show an inline error and reset loading. Pass `null`/`''` to clear.
+   * Note: calling this from inside `onConfirm` without throwing does NOT
+   * prevent the auto-close — throw to stay open with an error.
+   */
+  setError: (message: string | null | undefined) => void
+}
+
+interface PromptControl extends DialogControl {
+  values: Record<string, any>
+}
+
+/** A button in `actions[]`. Extends `ButtonProps` (theme, variant, icon, …). */
+type DialogAction = Omit<ButtonProps, 'onClick' | 'loading'> & {
+  label: string
+  onClick?: (ctx: DialogControl) => void | Promise<void>
+}
+
+interface ConfirmArgs {
+  title?: string
+  message?: string
+  confirmLabel?: string          // default 'Confirm'; ignored when actions[] is set
+  cancelLabel?: string           // default 'Cancel';  ignored when actions[] is set
+  theme?: DialogTheme            // colors the confirm button + picks default icon
+  icon?: string | DialogIcon     // overrides theme-derived default icon
+  size?: DialogSize              // default 'md'
+  dismissable?: boolean          // default true
+  onConfirm?: (ctx: DialogControl) => void | Promise<void>
+  onCancel?: () => void | Promise<void>
+  /**
+   * Override the default confirm+cancel pair. Each action is rendered as a
+   * Button; its onClick is awaited independently and shows a loading spinner
+   * while pending. When set, confirmLabel/cancelLabel/onConfirm are ignored.
+   */
+  actions?: DialogAction[]
+}
+
+/**
+ * Destructive preset for `dialog.danger`. Forces `theme: 'red'`, defaults
+ * `confirmLabel` to 'Delete', defaults the icon to `lucide-alert-triangle`.
+ * Everything else (actions[], dismissable, onCancel, …) works as in confirm.
+ */
+type DangerArgs = Omit<ConfirmArgs, 'theme' | 'icon'>
+
+interface PromptArgs {
+  title?: string
+  message?: string
+  fields: PromptField[]
+  confirmLabel?: string          // default 'Submit'
+  cancelLabel?: string           // default 'Cancel'
+  theme?: DialogTheme
+  icon?: string | DialogIcon
+  size?: DialogSize              // default 'md'
+  dismissable?: boolean          // default true
+  onConfirm: (ctx: PromptControl) => void | Promise<void>
+  onCancel?: () => void | Promise<void>
+}
+
+/**
+ * Per-field validator. Return a non-empty string to mark the field invalid;
+ * `null`/`undefined`/empty-string for valid. May be async — submit stays in
+ * its loading state until all validators settle. Runs after `required`.
+ */
+type PromptFieldValidator = (
+  value: any,
+  allValues: Record<string, any>,
+) => string | null | undefined | Promise<string | null | undefined>
+
+interface BasePromptField {
+  name: string
+  label?: string
+  placeholder?: string
+  required?: boolean
+  description?: string
+  validate?: PromptFieldValidator
+}
+
+type PromptField =
+  | (BasePromptField & { type?: 'text' | 'textarea'; defaultValue?: string })
+  | (BasePromptField & { type: 'select'; defaultValue?: string;
+                         options: Array<{ label: string; value: string }> })
+  | (BasePromptField & { type: 'checkbox'; defaultValue?: boolean })
+  | (BasePromptField & { type: 'combobox'; defaultValue?: string;
+                         options: ComboboxOption[]; allowCreate?: boolean })
+
+interface DialogHandle { close: () => void }
+
+declare const dialog: {
+  confirm(args: ConfirmArgs): DialogHandle
+  danger(args: DangerArgs): DialogHandle
+  prompt(args: PromptArgs): DialogHandle
+}
+```
+
+### Lifecycle contract
+
+| `onConfirm` outcome | Result |
+|---|---|
+| Resolves | Dialog auto-closes |
+| Throws / rejects | Dialog stays open. Thrown message is extracted via the internal `extractErrorMessage` (Frappe `messages[]`, `Error.message`, plain string, generic fallback) and rendered inline. Buttons re-enable. |
+| Calls `ctx.close()` before/during the await | Dialog closes immediately; the trailing auto-close is an idempotent no-op |
+| Calls `ctx.setError(msg)` without throwing | Inline error is set, but the dialog **still auto-closes** when `onConfirm` resolves. To stay open with an error, throw instead. |
+
+The confirm/submit button shows a loading spinner for as long as the `onConfirm` promise is pending. When `actions[]` is supplied, each action tracks its own loading state — the clicked button spins; every other button disables until it settles.
+
+`onCancel` fires on Cancel click, Escape, outside-click, or close-button click (whenever the dialog's `open` flag flips to `false` via dismissal). Set `dismissable: false` to disable Escape / outside-click / close-button.
+
+Each helper returns `{ close }` synchronously, so callers can dismiss the dialog from outside the callback chain — e.g., from a socket event or route change.
+
+### `theme` → default icon mapping
+
+When `theme` is set without an explicit `icon`, the helper uses these defaults (all overridable):
+
+| `theme` | Default icon | Confirm button color |
+|---|---|---|
+| `red` | `lucide-alert-triangle` | red solid |
+| `yellow` | `lucide-alert-triangle` | default solid (Button doesn't have a `yellow` theme — icon theme is honored, button falls back) |
+| `blue` | `lucide-info` | blue solid |
+| `green` | `lucide-check-circle` | green solid |
+| *(unset)* | none | default solid |
+
+`dialog.danger` pins `theme: 'red'` and inherits the alert-triangle default.
+
+### Examples
+
+```ts
+// Simple confirm — auto-closes when onConfirm resolves.
+dialog.confirm({
+  title: 'Import workbook',
+  message: 'Continue with the import?',
+  onConfirm: async () => {
+    await api.import()
+  },
+})
+```
+
+```ts
+// Destructive flow — dialog.danger is sugar for theme: 'red' + Delete label.
+dialog.danger({
+  title: 'Delete space',
+  message: 'This will permanently delete the space and all its content.',
+  onConfirm: async () => {
+    await spaces.delete.submit({ name: spaceId })
+  },
+})
+```
+
+```ts
+// Stay open after async — throw to surface a validation message.
+dialog.confirm({
+  title: 'Claim username',
+  confirmLabel: 'Claim',
+  onConfirm: async () => {
+    await api.checkAvailable()
+    throw new Error('That username is already taken.')
+  },
+})
+```
+
+```ts
+// Custom buttons via actions[]. Each onClick is awaited independently.
+dialog.confirm({
+  title: 'Paste page',
+  message: 'A page with this name already exists. Create a copy or replace?',
+  actions: [
+    { label: 'Cancel', variant: 'outline' },
+    { label: 'Create copy', onClick: async () => { await api.copy() } },
+    {
+      label: 'Replace',
+      variant: 'solid', theme: 'red',
+      onClick: async () => { await api.replace() },
+    },
+  ],
+})
+```
+
+```ts
+// Prompt with per-field async validation.
+dialog.prompt({
+  title: 'New folder',
+  fields: [
+    {
+      name: 'name',
+      label: 'Folder name',
+      type: 'text',
+      required: true,
+      validate: async (value) => {
+        const taken = await api.exists(value)
+        return taken ? 'A folder with that name already exists' : null
+      },
+    },
+    { name: 'description', label: 'Description', type: 'textarea' },
+  ],
+  onConfirm: async ({ values }) => {
+    await api.createFolder(values)
+  },
+})
+```
+
+```ts
+// Programmatic dismissal via the returned handle.
+const handle = dialog.confirm({
+  title: 'Waiting for upload…',
+  dismissable: false,
+})
+socket.once('upload:done', () => handle.close())
+```
+
+## Deprecations
+
+Each deprecated surface keeps working in v1, emits a one-time dev-mode console warning (per instance / per session), and includes the canonical replacement in the message.
+
+| Deprecated | Replacement |
+|---|---|
+| `options` blob prop | Flat top-level props |
+| `disableOutsideClickToClose` | `dismissable` (inverted) |
+| `icon: { appearance: 'warning' \| 'info' \| 'danger' \| 'success' }` | `icon: { theme: 'yellow' \| 'blue' \| 'red' \| 'green' }` |
+| `#body-content`, `#body-main` slots | `#default` |
+| `#body-title` slot | `#title` |
+| `#body-header` slot | (no replacement — use `#title` for extras) |
+| `#body` slot | `#default` + `bare` prop |
+| `action.onClick(callableContext)` shim | `action.onClick({ close })` |
+| `confirmDialog()` helper | `dialog.confirm()` |
+| `ConfirmDialog.vue` component | mounted internally by `dialog.confirm()`; not part of v1 public surface |
+
+`<Dialogs />` is **not** deprecated — it remains exported and is now rendered by `<FrappeUIProvider>` alongside `<Toasts />`. Apps that already mount it in their template continue to work; rendering it twice is safe (the second mount has no extra effect, but the imperative dialog stack lives in a shared module-level ref so the same stack drives both).
+
+## Migration notes
+
+### From `options` blob to flat props
+
+```vue
+<!-- before -->
+<Dialog v-model="show" :options="{ title: 'X', size: 'xl' }" />
+
+<!-- after -->
+<Dialog v-model:open="show" title="X" size="xl" />
+```
+
+The flat props win over `options` keys, so partial migration (changing some keys to flat while leaving others in `options`) is safe but will continue to warn.
+
+### From `#body` to `#default` + `bare`
+
+```vue
+<!-- before -->
+<Dialog v-model="show" :options="{ size: '5xl' }">
+  <template #body>
+    <div class="flex h-screen">...sidebar + content...</div>
+  </template>
+</Dialog>
+
+<!-- after -->
+<Dialog v-model:open="show" size="5xl" bare>
+  <template #default>
+    <div class="flex h-screen">...sidebar + content...</div>
+  </template>
+</Dialog>
+```
+
+This is the canonical migration for the ~30 in-the-wild apps using `#body` for full-canvas layouts (gameplan/Settings, helpdesk/SettingsModal, drive/SearchPopup, command palettes, etc.).
+
+### From `confirmDialog()` to `dialog.confirm()` / `dialog.danger()`
+
+```js
+// before — manual hideDialog after the work completes
+confirmDialog({
+  title: 'Delete?',
+  message: 'Cannot be undone.',
+  onConfirm: ({ hideDialog }) => {
+    api.deleteFile()
+    hideDialog()
+  },
+})
+
+// after — destructive preset; auto-closes when onConfirm resolves
+dialog.danger({
+  title: 'Delete?',
+  message: 'Cannot be undone.',
+  onConfirm: async () => {
+    await api.deleteFile()
+  },
+})
+```
+
+For non-destructive flows, use `dialog.confirm` with the same `onConfirm` shape. Throw from `onConfirm` to keep the dialog open with an inline error (e.g., for server-side validation failures).
+
+## Out of scope for v1
+
+These are intentionally not in this spec; revisit in `1.x`:
+
+- Cross-component rollout of `dismissable` to Popover, Dropdown, Tooltip.
+- Additional `PromptField` types beyond `text` / `textarea` / `select` / `checkbox` / `combobox` (`date`, `number`, `autocomplete`, multi-step wizards, etc.).
+- A `dialog.alert()` helper. The same affordance is achieved today with `dialog.confirm({ actions: [{ label: 'OK', variant: 'solid' }] })` or by passing only `cancelLabel`; not worth a dedicated entry point in v1.
+- `dialog.message()` or other named imperative helpers beyond `confirm` / `danger` / `prompt`.
+- A reactive imperative API that exposes the underlying Dialog instance for further mutation.
+- Custom `position` offsets beyond the existing `'center' | 'top'` + `paddingTop` surface.

--- a/spec/dropdown.md
+++ b/spec/dropdown.md
@@ -1,0 +1,584 @@
+# Dropdown Spec
+
+Status: accepted direction for `frappe-ui` v1 planning.
+
+This document defines the exact public API for `Dropdown`. It is a sub-spec of
+[`selection.md`](./selection.md) and
+inherits the shared design rules from that document.
+
+## Role
+
+`Dropdown` is the action menu component.
+
+It should continue to support:
+
+- simple action lists
+- grouped actions
+- submenus
+- switch/toggle rows
+- route-based actions
+- occasional advanced custom rows
+- menu-style "choose one of a few actions" cases where the app marks the current
+  choice
+
+Important boundary:
+
+- if the UI is semantically choosing a form value or picker value, use `Select`
+- if the UI is a menu of actions or view/filter/sort modes and one is currently
+  active, `Dropdown` is still acceptable
+
+So `Dropdown` can support checkmarks and active menu items, but it should not
+become the generic replacement for `Select`.
+
+## Exact public API for v1
+
+### Props
+
+```ts
+type PopoverSide = 'top' | 'right' | 'bottom' | 'left'
+type PopoverAlign = 'start' | 'center' | 'end'
+
+/** @deprecated use `align` with start | center | end */
+type DropdownPlacement = 'left' | 'center' | 'right'
+
+interface DropdownProps {
+  button?: ButtonProps
+  options?: DropdownOptions
+  open?: boolean
+  side?: PopoverSide
+  align?: PopoverAlign
+  offset?: number
+  portalTo?: string | HTMLElement
+  emptyText?: string
+  /** @deprecated alias for `align`; maps left→start, center→center, right→end */
+  placement?: DropdownPlacement
+}
+```
+
+Defaults:
+
+- `options = []`
+- `open = false`
+- `side = 'bottom'`
+- `align = 'start'`
+- `offset = 4`
+- `portalTo = 'body'`
+- `emptyText = 'No options'`
+
+Positioning follows the shared popover positioning conventions in
+[`selection.md`](./selection.md).
+
+Compatibility rules for `placement`:
+
+- `placement` remains supported through `v1.x`
+- if `placement` is provided without `align`, it is silently mapped:
+  - `'left'` → `align: 'start'`
+  - `'center'` → `align: 'center'`
+  - `'right'` → `align: 'end'`
+- if both `placement` and `align` are provided, `align` wins and a dev warning
+  is emitted
+- docs should show `align` in primary examples; `placement` should only appear
+  in the deprecation table
+
+State conventions:
+
+- visibility is controlled with `v-model:open`
+- `Dropdown` does **not** expose `v-model` for a selected value
+- `Dropdown` does **not** own query state
+
+`button` is only used when no custom trigger slot is provided.
+
+### Emits
+
+```ts
+interface DropdownEmits {
+  'update:open': [value: boolean]
+}
+```
+
+There is no component-level `select` event in v1. Action handling stays
+item-owned through `route` and `onClick`.
+
+### Slots
+
+Guaranteed slot props:
+
+```ts
+type DropdownTriggerSlotProps = {
+  open: boolean
+  close: () => void
+  disabled: boolean
+}
+
+type DropdownItemSlotProps = {
+  item: DropdownOption
+  close: () => void
+  selected: boolean
+}
+
+type DropdownGroupLabelSlotProps = {
+  group: DropdownGroupOption
+}
+```
+
+Supported slots:
+
+- `#trigger="{ open, close, disabled }"`
+  - preferred advanced trigger slot
+- default slot
+  - supported trigger slot with the same contract as `#trigger`
+  - especially ergonomic when trigger customization is the only customization
+    needed
+- `#item-prefix="{ item, close, selected }"`
+  - custom leading content for all item rows, including submenu and switch rows
+- `#item-label="{ item, close, selected }"`
+  - custom label/content region for all item rows
+- `#item-suffix="{ item, close, selected }"`
+  - custom trailing content for all item rows
+- `#item="{ item, close, selected }"`
+  - full-row escape hatch for leaf action rows only
+- `#item-<slot>="{ item, close, selected }"`
+  - dynamic named label slot selected via `item.slot`
+- `#group-label="{ group }"`
+  - optional custom group label rendering
+- `#empty`
+  - empty state for any menu level with no visible items
+
+Exact slot rules:
+
+- `#trigger` wins over the default slot
+- the default slot wins over the generated `button` trigger
+- `close()` closes the whole dropdown, not just the current submenu
+- `selected` is always `Boolean(item.selected)`
+- `#item-<slot>` overrides the label region only; it does not replace the full
+  row shell
+- `#item` is an escape hatch for leaf action rows only
+- submenu and switch rows keep their shell-owned structure even when `#item`
+  exists
+- `#item-prefix`, `#item-label`, and `#item-suffix` apply at every menu depth
+- on submenu rows, `#item-suffix` renders before the built-in submenu chevron
+- on switch rows, `#item-suffix` renders before the built-in switch control
+
+## Exact option shape for v1
+
+```ts
+type DropdownTheme = 'gray' | 'red'
+
+type SlotFn<TProps> = (props: TProps) => VNodeChild
+
+interface ItemSlots<TProps> {
+  prefix?: SlotFn<TProps>
+  label?: SlotFn<TProps>
+  suffix?: SlotFn<TProps>
+  /** Full-row replacement; mutually exclusive with prefix/label/suffix */
+  item?: SlotFn<TProps>
+}
+
+interface DropdownBaseOption {
+  icon?: string | Component | null
+  description?: string
+  selected?: boolean
+  disabled?: boolean
+  theme?: DropdownTheme
+  slot?: string
+  slots?: ItemSlots<DropdownItemSlotProps>
+  condition?: () => boolean
+  [key: string]: any
+}
+
+interface DropdownActionOption extends DropdownBaseOption {
+  label: string
+  route?: RouteLocationRaw
+  onClick?: (event: PointerEvent) => void
+  submenu?: never
+  switch?: never
+  switchValue?: never
+  component?: never
+}
+
+interface DropdownSwitchOption extends DropdownBaseOption {
+  label: string
+  switch: true
+  switchValue?: boolean
+  onClick?: (value: boolean) => void
+  route?: never
+  submenu?: never
+  component?: never
+}
+
+interface DropdownSubmenuOption extends DropdownBaseOption {
+  label: string
+  submenu: DropdownOptions
+  route?: never
+  onClick?: never
+  switch?: never
+  switchValue?: never
+  component?: never
+}
+
+/** @deprecated use `slots: { item: fn }` */
+interface DropdownComponentOption extends DropdownBaseOption {
+  component: any
+  label?: string
+  route?: never
+  submenu?: never
+  switch?: never
+  switchValue?: never
+}
+
+interface DropdownGroupOption {
+  key?: string | number
+  group: string
+  hideLabel?: boolean
+  theme?: DropdownTheme
+  options: DropdownOption[]
+  /** @deprecated alias for `options` (Dropdown previously used `items`) */
+  items?: DropdownOption[]
+}
+
+type DropdownOption =
+  | DropdownActionOption
+  | DropdownSwitchOption
+  | DropdownSubmenuOption
+  | DropdownComponentOption
+
+type DropdownOptions = Array<DropdownOption | DropdownGroupOption>
+```
+
+Compatibility rule for the group field:
+
+- the canonical group entry is `{ group, options }`, matching `Combobox`,
+  `MultiSelect`, and `Select`
+- `{ group, items }` (the previous Dropdown shape) keeps working through
+  `v1.x` as a deprecated alias
+- if both `options` and `items` are provided on the same group entry,
+  `options` wins and a dev warning is emitted
+- if only `items` is provided, it is silently mapped to `options`
+
+Notes:
+
+- `label` is required for every standard action, switch, and submenu row
+- `label` is optional only for `component` escape-hatch rows
+- `submenu`, `switch`, and `component` are mutually exclusive item modes
+- app-defined extra fields like `value`, `id`, `image`, `shortcut`, and
+  analytics metadata are allowed and must be passed through unchanged to slot
+  props
+- `slot` is the preferred name for dynamic label slot selection
+- keep `onClick` and `condition` as canonical names
+
+## Rendering and behavior rules
+
+### Grouping and visibility
+
+- `options` may mix plain items and explicit groups
+- plain items are rendered as implicit unlabeled groups in source order
+- each menu level should normalize its `DropdownOptions` input into an explicit
+  grouped structure before row rendering
+- the normalization shape is internal to `Dropdown`; only the
+  `{ group, options }` external API contract is part of the public surface
+- `condition()` is evaluated before rendering at every menu depth
+- items whose `condition()` returns false are omitted
+- groups with zero visible items are omitted
+- if a menu or submenu level has no visible items, render `#empty`
+
+### Trigger behavior
+
+- if `#trigger` is provided, use it
+- else if the default slot is provided, use it as the compatibility trigger slot
+- else render the generated `Button` from `button`
+- trigger disabled state is derived from `button.disabled` or a forwarded
+  `disabled` attribute
+
+### Item behavior
+
+- `selected` is visual-only state owned by the app
+- `Dropdown` does not infer selection and does not emit selection changes
+- selected rows receive shell-owned selected styling, but `Dropdown` does
+  **not** render a trailing checkmark automatically
+- if any visible item in a group has an icon, items without icons in that same
+  group should reserve the same prefix space for alignment
+- `route` takes precedence over `onClick` on leaf action rows
+- leaf action rows close the dropdown on selection through menu semantics
+- switch rows do not auto-close on toggle
+- submenu rows open nested menu content and do not call `onClick`
+- `component` rows are escape hatches for exceptional content and do not receive
+  shell-owned prefix/label/suffix regions
+
+### Disabled handling
+
+Follows the shared disabled-option rule (shared design rule 8 in the main
+RFC):
+
+- disabled items are skipped by keyboard navigation and typeahead
+- disabled leaf actions do not call `onClick` and do not follow `route`
+- disabled submenu rows do not open their submenu
+- disabled switch rows do not toggle and do not emit
+- disabled items apply `ItemListRow` disabled styling and `data-disabled`
+
+### Rendering precedence
+
+For each visible item:
+
+1. if `item.submenu` exists, render a submenu row
+2. else if `item.switch === true`, render a switch row
+3. else determine the row by combining template slots, `item.slots`, and
+   the default shell (see per-region precedence below)
+
+Per-region precedence for standard action rows (following shared design
+rule 9):
+
+Full row (if any of these provide a full-row renderer, the per-region
+renderers below are skipped):
+
+1. `#item` slot
+2. `item.slots.item`
+3. `item.component` — kept as a deprecated alias of `item.slots.item`; if
+   both are present, `slots.item` wins and a dev warning fires
+
+Prefix region:
+
+1. `#item-prefix` slot
+2. `item.slots.prefix`
+3. default: `icon` with group-level alignment placeholder behavior
+
+Label region:
+
+1. `#item-<slot>` slot matching `item.slot`
+2. `#item-label` slot
+3. `item.slots.label`
+4. default: `label` plus optional `description`
+
+Suffix region:
+
+1. `#item-suffix` slot
+2. `item.slots.suffix`
+3. default: empty for leaf action rows; submenu chevron or switch control
+   is appended after the suffix region on submenu / switch rows
+
+Notes:
+
+- submenu and switch rows keep their shell-owned affordances even when a
+  full-row renderer is provided elsewhere — the full-row escape hatch
+  applies to leaf action rows only, matching the existing `#item` rule
+
+## Styling hooks
+
+Stable hooks for `Dropdown` should include:
+
+- `data-slot="content"`
+- `data-slot="group"`
+- `data-slot="group-label"`
+- `data-slot="item"`
+- `data-slot="empty"`
+
+Standard rows inside `Dropdown` should use `ItemListRow`, which provides:
+
+- `data-slot="item-list-row"`
+- `data-slot="item-prefix"`
+- `data-slot="item-label"`
+- `data-slot="item-suffix"`
+
+State hooks should include, where relevant:
+
+- `data-state="open|closed"` on menu content via the menu primitive
+- `data-disabled`
+- row-level selected/active styling hooks inherited from `ItemListRow`
+
+## Motion
+
+`Dropdown` follows the shared popover motion conventions (shared design
+rule 10 in the main RFC):
+
+- content scales in from the trigger via
+  `transform-origin: var(--reka-dropdown-menu-content-transform-origin)` on
+  the animated element (the inner content-body, not the outer positioned
+  wrapper)
+- enter `180ms` / exit `140ms` with `cubic-bezier(0.23, 1, 0.32, 1)`, from
+  `scale(0.97)` + `translateY(2px)` + `opacity: 0`
+- keyboard-driven opens (Enter, Space, ArrowUp, ArrowDown on the trigger)
+  skip the animation entirely
+- pointer-driven opens (click / tap) play the full animation
+- classification is pointer-recency based: an open transition counts as
+  pointer-driven only if a `pointerdown` fired on the trigger within
+  ~300ms before it; everything else defaults to keyboard. The resolved
+  mode is exposed as `data-motion="animated" | "instant"` on the
+  content-body
+- `prefers-reduced-motion: reduce` disables the content animation
+
+## Accessibility and semantics
+
+`Dropdown` should follow the menu button pattern, not the listbox/select
+pattern.
+
+That means:
+
+- trigger uses menu-trigger semantics
+- leaf actions are menu actions, not form options
+- submenu items expose submenu semantics
+- keyboard navigation, escape handling, typeahead, and submenu arrow-key
+  behavior are delegated to the underlying menu primitive
+- `selected` is visual state only; it does not change the component into a
+  single-select control
+
+## Keep supported in v1.x
+
+These stay supported:
+
+- `button`
+- `options`
+- `placement` (as an alias for `align`)
+- `side`
+- `offset`
+- `portalTo`
+- grouped items, including the legacy `{ group, items }` shape
+- `submenu`
+- `switch`
+- `switchValue`
+- `component`
+- `#item`
+- current default trigger slot behavior
+
+## Deprecate
+
+Keep working, but deprecate for ordinary row customization:
+
+- `#item` as the default recommendation
+- `item.component` in favor of `item.slots` (use `slots.item` for the
+  full-row escape hatch; use `slots.prefix` / `slots.label` /
+  `slots.suffix` for per-region customization)
+- `placement` prop in favor of `align`
+- `{ group, items }` group entries in favor of `{ group, options }` (for
+  symmetry with `Combobox` / `MultiSelect` / `Select`)
+
+Keep as escape hatches:
+
+- deeply custom rows
+- destructive full-width special rows
+- embedded app selectors or similar exceptional content
+
+Do **not** deprecate:
+
+- `onClick`
+- `condition`
+- `route`
+- `submenu`
+- `switch`
+
+## Migration path
+
+### Old
+
+```vue
+<Dropdown :options="items">
+  <template #item="{ item }">
+    <button class="flex h-7 w-full items-center justify-between rounded px-2 hover:bg-surface-gray-3">
+      <span>{{ item.label }}</span>
+      <LucideCheck v-if="active === item.value" class="size-4" />
+    </button>
+  </template>
+</Dropdown>
+```
+
+### New
+
+```vue
+<Dropdown :options="items">
+  <template #item-suffix="{ item }">
+    <LucideCheck v-if="item.selected" class="size-4" />
+  </template>
+</Dropdown>
+```
+
+### `{ group, items }` → `{ group, options }` rename
+
+Old:
+
+```ts
+const actions = [
+  {
+    group: 'Edit',
+    items: [
+      { label: 'Rename', onClick: rename },
+      { label: 'Duplicate', onClick: duplicate },
+    ],
+  },
+]
+```
+
+New:
+
+```ts
+const actions = [
+  {
+    group: 'Edit',
+    options: [
+      { label: 'Rename', onClick: rename },
+      { label: 'Duplicate', onClick: duplicate },
+    ],
+  },
+]
+```
+
+`{ group, items }` keeps working through `v1.x`; a dev warning fires if
+both `options` and `items` are provided on the same group entry.
+
+### Old: full-row escape hatch via `component`
+
+```ts
+{
+  label: 'Delete',
+  component: h(Button, { variant: 'solid', theme: 'red' }, () => 'Delete'),
+}
+```
+
+### New: full-row escape hatch via `slots.item`
+
+```ts
+{
+  label: 'Delete',
+  slots: {
+    item: () =>
+      h(Button, { variant: 'solid', theme: 'red' }, () => 'Delete'),
+  },
+}
+```
+
+### New: per-region `slots` (preferred when the shell still makes sense)
+
+```ts
+import { h } from 'vue'
+import LucideCheck from '~icons/lucide/check'
+import Avatar from '@/components/Avatar.vue'
+
+const options = users.map((user) => ({
+  label: user.name,
+  selected: user.id === activeId,
+  onClick: () => switchTo(user.id),
+  slots: {
+    prefix: ({ item }) =>
+      h(Avatar, { image: item.image, class: 'size-4' }),
+    suffix: ({ selected }) =>
+      selected ? h(LucideCheck, { class: 'size-4' }) : null,
+  },
+}))
+```
+
+### v1.x stance
+
+`component` is still supported as a deprecated alias for `slots.item`. Use
+`slots.prefix` / `slots.label` / `slots.suffix` for ordinary
+icon/label/check/suffix customization authored in JS; use `slots.item`
+when the whole row needs to be taken over.
+
+## Changelog
+
+### 2026-04-24
+
+- **`item.icon` accepts `lucide-*` strings.** Pass `icon: 'lucide-pen'`
+  directly in an item definition — no component import needed. Strings
+  starting with `lucide-` are rendered as a `<span>` styled via the Tailwind
+  CSS-mask plugin. Other strings still route to FeatherIcon (back-compat).
+  Component values continue to work unchanged.
+
+- **Group labels toned to `text-ink-gray-4`.** Separator group headings are
+  now visually quieter so they recede behind the action items.

--- a/spec/inputs.md
+++ b/spec/inputs.md
@@ -1,0 +1,631 @@
+# Input Components API Spec
+
+Status: accepted direction for `frappe-ui` v1 planning.
+
+This document defines the v1 API direction for the input-family components:
+
+- `TextInput`
+- `Textarea`
+- `Password`
+- `Checkbox`
+- `Switch`
+- `Rating`
+- `Slider`
+- `ErrorMessage`
+
+`FileUploader` is intentionally out of scope for this spec; it will be
+covered separately.
+
+It also covers the v1 stance on the deprecated `Input.vue` and `Autocomplete`,
+and the `FormControl type='autocomplete'` route.
+
+It is a sibling of [`selection.md`](./selection.md)
+and inherits any shared design rules from that document where they apply.
+
+## Scope
+
+This spec answers:
+
+- what the shared labeling, sizing, variant, and `v-model` contracts look like
+  across every input
+- which existing per-component issues must be resolved before v1
+- which deprecations must be wired with dev warnings
+
+Decisions involving real-world usage data are backed by
+[`v1-release/research/09-input-components-usage-audit.md`](../v1-release/research/09-input-components-usage-audit.md).
+
+## Decision summary
+
+- every input gets the same shared labeling props: `label`, `description`,
+  `error`, `required`
+- every input auto-generates an `id` and wires label-for, `aria-describedby`,
+  and `aria-errormessage` automatically
+- text-style inputs and binary/numeric controls follow two separate size
+  scales by component class
+- text inputs converge on a single `subtle | outline | ghost` variant set
+- every input uses `defineModel<T>()` for the primary value, with typed
+  `*Emits` interfaces only for non-model events
+- `FeatherIcon` is removed from `Switch` and `Rating`; both use Lucide
+- `Rating.rating_from` is renamed to `max`, with a deprecated alias
+- `Input.vue`, `Autocomplete`, and the `FormControl type='autocomplete'`
+  route all gain dev-mode deprecation warnings via a shared utility
+- `FormControl` stays a type-routing component for v1 (185 router-style call
+  sites, 0 wrapper-style)
+- `Switch.labelClasses` and `Checkbox.padding` are deprecated (warned, still
+  functional) in favor of `data-*` styling hooks; removal is post-v1
+- **v1 introduces no breaking changes.** Every API change is additive or
+  ships behind a `warnDeprecated` alias that keeps the old call site working
+
+## Shared labeling contract
+
+Every input that has a labelable role accepts the same four props.
+
+### Props
+
+```ts
+interface InputLabelingProps {
+  /** Label rendered above (or beside, for binary controls) the input. */
+  label?: string
+
+  /**
+   * Helper text rendered below the input.
+   * Hidden when `error` is set.
+   */
+  description?: string
+
+  /**
+   * Error message rendered below the input.
+   * Sets `aria-invalid="true"` and `data-state="invalid"` on the control.
+   * Accepts an `Error` object; `Error.messages` is rendered as stacked
+   * plain text, `Error.message` is the fallback.
+   */
+  error?: string | Error
+
+  /**
+   * Marks the field as required.
+   * Renders an asterisk after the label (with `sr-only` "(required)" text)
+   * and forwards `required` / `aria-required` to the underlying control.
+   */
+  required?: boolean
+}
+```
+
+### Slots
+
+```ts
+interface InputLabelingSlots {
+  /** Overrides the rendered label content. Receives `{ required }`. */
+  label?: (props: { required: boolean }) => any
+
+  /** Overrides the rendered description content. */
+  description?: () => any
+
+  // No `#error` slot. The error string is a stable contract; apps that need
+  // rich error UI should render it as a sibling. The error-state wiring
+  // (`aria-invalid`, `data-state`, `aria-errormessage`) stays driven by the
+  // `error` prop.
+}
+```
+
+### Layout
+
+Two layouts, automatic per component:
+
+- **Stack** (label above the control):
+  - `TextInput`, `Textarea`, `Password`, `Rating`, `Slider`
+- **Inline row** (label beside the control):
+  - `Checkbox`, `Switch`
+
+For inline-row controls, `description` and `error` stack below the row,
+indented to align under the label region (not under the control).
+
+### `id` association
+
+- Every input calls `const inputId = props.id ?? useId()`.
+- The generated id is shared between the rendered `<label for>` (or
+  `aria-labelledby` for non-form controls like `Slider`) and the underlying
+  control.
+- `description` is rendered with `id="${inputId}-description"` and linked via
+  `aria-describedby` on the control.
+- `error` is rendered with `id="${inputId}-error"` and linked via
+  `aria-errormessage` on the control. `aria-invalid="true"` is set when
+  `error` is non-empty.
+- Apps may pass `id` explicitly to override.
+
+### Required-indicator rendering
+
+Reuse `FormLabel`'s existing pattern as the canonical implementation:
+
+```html
+<label for="...">
+  Label text
+  <span aria-hidden="true" class="text-ink-red-3 select-none">*</span>
+  <span class="sr-only">(required)</span>
+</label>
+```
+
+Apps using the `#label` slot receive `{ required }` so they can render the
+indicator inside their custom label content.
+
+### `error` prop rules
+
+- `error: string` renders as a single line of text below the control.
+- `error: Error` renders `Error.messages` (joined with line breaks via
+  `whitespace-pre-line`) when present, otherwise `Error.message`.
+- The error region is rendered as plain text. **`v-html` is not used.**
+- `error` text uses `text-ink-red-3` (matches the required asterisk for
+  visual consistency of "needs attention" affordances).
+- Setting `error` automatically suppresses the `description` region.
+
+## Shared types
+
+```ts
+/** Size scale for text-style inputs. */
+export type InputSize = 'sm' | 'md' | 'lg' | 'xl'
+
+/** Size scale for binary and numeric range controls. */
+export type ToggleSize = 'sm' | 'md'
+
+/** Variant scale for text-style inputs that have a container surface. */
+export type InputVariant = 'subtle' | 'outline' | 'ghost'
+```
+
+Apply per component:
+
+| Component      | Size type   | Variant type       |
+| -------------- | ----------- | ------------------ |
+| `TextInput`    | `InputSize` | `InputVariant`     |
+| `Textarea`     | `InputSize` | `InputVariant`     |
+| `Password`     | `InputSize` | `InputVariant`     |
+| `Rating`       | `InputSize` | n/a                |
+| `Checkbox`     | `ToggleSize`| n/a                |
+| `Switch`       | `ToggleSize`| n/a                |
+| `Slider`       | `ToggleSize`| n/a                |
+
+Rationale: `lg` and `xl` produce useful visual range for text inputs and
+trigger surfaces but produce oversized chunky controls for binary
+affordances and sliders. Size scales follow the control's visual nature,
+not API symmetry.
+
+## `v-model` pattern
+
+Every input uses `defineModel<T>()` for the primary value:
+
+```ts
+const model = defineModel<string>()             // TextInput, Textarea, Password
+const model = defineModel<boolean>()            // Switch
+const model = defineModel<boolean | 1 | 0>()    // Checkbox (union retained for v1; coerce internally)
+const model = defineModel<number>()             // Rating
+const model = defineModel<SliderValue>()        // Slider
+```
+
+Typed `*Emits` interfaces are added only when a component emits non-model
+events:
+
+```ts
+// Slider
+interface SliderEmits {
+  'value-commit': [value: SliderValue]
+}
+```
+
+`*Props` interfaces in `types.ts` continue to declare every non-model prop;
+the model itself is documented at the component file via the
+`defineModel<T>()` generic.
+
+## Per-component changes
+
+### TextInput
+
+- Already at v1 baseline. No structural changes.
+- Apply shared labeling props (`label`, `description`, `error`, `required`).
+- Auto-generate `id` via `useId()` fallback.
+- Confirm `InputSize` and `InputVariant` (no change from current shape).
+
+### Textarea
+
+- Apply shared labeling props.
+- Drop the unused `type: 'text'` default in `withDefaults` (`type` is not in
+  `TextareaProps`).
+- Add `'ghost'` to the variant set so it matches `TextInput` and `Password`.
+- Add `required` prop for parity.
+- Consolidate the local `label` prop into the shared labeling contract
+  (same prop name, no breaking change — call sites continue to work).
+
+### Password
+
+- Add `defineModel<string>()`. This fixes the current bug where
+  `<Password v-model>` does not update from typing.
+- Deprecate the `value` prop alias (warn via `warnDeprecated`); remove in a
+  future major.
+- Add explicit `size`, `variant`, `disabled`, `placeholder`, `id`, `required`
+  props instead of routing through `$attrs`.
+- Apply shared labeling props.
+
+### Checkbox
+
+- Keep `modelValue` typed as `boolean | 1 | 0` for v1 — narrowing to
+  `boolean` is a breaking change for any consumer passing `1` / `0`. Use
+  `defineModel<boolean | 1 | 0>()` and coerce internally to `boolean` for
+  the rendered control state. Document `boolean` as the canonical type;
+  narrow in a future major.
+- Type emits via a `CheckboxEmits` interface.
+- Apply shared labeling props (inline-row layout).
+- Switch to `defineModel`.
+- Deprecate the `padding` prop (warn via `warnDeprecated`); keep functional
+  through `v1.x`. Styling moves to `data-*` hooks (see "Styling hooks"
+  below). Audit found 0 real call sites, so the warning is essentially a
+  no-op in practice.
+
+### Switch
+
+- Remove internal `FeatherIcon` import. Replace with Lucide. (Internal
+  refactor — no public API change.)
+- Retype `icon` from `any` to `string | Component`. Strings starting with
+  `lucide-` route through the shared Lucide Tailwind utility (matches the
+  pattern recently adopted by `Button.icon`). Existing values continue to
+  resolve.
+- Deprecate the `change` emit (warn via `warnDeprecated` when the parent
+  binds `@change`); keep firing through `v1.x`. It duplicates
+  `update:modelValue`; switches do not have a meaningful `input` vs
+  `change` distinction.
+- Apply shared labeling props (inline-row layout).
+- `Switch` already uses `defineModel<boolean>()` — no change to the model
+  wiring beyond the refactor.
+- Deprecate the `labelClasses` prop (warn via `warnDeprecated` when set);
+  keep applied to the `<label>` through `v1.x`. Styling moves to `data-*`
+  hooks (see "Styling hooks" below). Audit found 0 real call sites on
+  frappe-ui's `Switch`, so the warning is essentially a no-op in practice.
+
+### Rating
+
+- Remove internal `FeatherIcon` import. Default icon becomes `lucide-star`
+  via the shared Lucide Tailwind utility. Star icon stays hardcoded for v1;
+  configurable shape is a post-v1 additive change if needed.
+- Rename `rating_from` to `max`. Default `5`. Keep `rating_from` working as
+  a deprecated alias through `v1.x` with a `warnDeprecated` call.
+- Type emits via a `RatingEmits` interface (replace the current
+  `defineEmits(['update:modelValue'])` string-array form).
+- Apply shared labeling props.
+- Switch to `defineModel<number>()`.
+
+### Slider
+
+- Add `disabled` prop, forwarded to `SliderRoot.disabled` and
+  `aria-disabled`.
+- Add `size: ToggleSize` (`'sm' | 'md'`), default `'sm'`. `md` increases
+  track and thumb proportionally.
+- **Bug fix:** remove the hardcoded `aria-label="Volume"`. The string was
+  a leftover from a specific consumer and was incorrect for every other
+  call site (assistive tech announces every Slider as "Volume"). Labeling
+  now flows through the shared labeling contract; if no `label` is
+  provided, no `aria-label` is set and consumers should pass one
+  explicitly. Treated as a bug fix, not an API change.
+- Add a typed `SliderEmits` interface exposing
+  `'value-commit': [value: SliderValue]`, bound to `SliderRoot`'s
+  `@valueCommit`. Apps use this to fire side-effects only when the user
+  finishes dragging.
+- Apply shared labeling props.
+
+### ErrorMessage
+
+`ErrorMessage` continues to exist for direct use, but its v1 role narrows.
+
+- **`v-html` is preserved as-is for v1.** Removal is deferred — revisit
+  post-v1 once consumers are tracked.
+- Type the message prop as `string | Error` cleanly; remove the
+  `(message as any).messages` cast by typing `Error.messages?: string[]`
+  via a small library-level interface. (Internal typing improvement, not a
+  runtime change.)
+- Most consumers should migrate to the input-level `error` prop. Document
+  `ErrorMessage` as the standalone option for contexts where an input is
+  not present (e.g. form-level error banners).
+
+Note: the input-level `error` region (rendered by the shared labeling
+contract) is plain text and does not use `v-html`. That rule is about the
+new in-input rendering, independent of the standalone `ErrorMessage`
+component.
+
+## Deprecations
+
+### `warnDeprecated` utility
+
+Add `src/utils/warnDeprecated.ts`:
+
+```ts
+const warned = new Set<string>()
+
+export function warnDeprecated(
+  name: string,
+  replacement: string,
+  docHref?: string,
+) {
+  if (import.meta.env.PROD) return
+  if (warned.has(name)) return
+  warned.add(name)
+  const suffix = docHref ? ` See ${docHref}` : ''
+  console.warn(
+    `[frappe-ui] ${name} is deprecated. Use ${replacement} instead.${suffix}`,
+  )
+}
+```
+
+Rules:
+
+- dev-mode only (`import.meta.env.PROD` short-circuit)
+- module-level `Set` dedupes by `name` so the warning fires once per session
+- called from each deprecated component's `setup` (or the relevant code
+  path), not at import time, so stack traces point at the call site
+- consolidates the existing one-off pattern used by
+  `Divider.action.handler`
+
+### Wired warnings for v1
+
+| Component / API                     | Warning name                       | Replacement                  |
+| ----------------------------------- | ---------------------------------- | ---------------------------- |
+| `Input.vue`                         | `Input`                            | `TextInput`                  |
+| `Autocomplete`                      | `Autocomplete`                     | `Combobox` or `MultiSelect`  |
+| `FormControl type='autocomplete'`   | `FormControl type="autocomplete"`  | Use `Combobox` standalone    |
+| `Password.value` prop               | `Password.value`                   | `v-model` / `modelValue`     |
+| `Rating.rating_from` prop           | `Rating.rating_from`               | `max`                        |
+| `Switch.change` emit                | `Switch.change`                    | `update:modelValue` / `v-model` |
+| `Switch.labelClasses` prop          | `Switch.labelClasses`              | `data-*` styling hooks       |
+| `Checkbox.padding` prop             | `Checkbox.padding`                 | `data-*` styling hooks       |
+| `Divider.action.handler` (existing) | `Divider.action.handler`           | `Divider.action.onClick`     |
+
+`FeatherIcon` removal is tracked in the broader v1 plan and uses the same
+utility once finalized.
+
+### Deprecation policy
+
+Per the v1 plan:
+
+- deprecated APIs continue to work through `v1.x`
+- removal is a future-major concern
+- legacy and deprecated components move out of standard docs and onto the
+  single legacy-docs page
+- `FormControl type='autocomplete'` route warns but keeps rendering
+  `Autocomplete` (removing the route now would break consumers; removal is
+  a post-v1 step)
+
+## Decisions backed by the usage audit
+
+The two decisions below are backed by data in
+[`v1-release/research/09-input-components-usage-audit.md`](../v1-release/research/09-input-components-usage-audit.md).
+
+### 1. `FormControl` stays a router for v1
+
+The audit found 185 `FormControl` call sites across nine app frontends.
+**Every observed call site uses it as a type-routing component.** Zero
+sites use it as a slot-based label wrapper around a custom control.
+
+Deprecation pressure is narrow: only 7 `type='autocomplete'` call sites,
+concentrated in 2 files (`meet/.../DeviceSettingsTab.vue` and
+`insights/.../DashboardFilterEditor.vue`). All pass standard `:options`
+arrays of `{ label, value }` shape.
+
+**v1 decision:**
+
+- `FormControl` remains a type-routing component
+- the `type='autocomplete'` route stays functional, with a dev-mode
+  deprecation warning pointing consumers at `Combobox` standalone
+- a router-vs-wrapper redesign is not pursued; the data shows no real-world
+  consumer leans on a wrapper-style use that would block the router approach
+
+### 2. Class-injection props are deprecated, not removed in v1
+
+The audit found:
+
+- `Switch.labelClasses` — **0 real call sites** on frappe-ui's `Switch`.
+  Two files surface a `labelClasses` symbol but they are app-local
+  `Autocomplete` wrappers with their own internal API, not consumers of the
+  prop on the frappe-ui component.
+- `Checkbox.padding` — **0 real call sites** across all audited apps.
+- No other class-injection props were found on input components in real
+  usage.
+
+**v1 decision:**
+
+- both props remain functional in v1, with a `warnDeprecated` warning when
+  set; removal is post-v1
+- inputs additionally expose a `data-*` vocabulary for external styling:
+  `data-slot`, `data-size`, `data-variant`, `data-state`, `data-disabled`,
+  `data-required`
+- this matches the selection-spec (rule 4) precedent and keeps v1 strictly
+  non-breaking
+
+Migration load: zero apps affected.
+
+## Implementation notes
+
+The per-component changes above are the source of truth for behavior. This
+section captures the cross-cutting infrastructure, acceptance gates, and
+test/story expectations that apply to every input in scope.
+
+### Shared infrastructure
+
+- `src/utils/warnDeprecated.ts` — dev-mode warning utility (see
+  "Deprecations").
+- `src/composables/useInputLabeling.ts` — returns `{ inputId, labelledBy,
+  describedBy, errorMessageId, dataAttrs, hasError }`. Also exports the
+  shared `InputLabelingProps` and `InputLabelingSlots` interfaces from the
+  same module.
+- `src/composables/inputTypes.ts` — exports `InputSize`, `ToggleSize`,
+  `InputVariant` (shared types live next to composables; no separate
+  `src/types/` directory).
+- `src/components/FormLabel.vue` — required-indicator markup is extracted
+  here so every input reuses the same DOM.
+
+### Repo conventions
+
+- Input components live under `src/components/<Component>/` with
+  `<Component>.vue`, `index.ts`, `types.ts`, `<Component>.cy.ts`, and a
+  `stories/` directory.
+- Use the existing `src/utils/useId.ts` instead of re-implementing.
+- Use `<script setup lang="ts">` everywhere; never the Options API.
+- Lucide icons go through the shared Tailwind utility (see `Button.icon`
+  precedent).
+- Stories regenerate `meta/<Component>.md` via `propsgen` — don't hand-edit
+  meta files.
+
+### Acceptance gates
+
+Every change against this spec must pass:
+
+- `yarn typecheck` clean
+- `yarn test` (Cypress component tests) clean for touched components
+- Storybook stories render without console warnings or errors
+- No new `console.warn` from `warnDeprecated` in clean (non-deprecated) call
+  paths
+- No regressions in `propsgen`-generated meta — diffs reviewed
+- `dist/` builds without new warnings (`yarn build`)
+- **No breaking changes.** Every existing call site continues to work with
+  no source edits required. New behaviors are additive; old behaviors that
+  are being phased out fire `warnDeprecated` and continue to function
+  through `v1.x`.
+
+### Tests for every component
+
+Each touched component must ship updated/new Cypress tests
+(`<Component>.cy.ts`) covering, at minimum:
+
+- **v-model round trip** — `defineModel` writes propagate to the parent and
+  parent updates re-render the control
+- **Shared labeling contract** — `label`, `description`, `error`, `required`
+  each render correctly; `aria-describedby`, `aria-errormessage`,
+  `aria-invalid`, `aria-required` wire to the right ids
+- **`id` association** — `<label for>` matches the control's `id`; explicit
+  `id` prop overrides the generated one
+- **Sizes / variants** — every value in the component's `Size` / `Variant`
+  union renders (smoke-level is fine; visual regression is not required)
+- **Disabled state** — `disabled` forwards to the control and to
+  `data-disabled`
+- **Component-specific behaviors**:
+  - `Password` — toggling visibility, no plaintext leak in DOM when hidden
+  - `Switch` / `Checkbox` — clicking the label toggles the control
+  - `Slider` — `value-commit` fires on drag end (not on every step)
+  - `Rating` — `max` controls star count; `rating_from` alias still works
+- **Deprecation warnings** — when a deprecated API is used, the test
+  asserts `console.warn` fires once with the expected message; when the
+  modern API is used, the test asserts no warning fires
+
+Stories must cover the same surface visually so consumers can see the
+labeling contract in action.
+
+### Stories for manual testing
+
+Each touched component must ship Storybook stories that let a human
+exercise the component end-to-end, not just snapshot it. At minimum, every
+component gets:
+
+- **Default** — bare-bones usage with `v-model` bound to a story arg, so
+  the toggle in the controls panel updates the live component
+- **All sizes** — one story rendering every value of the component's size
+  union side by side, labeled with the size name
+- **All variants** (text inputs only) — one story rendering every value
+  of `InputVariant` side by side
+- **Labeling contract** — a story that exposes `label`, `description`,
+  `error`, `required` as story args so the reviewer can flip each one and
+  see the rendered label/description/error region update, including the
+  `aria-*` wiring (verify in browser devtools)
+- **Disabled** — disabled state rendered alongside enabled for visual
+  contrast
+- **Deprecated API** — one story per deprecated prop/emit on the component
+  that explicitly uses the old API, so the reviewer can confirm the
+  `console.warn` fires once and the component still works (e.g. a
+  `Switch` story binding `@change`, a `Rating` story passing
+  `:rating_from="10"`)
+- **Component-specific scenarios** — anything worth eyeballing:
+  - `Password` — visibility toggle in action
+  - `Slider` — drag interaction, watch `value-commit` in the actions panel
+  - `Rating` — different `max` values, hover state
+  - `Switch` / `Checkbox` — clicking the label vs the control
+
+Stories should be runnable with `yarn dev` against the local frappe-ui
+copy, so the reviewer can manually exercise every code path the spec
+introduces.
+
+**Rewrite existing stories where it makes sense.** Don't preserve old
+stories out of inertia. If a current story:
+
+- predates the shared labeling contract and renders a hand-rolled
+  `<label>` next to the control,
+- duplicates what the new "All sizes" / "All variants" / "Labeling
+  contract" stories cover,
+- demos a deprecated API as the primary example (e.g. `Rating` showing
+  `rating_from`, `Switch` showing `@change`), or
+- exists only to demo a removed structural detail,
+
+replace it with the v1 equivalent rather than keeping both. Keep an old
+story only when it covers a real scenario the new stories don't (e.g. an
+integration with another component, a non-obvious prop combination).
+Deprecated APIs still need their own dedicated story per the list above —
+that's separate from rewriting the *primary* examples to use the new
+contract.
+
+### Deprecation wiring
+
+`warnDeprecated(...)` is wired in the following files (matching the
+Deprecations table):
+
+- `src/components/Input.vue` — warn on mount: `Input` → `TextInput`
+- `src/components/Autocomplete/Autocomplete.vue` — warn on mount:
+  `Autocomplete` → `Combobox` or `MultiSelect`
+- `src/components/FormControl/FormControl.vue` — warn when
+  `props.type === 'autocomplete'`: → `Combobox` standalone
+- `src/components/Password/Password.vue` — `value` prop
+- `src/components/Rating/Rating.vue` — `rating_from` prop
+- `src/components/Switch/Switch.vue` — `change` emit, `labelClasses` prop
+- `src/components/Checkbox/Checkbox.vue` — `padding` prop
+- `src/components/Divider/Divider.vue` — `Divider.action.handler` (replaces
+  the prior ad-hoc deprecation log)
+
+`Input`, `Autocomplete`, and `FormControl type='autocomplete'` move out of
+standard component docs onto the single legacy-components docs page; the
+v1 migration guide points at the new APIs.
+
+### `data-*` styling hooks
+
+Every input shell renders the canonical `data-*` vocabulary:
+
+- `data-slot` — element role inside the component (e.g. `"label"`,
+  `"control"`, `"description"`, `"error"`)
+- `data-size` — current `size` value
+- `data-variant` — current `variant` value (where applicable)
+- `data-state` — `"valid" | "invalid" | "checked" | "unchecked" | …`
+- `data-disabled` — `"true"` when disabled, absent otherwise
+- `data-required` — `"true"` when required, absent otherwise
+
+The `useInputLabeling` composable returns a `dataAttrs` object that
+components spread onto their root element so the vocabulary stays
+consistent.
+
+`Switch.labelClasses` and `Checkbox.padding` continue to work alongside
+the `data-*` hooks. They are deprecated, not removed in v1.
+
+### Out of scope (do not silently expand)
+
+- `FileUploader` (covered in a separate spec)
+- removing the `FormControl type='autocomplete'` route (warn only — gated
+  on post-v1 `FormControl` scope decision)
+- removing `Switch.labelClasses`, `Checkbox.padding`, `Switch.change` emit,
+  or any other deprecated API in v1 (warn only — removal is post-v1)
+- narrowing `Checkbox.modelValue` to `boolean` (breaking; deferred to a
+  future major)
+- adding an `#error` slot on inputs (the spec rejects this)
+- removing `v-html` from `ErrorMessage` (deferred — preserved as-is for v1)
+- new size or variant tokens beyond `InputSize` / `ToggleSize` /
+  `InputVariant`
+- any change that requires consumer source edits to keep working
+
+## v1 release contract for this spec
+
+- **strictly no breaking changes** — every existing call site keeps working
+  with no source edits required
+- new shared labeling contract is additive on every input in scope
+- size and variant scales are codified into shared types
+- deprecated APIs continue to function with dev-mode warnings; removal is
+  post-v1
+- a more consistent mental model across `TextInput`, `Textarea`, `Password`,
+  `Checkbox`, `Switch`, `Rating`, and `Slider`
+- `FileUploader` is out of scope and addressed in a separate spec

--- a/spec/item-list-row.md
+++ b/spec/item-list-row.md
@@ -1,0 +1,114 @@
+# ItemListRow Spec
+
+Status: accepted direction for `frappe-ui` v1 planning.
+
+This document defines the exact public API for `ItemListRow`. It is a sub-spec
+of [`selection.md`](./selection.md)
+and inherits the shared design rules from that document.
+
+## Role
+
+`ItemListRow` is the single-row shell used internally by the selection/menu
+family for consistent row presentation. It is exported from `frappe-ui` so
+that app code building advanced or custom listboxes can match the design
+system row styling without copying markup.
+
+It is composed by:
+
+- `Dropdown`
+- `Select`
+- `Combobox`
+- `MultiSelect`
+
+## Scope
+
+`ItemListRow` is responsible for:
+
+- spacing
+- alignment
+- prefix / label / suffix regions
+- active / selected / disabled presentation
+- row-level styling hooks
+
+`ItemListRow` is **not** responsible for:
+
+- list-level grouping or normalization
+- empty / footer regions
+- keyboard navigation
+- selection state ownership
+- popover or trigger behavior
+
+Those concerns belong to the higher-level component that composes the row.
+
+## Exact public API for v1
+
+### Shared types
+
+```ts
+type ItemListSize = 'sm' | 'md' | 'lg' | 'xl'
+```
+
+`ItemListSize` is exported and reused by the higher-level selection
+components so that their `size` prop maps cleanly to the row size.
+
+### Props
+
+```ts
+interface ItemListRowProps {
+  as?: string | Component
+  size?: ItemListSize
+  active?: boolean
+  selected?: boolean
+  disabled?: boolean
+}
+```
+
+Defaults:
+
+- `as = 'div'`
+- `size = 'sm'`
+- `active = false`
+- `selected = false`
+- `disabled = false`
+
+### Slots
+
+- default slot
+- `#prefix`
+- `#label`
+- `#suffix`
+
+Rules:
+
+- `#label` overrides the default slot for the label region
+- prefix and suffix regions are omitted when they have no renderable content
+- `selected` and `active` share the same emphasized visual treatment in v1
+- `disabled` applies muted text and not-allowed cursor styling
+
+### Styling hooks
+
+`ItemListRow` should expose:
+
+- `data-slot="item-list-row"`
+- `data-slot="item-prefix"`
+- `data-slot="item-label"`
+- `data-slot="item-suffix"`
+- `data-size`
+- `data-state="active|inactive"`
+- `data-disabled`
+
+## Relationship to the higher-level components
+
+- `Dropdown` composes `ItemListRow` for action rows
+- `Select` composes `ItemListRow` for option rows
+- `Combobox` composes `ItemListRow` for search-results rows
+- `MultiSelect` composes `ItemListRow` for multi-select option rows
+
+The row shell is shared; each higher-level component owns its own listbox
+container.
+
+## v1 stance
+
+`ItemListRow` is public in v1. It is a small primitive, but worth exposing
+so that app code building advanced or custom listboxes can match the
+design system row styling without copying markup.

--- a/spec/multiselect.md
+++ b/spec/multiselect.md
@@ -1,0 +1,571 @@
+# MultiSelect Spec
+
+Status: accepted direction for `frappe-ui` v1 planning.
+
+This document defines the exact public API for `MultiSelect`. It is a sub-spec
+of [`selection.md`](./selection.md)
+and inherits the shared design rules from that document.
+
+## Role
+
+`MultiSelect` is the canonical searchable multi-choice picker.
+
+It should stay narrower than a full people-picker or chips input, but it
+should inherit the same item-slot model as `Combobox` and `Select`.
+
+Use `MultiSelect` when the UI needs:
+
+- multiple simultaneously selected values from a list
+- in-popover search over those values
+- clear-all / select-all affordances in the footer
+
+If the UI needs chips in the trigger, avatars everywhere, grouped async remote
+results, custom selected-summary behavior, create-new actions, or
+person-specific affordances all at once, that combination may justify a
+separate future component such as `MultiCombobox` or `PeoplePicker`.
+
+## Exact public API for v1
+
+### Types
+
+```ts
+type MultiSelectVariant = 'subtle' | 'outline' | 'ghost'
+type MultiSelectSize = 'sm' | 'md' | 'lg' | 'xl'
+
+type PopoverSide = 'top' | 'right' | 'bottom' | 'left'
+type PopoverAlign = 'start' | 'center' | 'end'
+
+type SlotFn<TProps> = (props: TProps) => VNodeChild
+
+interface ItemSlots<TProps> {
+  prefix?: SlotFn<TProps>
+  label?: SlotFn<TProps>
+  suffix?: SlotFn<TProps>
+  /** Full-row replacement; mutually exclusive with prefix/label/suffix */
+  item?: SlotFn<TProps>
+}
+
+interface MultiSelectOption {
+  label: string
+  value: string
+  icon?: string | Component
+  description?: string
+  disabled?: boolean
+  slot?: string
+  slots?: ItemSlots<MultiSelectItemSlotProps>
+  [key: string]: any
+}
+
+interface MultiSelectGroupedOption {
+  key?: string | number
+  group: string
+  hideLabel?: boolean
+  options: MultiSelectOption[]
+}
+
+type MultiSelectOptions = Array<MultiSelectOption | MultiSelectGroupedOption>
+```
+
+### Props
+
+```ts
+interface MultiSelectProps {
+  modelValue?: string[]
+  options?: MultiSelectOptions
+  variant?: MultiSelectVariant
+  size?: MultiSelectSize
+  placeholder?: string
+  disabled?: boolean
+  id?: string
+  open?: boolean
+  hideSearch?: boolean
+  loading?: boolean
+  emptyText?: string
+  side?: PopoverSide
+  align?: PopoverAlign
+  offset?: number
+  portalTo?: string | HTMLElement
+  compareFn?: (a: MultiSelectOption, b: MultiSelectOption) => boolean
+}
+```
+
+Defaults:
+
+- `modelValue = []`
+- `options = []`
+- `variant = 'subtle'`
+- `size = 'sm'`
+- `placeholder = 'Select option'`
+- `disabled = false`
+- `open = false`
+- `hideSearch = false`
+- `loading = false`
+- `emptyText = 'No results'`
+- `side = 'bottom'`
+- `align = 'start'`
+- `offset = 4`
+- `portalTo = 'body'`
+
+State conventions:
+
+- selected values use `v-model` / `modelValue` (array of option values)
+- menu visibility uses `v-model:open`
+- query state stays internal; `MultiSelect` emits `update:query` but does not
+  accept a `v-model:query` in v1
+- `compareFn` overrides the default `===` value equality used to decide which
+  options are selected; it is invoked with full option objects
+
+Positioning follows the shared popover positioning conventions in
+[`selection.md`](./selection.md).
+`side`, `align`, `offset`, and `portalTo` did not exist in previous versions
+of `MultiSelect`, so their addition is purely additive.
+
+### Emits
+
+```ts
+interface MultiSelectEmits {
+  'update:modelValue': [value: string[]]
+  'update:open': [value: boolean]
+  'update:query': [value: string]
+}
+```
+
+Emit rules:
+
+- `update:modelValue` fires with the new array whenever the selection changes
+  (add, remove, clear-all, select-all)
+- `update:open` fires on open/close transitions driven by user interaction
+- `update:query` fires on every user-driven change to the search input
+- disabled options do not toggle selection and do not emit
+  `update:modelValue`
+
+### Slots
+
+Guaranteed slot props:
+
+```ts
+// Shared shape for `#trigger`, `#prefix`, `#suffix`, and `#summary`
+// (the latter adds `summary`). `clearAll` / `toggleOpen` are exposed
+// on every slot so consumers don't need to hoist into `#trigger` just
+// to clear the selection or toggle the popover.
+type MultiSelectSlotProps = {
+  open: boolean
+  disabled: boolean
+  query: string
+  selectedOptions: MultiSelectOption[]
+  displayValue: string
+  clearAll: () => void
+  toggleOpen: () => void
+}
+
+type MultiSelectTriggerSlotProps = MultiSelectSlotProps
+type MultiSelectPrefixSlotProps = MultiSelectSlotProps
+type MultiSelectSuffixSlotProps = MultiSelectSlotProps
+
+type MultiSelectSummarySlotProps = MultiSelectSlotProps & {
+  // default summary text — placeholder, single label, or `"N selected"`
+  summary: string
+}
+
+type MultiSelectItemSlotProps = {
+  item: MultiSelectOption
+  query: string
+  selected: boolean
+}
+
+type MultiSelectFooterSlotProps = {
+  clearAll: () => void
+  selectAll: () => void
+  selectedOptions: MultiSelectOption[]
+  query: string
+}
+
+type MultiSelectGroupLabelSlotProps = {
+  group: MultiSelectGroupedOption
+}
+
+type MultiSelectEmptySlotProps = {
+  query: string
+}
+```
+
+Supported slots:
+
+- `#trigger="{ open, disabled, query, selectedOptions, displayValue, clearAll, toggleOpen }"`
+  - preferred advanced trigger slot; replaces the default button trigger
+- `#prefix="{ open, disabled, query, selectedOptions, displayValue, clearAll, toggleOpen }"`
+  - convenience slot rendered before the trigger label. When provided,
+    it owns the entire prefix area regardless of selection count — use
+    it for aggregate visuals like stacked avatars across multiple
+    selections. If omitted, the trigger auto-renders the selected
+    option's `#item-prefix` / `icon` when exactly one is selected
+- `#summary="{ open, disabled, query, selectedOptions, displayValue, clearAll, toggleOpen, summary }"`
+  - overrides the trigger's label region. Receives the default summary
+    text as `summary` — placeholder, single label, or `"N selected"` —
+    so the consumer can fall back to it or replace entirely (e.g. with
+    a comma-separated label list). Providing this slot suppresses the
+    default phantom-sizer (which only knows the default summary's
+    worst-case width), so the trigger is content-sized — pin a width
+    on the trigger (or wrap with one) if you need a stable layout
+- `#suffix="{ open, disabled, query, selectedOptions, displayValue, clearAll, toggleOpen }"`
+  - convenience slot rendered after the trigger label. **Replaces the
+    default chevron** — render an explicit chevron fallback when your
+    slot content is conditional. Use `@click.stop` / `@pointerdown.stop`
+    so the press doesn't toggle the popover. Canonical home for a
+    clear-all button — call `clearAll` from the slot prop
+- `#item-prefix="{ item, query, selected }"`
+- `#item-label="{ item, query, selected }"`
+- `#item-suffix="{ item, query, selected }"`
+- `#item="{ item, query, selected }"`
+  - full-row escape hatch for a single item
+- `#item-<slot>="{ item, query, selected }"`
+  - dynamic named label slot selected via `item.slot`
+- `#group-label="{ group }"`
+- `#empty="{ query }"`
+- `#footer="{ clearAll, selectAll, selectedOptions, query }"`
+  - compatibility alias for the current `#footer` slot; default footer contains
+    Clear All / Select All buttons
+
+Exact slot rules:
+
+- if `option.slot` is set, it maps to `#item-<slot>` and overrides the label
+  region
+- `#item-label` is the fallback label-region slot when no matching
+  `#item-<slot>` exists
+- `#item-prefix` and `#item-suffix` customize only those regions of the
+  standard option row shell
+- `#item-suffix` renders before the built-in selected checkmark indicator
+- `#item` is a per-row escape hatch and, when used, fully replaces the
+  standard row shell for that row
+- `#empty` receives the current query
+- `#footer` replaces the default Clear All / Select All footer; when not
+  provided, the default footer is rendered if either action is available
+
+## Option normalization and behavior
+
+Normalization rules:
+
+- nullish entries in `options` are ignored
+- options with missing or `undefined` `value` are omitted
+- grouped entries with empty `options` after filtering are omitted
+- `compareFn`, when provided, is used to resolve which options are currently
+  selected for display and rendering; otherwise `option.value` strict equality
+  against entries in `modelValue` is used
+
+Filtering rules:
+
+- filtering is internal to `MultiSelect` and is based on the current query
+- a case-insensitive substring match against `label` (and `value`) is used by
+  default
+- filtering never removes already-selected options from the selection; it
+  only hides them from the list
+
+Selection behavior:
+
+- clicking an enabled option toggles its value in `modelValue`
+- disabled options cannot be toggled and do not emit `update:modelValue`
+- the popover does not auto-close on selection; it stays open until the user
+  closes it
+- `clearAll` empties `modelValue`
+- `selectAll` sets `modelValue` to the concatenated values of every enabled,
+  non-disabled option across all groups
+
+Loading behavior:
+
+- when `loading` is `true`, the popover shows a loading indicator in the
+  search input (or in place of the list when `hideSearch` is true) and
+  suspends the empty state
+
+Search behavior:
+
+- when `hideSearch` is `true`, no search input is rendered and `update:query`
+  is never emitted
+- when `hideSearch` is `false`, the search input is always rendered at the
+  top of the popover
+
+Display rules:
+
+- when at least one option is selected, the trigger shows the comma-separated
+  labels of the selected options
+- otherwise the trigger shows `placeholder`
+- `displayValue` exposed to `#trigger` is the same comma-separated string or
+  `''`
+- `selectedOptions` exposed to `#trigger` is the resolved option objects
+  array, preserving `modelValue` order
+
+Disabled handling:
+
+- disabled items are skipped during keyboard navigation
+- disabled items cannot be clicked into selection
+- disabled items apply shared `ItemListRow` disabled styling
+- `selectAll` skips disabled options
+- selecting never emits `update:modelValue` from a disabled item
+
+## Rendering precedence
+
+Rows follow the per-region precedence from shared design rule 9. For each
+visible item:
+
+Full row:
+
+1. `#item` slot
+2. `item.slots.item`
+
+Prefix region:
+
+1. `#item-prefix` slot
+2. `item.slots.prefix`
+3. default: empty
+
+Label region:
+
+1. `#item-<slot>` slot matching `item.slot`
+2. `#item-label` slot
+3. `#option` slot (compatibility)
+4. `item.slots.label`
+5. default: `label` plus optional `description`
+
+Suffix region:
+
+1. `#item-suffix` slot
+2. `item.slots.suffix`
+3. default: built-in selected checkmark indicator
+
+## Styling hooks
+
+Stable hooks for `MultiSelect` should include:
+
+- `data-slot="trigger"`
+- `data-slot="content"`
+- `data-slot="search"`
+- `data-slot="group"`
+- `data-slot="group-label"`
+- `data-slot="item"`
+- `data-slot="empty"`
+- `data-slot="footer"`
+- `data-variant`
+- `data-size`
+
+MultiSelect rows should use `ItemListRow`, which provides:
+
+- `data-slot="item-list-row"`
+- `data-slot="item-prefix"`
+- `data-slot="item-label"`
+- `data-slot="item-suffix"`
+
+State hooks should include, where relevant:
+
+- `data-state="open|closed"` on trigger/content via the primitive
+- `data-state="checked|unchecked"` on option rows via the primitive
+- `data-loading` on content when `loading` is true
+- `data-disabled`
+- row-level selected styling inherited from `ItemListRow`
+
+## Motion
+
+`MultiSelect` follows the shared popover motion conventions (shared design
+rule 10 in the main RFC):
+
+- content scales in from the trigger via
+  `transform-origin: var(--reka-popper-transform-origin)` (or the
+  equivalent primitive-provided variable) on the animated element (the
+  inner content-body, not the outer positioned wrapper)
+- enter `180ms` / exit `140ms` with `cubic-bezier(0.23, 1, 0.32, 1)`, from
+  `scale(0.97)` + `translateY(2px)` + `opacity: 0`
+- keyboard-driven opens — Enter, Space, ArrowUp, ArrowDown on the trigger,
+  or typing in the search input when `hideSearch` is `false` — skip the
+  animation entirely
+- pointer-driven opens (click / tap) play the full animation
+- classification is pointer-recency based: an open transition counts as
+  pointer-driven only if a `pointerdown` fired on the trigger within
+  ~300ms before it; everything else defaults to keyboard. The resolved
+  mode is exposed as `data-motion="animated" | "instant"` on the
+  content-body
+- `prefers-reduced-motion: reduce` disables the content animation
+
+## Accessibility and semantics
+
+`MultiSelect` should follow the ARIA listbox pattern with multi-selection.
+
+That means:
+
+- the trigger uses `aria-haspopup="listbox"` and `aria-expanded`
+- the list exposes `role="listbox"` and `aria-multiselectable="true"`
+- items expose `role="option"` with `aria-selected` reflecting their presence
+  in `modelValue`
+- keyboard navigation (arrow keys, home/end, typeahead), escape handling, and
+  multi-select toggling are delegated to the underlying primitive
+- escape closes the popover without clearing selection
+- the `id` prop is forwarded to the trigger so `<label for="...">` works
+
+## Keep supported in v1.x
+
+Current API stays supported:
+
+- `v-model`
+- `placeholder`
+- `options`
+- `hideSearch`
+- `loading`
+- `compareFn`
+- `#option`
+- `#footer`
+
+## Add / prefer
+
+### Additive props
+
+- `size`, `variant`, `id`, `open`, `disabled`, `emptyText`
+- `side`, `align`, `offset`, `portalTo`
+
+### Advanced state
+
+- `v-model:open`
+
+### Query event
+
+- `@update:query`
+
+Query stays internal otherwise. The old version of `MultiSelect` did not
+expose a search event, so no alias is needed.
+
+### Preferred trigger API
+
+- `#trigger`
+- keep the default Button-based trigger as the fallback when `#trigger` is
+  not provided
+
+### Preferred item slots
+
+- `#item-prefix`
+- `#item-label`
+- `#item-suffix`
+- `#empty`
+- `#footer`
+- `#item` as the full takeover escape hatch
+
+### Preferred item schema
+
+Simple options can keep their current shape (`{ label, value, disabled? }`),
+but richer object items should converge on:
+
+```ts
+{
+  label: string
+  value: string
+  icon?: string | Component
+  description?: string
+  disabled?: boolean
+  slot?: string
+}
+```
+
+Grouped options should also be supported so apps do not keep building richer
+local multi-select variants just for grouped pickers:
+
+```ts
+{
+  group: string
+  key?: string | number
+  hideLabel?: boolean
+  options: MultiSelectOption[]
+}
+```
+
+## Deprecate
+
+Keep working, but deprecate for ordinary customization:
+
+- `#option` as the primary documented customization API once `#item-label`
+  exists
+
+`#option` remains as an alias for the label region through `v1.x`. Its slot
+prop signature (`{ item }`) continues to work unchanged.
+
+Do not deprecate:
+
+- `hideSearch`
+- `loading`
+- `compareFn`
+- default footer behavior
+
+## Scope guard
+
+Do not force every richer multi-picker need into the base component.
+
+If apps need all of these together:
+
+- chips in the trigger
+- avatars everywhere
+- grouped async remote results
+- custom selected summary behavior
+- create-new actions
+- person-specific affordances
+
+that may justify a separate future component such as `MultiCombobox` or
+`PeoplePicker`.
+
+## Migration path
+
+### Old
+
+```vue
+<MultiSelect v-model="values" :options="options">
+  <template #option="{ item }">
+    <div class="flex items-center gap-2">
+      <Avatar :image="item.image" class="size-4" />
+      <span>{{ item.label }}</span>
+    </div>
+  </template>
+</MultiSelect>
+```
+
+### New
+
+```vue
+<MultiSelect v-model="values" :options="options">
+  <template #item-prefix="{ item }">
+    <Avatar :image="item.image" class="size-4" />
+  </template>
+
+  <template #item-label="{ item }">
+    {{ item.label }}
+  </template>
+</MultiSelect>
+```
+
+### Query migration
+
+Old: no public search event.
+
+New:
+
+```vue
+<MultiSelect
+  v-model="values"
+  :options="options"
+  @update:query="onQueryChange"
+/>
+```
+
+### Grouped options
+
+Old: grouped options not supported; apps built custom variants.
+
+New:
+
+```ts
+const options = [
+  {
+    group: 'Active',
+    options: [
+      { label: 'Alpha', value: 'alpha' },
+      { label: 'Beta', value: 'beta' },
+    ],
+  },
+  {
+    group: 'Archived',
+    options: [{ label: 'Gamma', value: 'gamma' }],
+  },
+]
+```

--- a/spec/select.md
+++ b/spec/select.md
@@ -1,0 +1,352 @@
+# Select Spec
+
+Status: accepted direction for `frappe-ui` v1 planning.
+
+This document defines the exact public API for `Select`. It is a sub-spec of
+[`selection.md`](./selection.md) and
+inherits the shared design rules from that document.
+
+## Role
+
+`Select` is the simple single-choice picker for small static lists.
+
+It should stay narrow:
+
+- single selection only
+- local static options
+- no search input
+- no action-menu semantics
+- no grouped option support in v1
+
+If the UI needs search, use `Combobox`. If the UI is choosing actions, use
+`Dropdown`.
+
+## Exact public API for v1
+
+### Types
+
+```ts
+type SelectOptionValue = string | number | bigint | Record<string, any>
+
+type SlotFn<TProps> = (props: TProps) => VNodeChild
+
+interface ItemSlots<TProps> {
+  prefix?: SlotFn<TProps>
+  label?: SlotFn<TProps>
+  suffix?: SlotFn<TProps>
+  /** Full-row replacement; mutually exclusive with prefix/label/suffix */
+  item?: SlotFn<TProps>
+}
+
+type SelectOption =
+  | string
+  | {
+      label: string
+      value: SelectOptionValue
+      disabled?: boolean
+      icon?: string | Component
+      description?: string
+      slot?: string
+      slots?: ItemSlots<SelectOptionSlotProps>
+      [key: string]: any
+    }
+
+type PopoverSide = 'top' | 'right' | 'bottom' | 'left'
+type PopoverAlign = 'start' | 'center' | 'end'
+
+interface SelectProps {
+  size?: 'sm' | 'md' | 'lg' | 'xl'
+  variant?: 'subtle' | 'outline' | 'ghost'
+  placeholder?: string
+  disabled?: boolean
+  id?: string
+  modelValue?: SelectOptionValue
+  open?: boolean
+  options?: SelectOption[]
+  side?: PopoverSide
+  align?: PopoverAlign
+  offset?: number
+  portalTo?: string | HTMLElement
+  emptyText?: string
+}
+```
+
+Defaults:
+
+- `size = 'sm'`
+- `variant = 'subtle'`
+- `placeholder = 'Select option'`
+- `open = false`
+- `options = []`
+- `side = 'bottom'`
+- `align = 'start'`
+- `offset = 4`
+- `portalTo = 'body'`
+- `emptyText = 'No options'`
+
+Positioning follows the shared popover positioning conventions in
+[`selection.md`](./selection.md).
+
+`side`, `align`, `offset`, and `portalTo` are additive in v1.x: they did not
+exist in previous versions of `Select`, so no migration is needed. Apps that
+never pass them continue to see the same default positioning as before.
+
+State conventions:
+
+- selected value uses `v-model` / `modelValue`
+- menu visibility uses `v-model:open`
+- `Select` does not own query state
+- `Select` accepts flat options only in v1
+
+### Emits
+
+```ts
+interface SelectEmits {
+  'update:modelValue': [value: SelectOptionValue | undefined]
+  'update:open': [value: boolean]
+}
+```
+
+There is no separate component-level `select` event in v1.
+
+### Slots
+
+Guaranteed slot props:
+
+```ts
+type SelectTriggerSlotProps = {
+  open: boolean
+  disabled: boolean
+  selectedOption: Exclude<SelectOption, string> | null
+  displayValue: string
+}
+
+// `#trigger`, `#prefix`, and `#suffix` all receive the same shape.
+type SelectSlotProps = SelectTriggerSlotProps
+type SelectPrefixSlotProps = SelectSlotProps
+type SelectSuffixSlotProps = SelectSlotProps
+
+type SelectOptionSlotProps = {
+  option: Exclude<SelectOption, string>
+}
+```
+
+Supported slots:
+
+- `#trigger="{ open, disabled, selectedOption, displayValue }"`
+  - advanced trigger customization
+- `#prefix="{ open, disabled, selectedOption, displayValue }"`
+  - convenience slot inside the default trigger shell. `selectedOption`
+    is always `null` here (prefix renders pre-selection)
+- `#suffix="{ open, disabled, selectedOption, displayValue }"`
+  - convenience slot inside the default trigger shell. **Replaces the
+    default chevron** — render an explicit chevron fallback when your
+    slot content is conditional
+- `#item-prefix="{ option }"`
+- `#item-label="{ option }"`
+- `#item-suffix="{ option }"`
+- `#item-<slot>="{ option }"`
+- `#option="{ option }"`
+  - compatibility alias for item label customization through `v1.x`
+- `#empty`
+- `#footer`
+
+Exact slot rules:
+
+- if `#trigger` is provided, it replaces the default trigger content
+- when `#trigger` is used, `#prefix` and `#suffix` are ignored
+- if `option.slot` is set, it maps to `#item-<slot>` and overrides the label
+  region
+- `#item-label` is the preferred label-region slot
+- `#option` remains supported as the compatibility fallback for the label region
+  when `#item-label` is not used
+- `#item-prefix` and `#item-suffix` customize only those regions of the standard
+  option row shell
+- `#item-suffix` renders before the built-in selected checkmark indicator
+- `#footer` is rendered once after the option list
+- `#empty` is rendered when there are no normalized options
+
+Per-region precedence for each option row (following shared design rule 9):
+
+- Prefix: `#item-prefix` slot > `option.slots.prefix` > `option.icon`
+  auto-rendered (`lucide-*` string → Tailwind plugin, Component →
+  rendered directly) > default (empty)
+- Label: `#item-<slot>` slot (for `option.slot`) > `#item-label` slot >
+  `#option` slot (compatibility) > `option.slots.label` > default
+  (`label` + optional `description`)
+- Suffix: `#item-suffix` slot > `option.slots.suffix` > default (built-in
+  selected checkmark indicator)
+- Full row: `option.slots.item` replaces the standard row shell and skips
+  all per-region rendering; there is no full-row template slot on `Select`
+
+## Option normalization and behavior
+
+Normalization rules:
+
+- `Select` accepts flat `options` only in v1; it does not accept grouped options
+- string options normalize to `{ label: option, value: option }`
+- nullish options are ignored
+- options whose `value` is `undefined` or `null` are omitted
+- selected option lookup uses strict equality against `modelValue`
+
+Display rules:
+
+- if a selected option exists, its `label` is the default display value
+- otherwise the trigger shows `placeholder`
+- `displayValue` exposed to `#trigger` is the selected option label or `''`
+- `selectedOption` exposed to `#trigger` is the normalized object option or
+  `null`
+
+Row behavior:
+
+- option rows should use the shared `ItemListRow` shell
+- `selected` state is derived from `option.value === modelValue`
+- disabled options are not selectable
+- selecting an enabled option updates `modelValue` and closes the list through
+  select semantics
+- selected rows render a built-in trailing checkmark indicator
+- `option.icon` is allowed in the item shape but is **not** rendered by default;
+  consumers should use `#item-prefix` or trigger slots when they want icon
+  rendering
+- default label rendering is `label` plus optional `description`
+
+## Disabled handling
+
+Follows the shared disabled-option rule (shared design rule 8 in the main
+RFC):
+
+- disabled options are skipped by keyboard navigation and typeahead
+- disabled options cannot be selected by click or keyboard
+- disabled options never emit `update:modelValue`
+- disabled options apply `ItemListRow` disabled styling and `data-disabled`
+- an already-selected option that becomes disabled stays in `modelValue`;
+  it just stops being interactable
+
+## Styling hooks
+
+Stable hooks for `Select` should include:
+
+- `data-slot="trigger"`
+- `data-slot="content"`
+- `data-slot="item"`
+- `data-slot="empty"`
+- `data-slot="footer"`
+
+Select rows should use `ItemListRow`, which provides:
+
+- `data-slot="item-list-row"`
+- `data-slot="item-prefix"`
+- `data-slot="item-label"`
+- `data-slot="item-suffix"`
+
+State hooks should include, where relevant:
+
+- `data-state="open|closed"` on trigger/content via the select primitive
+- `data-state="checked|unchecked"` on option items via the select primitive
+- `data-disabled`
+- row-level selected styling inherited from `ItemListRow`
+
+## Motion
+
+`Select` follows the shared popover motion conventions (shared design rule
+10 in the main RFC):
+
+- content scales in from the trigger via
+  `transform-origin: var(--reka-select-content-transform-origin)` on the
+  animated element (the inner content-body, not the outer positioned wrapper)
+- enter `180ms` / exit `140ms` with `cubic-bezier(0.23, 1, 0.32, 1)`, from
+  `scale(0.97)` + `translateY(2px)` + `opacity: 0`
+- keyboard-driven opens (Enter, Space, ArrowUp, ArrowDown on the trigger)
+  skip the animation entirely
+- pointer-driven opens (click / tap) play the full animation
+- classification is pointer-recency based: an open transition counts as
+  pointer-driven only if a `pointerdown` fired on the trigger within
+  ~300ms before it; everything else defaults to keyboard. The resolved
+  mode is exposed as `data-motion="animated" | "instant"` on the
+  content-body
+- `prefers-reduced-motion: reduce` disables the content animation
+
+## Accessibility and semantics
+
+`Select` should follow the select/listbox pattern, not the menu button pattern.
+
+That means:
+
+- trigger and content use select semantics
+- items are options, not actions
+- keyboard navigation, typeahead, highlighted state, and selection behavior are
+  delegated to the underlying select primitive
+- selected state is semantic component state, not just visual decoration
+
+## Keep supported in v1.x
+
+These stay supported:
+
+- `v-model`
+- `v-model:open`
+- `size`
+- `variant`
+- `placeholder`
+- `disabled`
+- `id`
+- `options`
+- `side`, `align`, `offset`, `portalTo` (additive)
+- `emptyText` (additive)
+- `#trigger`
+- `#prefix`
+- `#suffix`
+- `#option`
+- `#footer`
+- string options
+
+## Deprecate
+
+Keep working, but deprecate for ordinary customization:
+
+- `#option` as the primary documented customization API once `#item-label`
+  exists
+
+`#option` should remain as an alias/fallback for the label region through
+`v1.x`.
+
+## Migration path
+
+### Old
+
+```vue
+<Select v-model="chartType" :options="options">
+  <template #option="{ option }">
+    <div class="flex items-center gap-2">
+      <component :is="option.icon" class="size-4" />
+      <span>{{ option.label }}</span>
+    </div>
+  </template>
+</Select>
+```
+
+### New
+
+```vue
+<Select v-model="chartType" :options="options">
+  <template #item-prefix="{ option }">
+    <component :is="option.icon" class="size-4" />
+  </template>
+
+  <template #item-label="{ option }">
+    {{ option.label }}
+  </template>
+</Select>
+```
+
+## Changelog
+
+### 2026-04-24
+
+- **`option.icon` is auto-rendered in the prefix region.** Setting `icon` on
+  an option now shows that icon automatically — no `#item-prefix` slot needed
+  for the common case. Precedence: `#item-prefix` slot → `option.slots.prefix`
+  → `option.icon` → empty. Existing prefix slots are unaffected.
+
+- **`option.icon` accepts `lucide-*` strings.** Pass `icon: 'lucide-user'`
+  directly in an option definition — rendered via the Tailwind CSS-mask plugin,
+  no import needed. Component values also work.

--- a/spec/selection.md
+++ b/spec/selection.md
@@ -1,0 +1,844 @@
+# Selection and Menu API RFC
+
+Status: accepted direction for `frappe-ui` v1 planning.
+
+This document defines the intended public API direction for:
+
+- `ItemListRow`
+- `Dropdown`
+- `Select`
+- `Combobox`
+- `MultiSelect`
+
+It is based on:
+
+- the v1 component philosophy
+- the real-world usage audit in
+  [`v1-release/research/07-selection-components-usage-audit.md`](../v1-release/research/07-selection-components-usage-audit.md)
+- the decision to prefer higher-level components with props and slots over
+  publicly exposing compound primitive families
+
+This RFC is meant to guide v1 implementation and cleanup. It does not authorize
+breaking removals in `1.0.0`.
+
+The shared design rules, goals, non-goals, component boundaries, deprecation
+policy, and implementation order live in this document. The detailed
+per-component specs live in sibling sub-spec files:
+
+- [`item-list-row.md`](./item-list-row.md) — `ItemListRow`
+- [`dropdown.md`](./dropdown.md) — `Dropdown`
+- [`select.md`](./select.md) — `Select`
+- [`combobox.md`](./combobox.md) — `Combobox`
+- [`multiselect.md`](./multiselect.md) — `MultiSelect`
+
+Each sub-spec inherits the shared design rules defined here and only restates
+rules where it narrows or specializes them for that component.
+
+## Decision summary
+
+- add `ItemListRow` as the shared row shell for item rendering across the
+  selection/menu family
+- keep `Dropdown`, `Select`, `Combobox`, and `MultiSelect` as separate
+  higher-level components with clear boundaries
+- treat `Dropdown` as an action menu, not as the generic value picker
+- standardize on shell-owned item customization
+- standardize slot vocabulary around `#trigger`, `#item-prefix`, `#item-label`,
+  `#item-suffix`, `#empty`, and `#footer`
+- support `v-model:open` across the family
+- keep query internal for now, but standardize on `@update:query`
+- keep older APIs working in v1.x, but move weaker customization patterns out of
+  the happy path
+- keep `onClick` and `condition` as canonical naming where they already match
+  library convention
+
+## Goals
+
+- keep these components separate and narrowly scoped
+- make app usage easier and more consistent
+- avoid breaking existing apps during `1.x`
+- aggressively deprecate awkward customization APIs when a better replacement
+  exists
+- standardize slot vocabulary, state vocabulary, and styling hooks
+- keep the component shell responsible for spacing, hover, selected, disabled,
+  and layout states
+- reuse one styled row primitive across selection and menu components instead
+  of duplicating row markup and classes
+
+## Non-goals
+
+- collapsing all pickers into a single do-everything component
+- exposing a broad set of low-level primitive families as the primary public API
+- removing legacy APIs immediately in v1
+- solving every richer people-picker or chip-input use case inside the base
+  `MultiSelect`
+
+## Component responsibilities
+
+These boundaries should stay clear.
+
+- `ItemListRow` = the shared row shell for item rendering
+- `Dropdown` = action menus
+- `Select` = small static choice lists
+- `Combobox` = searchable single-choice picker
+- `MultiSelect` = searchable multi-choice picker
+
+This means:
+
+- `ItemListRow` is an internal-leaning row primitive; each higher-level
+  component owns its own listbox shell (keyboard nav, grouping, empty/footer
+  slots) and composes `ItemListRow` for row presentation
+- do not grow `Dropdown` into a value picker
+- do not treat `Select` as the searchable story
+- do not keep `Autocomplete` as the long-term canonical public API once
+  `Combobox` and `MultiSelect` are good enough
+
+## Shared design rules
+
+### 1. State conventions
+
+Across this family:
+
+- primary value uses `v-model` / `modelValue`
+- visibility uses `v-model:open`
+- secondary state gets named models only when really needed
+
+For v1:
+
+- `Dropdown` should support `v-model:open`
+- `Select` should support `v-model:open`
+- `Combobox` should support `v-model:open`
+- `MultiSelect` should support `v-model:open`
+- query stays internal for now
+- searchable components may emit `update:query`, but should not require
+  `v-model:query`
+
+### 2. Trigger customization vocabulary
+
+Use one advanced trigger slot name across this family where a trigger exists:
+
+- `#trigger`
+
+Slot props should be component-specific but predictable. At minimum:
+
+- `open`
+- `disabled`
+
+Where relevant, also expose:
+
+- `selectedOption`
+- `selectedOptions`
+- `displayValue`
+- `toggleOpen`
+- `close`
+
+Compatibility aliases can remain:
+
+- `Dropdown` keeps its current default slot behavior as a supported trigger API
+  in `v1.x`
+- `Select`, `Combobox`, and `MultiSelect` can keep convenience slots like
+  `#prefix` and `#suffix`
+
+`#trigger` should remain the consistent explicit slot name across the family,
+but `Dropdown` should also continue to support and document the default slot for
+trigger-only customization because it is a common and ergonomic use case.
+
+### 3. Shell-owned item customization
+
+This is the most important API decision.
+
+`ItemListRow` is the shared row primitive that defines this shell once and is
+composed by every higher-level component in this family.
+
+The higher-level component should own the item shell, including:
+
+- spacing
+- row height
+- hover styling
+- active styling
+- selected styling
+- disabled styling
+- icon/check/suffix layout regions
+
+Consumers should customize content through shared sub-slots instead of
+rebuilding the whole row.
+
+Preferred shared item slots:
+
+- `#item-prefix`
+- `#item-label`
+- `#item-suffix`
+- `#empty`
+- `#footer`
+
+Escape hatch:
+
+- `#item`
+
+`#item` should remain supported, but it should be clearly documented as an
+escape hatch because it forces the consumer to own the full row shell.
+
+### 4. Styling hooks
+
+Owned shells should expose stable hooks:
+
+- `data-slot="trigger"`
+- `data-slot="content"`
+- `data-slot="item"`
+- `data-slot="item-prefix"`
+- `data-slot="item-label"`
+- `data-slot="item-suffix"`
+- `data-slot="empty"`
+- `data-slot="footer"`
+
+And state hooks where relevant:
+
+- `data-state="open|closed"`
+- `data-state="active|inactive"`
+- `data-state="checked|unchecked"`
+- `data-disabled`
+- `data-variant`
+- `data-size`
+
+These hooks should reduce the need for shell replacement just to change classes.
+
+### 5. Shared item object direction
+
+The option model does not need to become identical across all four components,
+but it should converge where practical.
+
+Common fields we should allow where they make sense:
+
+```ts
+{
+  label: string
+  value?: string | number | boolean
+  disabled?: boolean
+  icon?: string | Component
+  description?: string
+  slot?: string
+}
+```
+
+Notes:
+
+- `slot` should be the preferred field for alternate item rendering strategies
+- `slot` should map to `#item-<slot>`
+- old names like `slotName` should be deprecated in favor of `slot`
+
+### 6. Escape hatches stay, but move out of the happy path
+
+These remain supported in v1.x, but should be documented as advanced or
+deprecated depending on the component:
+
+- full `#item` takeover
+- per-item `component`
+- per-item `render`
+- old per-item custom slot fields like `slotName`
+
+The better API should be:
+
+- shell-owned rows
+- focused sub-slots
+- predictable state and styling hooks
+
+### 7. Popover positioning conventions
+
+Every component in this family that opens a popover over a trigger should use
+the same positioning vocabulary. Today, `Dropdown` and `Combobox` disagree
+(`placement: 'left' | 'center' | 'right'` vs `placement: 'start' | 'center' |
+'end'`), and `Select` / `MultiSelect` don't expose positioning props at all.
+
+For v1, the canonical positioning props across `Dropdown`, `Select`,
+`Combobox`, and `MultiSelect` are:
+
+```ts
+type PopoverSide = 'top' | 'right' | 'bottom' | 'left'
+type PopoverAlign = 'start' | 'center' | 'end'
+
+interface PopoverPositioningProps {
+  side?: PopoverSide
+  align?: PopoverAlign
+  offset?: number
+  portalTo?: string | HTMLElement
+}
+```
+
+Shared defaults:
+
+- `side = 'bottom'`
+- `align = 'start'`
+- `offset = 4`
+- `portalTo = 'body'`
+
+Rules:
+
+- `side` and `align` are logical and direction-aware; `start` / `end` flip with
+  `dir="rtl"`
+- components that don't currently expose positioning (`Select`, `MultiSelect`)
+  should add `side`, `align`, `offset`, and `portalTo` in v1.x as additive
+  props
+- components that currently expose positioning under different names keep the
+  old names working as compatibility aliases through `v1.x`
+
+Compatibility mapping:
+
+- `Dropdown.placement` (old: `'left' | 'center' | 'right'`) maps to `align`:
+  - `'left'` → `align: 'start'`
+  - `'center'` → `align: 'center'`
+  - `'right'` → `align: 'end'`
+- `Dropdown.side` keeps its current meaning; no rename needed
+- `Combobox.placement` (old: `'start' | 'center' | 'end'`) maps one-to-one to
+  `align` and should be accepted as an alias through `v1.x`
+
+Rules for old names in `v1.x`:
+
+- if both the new and the old name are provided, the new name wins and a dev
+  warning is emitted
+- if only the old name is provided, it is silently mapped to the new name
+- docs should show `side` + `align` in the primary examples; `placement`
+  continues to appear only in the deprecation table
+
+### 8. Uniform disabled-option handling
+
+Disabled items should behave the same way across `Dropdown`, `Select`,
+`Combobox`, and `MultiSelect`:
+
+- disabled items are skipped during keyboard navigation (arrow keys, typeahead,
+  home/end)
+- disabled items cannot be clicked into selection or activated
+- disabled items apply the shared `ItemListRow` disabled styling (muted text,
+  `not-allowed` cursor) and carry the `data-disabled` attribute
+- disabled items never emit `update:modelValue`, `update:selectedOption`, or
+  `item-click`
+- `Dropdown` route/submenu/switch rows also respect `disabled`: no navigation,
+  no submenu open, no toggle
+- `MultiSelect` `selectAll` skips disabled options
+- `Combobox` never uses a disabled option as the `allowCustomValue` target
+- if an option becomes disabled while already selected, it stays in
+  `modelValue`; it only stops being interactable
+
+This rule is the default behavior from the underlying primitives, but each
+component spec should state it explicitly so apps can rely on it.
+
+### 9. Per-item inline slots
+
+Templates (`#item-prefix`, `#item-label`, `#item-suffix`, `#item-<slot>`,
+`#item`) are the primary customization path. They are only usable where the
+app has a Vue template around the component.
+
+Some apps build option lists in JavaScript — in a composable, a config
+module, a remote API response, or a shared data layer — and therefore
+cannot reach a template. Historically this is why `Dropdown` grew
+`item.component` and `Combobox` grew `item.render`. Both are coarse: they
+replace the entire row and skip the shell-owned prefix/label/suffix
+regions.
+
+For v1, every item-accepting component in this family accepts a `slots`
+field on an item object. It matches the shape you already pass to Vue
+render functions — `h(Component, props, slots)` — so the same mental model
+applies at the item level:
+
+```ts
+type SlotFn<TProps> = (props: TProps) => VNodeChild
+
+interface ItemSlots<TProps> {
+  prefix?: SlotFn<TProps>
+  label?: SlotFn<TProps>
+  suffix?: SlotFn<TProps>
+  /** Full-row replacement; mutually exclusive with prefix/label/suffix */
+  item?: SlotFn<TProps>
+}
+
+// on any item object:
+slots?: ItemSlots<ItemSlotProps>
+```
+
+Key names mirror the template slot names one-to-one, with the redundant
+`item-` prefix stripped because we're already scoped to an item:
+
+| template slot     | `slots.*` key |
+| ----------------- | ------------- |
+| `#item-prefix`    | `prefix`      |
+| `#item-label`     | `label`       |
+| `#item-suffix`    | `suffix`      |
+| `#item`           | `item`        |
+
+Rules:
+
+- each key in `slots` is a function with the same slot props as the
+  corresponding template slot (see per-component table below)
+- `slots.item` is an escape hatch; when provided alongside `slots.prefix` /
+  `slots.label` / `slots.suffix` on the same object, `slots.item` wins and
+  a dev warning is emitted
+- `slots` never replaces the outer `ItemListRow` shell unless `slots.item`
+  is set — `slots.prefix` / `label` / `suffix` keep all other shell
+  behavior intact (spacing, hover, selected styling, `data-*` hooks)
+
+Slot-prop context per component:
+
+- `Dropdown`: `{ item, close, selected }`
+- `Select`: `{ option }`
+- `Combobox`: `{ item, query, selected }`
+- `MultiSelect`: `{ item, query, selected }`
+
+Region precedence (per row):
+
+1. template slot on the parent component (`#item-prefix`, `#item-<slot>`,
+   `#item-label`, `#item-suffix`, `#item`) — templates always win so local
+   overrides stay possible
+2. matching `item.slots.*` function
+3. default shell rendering (icon placeholder, `label` + `description`,
+   checkmark, etc.)
+
+Authoring example (options built in JS, shell-owned row preserved):
+
+```ts
+import { h } from 'vue'
+import LucideCheck from '~icons/lucide/check'
+import Avatar from '@/components/Avatar.vue'
+
+const options = users.map((user) => ({
+  label: user.name,
+  value: user.id,
+  slots: {
+    prefix: ({ item }) => h(Avatar, { image: item.image, class: 'size-4' }),
+    suffix: ({ selected }) =>
+      selected ? h(LucideCheck, { class: 'size-4' }) : null,
+  },
+}))
+```
+
+Full-row escape hatch:
+
+```ts
+const options = [
+  {
+    label: 'Danger zone',
+    value: 'danger',
+    slots: {
+      item: ({ item }) =>
+        h('div', { class: 'text-ink-red-5 px-2 py-1' }, item.label),
+    },
+  },
+]
+```
+
+#### Relationship to `slot: string`
+
+These are deliberately adjacent, singular vs plural:
+
+- `slot?: string` picks which `#item-<slot>` template slot on the parent
+  should render this item's **label** region (template-side dispatch)
+- `slots?: ItemSlots<...>` provides inline slot implementations for one or
+  more regions of this item (JS-side inline)
+
+The two can coexist on the same item. If both target the label region,
+normal region precedence applies: `#item-<slot>` template wins over
+`slots.label`.
+
+#### Backward compatibility
+
+Nothing existing breaks.
+
+- `Dropdown.item.component` keeps working as a deprecated alias of
+  `slots.item`. If both are present, `slots.item` wins and a dev warning
+  fires.
+- `Combobox.item.render` keeps working as a deprecated alias:
+  - if `render` is a function → treated as `slots.item = render`
+  - if `render` is an object (undocumented in older versions but tolerated
+    by some apps) → treated as `slots = render`
+- Apps that pass both `render` and `slots` see a dev warning and `slots`
+  wins.
+
+### 10. Popover motion conventions
+
+All components in this family that render a popover (`Dropdown`, `Select`,
+`Combobox`, `MultiSelect`) share one motion contract.
+
+Entry:
+
+- the popover content scales in from the trigger, not from the viewport
+  center — the element that actually scales should set
+  `transform-origin: var(--reka-<component>-content-transform-origin)`
+  (or the equivalent primitive-provided CSS variable)
+- strong ease-out curve `cubic-bezier(0.23, 1, 0.32, 1)`
+- enter duration 150–200ms, exit duration 130–160ms
+- enter from `scale(0.97)` + small `translateY(2px)` + `opacity: 0` —
+  never from `scale(0)`
+- `prefers-reduced-motion: reduce` disables the animation
+
+Keyboard-driven opens skip the enter/exit animation entirely:
+
+- when the popover is opened via keyboard — Enter / Space / ArrowUp /
+  ArrowDown on the trigger, typing in a searchable input, or tab-focus
+  with `openOnFocus` — the content appears and disappears without
+  transition
+- pointer-driven opens (click / tap) play the full animation
+- the mechanism: the component records the timestamp of each `pointerdown`
+  on the trigger, and when the popover transitions from closed → open it
+  classifies the open as pointer-driven only if a `pointerdown` fired
+  within a short window (~300ms) before the transition; anything else
+  defaults to keyboard
+- the resolved mode is exposed as `data-motion="animated" | "instant"` on
+  the content element and CSS gates the animation on that attribute
+- `data-motion="instant"` still runs a very short opacity-only fade
+  (~80ms, linear, no transform) on open. This is below the perception
+  threshold for motion — it feels instant — but long enough to mask the
+  1-frame position-settle the underlying popper performs on mount.
+  Without it, keyboard opens show an abrupt jump as the popper corrects
+  its position from the default frame to the measured frame. Close
+  uses `animation: none`.
+
+Rationale: pickers in this family are opened tens to hundreds of times a
+day. For keyboard users, any enter/exit motion is latency the system added
+between their keystroke and the next action. Pointer users open less
+frequently and benefit from the entrance cue.
+
+Tracking `keydown` alone isn't enough because tab-focus (combined with
+`openOnFocus`) emits no key on the trigger itself. The pointer-recency
+check catches every non-pointer path — tab-focus, typing, Enter, Space,
+arrow keys — as "keyboard" by exclusion.
+
+The pointer-recency check is factored into a shared composable
+(`usePopoverMotion(open)` → `{ motion, onPointerDown }`) so every
+component in this family wires the same ~10 lines of logic:
+`@pointerdown="onPointerDown"` on the trigger, `:data-motion="motion"` on
+the content, CSS that reads `[data-motion='animated']`. `Combobox`,
+`Select`, and `Dropdown` use it today; `MultiSelect` should adopt the
+same composable when it lands.
+
+### 11. String-based icons (`lucide-*`)
+
+Selection components in this family (`Select`, `Combobox`, `MultiSelect`,
+`Dropdown`) accept `item.icon` as either a Vue `Component` **or** a
+string. For strings, the family standardizes on the `lucide-<name>`
+convention powered by the shared Tailwind plugin
+(`tailwind/lucideIconsPlugin.js`):
+
+- `icon: 'lucide-edit'` / `'lucide-trash-2'` / `'lucide-more-horizontal'`
+  — the literal class name
+- auto-rendered as `<span :class="item.icon">` inside the prefix region
+  when no consumer slot (`#item-prefix` or `item.slots.prefix`) claims
+  that region
+- sizing (`size-4`), color (`text-ink-gray-6` by default, `text-ink-red-3`
+  for `theme: 'red'` in `Dropdown`) are applied by the component
+
+Benefits:
+
+- no per-call-site `import` for every icon
+- `item.icon` stays serialisable (survives JSON round-trips, server-
+  driven menus, feature-flag configs)
+- Tailwind's JIT scanner finds literal `lucide-*` strings in source and
+  only emits CSS for the icons actually referenced
+
+Limitations (worth documenting where consumers trip over them):
+
+- dynamic construction (`` `lucide-${action}` ``) bypasses the JIT
+  scanner and won't emit the class; consumers need either literal
+  strings or an explicit whitelist
+- consumer apps need `frappe-ui/src/**/*.vue` in their Tailwind
+  `content` paths so references inside frappe-ui itself are picked up
+
+Passing a Vue `Component` still works for cases where the plugin isn't
+desired (icons outside Lucide, dynamic icon composition, etc.).
+Consumer-authored prefix slots always take precedence — if the caller
+wants custom rendering, they wire `#item-prefix` or `item.slots.prefix`
+and the auto-icon branch is skipped.
+
+### 12. Group field naming
+
+Across the selection family (`Dropdown`, `Select`, `Combobox`,
+`MultiSelect`), the canonical field name inside a grouped entry is
+`options`:
+
+```ts
+{ group: 'Active', options: [...] }
+```
+
+Rules:
+
+- the grouped-entry field on every selection component is `options`
+- the top-level prop on each component is `options`
+- `Dropdown` previously used `{ group, items }`; it accepts `items` as a
+  deprecated alias on grouped entries through `v1.x`. If both are
+  provided, `options` wins and a dev warning is emitted; if only `items`
+  is provided, it is silently mapped to `options`.
+- `Combobox` and `MultiSelect` always used `{ group, options }`; they do
+  not accept an `items` alias because that shape was never part of their
+  public API.
+
+Rationale:
+
+- the original real-world inconsistency was Dropdown using `{ group, items }`
+  while Combobox / MultiSelect used `{ group, options }`. Selection
+  components agreeing on `options` matches form-control language
+  (`<select><option>`) and avoids renaming Combobox / MultiSelect.
+- Dropdown's group field changes from `items` → `options` to align. Old
+  `{ group, items }` shapes still work as the deprecated alias on Dropdown
+  only.
+
+### 13. Deprecation policy for this family
+
+For v1.x:
+
+- do not break existing public APIs
+- add the new preferred APIs first
+- keep older APIs exported and functioning
+- add dev warnings where detection is practical and low-noise
+- move older APIs out of the main docs path
+
+Good candidates for deprecation warnings:
+
+- `Combobox` custom items using `slotName`
+- `Combobox` query listeners using `input` instead of `update:query`
+- `Dropdown` items using `component` for ordinary row customization
+- `Select` / `MultiSelect` usage of `#option` once `#item-label` exists
+- any selection component receiving `{ group, items }` group entries
+  instead of `{ group, options }` (the deprecated alias for cross-component
+  symmetry)
+
+Harder-to-warn cases like `Dropdown #item` can be deprecated in docs first.
+
+---
+
+## Per-component specs
+
+The exact public APIs, behaviors, slots, styling hooks, and migration paths for
+the shared list surface and the single-choice pickers live in their own files:
+
+- [`item-list-row.md`](./item-list-row.md) — `ItemListRow`
+- [`dropdown.md`](./dropdown.md) — `Dropdown`
+- [`select.md`](./select.md) — `Select`
+- [`combobox.md`](./combobox.md) — `Combobox`
+- [`multiselect.md`](./multiselect.md) — `MultiSelect`
+
+---
+
+## Cohesion opportunities
+
+Prop and behavior inconsistencies across `Dropdown`, `Select`, `Combobox`, and
+`MultiSelect` that this RFC resolves. None require breaking changes; every
+change is additive or alias-based.
+
+This section tracks status: what the per-component specs now integrate, what
+is intentionally deferred, and what is explicitly out of scope.
+
+### Integrated into the per-component specs
+
+#### 0. Grouped-entry field name
+
+- Every selection component (`Dropdown`, `Select`, `Combobox`,
+  `MultiSelect`) uses `{ group, options }` as the canonical grouped-entry
+  shape.
+- `Dropdown` previously used `{ group, items }`; its canonical group field
+  is now `options`. `items` remains accepted as a deprecated alias on the
+  group entry through `v1.x` (warning fires if both are provided; silent
+  map if only `items` is given).
+- `Combobox` and `MultiSelect` always used `{ group, options }` — no
+  alias is added there because `items` was never part of their public API.
+- Top-level prop names are unchanged (`options` on all four).
+- See shared design rule 12 for the full rule.
+
+#### 1. Popover positioning
+
+- `side` + `align` + `offset` + `portalTo` are now documented on `Dropdown`,
+  `Select`, `Combobox`, and `MultiSelect`.
+- `Dropdown.placement` (`'left' | 'center' | 'right'`) and
+  `Combobox.placement` (`'start' | 'center' | 'end'`) remain supported as
+  deprecated aliases for `align`. Old → new mapping and precedence rules are
+  defined in shared design rule 7.
+- `Select` and `MultiSelect` had no prior positioning props; they gain the
+  four props purely additively.
+
+#### 2. `id` prop for form-label association
+
+- `Select`, `Combobox`, and `MultiSelect` all accept `id?: string` and
+  forward it to the focusable trigger/input so `<label for="...">`
+  associates correctly.
+- `Dropdown` is a menu button, not a form field, and does not take `id`.
+
+#### 3. Loading state
+
+- `Combobox` and `MultiSelect` both accept `loading?: boolean`.
+- When `true`: the popover shows a loading indicator, suspends `#empty`, and
+  on `Combobox` disables the create-new path for `allowCustomValue`.
+- `Select` does not get `loading` because its option set is static by
+  definition.
+
+#### 4. Empty state parity
+
+- `Dropdown`, `Select`, `Combobox`, and `MultiSelect` all accept:
+  - `emptyText?: string` with a sensible default per component
+  - a `#empty` slot that overrides the default empty rendering
+- Component defaults: `Dropdown` / `Select` use `'No options'`;
+  `Combobox` / `MultiSelect` use `'No results'`.
+
+#### 5. Uniform disabled-option handling
+
+- Defined once as shared design rule 8 and referenced from each
+  per-component spec: keyboard skip, no click activation, no emits, shared
+  `ItemListRow` disabled styling, `data-disabled`.
+- Component-specific extensions (e.g. `Dropdown` submenu/switch rows,
+  `Combobox` `allowCustomValue` skip, `MultiSelect` `selectAll` skip) are
+  called out in each spec.
+
+#### 6. `update:query` parity
+
+- `Combobox` emits `update:query` with `input` kept as a compatibility
+  alias.
+- `MultiSelect` emits `update:query` from v1 onward. The old `MultiSelect`
+  did not expose a public search event, so no alias is needed.
+
+#### 7. Item context field: `searchTerm` → `query`
+
+- `Combobox` custom-option `onClick` / `condition` now receive
+  `{ query }` as the canonical context.
+- For compatibility, the context also carries `searchTerm` with the same
+  value through `v1.x`, so existing handlers destructuring
+  `({ searchTerm })` keep working unchanged.
+- `searchTerm` is typed as `@deprecated` and will be removed in a future
+  major.
+
+#### 8. `onClick` / `condition` keep their names
+
+- These match broader library convention and stay canonical. No rename.
+
+#### 9. Per-item inline slots
+
+- All item-accepting components (`Dropdown`, `Select`, `Combobox`,
+  `MultiSelect`) now accept a `slots` field on item objects
+  whose shape matches Vue's render-function slots object.
+- Keys mirror the template slot names without the `item-` prefix:
+  `{ prefix, label, suffix, item }`.
+- This gives apps the same customization depth as `#item-prefix` /
+  `#item-label` / `#item-suffix` / `#item` template slots when options are
+  built in JavaScript and a template is not available.
+- Template slots always win over `item.slots.*` for the same region, so
+  local template overrides remain possible.
+- Compatibility: `Dropdown.item.component` remains a deprecated alias for
+  `item.slots.item`; `Combobox.item.render` remains a deprecated alias —
+  a function maps to `slots.item`, an object maps to `slots`.
+
+#### 10. Option object convergence (shared fields)
+
+- The canonical shared option body for selectable options is:
+
+  ```ts
+  {
+    label: string
+    value?: string | number | boolean
+    disabled?: boolean
+    icon?: string | Component
+    description?: string
+    slot?: string
+  }
+  ```
+
+- Per-component extensions are allowed only where they carry real semantics
+  (`Dropdown`: `submenu`, `switch`, `component`, `route`; `Combobox`:
+  `type: 'custom'`).
+- Non-breaking; current shapes are supersets or subsets of this set.
+
+### Deferred to a later `v1.x` minor
+
+#### Size and variant parity
+
+- `Select` has `size` + `variant`; `Combobox` now documents both in its
+  spec; `MultiSelect` now documents both in its spec. Implementation for
+  `MultiSelect` can land in a later `v1.x` minor since its current trigger
+  is a plain `Button`.
+- `Dropdown` continues to defer trigger sizing to its `button` prop; no
+  change planned.
+
+#### Grouped options for `Select`
+
+- `Select` explicitly does not accept grouped options in the initial v1
+  cut. `Combobox` and `MultiSelect` do.
+- Consider adding grouped support to `Select` in a later `v1.x` minor using
+  the same `{ group, options }` shape used by `Combobox` and `MultiSelect`.
+  Additive whenever it lands.
+
+### Non-goals for cohesion work
+
+- do not unify option value types (`string | number | bigint | object` for
+  `Select` vs `string` for `Combobox` / `MultiSelect`) — that divergence
+  has real semantics
+- do not merge `Dropdown`'s `button` trigger shape into the listbox trigger
+  shape used by `Select` / `Combobox` / `MultiSelect` — menu vs listbox is
+  a meaningful semantic boundary
+- do not remove `openOnFocus` / `openOnClick` from `Combobox` — they
+  describe combobox-specific input behavior that doesn't generalize
+- do not collapse `hideSearch` into a generic flag shared with `Select` —
+  `Select` does not have search; `Combobox` is always searchable
+
+---
+
+## Autocomplete compatibility note
+
+`Autocomplete` is not part of the long-term preferred API shape, but it is still
+heavily used across real apps.
+
+v1 direction:
+
+- keep `Autocomplete` exported and functioning
+- document it as a migration layer
+- direct new single-select searchable work toward `Combobox`
+- direct new multi-select searchable work toward `MultiSelect`
+
+Migration intent:
+
+- `Autocomplete` single-select -> `Combobox`
+- `Autocomplete` multi-select -> `MultiSelect`
+- `#target` -> `#trigger`
+- `#item-prefix` / `#item-label` / `#item-suffix` vocabulary should stay
+  recognizable across the migration path
+
+This should be a long migration, not an abrupt rename.
+
+---
+
+## Implementation order
+
+1. **ItemListRow**
+   - finalize the shared row shell (prefix/label/suffix regions, size,
+     active/selected/disabled states, styling hooks)
+   - keep its surface narrow; not promoted to a top-level public component
+
+2. **Dropdown**
+   - compose `ItemListRow`
+   - add shell-owned item slots
+   - add `selected` support
+   - add `v-model:open`
+   - keep `#item` and `component`, but move them to escape-hatch status
+
+3. **Combobox**
+   - compose `ItemListRow`
+   - add `update:query`
+   - add `v-model:open`
+   - add preferred alias: `slot`
+   - preserve `onClick` and `condition`
+   - preserve current custom item API while warning on old names where needed
+
+4. **Select**
+   - compose `ItemListRow`
+   - add `v-model:open`
+   - add `#item-prefix`, `#item-label`, `#item-suffix`
+   - keep `#option` as alias
+
+5. **MultiSelect**
+   - compose `ItemListRow`
+   - align with the same slot model as `Select` and `Combobox`
+   - add `v-model:open`
+   - add `update:query`
+   - add grouped option support
+
+## v1 release contract for this RFC
+
+For v1, this RFC means:
+
+- no breaking API removals
+- clear preferred APIs for new work
+- explicit deprecations for awkward legacy customization patterns
+- migration paths for existing apps
+- a more consistent mental model across `Dropdown`, `Select`, `Combobox`,
+  and `MultiSelect`

--- a/spec/toast.md
+++ b/spec/toast.md
@@ -1,0 +1,241 @@
+# Toast Spec
+
+Status: accepted direction for `frappe-ui` v1.
+
+This document defines the public toast API for `frappe-ui` v1. It is part of the overlay/floating stabilization workstream listed in [`v1-release/plan.md`](../v1-release/plan.md).
+
+## Role
+
+Toasts are short-lived, non-blocking notifications that surface in a fixed viewport (bottom-right by default) and auto-dismiss. Almost all usage is **imperative** via the `toast` namespace — apps reach for `toast.success('Saved')`, not a Vue component.
+
+## Headline decision
+
+`frappe-ui` v1 **vendors [`vue-sonner`](https://github.com/xiaoluoboding/vue-sonner)** and re-exports its `toast` namespace and `<Toaster>` component **with sonner's API surface unchanged**. Our only contribution is:
+
+1. **Visual defaults** — CSS overrides that match the current dark high-contrast toast (`bg-surface-gray-6` + `ink-white`).
+2. **Configuration defaults** — `position='bottom-right'`, `duration=5000`, `closeButton=true`.
+3. **Mount integration** — `<FrappeUIProvider>` renders `<Toaster>` with those defaults.
+
+We deliberately **do not** wrap sonner behind a frappe-ui-shaped API, do not rename options, and do not add convenience extensions. The contract is: if it's documented in vue-sonner's docs, it works here exactly the same way. If we ever swap implementations, that swap is a breaking change.
+
+## Why sonner over building on reka-ui
+
+The 0.1.x toast (built on `reka-ui`) covered the basics but didn't cover two common patterns in the bench:
+
+- **`builder`** uses sonner's `id`-keyed update-in-place pattern (`toast.loading('Pasting…', { id }); … toast.success('Done', { id })`) and imports `vue-sonner` directly.
+- **`insights`** uses `toast.custom(component, options)` to render arbitrary Vue components and likewise imports `vue-sonner` directly.
+
+Bolting both onto the reka-based implementation would essentially re-implement sonner inside frappe-ui. Vendoring sonner gets us those features plus stacking, swipe-to-dismiss, hover-to-expand, and a battle-tested viewport state machine.
+
+## Public surface
+
+```ts
+// Imperative API — sonner's `toast`, re-exported as-is.
+import { toast } from 'frappe-ui'
+
+// Viewport — our styled wrapper around sonner's `<Toaster>`, with the
+// frappe-ui defaults baked in. Raw `<Toaster>` is intentionally *not*
+// re-exported; consumers either mount `<FrappeUIProvider>` or
+// `<ToastProvider>` directly.
+import { ToastProvider } from 'frappe-ui'
+
+// One-stop provider — mounts <ToastProvider> with our defaults next to <Dialogs />.
+import { FrappeUIProvider } from 'frappe-ui'
+
+// Vestigial back-compat export. Not documented; not promoted.
+// Kept so that any code still importing `{ Toast }` keeps compiling.
+import { Toast } from 'frappe-ui'
+```
+
+That's the entire surface.
+
+**Removed exports:** `Toasts` (apps migrate to `<FrappeUIProvider>` or `<ToastProvider />`), raw `Toaster` (the styled `<ToastProvider>` is the only supported viewport surface).
+
+## Mount
+
+Wrap the app once with `<FrappeUIProvider>`:
+
+```vue
+<FrappeUIProvider>
+  <RouterView />
+</FrappeUIProvider>
+```
+
+The provider renders sonner's `<Toaster>` with our baked-in defaults. No other setup required.
+
+Apps that don't use the provider can mount the viewport themselves:
+
+```vue
+<template>
+  <RouterView />
+  <ToastProvider />
+</template>
+```
+
+## Defaults baked into `<FrappeUIProvider>`'s `<Toaster>`
+
+```ts
+{
+  position: 'bottom-right',  // sonner default is 'top-right'; matches current behaviour
+  duration: 5000,            // ms; matches current behaviour
+  closeButton: true,         // every toast shows the × unless caller passes dismissible:false
+  expand: false,             // no hover-to-expand stack
+  richColors: false,         // tone comes from icon + our dark theme, not tinted backgrounds
+  visibleToasts: 3,          // sonner default
+}
+```
+
+No app-level override knob is exposed for v1. If a real ask shows up (different position, expand-on-hover, custom `toastOptions.classes`), the additive fix is to thread a `toasterProps` slot through `<FrappeUIProvider>`. Deferred until needed.
+
+## Visual theme
+
+Sonner ships with light, light-rich-colors, and dark themes. None match the current frappe-ui toast (dark surface in both light and dark mode for high-contrast notifications).
+
+We apply a thin CSS override layer targeting sonner's CSS custom properties, scoped to the `<Toaster>` element. Approximate shape:
+
+```css
+[data-sonner-toaster] {
+  --normal-bg: theme(colors.surface-gray-6);
+  --normal-text: theme(colors.ink-white);
+  --normal-border: transparent;
+  --success-bg: var(--normal-bg);
+  --success-text: var(--normal-text);
+  /* …error / warning / info likewise … */
+  --border-radius: theme(borderRadius.md);
+}
+```
+
+Action button styling is applied via `toastOptions.classes.actionButton` on the `<Toaster>` config, matching the current `text-ink-blue-link hover:text-ink-gray-3` treatment.
+
+This is the only place where frappe-ui maintains styling on top of sonner. CSS-variable-first keeps the override small and predictable.
+
+## Imperative API
+
+Sonner's full `toast` namespace is exposed unchanged:
+
+```ts
+toast(message, options?)            // bare creator; same as toast.message
+toast.message(message, options?)    // default style, no semantic type
+toast.success(message, options?)
+toast.error(message, options?)
+toast.info(message, options?)
+toast.warning(message, options?)
+toast.loading(message, options?)    // persistent by default; spinner icon
+toast.custom(component, options?)   // arbitrary Vue component as the body
+toast.promise(promise, options)     // loading → success | error lifecycle
+toast.dismiss(id?)                  // dismiss one or all
+```
+
+All creators return the toast id (`string | number`) synchronously. Re-using an existing id updates that toast in place — this is the canonical pattern for "convert loading to success":
+
+```ts
+const id = toast.loading('Pasting…')
+try {
+  await doWork()
+  toast.success('Pasted', { id })
+} catch (err) {
+  toast.error(err.messages?.[0] ?? 'Paste failed', { id })
+}
+```
+
+`toast.promise` uses this same lifecycle under the hood:
+
+```ts
+toast.promise(saveDoc(), {
+  loading: 'Saving changes…',
+  success: (doc) => `Saved ${doc.name}`,
+  error: (err) => err.messages?.[0] ?? 'Failed to save',
+})
+```
+
+For the full option types (`ExternalToast`, action shapes, position values, etc.), see [vue-sonner's documentation](https://vue-sonner.vercel.app/). We don't redocument them here.
+
+## Standalone `<Toast>` component
+
+`src/components/Toast/Toast.vue` (the existing reka-based SFC) remains in the tree and is still exported from `index.ts` for back-compat. It is **not promoted**, not documented in v1 docs, and not the recommended way to use toasts. The imperative `toast` namespace is the only public API the v1 documentation teaches.
+
+Audit found zero apps importing `Toast` directly. The export is preserved purely to avoid an unnecessary "Module has no exported member 'Toast'" break for any out-of-tree consumer.
+
+## Migration from 0.1.x
+
+The 0.1.x → v1 cutover is a breaking change. A migration guide will be linked from `changelog.md`. Highlights:
+
+### Silent-breakage hazards
+
+These do **not** produce TypeScript or runtime errors — they only manifest as visual misbehaviour. They need a release-notes callout.
+
+**Duration units flip from seconds to milliseconds.**
+
+```ts
+// 0.1.x: 5 seconds
+toast.success('Saved', { duration: 5 })
+
+// v1: 5 milliseconds — toast vanishes before the user sees it
+toast.success('Saved', { duration: 5 })
+
+// v1 fix
+toast.success('Saved', { duration: 5000 })
+```
+
+Audit: ~6 callsites pass a numeric `duration`. Each needs `× 1000`.
+
+**HTML in messages is rendered as text.** 0.1.x ran `message` through DOMPurify with a small inline-tag safelist (`a`, `em`, `strong`, `i`, `b`, `u`). Sonner renders `title`/`description` as plain text. Audit found zero callsites using inline HTML in toast messages, so no app should be affected — but worth noting.
+
+### Renamed / removed APIs
+
+| 0.1.x | v1 | Audited callsites |
+|---|---|---|
+| `toast.create({ message, ... })` | `toast(message, { ... })` or `toast.message(message, { ... })` | 5 (helpdesk) |
+| `toast.remove(id)` | `toast.dismiss(id)` | 0 |
+| `toast.removeAll()` | `toast.dismiss()` | 0 |
+| `import { Toasts } from 'frappe-ui'`<br>`<Toasts />` | `<FrappeUIProvider>` wrap, **or** `import { ToastProvider } from 'frappe-ui'`; `<ToastProvider />` | 2 (crm, hrms) |
+| `<ToastProvider>` SFC | `import { ToastProvider } from 'frappe-ui'` (styled wrapper around sonner's `<Toaster>`) | 0 |
+| Options field: `message` | `title` | several (all `toast.create` callsites) |
+| Options field: `closable` | `closeButton` (sonner global) or `dismissible` (per-toast) | several |
+| Options field: `type` (on raw options) | use the type helper instead (`toast.success`, etc.) | n/a |
+
+### Dropped `toast.promise` extensions
+
+0.1.x added `successDuration`, `errorDuration`, `successAction`, `errorAction` to `toast.promise` (PR #450). Sonner's `toast.promise` doesn't support them. v1 drops all four.
+
+Audit: **one** callsite uses any of them — `drive/frontend/src/components/Navbar.vue:304` sets `successDuration: 1`. Migration: drop the option (the page redirects immediately after success anyway), or do the manual id pattern:
+
+```ts
+const id = toast.loading(`Creating ${type}…`)
+try {
+  const data = await createDoc()
+  toast.success(`Created ${type}`, { id, duration: 1000 })
+} catch (err) {
+  toast.error(err.messages?.[0] ?? 'Failed', { id })
+}
+```
+
+### Out of scope: app-local `createToast({...})`
+
+The `createToast({ title, message, variant, duration })` helper found in helpdesk, insights, gameplan, and similar (`{ title, text, icon, iconClasses }` in crm) is defined **locally per app**, not exported from frappe-ui. The ~69 callsites are not our migration concern.
+
+App owners replace their local helper with direct `toast.*` calls when they're ready. A representative one-line adapter for transitional use:
+
+```ts
+// app-local shim, lives in the app, not frappe-ui
+import { toast } from 'frappe-ui'
+
+export function createToast({ title, message, variant = 'info', duration }) {
+  return (toast[variant] ?? toast.info)(title, {
+    description: message,
+    duration: duration,  // already in ms in legacy createToast — no conversion
+  })
+}
+```
+
+## Out of scope for v1
+
+- **Configurable viewport position from the provider.** Hardcoded `bottom-right`. Apps needing otherwise mount their own `<Toaster>`.
+- **Hover-to-expand / stacking config.** Sonner supports it; we keep `expand: false` and don't expose a knob.
+- **Rich-color theming.** Type is conveyed by icon + the universal dark surface.
+- **Multiple actions per toast.** Sonner supports `action` + `cancel` natively — exposed by virtue of "exact sonner API" — but our docs only show single-action patterns. No audited callsite uses two actions.
+- **Codemods.** The 0.1.x → v1 changes are too sparse to justify automated rewrites. Manual migration with a release-notes callout is sufficient.
+
+## Open questions
+
+None blocking. Spec is ready for implementation.


### PR DESCRIPTION
## Summary
- move durable component API contracts into the top-level spec directory
- add ADR index and dialog ADRs
- update CONTEXT.md to point at spec/ for current contracts

Editor-specific spec files and editor implementation changes are intentionally excluded from this PR.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-725/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 48.92% (±0.00% vs `main`)
<!-- coverage-report:end -->

