### PR TITLE
ci: auto-publish beta on labeled PR merge

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -23,10 +23,20 @@ jobs:
     permissions:
       contents: write # push the version-bump commit back to main
     steps:
+      # RELEASE_TOKEN (a PAT) is REQUIRED, not optional: a push made with the
+      # default GITHUB_TOKEN does NOT trigger other workflows, so the bump would
+      # land on main but Tests -> Publish on NPM would never run -> no publish.
+      # Fail loudly here rather than silently bumping without publishing.
+      - name: Require RELEASE_TOKEN
+        if: ${{ secrets.RELEASE_TOKEN == '' }}
+        run: |
+          echo "::error::RELEASE_TOKEN secret is not set. It's required so the version-bump push triggers the publish pipeline (GITHUB_TOKEN pushes don't trigger workflows). See .github/workflows/beta-release.yml header."
+          exit 1
+
       - uses: actions/checkout@v4
         with:
           ref: main # post-merge main, which includes the just-merged PR
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,54 @@
+name: Bump Beta Version
+
+# When a PR labeled `beta-release` is merged into main, bump the beta
+# prerelease in package.json (e.g. 1.0.0-beta.0 -> 1.0.0-beta.1) and push it.
+# The push triggers Tests -> "Publish on NPM" (publish.yml), which detects the
+# version change and publishes to the matching dist-tag (beta).
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+# Serialize so two quickly-merged PRs can't race the version-bump commit.
+concurrency:
+  group: bump-beta
+  cancel-in-progress: false
+
+jobs:
+  bump-beta:
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'beta-release')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the version-bump commit back to main
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main # post-merge main, which includes the just-merged PR
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Bump beta prerelease
+        id: bump
+        run: |
+          current=$(node -p "require('./package.json').version")
+          if ! echo "$current" | grep -q -- '-beta\.[0-9]\+$'; then
+            echo "::error::package.json version ('$current') is not an X.Y.Z-beta.N prerelease; refusing to auto-bump."
+            exit 1
+          fi
+          next=$(npm version prerelease --preid=beta --no-git-tag-version)
+          next="${next#v}" # npm prints "v1.0.0-beta.1"
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+          echo "Bumping $current -> $next"
+
+      - name: Commit and push version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore(release): v${{ steps.bump.outputs.next }}"
+          git push origin HEAD:main


### PR DESCRIPTION
## What

Adds `.github/workflows/beta-release.yml`. When a PR labeled **`beta-release`** is merged into `main`, it bumps the beta prerelease in `package.json` (e.g. `1.0.0-beta.0` → `1.0.0-beta.1`) and pushes the bump to `main`.

It does **not** publish. The push triggers the existing **Tests → Publish on NPM** pipeline (`publish.yml` + `.github/scripts/publish-tag.ts`), which already detects the version change and publishes to the matching dist-tag (`beta`). So this workflow is just the missing "auto-bump on merge" trigger.

- Refuses to run unless `package.json` is an `X.Y.Z-beta.N` version.
- Serialized via a `concurrency` group so two quick merges can't race the bump.

## Setup needed
- [x] `beta-release` label created
- [x] If `main` is a protected branch, add a `RELEASE_TOKEN` secret (PAT/app token that can push to main) — the workflow falls back to it for the push-back. npm auth is already handled by `publish.yml`.

## Usage
Add the **`beta-release`** label to a PR before merging → on merge it bumps to the next beta and the existing pipeline publishes it. Unlabeled merges do nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-742/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 49.32% (±0.00% vs `main`)
<!-- coverage-report:end -->

