### PR TITLE
docs(skill): spacing pattern + skill refresh

### DIFF
--- a/.github/scripts/docs-pages.sh
+++ b/.github/scripts/docs-pages.sh
@@ -96,7 +96,7 @@ case "$COMMAND" in
 
     prepare_pages_worktree
     deploy_preview "$BUILD_DIR" "$PR_NUMBER"
-    commit_and_push "deploy: update docs preview for pr #$PR_NUMBER"
+    commit_and_push "deploy: update docs preview for pr-$PR_NUMBER"
     ;;
   remove-preview)
     PR_NUMBER="${2:?pr number is required}"
@@ -108,7 +108,7 @@ case "$COMMAND" in
 
     prepare_pages_worktree
     remove_preview "$PR_NUMBER"
-    commit_and_push "deploy: remove docs preview for pr #$PR_NUMBER"
+    commit_and_push "deploy: remove docs preview for pr-$PR_NUMBER"
     ;;
   *)
     echo "Unknown command: $COMMAND" >&2

--- a/skills/frappe-ui/COMPONENTS.md
+++ b/skills/frappe-ui/COMPONENTS.md
@@ -180,31 +180,14 @@ const ping = useCall<string>({
 // ping.data, ping.loading, ping.error, ping.execute(), ping.reload(), ping.abort()
 ```
 
-**Options** (`UseCallOptions<TResponse, TParams>`):
-- `url: string | Ref<string>` — the API endpoint. Use a `Ref` / `computed` for reactive URLs (e.g. resource ID in the path).
-- `method?: 'GET' | 'POST' | 'PUT' | 'DELETE'` — default `GET`.
-- `params?: TParams | (() => TParams)` — request params. Pass a function for reactive params; refs inside are auto-unwrapped. GET requests serialise to the query string; non-GET sends a JSON body.
-- `immediate?: boolean` — default `true`. Set `false` for write-style calls you'll trigger with `submit` / `execute`.
-- `refetch?: boolean` — re-run automatically when reactive `url` / `params` change.
-- `baseUrl?: string` — prefix for `url`.
-- `initialData?: TResponse` — value of `.data` before the first response.
-- `cacheKey?: string | Array<...>` — when set, the response is persisted in IndexedDB. On next mount, cached data hydrates `.data` while a fresh request runs in the background. Great for "instant" perceived loads.
-- `transform?: (data) => data` — mutate or replace the response shape before it lands in `.data`.
-- `beforeSubmit?: (params) => void | Promise<void>` — async hook before `submit` fires; throw to abort and surface the error on `.error`.
-- `onSuccess?: (data) => void` — fires after a successful response.
-- `onError?: (error) => void` — fires after a failed response.
+**Options most worth knowing** (`UseCallOptions<TResponse, TParams>` — full list in the upstream docs):
+- `url` — `string` or a `Ref` / `computed` for reactive URLs; `method` (default `GET`); `params` — object or a function for reactive params.
+- `immediate: false` — for write-style calls you trigger with `submit` / `execute` (default `true` auto-fetches on mount).
+- `refetch: true` — re-run when reactive `url` / `params` change.
+- `cacheKey` — persist the response in IndexedDB; cached data hydrates `.data` on next mount while a fresh request runs (instant perceived loads).
+- `onSuccess` / `onError` / `transform` / `beforeSubmit` — lifecycle hooks.
 
-**Reactive return** (treat as a `reactive` object — no `.value`):
-- `data` — response data (or cached data while loading).
-- `error` — `Error` instance on failure.
-- `loading` / `isFetching` — boolean.
-- `isFinished` — boolean, true after the first response.
-- `canAbort` / `aborted` / `abort()` — request cancellation.
-- `promise` — resolves on the next response (success or error); resets after each call so you can `await` the latest.
-- `execute()` / `fetch()` / `reload()` — re-run the request; returns `Promise<TResponse | null>`.
-- `submit(params?)` — write-style trigger; stores `params` as the current params and runs the request. Typed so calls without a `TParams` generic accept no args.
-- `reset()` — clear `submit`-supplied params.
-- `url` / `params` — the computed URL and params actually sent.
+**Reactive return** (a `reactive` object — no `.value`): `data`, `error`, `loading` / `isFetching`, `isFinished`, `abort()` / `aborted`, `promise` (resolves on next response), `execute()` / `reload()`, `submit(params?)` (write trigger), `reset()`. For the exhaustive option and return surface, see `ui.frappe.io/llms.txt`.
 
 **Read pattern (auto-fetch on mount):**
 

--- a/skills/frappe-ui/PATTERNS.md
+++ b/skills/frappe-ui/PATTERNS.md
@@ -91,37 +91,7 @@ Rules:
 
 ## API calls
 
-Always use `useCall` (or `useList` / `useDoc`) — never raw `fetch` / `axios`.
-
-**Read (auto on mount):**
-```ts
-import { useCall } from 'frappe-ui'
-
-const user = useCall<User>({
-  url: computed(() => `/api/v2/document/User/${userId.value}`),
-  refetch: true,
-  cacheKey: ['user', userId],
-})
-```
-
-**Write (trigger on action):**
-```ts
-import { useCall, toast } from 'frappe-ui'
-
-const saveTask = useCall<Task, { title: string }>({
-  url: '/api/v2/method/myapp.api.create_task',
-  method: 'POST',
-  immediate: false,
-  onSuccess: () => toast.success('Saved'),
-  onError: (err) => toast.error(err.message),
-})
-
-async function onSubmit() {
-  await saveTask.submit({ title: form.title })
-}
-```
-
-Bind `saveTask.loading` to `<Button :loading>`; render `saveTask.error?.message` next to the form.
+Always use `useCall` (or `useList` / `useDoc`) — never raw `fetch` / `axios`. Read = auto-fetch on mount; write = `immediate: false` + `submit(params)`. Bind `.loading` to `<Button :loading>` and render `.error?.message` next to the form. Canonical read/write examples and the full option/return surface: [COMPONENTS.md](COMPONENTS.md) → Data & resources.
 
 ## Confirmation flow
 

--- a/skills/frappe-ui/PATTERNS.md
+++ b/skills/frappe-ui/PATTERNS.md
@@ -13,6 +13,48 @@ Apply these before reaching for any specific pattern below — they're what make
 5. **Pick the right text scale.** Use `text-*` for single-line labels (headings, button text, badges, "2h ago"). Use `text-p-*` for anything that wraps — descriptions, helper text, feed entries, paragraphs. Multi-line copy in `text-*` looks cramped; one-line labels in `text-p-*` look floppy. See [TOKENS.md](TOKENS.md) → Typography.
 6. **Borders earn their place — don't box everything.** A border or `rounded-md` surface should signal something: an interactive affordance (clickable card / button), grouping that crosses a visual boundary (a popover, a dialog), or a distinct surface (an inset code block, a callout). Static sections — stats, lists, feeds, "section + items" groups — don't need an outer box; a section heading plus `divide-y divide-outline-gray-1` between rows reads cleaner than wrapping the whole thing in a card. Reach for boxes only when removing them would lose meaning.
 
+## Spacing & content width
+
+Frappe screens share one spacing rhythm. Match it instead of picking ad-hoc values — a page that uses `px-6` gutters and full-width content reads as foreign next to the rest of the product.
+
+**Horizontal gutters scale with the viewport: `px-3 sm:px-5`** (12px mobile → 20px desktop). Use this same pair on the page header, the content container, and any full-bleed row. Don't use a flat `px-6`.
+
+**Constrain reading content to a centered column.** Don't let text, forms, or cards stretch the full width of a wide screen. Wrap the scrollable page body in a centered max-width container, defined once as a reusable utility and applied to every page:
+
+```css
+/* tailwind @layer components — Gameplan calls this .body-container */
+.body-container {
+  @apply mx-auto w-full max-w-[940px] px-3 sm:px-5;
+}
+```
+
+```vue
+<div class="body-container pt-5 pb-40">
+  <!-- page content -->
+</div>
+```
+
+~940px (`max-w-4xl` is the close stock equivalent) is the standard content width. A single long-form reading surface (one discussion / article) narrows to ~720px; a dense table view may opt out and run full-width.
+
+**Vertical rhythm — keep it on the standard steps:**
+- Top of a page body: `pt-5` / `pt-6` (20–24px).
+- Between sibling sections: `space-y-5`, or `mt-5` / `mt-6` on each block.
+- Stack of form fields: `space-y-4`.
+- Tight list rows / sidebar nav items: `space-y-0.5`.
+- Bottom of any scroll area: generous `pb-40`, so the last row clears floating UI and the scroll feels finished.
+
+**Gaps:** `gap-2` for inline button / icon groups, `gap-3` for card grids, `gap-5` for major section blocks.
+
+**Cards are flush on mobile, boxed on desktop.** A section card carries its border, rounding, and inner padding only at `sm:` and up — on mobile it runs edge-to-edge inside the gutter:
+
+```vue
+<div class="sm:rounded sm:border sm:border-outline-gray-1 sm:px-4 sm:py-3">
+  <!-- section content -->
+</div>
+```
+
+(This is subordinate to layout principle #6 — only box a section when the border earns its place.)
+
 ## App shell
 
 ```vue
@@ -36,12 +78,13 @@ Mount `FrappeUIProvider` once at the app root so imperative `dialog.*` / `toast.
 
 ## Page header
 
+Single row, **48px tall (`min-h-12`)**, sticky to the top, with a bottom border and the same `px-3 sm:px-5` gutter as the page body:
+
 ```vue
-<header class="flex items-center justify-between border-b border-outline-gray-1 px-6 py-4">
-  <div>
-    <Breadcrumbs :items="crumbs" />
-    <h1 class="mt-1 text-xl text-ink-gray-9">{{ title }}</h1>
-  </div>
+<header
+  class="sticky top-0 z-10 flex min-h-12 items-center justify-between border-b border-outline-gray-1 bg-surface-white px-3 sm:px-5"
+>
+  <Breadcrumbs :items="crumbs" />
   <div class="flex gap-2">
     <Button icon="lucide-filter" label="Filter" />
     <Button variant="solid" theme="gray" icon-left="lucide-plus" label="New" @click="create" />
@@ -49,7 +92,7 @@ Mount `FrappeUIProvider` once at the app root so imperative `dialog.*` / `toast.
 </header>
 ```
 
-Primary action: `variant="solid" theme="gray"`. Secondary actions: default `subtle`.
+Primary action: `variant="solid" theme="gray"`. Secondary actions: default `subtle`. Keep the header to one row — use `Breadcrumbs` for context rather than stacking a separate `<h1>` that pushes it past 48px.
 
 ## Form page
 
@@ -128,7 +171,7 @@ const tasks = useList<Task>({
 
 <template>
   <div class="flex h-full flex-col">
-    <header class="flex items-center justify-between border-b border-outline-gray-1 px-6 py-3">
+    <header class="flex min-h-12 items-center justify-between border-b border-outline-gray-1 px-3 sm:px-5">
       <h1 class="text-lg text-ink-gray-9">Tasks</h1>
       <Button variant="solid" theme="gray" icon-left="lucide-plus" label="New Task" />
     </header>

--- a/skills/frappe-ui/SETUP.md
+++ b/skills/frappe-ui/SETUP.md
@@ -14,7 +14,7 @@ npm install -D \
   vue-router@^4 \
   unplugin-auto-import unplugin-vue-components unplugin-icons \
   lucide-static @iconify/json
-npm install frappe-ui
+npm install frappe-ui@beta
 ```
 
 - **Tailwind must be v3.** frappe-ui's preset is a Tailwind v3 config (`darkMode`, `plugins`, `content`). Tailwind v4 ignores that shape entirely and the design tokens silently won't load.

--- a/skills/frappe-ui/SKILL.md
+++ b/skills/frappe-ui/SKILL.md
@@ -28,17 +28,21 @@ const name = ref('')
 </template>
 ```
 
-## Workflow
+## Rules
 
-1. **Pick the component, don't build one.** Consult `COMPONENTS.md` — if any entry fits, use it. Only fall back to raw HTML for layout (grids, flex containers).
-2. **Use semantic tokens, not raw colors.** No `bg-gray-100`, `text-gray-900`, `border-gray-300`. Use `bg-surface-*`, `text-ink-*`, `border-outline-*`. See `TOKENS.md`.
-3. **Follow the two-axis color rule.** Component color = `variant` (`solid | outline | subtle | ghost`) + `theme` (`gray | blue | green | red | orange`). Never invent `intent`, `kind`, `severity`, `appearance`.
-4. **Wire two-way state with `v-model`.** Overlays use `v-model:open`. Inputs use `v-model`. Comboboxes use `v-model` + `v-model:query`. Never `:value` + `@change`.
-5. **Use the labeling contract on inputs.** Every input control accepts `label`, `description`, `error`, `required` — use these instead of placeholder hacks or separate `<label>` elements.
-6. **Slot vocabulary is fixed.** `#prefix`, `#suffix`, `#trigger`, `#empty`, `#header`, `#footer`, `#default`. Scoped per-item slots: `#item-prefix`, `#item-suffix`. No `#icon-left` / `#avatar-right`.
-7. **Icons are CSS classes.** Render an icon as `<span class="lucide-<name> size-4" aria-hidden="true" />`. For frappe-ui props that accept an icon (e.g. `Button.icon`, `Dropdown` option `icon`), pass the namespaced string `"lucide-edit"`. Never import per-icon Vue components.
-8. **Imperative for one-shot UI.** Use `dialog.confirm`, `dialog.alert`, `dialog.prompt`, `toast.success/error/info` — don't manually mount `<Dialog>` for confirmations.
-9. **API calls go through `useCall`.** Use the `useCall` composable (or `useList` / `useDoc` for higher-level shapes) for every Frappe API call. Never `fetch` / `axios` directly. `immediate: false` + `submit(params)` for writes; default behavior auto-fetches on mount. See `COMPONENTS.md` → Data & resources.
+Each rule states what to do and what to avoid — one canonical place, no separate anti-pattern list.
+
+1. **Pick the component, don't build one.** Consult `COMPONENTS.md`; only fall back to raw HTML for layout (grids, flex). Never hand-roll `<button class="bg-blue-500 …">`.
+2. **Semantic tokens, not raw colors.** `bg-surface-*`, `text-ink-*`, `border-outline-*` — never `bg-gray-100`, `text-gray-900`, `border-gray-300`. See `TOKENS.md`.
+3. **Color = `variant` + `theme`.** `variant` (`solid | outline | subtle | ghost`) + `theme` (`gray | blue | green | red | orange`). Never invent `intent` / `kind` / `severity` / `appearance`.
+4. **Two-way state via `v-model`.** Inputs `v-model`; overlays `v-model:open`; comboboxes `v-model` + `v-model:query`. Never `:value` + `@change`, never bare `v-model` on `<Dialog>`. Writes: `immediate: false` + `submit(params)`.
+5. **Use the input labeling contract.** Every control accepts `label`, `description`, `error`, `required` — use them, not placeholder-as-label or a separate `<label>`.
+6. **Slot vocabulary is fixed.** `#prefix`, `#suffix`, `#trigger`, `#empty`, `#header`, `#footer`, `#default`; per-item `#item-prefix` / `#item-suffix`. No `#icon-left` / `#avatar-right`.
+7. **Icons are CSS classes.** `<span class="lucide-<name> size-4" aria-hidden="true" />`; for icon props pass the string `"lucide-edit"`. Never import per-icon Vue components. See `COMPONENTS.md` → Icons.
+8. **Imperative for one-shot UI.** `dialog.confirm` / `alert` / `prompt`, `toast.success` / `error` / `info` — don't hand-mount `<Dialog>` to ask "are you sure?".
+9. **API calls go through `useCall`** (or `useList` / `useDoc`). Never `fetch` / `axios`; don't reach for the legacy `createResource` family in new code. See `COMPONENTS.md` → Data & resources.
+10. **Style components via `data-slot` / `data-state`, not class injection.** No `triggerClass` / `contentClass` props — they don't exist by design. See `TOKENS.md` → Custom CSS hooks.
+11. **Bootstrapping from scratch?** Follow `SETUP.md` exactly — version pins (Tailwind v3, Vite 5), `exports` subpaths, `optimizeDeps.exclude: ['frappe-ui']`, `app.use(FrappeUI)`, and `vue-router` are all required and easy to miss.
 
 ## Reference files
 
@@ -53,23 +57,4 @@ When the bundled refs don't answer a specific API question, fetch the official L
 
 - **https://ui.frappe.io/llms.txt** — curated index of every component doc, design-system tokens page, and data-fetching guide. Always current with the published library; follow the links inside for full details on a specific component.
 
-Prefer the upstream `llms.txt` over guessing — it lists every component's docs page and the canonical design-system / data-fetching pages.
-
-## Anti-patterns to flag
-
-- Scaffolding a fresh project with `npm create vite` and using whatever versions it gives you — current defaults (Vite 8 + Tailwind v4) are incompatible with frappe-ui 0.1.x. See [SETUP.md](SETUP.md).
-- Importing `'frappe-ui/tailwind/preset'` or `'frappe-ui/src/style.css'` — these paths are not in the package's `exports` map. Use `'frappe-ui/tailwind'` and `'frappe-ui/style.css'`.
-- Omitting `optimizeDeps.exclude: ['frappe-ui']` — esbuild's prebundler will choke on the package's `~icons/lucide/*` virtual imports before any Vite plugin runs.
-- Forgetting `app.use(FrappeUI)` because you only saw `<FrappeUIProvider>` mentioned — both are required. Plugin handles app-level injections; provider mounts the imperative dialog/toast portals.
-- Skipping `vue-router` for single-page prototypes — `<Button>` injects `Symbol(router)` and warns on every render without it.
-- Hand-rolled `<button class="bg-blue-500 ...">` instead of `<Button>`.
-- Raw Tailwind palette colors (`gray-`, `blue-`) outside the semantic tokens.
-- `intent="warning"` / `appearance="primary"` / `kind="success"` props — collapse to `variant` + `theme`.
-- Class-injection props (`triggerClass`, `contentClass`). Use the component's `data-slot` / `data-state` attributes from CSS instead.
-- Manually mounting `<Dialog>` just to ask "are you sure?" — use `dialog.confirm`.
-- Bare `v-model` on `<Dialog>` for visibility — use `v-model:open`.
-- Placeholder-as-label on `TextInput` / `Select` / `DatePicker` — pass `label`.
-- Raw `fetch` / `axios` for API calls — use `useCall` (or `useList` / `useDoc`).
-- `createResource` / `createListResource` / `createDocumentResource` in new code — those are legacy v1 APIs; the v3 composables (`useCall`, `useList`, `useDoc`) are the recommended path.
-
-When in doubt about an API, start at https://ui.frappe.io/llms.txt and follow the link for the component or topic in question. Source lives in the `frappe/frappe-ui` GitHub repo (`src/components/<Name>/`, plus `PHILOSOPHY.md` and `CONTEXT.md` at the repo root).
+Prefer the upstream `llms.txt` over guessing — it lists every component's docs page and the canonical design-system / data-fetching pages. Source lives in the `frappe/frappe-ui` GitHub repo (`src/components/<Name>/`, plus `PHILOSOPHY.md` and `CONTEXT.md` at the repo root).

--- a/skills/frappe-ui/TOKENS.md
+++ b/skills/frappe-ui/TOKENS.md
@@ -76,6 +76,8 @@ Pick the wrong one and copy looks cramped (multi-line text in `text-*`) or flopp
 
 All have tuned letter-spacing — don't override unless you know why.
 
+**Never uppercase headers.** Don't apply `uppercase` (or `tracking-wider` to fake all-caps) to headings, section titles, table-column headers, or labels. Frappe UIs use sentence case — write "Recent activity", not "RECENT ACTIVITY". Distinguish a header by size/weight/color (`text-ink-gray-5` + `text-sm` for a quiet section label), not by capitalization.
+
 ## Radius
 
 | Class            | px    | Use                            |


### PR DESCRIPTION
Updates the bundled **frappe-ui** skill and quiets the docs-preview CI noise.

## Changes

### Spacing & content-width pattern (new)
Codifies the de-facto layout conventions scanned from the Gameplan frontend into `PATTERNS.md`:
- **`px-3 sm:px-5` responsive gutters** (12px → 20px) on headers, containers, and rows — replacing ad-hoc `px-6`.
- **Centered max-width content column** — the `.body-container` recipe (`mx-auto w-full max-w-[940px] px-3 sm:px-5`, ~`max-w-4xl`); ~720px for long-form reading surfaces.
- **Vertical rhythm** steps — `pt-5`/`pt-6` page top, `space-y-5`/`mt-6` between sections, `space-y-4` form fields, `space-y-0.5` tight nav, `pb-40` scroll-area bottom.
- **Gap scale** — `gap-2` inline, `gap-3` card grids, `gap-5` section blocks.
- **Flush-on-mobile / boxed-on-desktop cards** (`sm:rounded sm:border sm:px-4 sm:py-3`).
- Reconciled both page-header examples to the real **48px (`min-h-12`)** convention.

All values verified directly against the Gameplan source (`.body-container` used 15×, `PageHeader` class string, card pattern 5×).

### Skill refresh (prior commit)
- Install `frappe-ui@beta` in setup guidance, add a sentence-case rule, and dedupe overlapping content across `SKILL.md` / `COMPONENTS.md` / `PATTERNS.md`.

### Docs-preview CI: stop spamming the PR timeline
- The `gh-pages` deploy commit used `pr #N` in its message, which GitHub auto-links into the PR activity timeline on every preview rebuild. Switched to the `pr-N` form (also matches the preview directory naming) so previews no longer post cross-references. (`.github/scripts/docs-pages.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-740/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 49.19% (±0.00% vs `main`)
<!-- coverage-report:end -->
