### PR TITLE
fix(toast): remove successAction from toast.promise

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -153,9 +153,24 @@ export default defineConfig({
     if (!css) return []
     return [['style', { 'data-shiki': '' }, css]]
   },
+  transformPageData() {
+    // Dev mode only — buildEnd doesn't run while `vitepress dev` is up, so
+    // theme/index.ts's eager `import '../../css/shiki.css'` would stay empty
+    // on a fresh checkout and code blocks would render unstyled. Write the
+    // collected CSS after each markdown page is processed; Vite's file
+    // watcher then HMRs the import.
+    if (process.env.NODE_ENV === 'production') return
+    const css = toClass.getCSS()
+    if (!css) return
+    const next = '/* Auto-generated on build-time */\n\n' + css
+    try {
+      const current = fs.readFileSync(shikiCssPath, 'utf-8')
+      if (current === next) return
+    } catch {}
+    fs.writeFileSync(shikiCssPath, next, 'utf-8')
+  },
   buildEnd: async () => {
     const str = '/* Auto-generated on build-time */ \n\n ' + toClass.getCSS()
-    const cssPath = path.resolve(__dirname, '../css/shiki.css')
-    await fs.promises.writeFile(cssPath, str, 'utf-8')
+    await fs.promises.writeFile(shikiCssPath, str, 'utf-8')
   },
 })

--- a/src/components/Toast/Toast.md
+++ b/src/components/Toast/Toast.md
@@ -26,6 +26,10 @@ Pass a render function to `icon` to replace the default type icon — handy for 
 
 ## Asynchronous
 
-Use `toast.promise` to wire a single toast to a promise lifecycle, or pass an `id` to update an existing toast in place — useful for multi-step progress.
+Use `toast.promise` to wire a single toast to a promise lifecycle — the same row transitions through loading → success/error in place, no stacking.
+
+`success` and `error` accept either a string or a callback that returns a string or full toast config. Returning an object unlocks `action`, `description`, `duration`, etc. — and lets the callback close over the resolved value (or thrown error) to wire up follow-ups like **Undo** on success or **Retry** on failure.
+
+For multi-step progress without a single promise, pass an `id` to `toast.loading` / `toast.success` to update an existing toast in place.
 
 <ComponentPreview name="Toast-Async" />

--- a/src/components/Toast/ToastProvider.vue
+++ b/src/components/Toast/ToastProvider.vue
@@ -16,7 +16,7 @@
         closeButton:
           'order-1 ml-auto group-has-[[data-action]]:ml-0 grid place-items-center rounded-sm text-ink-white hover:bg-surface-gray-5 size-5 !transition-colors [&_svg]:size-4',
         actionButton:
-          'flex text-ink-blue-link font-medium py-1.5 px-2 h-7 text-base mr-2 ml-auto bg-transparent hover:bg-surface-gray-5 rounded !transition-colors',
+          'flex shrink-0 text-ink-blue-link font-medium py-1.5 px-2 h-7 text-base mr-2 ml-auto bg-transparent hover:bg-surface-gray-5 rounded !transition-colors',
         cancelButton:
           'flex text-ink-blue-link font-medium py-1.5 px-2 text-base hover:bg-surface-gray-5 transition-colors',
         error: '[&_[data-icon]]:text-ink-red-2',

--- a/src/components/Toast/stories/Async.vue
+++ b/src/components/Toast/stories/Async.vue
@@ -9,15 +9,36 @@ function sendInvite() {
   })
 }
 
-function uploadFails() {
+function deleteFile() {
+  const file = { id: 'f_42', name: 'report.pdf' }
+  const willFail = Math.random() < 0.5
+
   toast.promise(
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('Network error')), 1500),
+    new Promise<{ id: string; name: string }>((resolve, reject) =>
+      setTimeout(
+        () =>
+          willFail
+            ? reject(new Error('Network error'))
+            : resolve(file),
+        1500,
+      ),
     ),
     {
-      loading: 'Uploading report.pdf…',
-      success: 'Upload complete',
-      error: (err: Error) => `Upload failed: ${err.message}`,
+      loading: `Deleting ${file.name}…`,
+      success: (deleted) => ({
+        message: `Deleted ${deleted.name}`,
+        action: {
+          label: 'Undo',
+          onClick: () => toast.success(`Restored ${deleted.name}`),
+        },
+      }),
+      error: (err: Error) => ({
+        message: `Couldn't delete ${file.name} — ${err.message}`,
+        action: {
+          label: 'Retry',
+          onClick: () => deleteFile(),
+        },
+      }),
     },
   )
 }
