### PR TITLE
fix(ci): use env, not secrets context, in beta-release if condition

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -22,13 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # push the version-bump commit back to main
+    # The `secrets` context is NOT available in step `if:` conditions, so expose
+    # the token as an env var here and test `env.RELEASE_TOKEN` below instead.
+    env:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     steps:
       # RELEASE_TOKEN (a PAT) is REQUIRED, not optional: a push made with the
       # default GITHUB_TOKEN does NOT trigger other workflows, so the bump would
       # land on main but Tests -> Publish on NPM would never run -> no publish.
       # Fail loudly here rather than silently bumping without publishing.
       - name: Require RELEASE_TOKEN
-        if: ${{ secrets.RELEASE_TOKEN == '' }}
+        if: ${{ env.RELEASE_TOKEN == '' }}
         run: |
           echo "::error::RELEASE_TOKEN secret is not set. It's required so the version-bump push triggers the publish pipeline (GITHUB_TOKEN pushes don't trigger workflows). See .github/workflows/beta-release.yml header."
           exit 1


### PR DESCRIPTION
## Problem

PR #718 (`feat(editor): Editor molecule`) was merged with the `beta-release` label, but **no beta was published**.

The `Bump Beta Version` workflow (`beta-release.yml`) failed at **parse time** on every push/merge to `main` — GitHub reports *"This run likely failed because of a workflow file issue"* and the run log is `not found`. No job ever ran, so the version was never bumped and `publish.yml` never published.

## Root cause

```yaml
- name: Require RELEASE_TOKEN
  if: ${{ secrets.RELEASE_TOKEN == '' }}   # ❌ secrets context not allowed in step if:
```

The `secrets` context is **not available in step `if:` conditions** (allowed contexts: `github, needs, strategy, matrix, job, runner, env, vars, steps, inputs`). This makes the workflow file invalid. The guard added in d721c92b0 to "fail loudly if RELEASE_TOKEN is missing" instead silently broke the whole pipeline.

`package.json` on `main` is still `1.0.0-beta.0`, confirming the bump never ran.

## Fix

Hoist the token to a job-level `env` var and test `env.RELEASE_TOKEN` (the standard pattern for gating on a secret's presence). One-line behavior change; the `with: token:` usage is untouched (`secrets` is valid in `with`).

## Follow-up (not in this PR)

The fix only affects **future** labeled merges. #718's beta won't release retroactively — a manual bump/publish (or an empty `beta-release`-labeled PR) is needed to ship `1.0.0-beta.1` now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-748/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 56.13% (±0.00% vs `main`)
<!-- coverage-report:end -->
