### PR TITLE
ci: auto-create git tag on npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write # Required for OIDC
-  contents: read
+  contents: write # push the release tag
 
 jobs:
   publish:
@@ -35,3 +35,20 @@ jobs:
         run: npm test
       - if: steps.publish_tag.outputs.changed == 'true'
         run: npm publish --tag ${{ steps.publish_tag.outputs.tag }}
+
+      # Tag the exact commit that was published (head_sha checked out above).
+      # Idempotent: skips if the tag already exists, so workflow re-runs are safe.
+      - name: Tag the release
+        if: steps.publish_tag.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.publish_tag.outputs.version }}
+        run: |
+          tag="v$VERSION"
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists on origin, skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "$tag"
+          git push origin "$tag"


### PR DESCRIPTION
## Problem

The release pipeline publishes to npm but never creates a git tag:
- `beta-release.yml` bumps with `npm version --no-git-tag-version`
- `publish.yml` only runs `npm publish`

So releases leave **no tag on GitHub** — e.g. `1.0.0-beta.0` and `1.0.0-beta.1` are on npm but had no corresponding tag until one was pushed manually.

## Change

After a successful `npm publish`, tag the exact published commit and push it:
- Tags `v<version>` using the `version` output already emitted by `publish-tag.ts`.
- Tags `github.event.workflow_run.head_sha` (the commit checked out and published) — not a moving branch ref.
- **Idempotent**: skips if the tag already exists on origin, so workflow re-runs are safe.
- Bumps the workflow `contents` permission `read → write` so it can push the tag (OIDC `id-token: write` unchanged).

Only runs when `changed == 'true'` (i.e. a publish actually happened). No GitHub Release is created — tag only, by request.

## Result

Every future `beta-release`-labeled merge will publish to npm **and** leave a matching `v<version>` tag on GitHub automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-749/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 56.13% (±0.00% vs `main`)
<!-- coverage-report:end -->
