### PR TITLE
fix: add default export for tailwind tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
       "default": "./tailwind/index.js"
     },
     "./tailwind/tokens.js": {
-      "import": "./tailwind/tokens.js"
+      "import": "./tailwind/tokens.js",
+      "default": "./tailwind/tokens.js"
     },
     "./vite": {
       "import": "./vite/index.js"


### PR DESCRIPTION
Needed for non-ESM environments

<!-- coverage-report:start -->
Coverage: 48.94% (±0.00% vs `main`)
<!-- coverage-report:end -->