@@ -47,6 +68,6 @@ function deployPipeline() {
 
 <template>
   <Button label="Send invite" @click="sendInvite" />
-  <Button label="Upload fails" @click="uploadFails" />
+  <Button label="Delete file" @click="deleteFile" />
   <Button label="Deploy pipeline" @click="deployPipeline" />
 </template>

--- a/src/components/Toast/toast.ts
+++ b/src/components/Toast/toast.ts
@@ -131,44 +131,12 @@ function create(options: LegacyCreateOptions) {
   })
 }
 
-type SuccessAction<T> = {
-  label: string
-  onClick: (data: T) => void
-  altText?: string
-}
-
 function promise<T>(
   p: Promise<T> | (() => Promise<T>),
-  options: Parameters<typeof sonnerToast.promise>[1] & {
-    successAction?: SuccessAction<T>
-  },
+  options: Parameters<typeof sonnerToast.promise>[1],
 ): string | number {
-  const { successAction, ...rest } = options
   const resolvedPromise = typeof p === 'function' ? p() : p
-
-  if (successAction) {
-    const originalSuccess = rest.success
-    rest.success = (data: T) => {
-      const raw =
-        typeof originalSuccess === 'function'
-          ? (originalSuccess as (data: T) => unknown)(data)
-          : originalSuccess
-      const msg =
-        raw && typeof raw === 'object' && 'message' in raw
-          ? String((raw as { message: unknown }).message)
-          : String(raw ?? '')
-      return {
-        message: msg,
-        action: {
-          label: successAction.label,
-          onClick: () => successAction.onClick(data),
-          altText: successAction.altText,
-        },
-      }
-    }
-  }
-
-  return sonnerToast.promise(resolvedPromise, rest) as unknown as string | number
+  return sonnerToast.promise(resolvedPromise, options) as unknown as string | number
 }
 
 function remove(id: string | number) {

--- a/src/components/Toast/toast.ts
+++ b/src/components/Toast/toast.ts
@@ -131,14 +131,6 @@ function create(options: LegacyCreateOptions) {
   })
 }
 
-function promise<T>(
-  p: Promise<T> | (() => Promise<T>),
-  options: Parameters<typeof sonnerToast.promise>[1],
-): string | number {
-  const resolvedPromise = typeof p === 'function' ? p() : p
-  return sonnerToast.promise(resolvedPromise, options) as unknown as string | number
-}
-
 function remove(id: string | number) {
   warnDeprecated(`toast.remove(id)`, `toast.dismiss(id)`, TOAST_DOCS)
   return sonnerToast.dismiss(id)
@@ -153,7 +145,6 @@ export const toast = Object.assign(toastFn, sonnerToast, {
   create,
   remove,
   removeAll,
-  promise,
 }) as typeof sonnerToast & {
   (
     message: string | LegacyToastObject,
@@ -162,5 +153,4 @@ export const toast = Object.assign(toastFn, sonnerToast, {
   create: typeof create
   remove: typeof remove
   removeAll: typeof removeAll
-  promise: typeof promise
 }


### PR DESCRIPTION
Removes the custom `successAction` option from `toast.promise`.

`successAction` was a non-native wrapper that Sonner doesn't support natively. Callers should use the standard approach of returning `{ message, action }` from the `success` callback instead:

```ts
// Before
toast.promise(p, {
  success: 'Done',
  successAction: { label: 'Undo', onClick: () => undo() },
})

// After
toast.promise(p, {
  success: () => ({
    message: 'Done',
    action: { label: 'Undo', onClick: () => undo() },
  }),
})
```

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-741/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 49.32% (+0.13% vs `main`)
<!-- coverage-report:end -->


