### PR TITLE
feat(editor): link popup, tables, shared popover, and file drop improvements

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -143,6 +143,7 @@ declare module 'vue' {
     TocNodeView: typeof import('./src/components/TextEditor/extensions/toc-node/TocNodeView.vue')['default']
     Tooltip: typeof import('./src/components/Tooltip/Tooltip.vue')['default']
     TooltipBubble: typeof import('./src/components/Tooltip/TooltipBubble.vue')['default']
+    TooltipProvider: typeof import('./src/components/Tooltip/TooltipProvider.vue')['default']
     Tree: typeof import('./src/components/Tree/Tree.vue')['default']
     WeekIcon: typeof import('./src/components/Calendar/Icon/WeekIcon.vue')['default']
   }

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -1,300 +1,292 @@
-<template>
-  <TooltipProvider>
-    <TooltipRoot>
-      <TooltipTrigger as-child>
-        <component
-          :is="Root"
-          v-bind="$attrs"
-          :class="buttonClasses"
-          :aria-label="label"
-          ref="rootRef"
-        >
-      <LoadingIndicator
-        v-if="loading"
-        :class="{
-          'h-3 w-3': size == 'xs' || size == 'sm',
-          'h-[13.5px] w-[13.5px]': size == 'md',
-          'h-[15px] w-[15px]': size == 'lg',
-          'h-4.5 w-4.5': size == 'xl' || size == '2xl',
-        }"
-      />
-      <slot name="prefix" v-else-if="$slots['prefix'] || iconLeft">
-        <span
-          v-if="iconLeft && typeof iconLeft === 'string' && iconLeft.startsWith('lucide-')"
-          :class="[iconLeft, lucideSlotClasses]"
-          aria-hidden="true"
-        />
-        <FeatherIcon
-          v-else-if="iconLeft && typeof iconLeft === 'string'"
-          :name="iconLeft"
-          :class="slotClasses"
-          aria-hidden="true"
-        />
-        <component v-else-if="iconLeft" :is="iconLeft" :class="slotClasses" />
-      </slot>
-
-      <template v-if="loading && loadingText">{{ loadingText }}</template>
-      <template v-else-if="isIconButton && !loading">
-        <span
-          v-if="icon && typeof icon === 'string' && icon.startsWith('lucide-')"
-          :class="[icon, lucideSlotClasses]"
-          aria-hidden="true"
-        />
-        <FeatherIcon
-          v-else-if="icon && typeof icon === 'string'"
-          :name="icon"
-          :class="slotClasses"
-        />
-        <component v-else-if="icon" :is="icon" :class="slotClasses" />
-        <slot name="icon" v-else-if="$slots.icon" />
-        <div v-else-if="hasLucideIconInDefaultSlot" :class="slotClasses">
-          <slot>{{ label }}</slot>
-        </div>
-      </template>
-      <span v-else :class="{ 'sr-only': isIconButton }" class="truncate">
-        <slot>{{ label }}</slot>
-      </span>
-
-      <slot name="suffix">
-        <span
-          v-if="iconRight && typeof iconRight === 'string' && iconRight.startsWith('lucide-')"
-          :class="[iconRight, lucideSlotClasses]"
-          aria-hidden="true"
-        />
-        <FeatherIcon
-          v-else-if="iconRight && typeof iconRight === 'string'"
-          :name="iconRight"
-          :class="slotClasses"
-          aria-hidden="true"
-        />
-        <component
-          v-else-if="iconRight"
-          :is="iconRight"
-          :class="slotClasses"
-        />
-      </slot>
-        </component>
-      </TooltipTrigger>
-      <TooltipBubble v-if="tooltip?.length" :text="tooltip" />
-    </TooltipRoot>
-  </TooltipProvider>
-</template>
-<script lang="ts" setup>
-import { computed, h, ref, useSlots, watchEffect } from 'vue'
+<script lang="ts">
+import {
+  computed,
+  defineComponent,
+  h,
+  ref,
+  watchEffect,
+  type Component,
+  type SlotsType,
+  type VNode,
+} from 'vue'
 import { TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui'
+import { RouterLink } from 'vue-router'
 import FeatherIcon from '../FeatherIcon.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import TooltipBubble from '../Tooltip/TooltipBubble.vue'
-import { RouterLink } from 'vue-router'
 import { warnFeatherIconUsage } from '../../utils/iconString'
-import type { ButtonProps, ThemeVariant } from './types'
+import { buttonProps, type ThemeVariant } from './types'
 
-defineOptions({ inheritAttrs: false })
-
-const props = withDefaults(defineProps<ButtonProps>(), {
-  theme: 'gray',
-  size: 'sm',
-  variant: 'subtle',
-  loading: false,
-  disabled: false,
-  type: 'button',
-})
-
-watchEffect(() => {
-  warnFeatherIconUsage('Button', 'icon', props.icon)
-  warnFeatherIconUsage('Button', 'iconLeft', props.iconLeft)
-  warnFeatherIconUsage('Button', 'iconRight', props.iconRight)
-})
-
-const slots = useSlots()
-
-const buttonClasses = computed(() => {
-  let solidClasses = {
-    gray: 'text-ink-white bg-surface-gray-7 hover:bg-surface-gray-6 active:bg-surface-gray-5',
-    blue: 'text-ink-white bg-blue-500 hover:bg-surface-blue-3 active:bg-blue-700',
-    green:
-      'text-ink-white bg-surface-green-3 hover:bg-green-700 active:bg-green-800',
-    red: 'text-ink-white bg-surface-red-5 hover:bg-surface-red-6 active:bg-surface-red-7',
-  }[props.theme]
-
-  let subtleClasses = {
-    gray: 'text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4',
-    blue: 'text-ink-blue-3 bg-surface-blue-2 hover:bg-blue-200 active:bg-blue-300',
-    green:
-      'text-green-800 bg-surface-green-2 hover:bg-green-200 active:bg-green-300',
-    red: 'text-red-700 bg-surface-red-2 hover:bg-surface-red-3 active:bg-surface-red-4',
-  }[props.theme]
-
-  let outlineClasses = {
-    gray: 'text-ink-gray-8 bg-surface-white bg-surface-white border border-outline-gray-2 hover:border-outline-gray-3 active:border-outline-gray-3 active:bg-surface-gray-4',
-    blue: 'text-ink-blue-3 bg-surface-white border border-outline-blue-1 hover:border-blue-400 active:border-blue-400 active:bg-blue-300',
-    green:
-      'text-green-800 bg-surface-white border border-outline-green-2 hover:border-green-500 active:border-green-500 active:bg-green-300',
-    red: 'text-red-700 bg-surface-white border border-outline-red-1 hover:border-outline-red-2 active:border-outline-red-2 active:bg-surface-red-3',
-  }[props.theme]
-
-  let ghostClasses = {
-    gray: 'text-ink-gray-8 bg-transparent hover:bg-surface-gray-3 active:bg-surface-gray-4',
-    blue: 'text-ink-blue-3 bg-transparent hover:bg-blue-200 active:bg-blue-300',
-    green:
-      'text-green-800 bg-transparent hover:bg-green-200 active:bg-green-300',
-    red: 'text-red-700 bg-transparent hover:bg-surface-red-3 active:bg-surface-red-4',
-  }[props.theme]
-
-  let focusClasses = {
-    gray: 'focus-visible:ring focus-visible:ring-outline-gray-3',
-    blue: 'focus-visible:ring focus-visible:ring-blue-400',
-    green: 'focus-visible:ring focus-visible:ring-outline-green-2',
-    red: 'focus-visible:ring focus-visible:ring-outline-red-2',
-  }[props.theme]
-
-  let variantClasses = {
-    subtle: subtleClasses,
-    solid: solidClasses,
-    outline: outlineClasses,
-    ghost: ghostClasses,
-  }[props.variant]
-
-  let themeVariant: ThemeVariant = `${props.theme}-${props.variant}`
-
-  let disabledClassesMap: Record<ThemeVariant, string> = {
-    'gray-solid': 'bg-surface-gray-2 text-ink-gray-4',
-    'gray-subtle': 'bg-surface-gray-2 text-ink-gray-4',
-    'gray-outline':
-      'bg-surface-gray-2 text-ink-gray-4 border border-outline-gray-2',
-    'gray-ghost': 'text-ink-gray-4',
-
-    'blue-solid': 'bg-blue-300 text-ink-white',
-    'blue-subtle': 'bg-surface-blue-2 text-ink-blue-link',
-    'blue-outline':
-      'bg-surface-blue-2 text-ink-blue-link border border-outline-blue-1',
-    'blue-ghost': 'text-ink-blue-link',
-
-    'green-solid': 'bg-surface-green-2 text-ink-green-2',
-    'green-subtle': 'bg-surface-green-2 text-ink-green-2',
-    'green-outline':
-      'bg-surface-green-2 text-ink-green-2 border border-outline-green-2',
-    'green-ghost': 'text-ink-green-2',
-
-    'red-solid': 'bg-surface-red-2 text-ink-red-2',
-    'red-subtle': 'bg-surface-red-2 text-ink-red-2',
-    'red-outline':
-      'bg-surface-red-2 text-ink-red-2 border border-outline-red-1',
-    'red-ghost': 'text-ink-red-2',
-  }
-  let disabledClasses = disabledClassesMap[themeVariant]
-
-  let sizeClasses = {
-    xs: 'h-6 text-sm px-1.5 rounded',
-    sm: 'h-7 text-base px-2 rounded',
-    md: 'h-8 text-base font-medium px-2.5 rounded',
-    lg: 'h-10 text-lg font-medium px-3 rounded-md',
-    xl: 'h-11.5 text-xl font-medium px-3.5 rounded-lg',
-    '2xl': 'h-13 text-2xl font-medium px-3.5 rounded-xl',
-  }[props.size]
-
-  if (isIconButton.value) {
-    sizeClasses = {
-      xs: 'h-6 w-6 rounded',
-      sm: 'h-7 w-7 rounded',
-      md: 'h-8 w-8 rounded',
-      lg: 'h-10 w-10 rounded-md',
-      xl: 'h-11.5 w-11.5 rounded-lg',
-      '2xl': 'h-13 w-13 rounded-xl',
-    }[props.size]
-  }
-
-  return [
-    'inline-flex items-center justify-center gap-2 transition-colors focus:outline-none shrink-0',
-    isDisabled.value ? disabledClasses : variantClasses,
-    focusClasses,
-    sizeClasses,
-  ]
-})
-
-const slotClasses = computed(() => {
-  let classes = {
-    xs: 'h-4',
-    sm: 'h-4',
-    md: 'h-4.5',
-    lg: 'h-5',
-    xl: 'h-6',
-    '2xl': 'h-6',
-  }[props.size]
-
-  return classes
-})
-
-const lucideSlotClasses = computed(() => {
-  return {
-    xs: 'size-4',
-    sm: 'size-4',
-    md: 'size-4.5',
-    lg: 'size-5',
-    xl: 'size-6',
-    '2xl': 'size-6',
-  }[props.size]
-})
-
-const isDisabled = computed(() => {
-  return props.disabled || props.loading
-})
-
-// Avoid "Maximum call stack size exceeded" error
-// when using <component is='button' /> inside <Button /> component
-// by using "render" function here to avoid conflicting html "button" component with
-// globally registered "Button" component in consumer apps
-const Root = computed(() => {
-  if (!isDisabled.value && props.route) {
-    return h(RouterLink, { to: props.route })
-  }
-
-  if (!isDisabled.value && props.link) {
-    return h('a', {
-      href: props.link,
-      target: '_blank',
-      rel: 'noreferrer noopener',
+export default defineComponent({
+  name: 'Button',
+  inheritAttrs: false,
+  props: buttonProps,
+  slots: Object as SlotsType<{
+    /** Content shown before the button label (left icon / custom content) */
+    prefix: void
+    /** Icon-only content for icon buttons */
+    icon: void
+    /** Main button content (overrides `label`) */
+    default: void
+    /** Content shown after the button label (right icon / custom content) */
+    suffix: void
+  }>,
+  setup(props, { attrs, slots, expose }) {
+    watchEffect(() => {
+      warnFeatherIconUsage('Button', 'icon', props.icon)
+      warnFeatherIconUsage('Button', 'iconLeft', props.iconLeft)
+      warnFeatherIconUsage('Button', 'iconRight', props.iconRight)
     })
-  }
 
-  return h('button', { type: props.type, disabled: isDisabled.value })
+    const isDisabled = computed(() => props.disabled || props.loading)
+    const hasTooltip = computed(() => Boolean(props.tooltip?.length))
+
+    // Render as an icon button when the default slot is exactly one lucide-* icon.
+    const hasLucideIconInDefaultSlot = computed(() => {
+      const content = slots.default?.()
+      if (!Array.isArray(content)) return false
+      const name = (content[0]?.type as { name?: string })?.name
+      return typeof name === 'string' && name.startsWith('lucide-')
+    })
+
+    const isIconButton = computed(
+      () =>
+        Boolean(props.icon) ||
+        Boolean(slots.icon) ||
+        hasLucideIconInDefaultSlot.value,
+    )
+
+    const slotClasses = computed(
+      () =>
+        ({ xs: 'h-4', sm: 'h-4', md: 'h-4.5', lg: 'h-5', xl: 'h-6', '2xl': 'h-6' })[
+          props.size
+        ],
+    )
+
+    const lucideSlotClasses = computed(
+      () =>
+        ({
+          xs: 'size-4',
+          sm: 'size-4',
+          md: 'size-4.5',
+          lg: 'size-5',
+          xl: 'size-6',
+          '2xl': 'size-6',
+        })[props.size],
+    )
+
+    const buttonClasses = computed(() => {
+      const solidClasses = {
+        gray: 'text-ink-white bg-surface-gray-7 hover:bg-surface-gray-6 active:bg-surface-gray-5',
+        blue: 'text-ink-white bg-blue-500 hover:bg-surface-blue-3 active:bg-blue-700',
+        green:
+          'text-ink-white bg-surface-green-3 hover:bg-green-700 active:bg-green-800',
+        red: 'text-ink-white bg-surface-red-5 hover:bg-surface-red-6 active:bg-surface-red-7',
+      }[props.theme]
+
+      const subtleClasses = {
+        gray: 'text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4',
+        blue: 'text-ink-blue-3 bg-surface-blue-2 hover:bg-blue-200 active:bg-blue-300',
+        green:
+          'text-green-800 bg-surface-green-2 hover:bg-green-200 active:bg-green-300',
+        red: 'text-red-700 bg-surface-red-2 hover:bg-surface-red-3 active:bg-surface-red-4',
+      }[props.theme]
+
+      const outlineClasses = {
+        gray: 'text-ink-gray-8 bg-surface-white bg-surface-white border border-outline-gray-2 hover:border-outline-gray-3 active:border-outline-gray-3 active:bg-surface-gray-4',
+        blue: 'text-ink-blue-3 bg-surface-white border border-outline-blue-1 hover:border-blue-400 active:border-blue-400 active:bg-blue-300',
+        green:
+          'text-green-800 bg-surface-white border border-outline-green-2 hover:border-green-500 active:border-green-500 active:bg-green-300',
+        red: 'text-red-700 bg-surface-white border border-outline-red-1 hover:border-outline-red-2 active:border-outline-red-2 active:bg-surface-red-3',
+      }[props.theme]
+
+      const ghostClasses = {
+        gray: 'text-ink-gray-8 bg-transparent hover:bg-surface-gray-3 active:bg-surface-gray-4',
+        blue: 'text-ink-blue-3 bg-transparent hover:bg-blue-200 active:bg-blue-300',
+        green:
+          'text-green-800 bg-transparent hover:bg-green-200 active:bg-green-300',
+        red: 'text-red-700 bg-transparent hover:bg-surface-red-3 active:bg-surface-red-4',
+      }[props.theme]
+
+      const focusClasses = {
+        gray: 'focus-visible:ring focus-visible:ring-outline-gray-3',
+        blue: 'focus-visible:ring focus-visible:ring-blue-400',
+        green: 'focus-visible:ring focus-visible:ring-outline-green-2',
+        red: 'focus-visible:ring focus-visible:ring-outline-red-2',
+      }[props.theme]
+
+      const variantClasses = {
+        subtle: subtleClasses,
+        solid: solidClasses,
+        outline: outlineClasses,
+        ghost: ghostClasses,
+      }[props.variant]
+
+      const themeVariant: ThemeVariant = `${props.theme}-${props.variant}`
+
+      const disabledClassesMap: Record<ThemeVariant, string> = {
+        'gray-solid': 'bg-surface-gray-2 text-ink-gray-4',
+        'gray-subtle': 'bg-surface-gray-2 text-ink-gray-4',
+        'gray-outline':
+          'bg-surface-gray-2 text-ink-gray-4 border border-outline-gray-2',
+        'gray-ghost': 'text-ink-gray-4',
+
+        'blue-solid': 'bg-blue-300 text-ink-white',
+        'blue-subtle': 'bg-surface-blue-2 text-ink-blue-link',
+        'blue-outline':
+          'bg-surface-blue-2 text-ink-blue-link border border-outline-blue-1',
+        'blue-ghost': 'text-ink-blue-link',
+
+        'green-solid': 'bg-surface-green-2 text-ink-green-2',
+        'green-subtle': 'bg-surface-green-2 text-ink-green-2',
+        'green-outline':
+          'bg-surface-green-2 text-ink-green-2 border border-outline-green-2',
+        'green-ghost': 'text-ink-green-2',
+
+        'red-solid': 'bg-surface-red-2 text-ink-red-2',
+        'red-subtle': 'bg-surface-red-2 text-ink-red-2',
+        'red-outline':
+          'bg-surface-red-2 text-ink-red-2 border border-outline-red-1',
+        'red-ghost': 'text-ink-red-2',
+      }
+      const disabledClasses = disabledClassesMap[themeVariant]
+
+      const sizeClasses = isIconButton.value
+        ? {
+            xs: 'h-6 w-6 rounded',
+            sm: 'h-7 w-7 rounded',
+            md: 'h-8 w-8 rounded',
+            lg: 'h-10 w-10 rounded-md',
+            xl: 'h-11.5 w-11.5 rounded-lg',
+            '2xl': 'h-13 w-13 rounded-xl',
+          }[props.size]
+        : {
+            xs: 'h-6 text-sm px-1.5 rounded',
+            sm: 'h-7 text-base px-2 rounded',
+            md: 'h-8 text-base font-medium px-2.5 rounded',
+            lg: 'h-10 text-lg font-medium px-3 rounded-md',
+            xl: 'h-11.5 text-xl font-medium px-3.5 rounded-lg',
+            '2xl': 'h-13 text-2xl font-medium px-3.5 rounded-xl',
+          }[props.size]
+
+      return [
+        'inline-flex items-center justify-center gap-2 transition-colors focus:outline-none shrink-0',
+        isDisabled.value ? disabledClasses : variantClasses,
+        focusClasses,
+        sizeClasses,
+      ]
+    })
+
+    const rootRef = ref()
+    expose({ rootRef })
+
+    // The dynamic root: router link, external anchor, or native button. Using the
+    // raw 'button' string (not <component :is>) sidesteps the historic recursion
+    // with a globally-registered <Button> in consumer apps.
+    const root = computed<{ is: Component | string; props: Record<string, unknown> }>(
+      () => {
+        if (!isDisabled.value && props.route) {
+          return { is: RouterLink, props: { to: props.route } }
+        }
+        if (!isDisabled.value && props.link) {
+          return {
+            is: 'a',
+            props: { href: props.link, target: '_blank', rel: 'noreferrer noopener' },
+          }
+        }
+        return { is: 'button', props: { type: props.type, disabled: isDisabled.value } }
+      },
+    )
+
+    /** Resolve an icon prop to a vnode: lucide class-span, FeatherIcon, or component. */
+    function renderIcon(
+      icon: string | Component | undefined,
+      featherHidden: boolean,
+    ): VNode | null {
+      if (!icon) return null
+      if (typeof icon === 'string') {
+        if (icon.startsWith('lucide-')) {
+          return h('span', {
+            class: [icon, lucideSlotClasses.value],
+            'aria-hidden': 'true',
+          })
+        }
+        return h(FeatherIcon, {
+          name: icon,
+          class: slotClasses.value,
+          ...(featherHidden ? { 'aria-hidden': 'true' } : {}),
+        })
+      }
+      return h(icon, { class: slotClasses.value })
+    }
+
+    function renderPrefix() {
+      if (props.loading) {
+        return h(LoadingIndicator, {
+          class: {
+            'h-3 w-3': props.size === 'xs' || props.size === 'sm',
+            'h-[13.5px] w-[13.5px]': props.size === 'md',
+            'h-[15px] w-[15px]': props.size === 'lg',
+            'h-4.5 w-4.5': props.size === 'xl' || props.size === '2xl',
+          },
+        })
+      }
+      if (slots.prefix) return slots.prefix()
+      return renderIcon(props.iconLeft, true)
+    }
+
+    function renderMain() {
+      if (props.loading && props.loadingText) return props.loadingText
+      if (isIconButton.value && !props.loading) {
+        if (props.icon) return renderIcon(props.icon, false)
+        if (slots.icon) return slots.icon()
+        if (hasLucideIconInDefaultSlot.value) {
+          return h('div', { class: slotClasses.value }, slots.default?.() ?? props.label)
+        }
+        return null
+      }
+      return h(
+        'span',
+        { class: ['truncate', { 'sr-only': isIconButton.value }] },
+        slots.default?.() ?? props.label,
+      )
+    }
+
+    function renderSuffix() {
+      if (slots.suffix) return slots.suffix()
+      return renderIcon(props.iconRight, true)
+    }
+
+    return () => {
+      const { class: attrClass, ...restAttrs } = attrs
+      const { is, props: rootProps } = root.value
+      const children = [renderPrefix(), renderMain(), renderSuffix()]
+      const mergedProps = {
+        ...rootProps,
+        ...restAttrs,
+        class: [attrClass, buttonClasses.value],
+        'aria-label': props.label,
+        ref: rootRef,
+      }
+      const button =
+        typeof is === 'string'
+          ? h(is, mergedProps, children)
+          : h(is, mergedProps, { default: () => children })
+
+      if (!hasTooltip.value) return button
+
+      // Tooltip scaffolding renders only when a tooltip is set, so a bare button
+      // ships without any tooltip context, listeners, or pointerdown-to-close.
+      return h(TooltipProvider, null, {
+        default: () =>
+          h(TooltipRoot, null, {
+            default: () => [
+              h(TooltipTrigger, { asChild: true }, { default: () => button }),
+              h(TooltipBubble, { text: props.tooltip }),
+            ],
+          }),
+      })
+    }
+  },
 })
-
-const isIconButton = computed(() => {
-  return props.icon || slots.icon || hasLucideIconInDefaultSlot.value
-})
-
-const hasLucideIconInDefaultSlot = computed(() => {
-  if (!slots.default) return false
-
-  const slotContent = slots.default()
-  if (!Array.isArray(slotContent)) return false
-  // if the slot contains only one element and it's a lucide icon
-  // render it as an icon button
-  let firstVNode = slotContent[0]
-  if (
-    typeof firstVNode.type?.name == 'string' &&
-    firstVNode.type?.name?.startsWith('lucide-')
-  ) {
-    return true
-  }
-  return false
-})
-
-const rootRef = ref()
-defineExpose({ rootRef })
-
-defineSlots<{
-  /** Content shown before the button label (left icon / custom content) */
-  prefix?: () => any
-
-  /** Icon-only content for icon buttons */
-  icon?: () => any
-
-  /** Main button content (overrides `label`) */
-  default?: () => any
-
-  /** Content shown after the button label (right icon / custom content) */
-  suffix?: () => any
-}>()
 </script>

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -9,7 +9,12 @@ import {
   type SlotsType,
   type VNode,
 } from 'vue'
-import { TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui'
+import {
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
+  injectTooltipProviderContext,
+} from 'reka-ui'
 import { RouterLink } from 'vue-router'
 import FeatherIcon from '../FeatherIcon.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
@@ -40,6 +45,10 @@ export default defineComponent({
 
     const isDisabled = computed(() => props.disabled || props.loading)
     const hasTooltip = computed(() => Boolean(props.tooltip?.length))
+
+    // Reuse a surrounding <TooltipProvider> (button group) when present so the
+    // group's skip-delay applies to this button instead of a private provider.
+    const parentTooltipProvider = injectTooltipProviderContext(null)
 
     // Render as an icon button when the default slot is exactly one lucide-* icon.
     const hasLucideIconInDefaultSlot = computed(() => {
@@ -277,15 +286,18 @@ export default defineComponent({
 
       // Tooltip scaffolding renders only when a tooltip is set, so a bare button
       // ships without any tooltip context, listeners, or pointerdown-to-close.
-      return h(TooltipProvider, null, {
-        default: () =>
-          h(TooltipRoot, null, {
-            default: () => [
-              h(TooltipTrigger, { asChild: true }, { default: () => button }),
-              h(TooltipBubble, { text: props.tooltip }),
-            ],
-          }),
+      const tooltipRoot = h(TooltipRoot, null, {
+        default: () => [
+          h(TooltipTrigger, { asChild: true }, { default: () => button }),
+          h(TooltipBubble, { text: props.tooltip }),
+        ],
       })
+
+      // Inside a button group, the provider already exists upstream — mounting
+      // our own here would isolate this button from the shared skip-delay.
+      return parentTooltipProvider
+        ? tooltipRoot
+        : h(TooltipProvider, null, { default: () => tooltipRoot })
     }
   },
 })

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -12,7 +12,7 @@
       <LoadingIndicator
         v-if="loading"
         :class="{
-          'h-3 w-3': size == 'sm',
+          'h-3 w-3': size == 'xs' || size == 'sm',
           'h-[13.5px] w-[13.5px]': size == 'md',
           'h-[15px] w-[15px]': size == 'lg',
           'h-4.5 w-4.5': size == 'xl' || size == '2xl',
@@ -185,6 +185,7 @@ const buttonClasses = computed(() => {
   let disabledClasses = disabledClassesMap[themeVariant]
 
   let sizeClasses = {
+    xs: 'h-6 text-sm px-1.5 rounded',
     sm: 'h-7 text-base px-2 rounded',
     md: 'h-8 text-base font-medium px-2.5 rounded',
     lg: 'h-10 text-lg font-medium px-3 rounded-md',
@@ -194,6 +195,7 @@ const buttonClasses = computed(() => {
 
   if (isIconButton.value) {
     sizeClasses = {
+      xs: 'h-6 w-6 rounded',
       sm: 'h-7 w-7 rounded',
       md: 'h-8 w-8 rounded',
       lg: 'h-10 w-10 rounded-md',
@@ -212,6 +214,7 @@ const buttonClasses = computed(() => {
 
 const slotClasses = computed(() => {
   let classes = {
+    xs: 'h-4',
     sm: 'h-4',
     md: 'h-4.5',
     lg: 'h-5',
@@ -224,6 +227,7 @@ const slotClasses = computed(() => {
 
 const lucideSlotClasses = computed(() => {
   return {
+    xs: 'size-4',
     sm: 'size-4',
     md: 'size-4.5',
     lg: 'size-5',

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -1,53 +1,59 @@
 import { type RouterLinkProps } from 'vue-router'
-import { type Component } from 'vue'
+import { type Component, type ExtractPublicPropTypes, type PropType } from 'vue'
 
-type Theme = 'gray' | 'blue' | 'green' | 'red'
-type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
-type Variant = 'solid' | 'subtle' | 'outline' | 'ghost'
+export type Theme = 'gray' | 'blue' | 'green' | 'red'
+export type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
+export type Variant = 'solid' | 'subtle' | 'outline' | 'ghost'
 
-export interface ButtonProps {
-  /** Visual color theme of the button */
-  theme?: Theme
-
-  /** Controls the button size */
-  size?: Size
-
-  /** Visual style of the button */
-  variant?: Variant
-
-  /** Text label displayed inside the button */
-  label?: string
-
-  /** Icon shown when no left or right icon is specified */
-  icon?: string | Component
-
-  /** Icon shown before the label */
-  iconLeft?: string | Component
-
-  /** Icon shown after the label */
-  iconRight?: string | Component
-
-  /** Tooltip text shown on hover */
-  tooltip?: string
-
-  /** Shows a loading state and disables interaction */
-  loading?: boolean
-
-  /** Text shown while the button is loading */
-  loadingText?: string
-
-  /** Disables the button */
-  disabled?: boolean
-
-  /** Router destination when used as a link */
-  route?: RouterLinkProps['to']
-
-  /** External link URL */
-  link?: string
-
-  /** Native button type */
-  type?: 'button' | 'submit' | 'reset'
+const iconProp = {
+  type: [String, Object, Function] as PropType<string | Component>,
+  default: undefined,
 }
+
+/**
+ * Runtime prop definitions — the single source of truth for the button's props.
+ * `Button.vue` spreads these into `defineComponent`, and the public `ButtonProps`
+ * type is derived from them, so the runtime and the type can never drift apart.
+ */
+export const buttonProps = {
+  /** Visual color theme of the button */
+  theme: { type: String as PropType<Theme>, default: 'gray' },
+  /** Controls the button size */
+  size: { type: String as PropType<Size>, default: 'sm' },
+  /** Visual style of the button */
+  variant: { type: String as PropType<Variant>, default: 'subtle' },
+  /** Text label displayed inside the button */
+  label: { type: String, default: undefined },
+  /** Icon shown when no left or right icon is specified */
+  icon: iconProp,
+  /** Icon shown before the label */
+  iconLeft: iconProp,
+  /** Icon shown after the label */
+  iconRight: iconProp,
+  /** Tooltip text shown on hover */
+  tooltip: { type: String, default: undefined },
+  /** Shows a loading state and disables interaction */
+  loading: { type: Boolean, default: false },
+  /** Text shown while the button is loading */
+  loadingText: { type: String, default: undefined },
+  /** Disables the button */
+  disabled: { type: Boolean, default: false },
+  /** Router destination when used as a link */
+  route: {
+    type: [String, Object] as PropType<RouterLinkProps['to']>,
+    default: undefined,
+  },
+  /** External link URL */
+  link: { type: String, default: undefined },
+  /** Native button type */
+  type: {
+    type: String as PropType<'button' | 'submit' | 'reset'>,
+    default: 'button',
+  },
+}
+
+/** Public prop types for `<Button>`. Derived from {@link buttonProps}. */
+export type ButtonProps = ExtractPublicPropTypes<typeof buttonProps>
 
 /** Combined theme and variant key */
 export type ThemeVariant = `${Theme}-${Variant}`

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -2,7 +2,7 @@ import { type RouterLinkProps } from 'vue-router'
 import { type Component } from 'vue'
 
 type Theme = 'gray' | 'blue' | 'green' | 'red'
-type Size = 'sm' | 'md' | 'md' | 'lg' | 'xl' | '2xl'
+type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
 type Variant = 'solid' | 'subtle' | 'outline' | 'ghost'
 
 export interface ButtonProps {

--- a/src/components/Tooltip/Tooltip.cy.ts
+++ b/src/components/Tooltip/Tooltip.cy.ts
@@ -1,4 +1,5 @@
 import Tooltip from './Tooltip.vue'
+import TooltipProvider from './TooltipProvider.vue'
 import Button from '../Button/Button.vue'
 import { h } from 'vue'
 
@@ -62,5 +63,52 @@ describe('Tooltip', () => {
 
     cy.get('button').trigger('focus')
     cy.get('svg').should('has.class', 'fill-red-500')
+  })
+
+  it('grouping under a shared TooltipProvider skips the re-delay between triggers', () => {
+    // `disableHoverableContent` makes leaving the trigger close its tooltip,
+    // which opens the provider's skip-delay window — the toolbar use case.
+    const Group = () =>
+      h(
+        TooltipProvider,
+        { hoverDelay: 0.5, skipDelay: 0.3, disableHoverableContent: true },
+        () => [
+          h(Tooltip, { text: 'First' }, () =>
+            h('button', { 'data-cy': 'first' }, 'one'),
+          ),
+          h(Tooltip, { text: 'Second' }, () =>
+            h('button', { 'data-cy': 'second' }, 'two'),
+          ),
+        ],
+      )
+
+    cy.clock()
+    cy.mount(Group)
+
+    // First trigger incurs the full hover delay before opening.
+    cy.get('[data-cy=first]').trigger('pointermove')
+    cy.get('[role=tooltip]').should('not.exist')
+    cy.tick(500)
+    cy.get('[role=tooltip]').should('have.text', 'First')
+    cy.get('[data-cy=first]').should('have.attr', 'data-state', 'delayed-open')
+
+    // Leaving closes it and opens the skip-delay window.
+    cy.get('[data-cy=first]').trigger('pointerleave')
+
+    // Moving to the neighbour opens instantly — no clock tick needed.
+    cy.get('[data-cy=second]').trigger('pointermove')
+    cy.get('[role=tooltip]').should('have.text', 'Second')
+    cy.get('[data-cy=second]').should('have.attr', 'data-state', 'instant-open')
+  })
+
+  it('a standalone Tooltip still mounts its own provider (no grouping)', () => {
+    // Without a surrounding provider every tooltip delays independently.
+    cy.clock()
+    cy.mount(h(Tooltip, { text: 'solo', hoverDelay: 0.5 }, () => h('button', 'k')))
+
+    cy.get('button').trigger('pointermove')
+    cy.get('[role=tooltip]').should('not.exist')
+    cy.tick(500)
+    cy.get('button').should('have.attr', 'data-state', 'delayed-open')
   })
 })

--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -9,4 +9,10 @@ A popup that displays information related to an element when the element receive
 
 <ComponentPreview name="Tooltip-Slots" />
 
+## Grouping (shared hover delay)
+
+Wrap a group of buttons in a `TooltipProvider` so that once one tooltip is open, moving the pointer to a neighbouring trigger within `skip-delay` opens its tooltip instantly — no delay between adjacent buttons. `Tooltip` and tooltip-bearing `Button`s automatically reuse a surrounding provider instead of creating their own.
+
+<ComponentPreview name="Tooltip-Group" />
+
 <!-- @include: ./Tooltip.api.md -->

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
-import { TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui'
+import {
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
+  injectTooltipProviderContext,
+} from 'reka-ui'
 import TooltipBubble from './TooltipBubble.vue'
-import { computed } from 'vue'
+import { computed, type Component } from 'vue'
 import type { TooltipProps } from './types'
 
 defineOptions({
@@ -17,6 +22,16 @@ const props = withDefaults(defineProps<TooltipProps>(), {
 })
 
 const delayDuration = computed(() => props.hoverDelay * 1000)
+
+// When already inside a <TooltipProvider> (a button group), reuse that shared
+// context so the group's skip-delay spans this tooltip too, instead of
+// mounting a private provider that would isolate it.
+const parentProvider = injectTooltipProviderContext(null)
+const Passthrough: Component = (_, { slots }) => slots.default?.()
+const Provider = computed(() => (parentProvider ? Passthrough : TooltipProvider))
+const providerProps = computed(() =>
+  parentProvider ? {} : { delayDuration: delayDuration.value },
+)
 
 defineSlots<{
   /**
@@ -42,7 +57,7 @@ defineSlots<{
 
 <template>
   <slot v-if="disabled" />
-  <TooltipProvider v-else :delayDuration="delayDuration">
+  <component :is="Provider" v-else v-bind="providerProps">
     <TooltipRoot>
       <TooltipTrigger as-child>
         <slot />
@@ -61,5 +76,5 @@ defineSlots<{
         </template>
       </TooltipBubble>
     </TooltipRoot>
-  </TooltipProvider>
+  </component>
 </template>

--- a/src/components/Tooltip/TooltipProvider.vue
+++ b/src/components/Tooltip/TooltipProvider.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { TooltipProvider as RekaTooltipProvider } from 'reka-ui'
+import { computed } from 'vue'
+
+/**
+ * Groups multiple `<Tooltip>`s (and tooltip-bearing `<Button>`s) under a
+ * single tooltip context. Once any tooltip in the group has opened, moving
+ * the pointer to another trigger within `skipDelay` opens its tooltip
+ * instantly — no hover delay between neighbouring buttons.
+ *
+ * `<Tooltip>` and `<Button>` detect this provider and skip mounting their
+ * own, so the shared skip-delay window spans the whole group:
+ *
+ * ```vue
+ * <TooltipProvider>
+ *   <Button icon="bold" :tooltip="'Bold'" />
+ *   <Tooltip text="Italic"><button>…</button></Tooltip>
+ *   <Tooltip text="Underline"><button>…</button></Tooltip>
+ * </TooltipProvider>
+ * ```
+ */
+const props = withDefaults(
+  defineProps<{
+    /** Delay (in seconds) before the first tooltip in the group opens. */
+    hoverDelay?: number
+    /**
+     * Window (in seconds) during which moving to another trigger in this
+     * group opens its tooltip with no delay. Mirrors reka's
+     * `skipDelayDuration`.
+     */
+    skipDelay?: number
+    /**
+     * When `true`, hovering the tooltip body closes it as the pointer
+     * leaves the trigger.
+     */
+    disableHoverableContent?: boolean
+  }>(),
+  { hoverDelay: 0.5, skipDelay: 0.3, disableHoverableContent: false },
+)
+
+const delayDuration = computed(() => props.hoverDelay * 1000)
+const skipDelayDuration = computed(() => props.skipDelay * 1000)
+</script>
+
+<template>
+  <RekaTooltipProvider
+    :delay-duration="delayDuration"
+    :skip-delay-duration="skipDelayDuration"
+    :disable-hoverable-content="disableHoverableContent"
+  >
+    <slot />
+  </RekaTooltipProvider>
+</template>

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,3 +1,4 @@
 export { default as Tooltip } from './Tooltip.vue'
 export { default as TooltipBubble } from './TooltipBubble.vue'
+export { default as TooltipProvider } from './TooltipProvider.vue'
 export type { TooltipProps } from './types'

--- a/src/components/Tooltip/stories/Group.vue
+++ b/src/components/Tooltip/stories/Group.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { Button, Tooltip, TooltipProvider } from 'frappe-ui'
+</script>
+
+<template>
+  <!--
+    Hover any button to open its tooltip after `hover-delay`. Sweeping the
+    pointer to a neighbour within `skip-delay` opens the next tooltip
+    instantly — no per-button flicker — because the whole row shares one
+    tooltip context.
+  -->
+  <TooltipProvider :hover-delay="0.5" :skip-delay="0.3">
+    <div class="flex items-center gap-1">
+      <Button icon="bold" :tooltip="'Bold'" />
+      <Button icon="italic" :tooltip="'Italic'" />
+      <Button icon="underline" :tooltip="'Underline'" />
+      <Tooltip text="Strikethrough">
+        <Button icon="minus" />
+      </Tooltip>
+    </div>
+  </TooltipProvider>
+</template>

--- a/src/molecules/editor/EditorTableMenu.vue
+++ b/src/molecules/editor/EditorTableMenu.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import EditorBubbleMenu from './EditorBubbleMenu.vue'
+import { tableToolbar } from './menu'
+import type { Editor } from './useEditor'
+import { useResolvedEditor } from './editor-context'
+
+/**
+ * Contextual table toolbar: a bubble menu that appears only while the selection
+ * is inside a table, with row/column insert + delete, header-row toggle,
+ * merge/split, and delete-table controls (see `tableToolbar`).
+ *
+ * It carries its own `pluginKey` so it coexists with a text-formatting bubble
+ * menu, and it's safe to render unconditionally — `shouldShow` keeps it hidden
+ * outside tables, and the items self-prune when the Table extension is absent,
+ * so the same component is inert in a comment editor.
+ */
+const props = defineProps<{
+  // Optional inside <Editor> — falls back to the provided editor context.
+  editor?: Editor | null
+}>()
+
+const editor = useResolvedEditor(() => props.editor)
+
+const options = {
+  pluginKey: 'tableBubbleMenu',
+  placement: 'top' as const,
+  shouldShow: ({ editor }: { editor: Editor }) =>
+    editor.isEditable && editor.isActive('table'),
+}
+</script>
+
+<template>
+  <EditorBubbleMenu
+    v-if="editor"
+    :editor="editor"
+    :items="tableToolbar"
+    :options="options"
+  />
+</template>

--- a/src/molecules/editor/EditorTableMenu.vue
+++ b/src/molecules/editor/EditorTableMenu.vue
@@ -52,7 +52,7 @@ function reposition() {
   if (!reference || !el) return
   void computePosition(reference, el, {
     strategy: 'fixed',
-    placement: 'top-start',
+    placement: 'top',
     middleware: [offset(8), flip(), shift({ padding: 8 })],
   }).then(({ x, y }) => {
     el.style.left = `${x}px`

--- a/src/molecules/editor/EditorTableMenu.vue
+++ b/src/molecules/editor/EditorTableMenu.vue
@@ -179,7 +179,7 @@ onBeforeUnmount(closeContextMenu)
       v-show="visible && editor"
       ref="floating"
       data-slot="table-menu"
-      class="fixed left-0 top-0 z-[100] flex items-center gap-1 rounded border border-outline-gray-2 bg-surface-white p-1 shadow-sm"
+      class="fixed left-0 top-0 z-[100] flex items-center gap-1 rounded-lg border border-outline-gray-2 bg-surface-white p-1 shadow-sm"
     >
       <MenuItems v-if="editor" :editor="editor" :items="tableToolbar" />
     </div>

--- a/src/molecules/editor/EditorTableMenu.vue
+++ b/src/molecules/editor/EditorTableMenu.vue
@@ -1,10 +1,23 @@
 <script setup lang="ts">
-import { nextTick, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import {
+  nextTick,
+  onBeforeUnmount,
+  ref,
+  shallowRef,
+  useTemplateRef,
+  watch,
+} from 'vue'
 import { computePosition, flip, offset, shift } from '@floating-ui/dom'
+import { CellSelection, cellAround } from '@tiptap/pm/tables'
 import MenuItems from './MenuItems.vue'
+import TableContextMenu from './components/TableContextMenu.vue'
 import { tableToolbar } from './menu'
 import type { Editor } from './useEditor'
 import { useResolvedEditor } from './editor-context'
+import {
+  useFloatingPopup,
+  type FloatingPopupHandle,
+} from './composables/useFloatingPopup'
 
 /**
  * Contextual table toolbar with row/column insert + delete, header-row toggle,
@@ -69,6 +82,57 @@ function sync() {
   if (table) void nextTick(reposition)
 }
 
+// --- Right-click context menu ---------------------------------------------
+let contextMenu: FloatingPopupHandle | null = null
+
+function closeContextMenu() {
+  contextMenu?.destroy()
+  contextMenu = null
+}
+
+function openContextMenu(ed: Editor, clientX: number, clientY: number) {
+  closeContextMenu()
+  contextMenu = useFloatingPopup({
+    anchor: ed.view.dom,
+    component: TableContextMenu,
+    props: { editor: ed, items: tableToolbar, onRun: closeContextMenu },
+    // Anchor at the cursor point so the menu opens where the user clicked.
+    virtualReference: {
+      getBoundingClientRect: () => new DOMRect(clientX, clientY, 0, 0),
+    },
+    closeOnAnchorPointerDown: true,
+    floatingOptions: { placement: 'right-start', strategy: 'fixed', offset: 0 },
+  })
+}
+
+function onContextMenu(event: MouseEvent) {
+  const ed = editor.value
+  if (!ed || ed.isDestroyed || !ed.isEditable) return
+  // The view getter throws until the editor is mounted; a real right-click
+  // always happens after mount, but guard anyway.
+  let dom: HTMLElement
+  try {
+    dom = ed.view.dom as HTMLElement
+  } catch {
+    return
+  }
+  const target = event.target
+  if (!(target instanceof Node) || !dom.contains(target)) return
+  const coords = ed.view.posAtCoords({
+    left: event.clientX,
+    top: event.clientY,
+  })
+  if (!coords) return
+  const $cell = cellAround(ed.state.doc.resolve(coords.pos))
+  if (!$cell) return // not in a table — let the native menu through
+  event.preventDefault()
+  // Select the right-clicked cell so the actions target it.
+  ed.view.dispatch(
+    ed.state.tr.setSelection(CellSelection.create(ed.state.doc, $cell.pos)),
+  )
+  openContextMenu(ed, event.clientX, event.clientY)
+}
+
 // (Re)subscribe whenever the editor instance changes. Repositioning is driven by
 // transactions (selection / content) and by scroll/resize — anchored to the
 // table, so cell-to-cell caret moves don't move the toolbar.
@@ -86,16 +150,23 @@ watch(
     // Capture phase so inner scroll containers are caught too.
     document.addEventListener('scroll', onScroll, true)
     window.addEventListener('resize', onScroll)
+    // Bound on document (not the view DOM) so it never touches `ed.view` before
+    // the view is mounted; the handler scopes itself to this editor.
+    document.addEventListener('contextmenu', onContextMenu, true)
     sync()
     onCleanup(() => {
       ed.off('transaction', onChange)
       ed.off('focus', onChange)
       document.removeEventListener('scroll', onScroll, true)
       window.removeEventListener('resize', onScroll)
+      document.removeEventListener('contextmenu', onContextMenu, true)
+      closeContextMenu()
     })
   },
   { immediate: true },
 )
+
+onBeforeUnmount(closeContextMenu)
 </script>
 
 <template>

--- a/src/molecules/editor/EditorTableMenu.vue
+++ b/src/molecules/editor/EditorTableMenu.vue
@@ -1,18 +1,24 @@
 <script setup lang="ts">
-import EditorBubbleMenu from './EditorBubbleMenu.vue'
+import { nextTick, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computePosition, flip, offset, shift } from '@floating-ui/dom'
+import MenuItems from './MenuItems.vue'
 import { tableToolbar } from './menu'
 import type { Editor } from './useEditor'
 import { useResolvedEditor } from './editor-context'
 
 /**
- * Contextual table toolbar: a bubble menu that appears only while the selection
- * is inside a table, with row/column insert + delete, header-row toggle,
+ * Contextual table toolbar with row/column insert + delete, header-row toggle,
  * merge/split, and delete-table controls (see `tableToolbar`).
  *
- * It carries its own `pluginKey` so it coexists with a text-formatting bubble
- * menu, and it's safe to render unconditionally — `shouldShow` keeps it hidden
- * outside tables, and the items self-prune when the Table extension is absent,
- * so the same component is inert in a comment editor.
+ * Unlike a stock bubble menu — which anchors to the text selection and so jumps
+ * from cell to cell as the caret moves — this anchors to the *table* element. It
+ * therefore stays put while you move between cells and only re-positions when
+ * you enter a different table (or the table / viewport changes). The buttons
+ * still act on the active cell, so the toolbar adapts to context without moving.
+ *
+ * Safe to render unconditionally: it's hidden outside tables and the items
+ * self-prune when the Table extension is absent, so it's inert in a comment
+ * editor.
  */
 const props = defineProps<{
   // Optional inside <Editor> — falls back to the provided editor context.
@@ -21,19 +27,86 @@ const props = defineProps<{
 
 const editor = useResolvedEditor(() => props.editor)
 
-const options = {
-  pluginKey: 'tableBubbleMenu',
-  placement: 'top' as const,
-  shouldShow: ({ editor }: { editor: Editor }) =>
-    editor.isEditable && editor.isActive('table'),
+const floating = useTemplateRef<HTMLElement>('floating')
+const anchor = shallowRef<HTMLElement | null>(null)
+const visible = ref(false)
+
+/** The DOM element of the table the selection is currently inside, if any. */
+function activeTableEl(ed: Editor): HTMLElement | null {
+  if (!ed.isEditable || !ed.isActive('table')) return null
+  const { $from } = ed.state.selection
+  for (let depth = $from.depth; depth > 0; depth--) {
+    if ($from.node(depth).type.name === 'table') {
+      const dom = ed.view.nodeDOM($from.before(depth))
+      // nodeDOM returns the table's wrapper (or the table itself) — both give a
+      // stable bounding box to anchor against.
+      if (dom instanceof HTMLElement) return dom
+    }
+  }
+  return null
 }
+
+function reposition() {
+  const reference = anchor.value
+  const el = floating.value
+  if (!reference || !el) return
+  void computePosition(reference, el, {
+    strategy: 'fixed',
+    placement: 'top-start',
+    middleware: [offset(8), flip(), shift({ padding: 8 })],
+  }).then(({ x, y }) => {
+    el.style.left = `${x}px`
+    el.style.top = `${y}px`
+  })
+}
+
+function sync() {
+  const ed = editor.value
+  const table = ed ? activeTableEl(ed) : null
+  anchor.value = table
+  visible.value = !!table
+  // Wait for v-show to reveal the element before measuring it.
+  if (table) void nextTick(reposition)
+}
+
+// (Re)subscribe whenever the editor instance changes. Repositioning is driven by
+// transactions (selection / content) and by scroll/resize — anchored to the
+// table, so cell-to-cell caret moves don't move the toolbar.
+watch(
+  editor,
+  (ed, _old, onCleanup) => {
+    if (typeof ed?.on !== 'function') {
+      visible.value = false
+      return
+    }
+    const onChange = () => sync()
+    const onScroll = () => reposition()
+    ed.on('transaction', onChange)
+    ed.on('focus', onChange)
+    // Capture phase so inner scroll containers are caught too.
+    document.addEventListener('scroll', onScroll, true)
+    window.addEventListener('resize', onScroll)
+    sync()
+    onCleanup(() => {
+      ed.off('transaction', onChange)
+      ed.off('focus', onChange)
+      document.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('resize', onScroll)
+    })
+  },
+  { immediate: true },
+)
 </script>
 
 <template>
-  <EditorBubbleMenu
-    v-if="editor"
-    :editor="editor"
-    :items="tableToolbar"
-    :options="options"
-  />
+  <Teleport to="body">
+    <div
+      v-show="visible && editor"
+      ref="floating"
+      data-slot="table-menu"
+      class="fixed left-0 top-0 z-[100] flex items-center gap-1 rounded border border-outline-gray-2 bg-surface-white p-1 shadow-sm"
+    >
+      <MenuItems v-if="editor" :editor="editor" :items="tableToolbar" />
+    </div>
+  </Teleport>
 </template>

--- a/src/molecules/editor/EditorTableMenu.vue
+++ b/src/molecules/editor/EditorTableMenu.vue
@@ -47,6 +47,10 @@ const visible = ref(false)
 /** The DOM element of the table the selection is currently inside, if any. */
 function activeTableEl(ed: Editor): HTMLElement | null {
   if (!ed.isEditable || !ed.isActive('table')) return null
+  // `editor.view` is a proxy that throws on access until the view is mounted;
+  // the immediate watch can run sync() before that. `isInitialized` flips true
+  // on mount, so bail until then.
+  if (!ed.isInitialized) return null
   const { $from } = ed.state.selection
   for (let depth = $from.depth; depth > 0; depth--) {
     if ($from.node(depth).type.name === 'table') {
@@ -105,6 +109,7 @@ function openContextMenu(ed: Editor, clientX: number, clientY: number) {
       getBoundingClientRect: () => new DOMRect(clientX, clientY, 0, 0),
     },
     closeOnAnchorPointerDown: true,
+    animate: true,
     floatingOptions: { placement: 'right-start', strategy: 'fixed', offset: 0 },
   })
 }
@@ -175,13 +180,37 @@ onBeforeUnmount(closeContextMenu)
 
 <template>
   <Teleport to="body">
-    <div
-      v-show="visible && editor"
-      ref="floating"
-      data-slot="table-menu"
-      class="fixed left-0 top-0 z-[100] flex items-center gap-1 rounded-lg border border-outline-gray-2 bg-surface-white p-1 shadow-sm"
-    >
-      <MenuItems v-if="editor" :editor="editor" :items="tableToolbar" />
-    </div>
+    <Transition name="table-menu">
+      <div
+        v-show="visible && editor"
+        ref="floating"
+        data-slot="table-menu"
+        class="fixed left-0 top-0 z-[100] flex items-center gap-1 rounded-lg border border-outline-gray-2 bg-surface-white p-1 shadow-sm"
+      >
+        <MenuItems v-if="editor" :editor="editor" :items="tableToolbar" />
+      </div>
+    </Transition>
   </Teleport>
 </template>
+
+<style scoped>
+/* Fast appear only; leave is instant so the toolbar clears the moment the
+ * selection leaves a table. Mirrors EditorPopover's 90ms fade+scale. */
+.table-menu-enter-active {
+  transition:
+    opacity 90ms ease-out,
+    transform 90ms ease-out;
+  transform-origin: center bottom;
+}
+
+.table-menu-enter-from {
+  opacity: 0;
+  transform: scale(0.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .table-menu-enter-active {
+    transition: none;
+  }
+}
+</style>

--- a/src/molecules/editor/EditorTableMenu.vue
+++ b/src/molecules/editor/EditorTableMenu.vue
@@ -51,9 +51,13 @@ function activeTableEl(ed: Editor): HTMLElement | null {
   for (let depth = $from.depth; depth > 0; depth--) {
     if ($from.node(depth).type.name === 'table') {
       const dom = ed.view.nodeDOM($from.before(depth))
-      // nodeDOM returns the table's wrapper (or the table itself) — both give a
-      // stable bounding box to anchor against.
-      if (dom instanceof HTMLElement) return dom
+      // nodeDOM returns the table's wrapper; anchor to the inner <table> so the
+      // toolbar sits against the table edge, not the wrapper's outer spacing.
+      if (dom instanceof HTMLElement) {
+        return dom.tagName === 'TABLE'
+          ? dom
+          : (dom.querySelector('table') ?? dom)
+      }
     }
   }
   return null
@@ -66,7 +70,7 @@ function reposition() {
   void computePosition(reference, el, {
     strategy: 'fixed',
     placement: 'top',
-    middleware: [offset(8), flip(), shift({ padding: 8 })],
+    middleware: [offset(4), flip(), shift({ padding: 8 })],
   }).then(({ x, y }) => {
     el.style.left = `${x}px`
     el.style.top = `${y}px`

--- a/src/molecules/editor/MenuItems.vue
+++ b/src/molecules/editor/MenuItems.vue
@@ -2,6 +2,7 @@
 import { computed, h, ref, watch, type Component } from 'vue'
 import type { CommandMenuItem, MenuGroupItem, MenuItem } from './menu'
 import type { Editor } from './useEditor'
+import Tooltip from '#components/Tooltip/Tooltip.vue'
 
 const props = defineProps<{
   editor: Editor | null
@@ -139,29 +140,34 @@ function run(item: CommandMenuItem, event?: MouseEvent) {
       <span class="px-2 text-sm font-medium text-ink-gray-7">{{
         item.label
       }}</span>
-      <button
+      <Tooltip
         v-for="groupItem in item.items"
         :key="groupItem.label"
+        :text="groupItem.label"
+      >
+        <button
+          type="button"
+          class="inline-flex size-6 items-center justify-center rounded text-sm text-ink-gray-7 hover:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50 aria-pressed:bg-surface-gray-3"
+          :aria-label="groupItem.label"
+          :aria-pressed="isPressed(groupItem)"
+          :disabled="isItemDisabled(groupItem)"
+          @click="run(groupItem, $event)"
+        >
+          <ItemContent :item="groupItem" />
+        </button>
+      </Tooltip>
+    </div>
+    <Tooltip v-else :text="item.label">
+      <button
         type="button"
         class="inline-flex size-6 items-center justify-center rounded text-sm text-ink-gray-7 hover:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50 aria-pressed:bg-surface-gray-3"
-        :aria-label="groupItem.label"
-        :aria-pressed="isPressed(groupItem)"
-        :disabled="isItemDisabled(groupItem)"
-        @click="run(groupItem, $event)"
+        :aria-label="item.label"
+        :aria-pressed="isPressed(item)"
+        :disabled="isItemDisabled(item)"
+        @click="run(item, $event)"
       >
-        <ItemContent :item="groupItem" />
+        <ItemContent :item="item" />
       </button>
-    </div>
-    <button
-      v-else
-      type="button"
-      class="inline-flex size-6 items-center justify-center rounded text-sm text-ink-gray-7 hover:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50 aria-pressed:bg-surface-gray-3"
-      :aria-label="item.label"
-      :aria-pressed="isPressed(item)"
-      :disabled="isItemDisabled(item)"
-      @click="run(item, $event)"
-    >
-      <ItemContent :item="item" />
-    </button>
+    </Tooltip>
   </template>
 </template>

--- a/src/molecules/editor/MenuItems.vue
+++ b/src/molecules/editor/MenuItems.vue
@@ -3,6 +3,7 @@ import { computed, h, ref, watch, type Component } from 'vue'
 import type { CommandMenuItem, MenuGroupItem, MenuItem } from './menu'
 import type { Editor } from './useEditor'
 import Tooltip from '#components/Tooltip/Tooltip.vue'
+import TooltipProvider from '#components/Tooltip/TooltipProvider.vue'
 
 const props = defineProps<{
   editor: Editor | null
@@ -104,70 +105,75 @@ function run(item: CommandMenuItem, event?: MouseEvent) {
 </script>
 
 <template>
-  <template
-    v-for="(item, index) in visibleItems"
-    :key="`${'label' in item ? item.label : item.type}-${index}`"
-  >
-    <span
-      v-if="isSeparator(item)"
-      data-slot="menu-separator"
-      class="mx-1 h-5 w-px bg-surface-gray-3"
-      aria-hidden="true"
-    />
-    <component
-      :is="item.component"
-      v-else-if="isComponentItem(item) && editor"
-      :editor="editor"
+  <!-- One shared provider so once any button's tooltip opens, neighbouring
+       buttons show theirs instantly (skip-delay) — toolbar-friendly. Renderless,
+       so the parent's flex layout is unaffected. -->
+  <TooltipProvider>
+    <template
+      v-for="(item, index) in visibleItems"
+      :key="`${'label' in item ? item.label : item.type}-${index}`"
     >
-      <template #default="trigger">
+      <span
+        v-if="isSeparator(item)"
+        data-slot="menu-separator"
+        class="mx-1 h-5 w-px bg-surface-gray-3"
+        aria-hidden="true"
+      />
+      <component
+        :is="item.component"
+        v-else-if="isComponentItem(item) && editor"
+        :editor="editor"
+      >
+        <template #default="trigger">
+          <button
+            type="button"
+            class="inline-flex size-6 items-center justify-center rounded text-sm text-ink-gray-7 hover:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50 aria-pressed:bg-surface-gray-3"
+            :aria-label="item.label"
+            :aria-pressed="trigger.isActive === true || isPressed(item)"
+            :disabled="isItemDisabled(item)"
+            @click="isItemDisabled(item) ? undefined : trigger.onClick()"
+          >
+            <ItemContent :item="item" />
+          </button>
+        </template>
+      </component>
+      <div
+        v-else-if="isGroup(item)"
+        data-slot="menu-group"
+        class="flex items-center gap-1"
+      >
+        <span class="px-2 text-sm font-medium text-ink-gray-7">{{
+          item.label
+        }}</span>
+        <Tooltip
+          v-for="groupItem in item.items"
+          :key="groupItem.label"
+          :text="groupItem.label"
+        >
+          <button
+            type="button"
+            class="inline-flex size-6 items-center justify-center rounded text-sm text-ink-gray-7 hover:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50 aria-pressed:bg-surface-gray-3"
+            :aria-label="groupItem.label"
+            :aria-pressed="isPressed(groupItem)"
+            :disabled="isItemDisabled(groupItem)"
+            @click="run(groupItem, $event)"
+          >
+            <ItemContent :item="groupItem" />
+          </button>
+        </Tooltip>
+      </div>
+      <Tooltip v-else :text="item.label">
         <button
           type="button"
           class="inline-flex size-6 items-center justify-center rounded text-sm text-ink-gray-7 hover:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50 aria-pressed:bg-surface-gray-3"
           :aria-label="item.label"
-          :aria-pressed="trigger.isActive === true || isPressed(item)"
+          :aria-pressed="isPressed(item)"
           :disabled="isItemDisabled(item)"
-          @click="isItemDisabled(item) ? undefined : trigger.onClick()"
+          @click="run(item, $event)"
         >
           <ItemContent :item="item" />
         </button>
-      </template>
-    </component>
-    <div
-      v-else-if="isGroup(item)"
-      data-slot="menu-group"
-      class="flex items-center gap-1"
-    >
-      <span class="px-2 text-sm font-medium text-ink-gray-7">{{
-        item.label
-      }}</span>
-      <Tooltip
-        v-for="groupItem in item.items"
-        :key="groupItem.label"
-        :text="groupItem.label"
-      >
-        <button
-          type="button"
-          class="inline-flex size-6 items-center justify-center rounded text-sm text-ink-gray-7 hover:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50 aria-pressed:bg-surface-gray-3"
-          :aria-label="groupItem.label"
-          :aria-pressed="isPressed(groupItem)"
-          :disabled="isItemDisabled(groupItem)"
-          @click="run(groupItem, $event)"
-        >
-          <ItemContent :item="groupItem" />
-        </button>
       </Tooltip>
-    </div>
-    <Tooltip v-else :text="item.label">
-      <button
-        type="button"
-        class="inline-flex size-6 items-center justify-center rounded text-sm text-ink-gray-7 hover:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50 aria-pressed:bg-surface-gray-3"
-        :aria-label="item.label"
-        :aria-pressed="isPressed(item)"
-        :disabled="isItemDisabled(item)"
-        @click="run(item, $event)"
-      >
-        <ItemContent :item="item" />
-      </button>
-    </Tooltip>
-  </template>
+    </template>
+  </TooltipProvider>
 </template>

--- a/src/molecules/editor/components/EditorDropZone.vue
+++ b/src/molecules/editor/components/EditorDropZone.vue
@@ -18,22 +18,20 @@ import { useEditorFileDrop } from '../composables/useEditorFileDrop'
  * (a discussion body plus per-comment composers), so a window-wide drop *target*
  * would be ambiguous about which editor receives the file. (The window-wide
  * *hint* is fine: every editable editor lights up, the user picks one.)
+ *
+ * The overlay's look is replaceable via the `#overlay` scoped slot, which
+ * receives the two drag signals; the component still owns when it shows and how
+ * it's positioned/animated.
  */
 const props = withDefaults(
   defineProps<{
     editor: Editor | null
     /** Disable dropping (e.g. read-only editors). */
     disabled?: boolean
-    /** Overlay label. */
+    /** Default overlay label. */
     label?: string
-    /** Secondary hint under the label. */
-    hint?: string
   }>(),
-  {
-    disabled: false,
-    label: 'Drop to add',
-    hint: 'Images, videos & files',
-  },
+  { disabled: false, label: 'Drop files to upload' },
 )
 
 const root = useTemplateRef<HTMLElement>('root')
@@ -55,46 +53,36 @@ const showOverlay = computed(() => isWindowDragging.value && !props.disabled)
     <slot />
 
     <Transition
-      enter-active-class="transition duration-150 ease-out"
-      leave-active-class="transition duration-150 ease-in"
+      enter-active-class="transition-opacity duration-150"
+      leave-active-class="transition-opacity duration-150"
       enter-from-class="opacity-0"
       leave-to-class="opacity-0"
     >
       <div
         v-if="showOverlay"
-        class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-[inherit] border-2 border-dashed p-3 backdrop-blur-[2px] transition-colors duration-150"
-        :class="
-          isOverZone
-            ? 'border-ink-gray-8 bg-surface-white/80'
-            : 'border-outline-gray-3 bg-surface-white/60'
-        "
+        class="pointer-events-none absolute inset-0 z-10 rounded-[inherit]"
       >
-        <div
-          class="flex flex-col items-center gap-3 text-center transition-transform duration-150 ease-out"
-          :class="isOverZone ? 'scale-105' : 'scale-100'"
+        <slot
+          name="overlay"
+          :is-over-zone="isOverZone"
+          :is-window-dragging="isWindowDragging"
         >
           <div
-            class="flex size-12 items-center justify-center rounded-full ring-1 transition-colors duration-150"
+            class="flex h-full w-full items-center justify-center rounded-[inherit] border-2 border-dashed transition-colors duration-150"
             :class="
               isOverZone
-                ? 'bg-surface-gray-3 text-ink-gray-9 ring-outline-gray-3'
-                : 'bg-surface-gray-2 text-ink-gray-5 ring-outline-gray-2'
+                ? 'border-outline-gray-4 bg-surface-gray-2/80'
+                : 'border-outline-gray-3 bg-surface-white/70'
             "
           >
-            <span class="lucide-upload size-5" />
-          </div>
-          <div class="flex flex-col gap-0.5">
             <span
-              class="text-base font-semibold transition-colors duration-150"
-              :class="isOverZone ? 'text-ink-gray-9' : 'text-ink-gray-7'"
+              class="text-base font-medium transition-colors duration-150"
+              :class="isOverZone ? 'text-ink-gray-8' : 'text-ink-gray-5'"
             >
               {{ label }}
             </span>
-            <span class="text-sm text-ink-gray-5">
-              {{ hint }}
-            </span>
           </div>
-        </div>
+        </slot>
       </div>
     </Transition>
   </div>

--- a/src/molecules/editor/components/EditorDropZone.vue
+++ b/src/molecules/editor/components/EditorDropZone.vue
@@ -37,10 +37,8 @@ const { isWindowDragging, isOverZone } = useEditorFileDrop(root, (files) => {
   if (props.disabled || !editor || editor.isDestroyed || !editor.isEditable) {
     return
   }
-  const images = files.filter((f) => /image/i.test(f.type))
-  const videos = files.filter((f) => /video/i.test(f.type))
-  if (images.length) editor.commands.uploadImageFiles(images)
-  if (videos.length) editor.commands.uploadVideoFiles(videos)
+  // The single drop pipeline decides single-image vs group dialog vs video.
+  editor.commands.dropFiles(files)
 })
 
 const showOverlay = computed(() => isWindowDragging.value && !props.disabled)

--- a/src/molecules/editor/components/EditorDropZone.vue
+++ b/src/molecules/editor/components/EditorDropZone.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { computed, useTemplateRef } from 'vue'
+import type { Editor } from '../useEditor'
+import { useScopedFileDrop } from '../composables/useScopedFileDrop'
+
+/**
+ * Generous, editor-scoped file drop target.
+ *
+ * Wraps the editor surface (toolbar + content) so a file dropped anywhere over
+ * it uploads and inserts, with a clear overlay while dragging. Drops that land
+ * directly on the prose are handled by the media ProseMirror plugin (precise
+ * insert at the cursor) and stop there; this zone only catches drops on the
+ * surrounding chrome (toolbar, padding) and inserts at the document end.
+ *
+ * Scoped on purpose — see `useScopedFileDrop`. A page often has several editors
+ * (a discussion body plus per-comment composers), so a window-wide target would
+ * be ambiguous about which editor receives the file.
+ */
+const props = withDefaults(
+  defineProps<{
+    editor: Editor | null
+    /** Disable dropping (e.g. read-only editors). */
+    disabled?: boolean
+    /** Overlay label. */
+    label?: string
+  }>(),
+  { disabled: false, label: 'Drop files to upload' },
+)
+
+const root = useTemplateRef<HTMLElement>('root')
+
+const { isFileDragging } = useScopedFileDrop(root, (files) => {
+  const editor = props.editor
+  if (props.disabled || !editor || editor.isDestroyed || !editor.isEditable) {
+    return
+  }
+  const images = files.filter((f) => /image/i.test(f.type))
+  const videos = files.filter((f) => /video/i.test(f.type))
+  if (images.length) editor.commands.uploadImageFiles(images)
+  if (videos.length) editor.commands.uploadVideoFiles(videos)
+})
+
+const showOverlay = computed(() => isFileDragging.value && !props.disabled)
+</script>
+
+<template>
+  <div ref="root" class="relative">
+    <slot />
+
+    <Transition
+      enter-active-class="transition-opacity duration-150"
+      leave-active-class="transition-opacity duration-150"
+      enter-from-class="opacity-0"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="showOverlay"
+        class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-[inherit] border-2 border-dashed border-outline-gray-3 bg-surface-white/80"
+      >
+        <span class="text-base font-medium text-ink-gray-7">{{ label }}</span>
+      </div>
+    </Transition>
+  </div>
+</template>

--- a/src/molecules/editor/components/EditorDropZone.vue
+++ b/src/molecules/editor/components/EditorDropZone.vue
@@ -26,8 +26,14 @@ const props = withDefaults(
     disabled?: boolean
     /** Overlay label. */
     label?: string
+    /** Secondary hint under the label. */
+    hint?: string
   }>(),
-  { disabled: false, label: 'Drop files to upload' },
+  {
+    disabled: false,
+    label: 'Drop to add',
+    hint: 'Images, videos & files',
+  },
 )
 
 const root = useTemplateRef<HTMLElement>('root')
@@ -49,26 +55,46 @@ const showOverlay = computed(() => isWindowDragging.value && !props.disabled)
     <slot />
 
     <Transition
-      enter-active-class="transition-opacity duration-150"
-      leave-active-class="transition-opacity duration-150"
+      enter-active-class="transition duration-150 ease-out"
+      leave-active-class="transition duration-150 ease-in"
       enter-from-class="opacity-0"
       leave-to-class="opacity-0"
     >
       <div
         v-if="showOverlay"
-        class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-[inherit] border-2 border-dashed transition-colors duration-150"
+        class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-[inherit] border-2 border-dashed p-3 backdrop-blur-[2px] transition-colors duration-150"
         :class="
           isOverZone
-            ? 'border-outline-gray-4 bg-surface-gray-2/80'
-            : 'border-outline-gray-3 bg-surface-white/70'
+            ? 'border-ink-gray-8 bg-surface-white/80'
+            : 'border-outline-gray-3 bg-surface-white/60'
         "
       >
-        <span
-          class="text-base font-medium transition-colors duration-150"
-          :class="isOverZone ? 'text-ink-gray-8' : 'text-ink-gray-5'"
+        <div
+          class="flex flex-col items-center gap-3 text-center transition-transform duration-150 ease-out"
+          :class="isOverZone ? 'scale-105' : 'scale-100'"
         >
-          {{ label }}
-        </span>
+          <div
+            class="flex size-12 items-center justify-center rounded-full ring-1 transition-colors duration-150"
+            :class="
+              isOverZone
+                ? 'bg-surface-gray-3 text-ink-gray-9 ring-outline-gray-3'
+                : 'bg-surface-gray-2 text-ink-gray-5 ring-outline-gray-2'
+            "
+          >
+            <span class="lucide-upload size-5" />
+          </div>
+          <div class="flex flex-col gap-0.5">
+            <span
+              class="text-base font-semibold transition-colors duration-150"
+              :class="isOverZone ? 'text-ink-gray-9' : 'text-ink-gray-7'"
+            >
+              {{ label }}
+            </span>
+            <span class="text-sm text-ink-gray-5">
+              {{ hint }}
+            </span>
+          </div>
+        </div>
       </div>
     </Transition>
   </div>

--- a/src/molecules/editor/components/EditorDropZone.vue
+++ b/src/molecules/editor/components/EditorDropZone.vue
@@ -1,20 +1,23 @@
 <script setup lang="ts">
 import { computed, useTemplateRef } from 'vue'
 import type { Editor } from '../useEditor'
-import { useScopedFileDrop } from '../composables/useScopedFileDrop'
+import { useEditorFileDrop } from '../composables/useEditorFileDrop'
 
 /**
  * Generous, editor-scoped file drop target.
  *
  * Wraps the editor surface (toolbar + content) so a file dropped anywhere over
- * it uploads and inserts, with a clear overlay while dragging. Drops that land
- * directly on the prose are handled by the media ProseMirror plugin (precise
+ * it uploads and inserts. The overlay is a two-stage affordance: it appears as a
+ * hint the moment a file enters the window (so the drop target is discoverable),
+ * then emphasises itself when the file is actually over this editor. Drops that
+ * land directly on the prose are handled by the media ProseMirror plugin (precise
  * insert at the cursor) and stop there; this zone only catches drops on the
  * surrounding chrome (toolbar, padding) and inserts at the document end.
  *
- * Scoped on purpose — see `useScopedFileDrop`. A page often has several editors
- * (a discussion body plus per-comment composers), so a window-wide target would
- * be ambiguous about which editor receives the file.
+ * Scoped on purpose — see `useEditorFileDrop`. A page often has several editors
+ * (a discussion body plus per-comment composers), so a window-wide drop *target*
+ * would be ambiguous about which editor receives the file. (The window-wide
+ * *hint* is fine: every editable editor lights up, the user picks one.)
  */
 const props = withDefaults(
   defineProps<{
@@ -29,7 +32,7 @@ const props = withDefaults(
 
 const root = useTemplateRef<HTMLElement>('root')
 
-const { isFileDragging } = useScopedFileDrop(root, (files) => {
+const { isWindowDragging, isOverZone } = useEditorFileDrop(root, (files) => {
   const editor = props.editor
   if (props.disabled || !editor || editor.isDestroyed || !editor.isEditable) {
     return
@@ -40,7 +43,7 @@ const { isFileDragging } = useScopedFileDrop(root, (files) => {
   if (videos.length) editor.commands.uploadVideoFiles(videos)
 })
 
-const showOverlay = computed(() => isFileDragging.value && !props.disabled)
+const showOverlay = computed(() => isWindowDragging.value && !props.disabled)
 </script>
 
 <template>
@@ -55,9 +58,19 @@ const showOverlay = computed(() => isFileDragging.value && !props.disabled)
     >
       <div
         v-if="showOverlay"
-        class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-[inherit] border-2 border-dashed border-outline-gray-3 bg-surface-white/80"
+        class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-[inherit] border-2 border-dashed transition-colors duration-150"
+        :class="
+          isOverZone
+            ? 'border-outline-gray-4 bg-surface-gray-2/80'
+            : 'border-outline-gray-3 bg-surface-white/70'
+        "
       >
-        <span class="text-base font-medium text-ink-gray-7">{{ label }}</span>
+        <span
+          class="text-base font-medium transition-colors duration-150"
+          :class="isOverZone ? 'text-ink-gray-8' : 'text-ink-gray-5'"
+        >
+          {{ label }}
+        </span>
       </div>
     </Transition>
   </div>

--- a/src/molecules/editor/components/EditorPopover.vue
+++ b/src/molecules/editor/components/EditorPopover.vue
@@ -3,9 +3,9 @@
     role="dialog"
     :aria-label="dialogLabel"
     tabindex="-1"
-    loop
-    trapped
-    class="editor-popover rounded-md border border-outline-gray-1 bg-surface-white shadow-xl outline-none"
+    :loop="loop"
+    :trapped="trapped"
+    class="editor-popover border border-outline-gray-1 bg-surface-white shadow-xl outline-none"
     :class="contentClass"
     @mount-auto-focus="onMountAutoFocus"
     @unmount-auto-focus="onUnmountAutoFocus"
@@ -20,13 +20,20 @@ import { FocusScope } from 'reka-ui'
 /**
  * Shared chrome for editor popups mounted via `useFloatingPopup`
  * (link editor, font-color picker, …). It owns the cross-cutting concerns a
- * floating panel needs — surface styling, `role="dialog"` + label, an enter
- * animation, and a looping focus trap (reka-ui `FocusScope`) — so each feature
- * only renders its own contents.
+ * floating panel needs — border/background/shadow, `role="dialog"` + label, an
+ * enter animation, and a looping focus trap (reka-ui `FocusScope`) — so each
+ * feature only renders its own contents. The corner radius is intentionally NOT
+ * owned here: each popup sets its own via `content-class` (e.g. `rounded-md`).
  *
  * It deliberately does NOT handle Escape or scroll-locking: dismissal and
  * scroll policy vary per popup and are owned by the opener (see the link
  * controller's two-stage Escape and scroll lock).
+ *
+ * Focus trapping is on by default (standalone dialogs like the link/color
+ * editors that own focus), but can be turned off for popups that must leave
+ * focus in the editor — e.g. suggestion lists, where the user keeps typing to
+ * filter. Trapping those would let FocusScope's MutationObserver steal focus on
+ * every keystroke-driven re-render.
  */
 const props = withDefaults(
   defineProps<{
@@ -36,8 +43,12 @@ const props = withDefaults(
     contentClass?: string | string[]
     /** Let FocusScope move focus to the first tabbable on open. Defaults `true`. */
     autofocus?: boolean
+    /** Keep focus inside the panel (focus trap). Defaults `true`. */
+    trapped?: boolean
+    /** Loop Tab focus at the panel edges. Defaults `true`. */
+    loop?: boolean
   }>(),
-  { autofocus: true },
+  { autofocus: true, trapped: true, loop: true },
 )
 
 function onMountAutoFocus(event: Event) {

--- a/src/molecules/editor/components/EditorPopover.vue
+++ b/src/molecules/editor/components/EditorPopover.vue
@@ -1,0 +1,78 @@
+<template>
+  <FocusScope
+    role="dialog"
+    :aria-label="dialogLabel"
+    tabindex="-1"
+    loop
+    trapped
+    class="editor-popover rounded-md border border-outline-gray-1 bg-surface-white shadow-xl outline-none"
+    :class="contentClass"
+    @mount-auto-focus="onMountAutoFocus"
+    @unmount-auto-focus="onUnmountAutoFocus"
+  >
+    <slot />
+  </FocusScope>
+</template>
+
+<script setup lang="ts">
+import { FocusScope } from 'reka-ui'
+
+/**
+ * Shared chrome for editor popups mounted via `useFloatingPopup`
+ * (link editor, font-color picker, …). It owns the cross-cutting concerns a
+ * floating panel needs — surface styling, `role="dialog"` + label, an enter
+ * animation, and a looping focus trap (reka-ui `FocusScope`) — so each feature
+ * only renders its own contents.
+ *
+ * It deliberately does NOT handle Escape or scroll-locking: dismissal and
+ * scroll policy vary per popup and are owned by the opener (see the link
+ * controller's two-stage Escape and scroll lock).
+ */
+const props = withDefaults(
+  defineProps<{
+    /** Accessible name announced for the dialog. */
+    dialogLabel: string
+    /** Layout/spacing classes for the panel body (width, padding, flex, …). */
+    contentClass?: string | string[]
+    /** Let FocusScope move focus to the first tabbable on open. Defaults `true`. */
+    autofocus?: boolean
+  }>(),
+  { autofocus: true },
+)
+
+function onMountAutoFocus(event: Event) {
+  // When the content focuses itself (e.g. the link input autofocuses on its own
+  // nextTick), don't let FocusScope steal focus to the first tabbable on open.
+  if (!props.autofocus) event.preventDefault()
+}
+
+function onUnmountAutoFocus(event: Event) {
+  // Don't restore focus on close: the popup owner returns focus on Escape, and
+  // a deliberate click-outside should keep focus where the user clicked.
+  event.preventDefault()
+}
+</script>
+
+<style scoped>
+.editor-popover {
+  animation: editor-popover-in 90ms ease-out;
+  transform-origin: center;
+}
+
+@keyframes editor-popover-in {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .editor-popover {
+    animation: none;
+  }
+}
+</style>

--- a/src/molecules/editor/components/TableContextMenu.vue
+++ b/src/molecules/editor/components/TableContextMenu.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Editor } from '../useEditor'
+import type { CommandMenuItem, MenuItem } from '../menu'
+
+/**
+ * Vertical, labelled table actions for the right-click context menu. Renders the
+ * same `tableToolbar` items the floating toolbar uses (icon + label here), and
+ * runs them against the editor. Mounted imperatively by `EditorTableMenu` via
+ * `useFloatingPopup`, which owns positioning and outside-click / Escape close.
+ */
+const props = defineProps<{
+  editor: Editor
+  items: MenuItem[]
+  /** Called after an action runs, so the host can close the menu. */
+  onRun?: () => void
+}>()
+
+function isSeparator(item: MenuItem): item is { type: 'separator' } {
+  return 'type' in item && item.type === 'separator'
+}
+function isCommand(item: MenuItem): item is CommandMenuItem {
+  return !('type' in item)
+}
+function isAvailable(item: CommandMenuItem): boolean {
+  return item.isAvailable?.(props.editor) !== false
+}
+
+// Keep available commands; collapse separators so none ends up leading,
+// trailing, or doubled after filtering.
+const visible = computed<MenuItem[]>(() => {
+  const out: MenuItem[] = []
+  for (const item of props.items) {
+    if (isSeparator(item)) {
+      const last = out[out.length - 1]
+      if (last && !isSeparator(last)) out.push(item)
+    } else if (isCommand(item) && isAvailable(item)) {
+      out.push(item)
+    }
+  }
+  if (out.length && isSeparator(out[out.length - 1])) out.pop()
+  return out
+})
+
+function disabled(item: CommandMenuItem): boolean {
+  return item.isDisabled?.(props.editor) === true
+}
+
+function run(item: CommandMenuItem, event: MouseEvent): void {
+  if (disabled(item)) return
+  item.action(props.editor, {
+    event,
+    trigger: event.currentTarget as HTMLElement | undefined,
+  })
+  props.onRun?.()
+}
+</script>
+
+<template>
+  <div
+    role="menu"
+    class="min-w-[208px] rounded-lg border border-outline-gray-1 bg-surface-white p-1 text-base shadow-xl outline-none"
+  >
+    <template v-for="(item, index) in visible" :key="index">
+      <div
+        v-if="isSeparator(item)"
+        class="my-1 h-px bg-surface-gray-2"
+        aria-hidden="true"
+      />
+      <button
+        v-else-if="isCommand(item)"
+        type="button"
+        role="menuitem"
+        class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-ink-gray-8 hover:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50"
+        :disabled="disabled(item)"
+        @click="run(item, $event)"
+      >
+        <span
+          v-if="typeof item.icon === 'string'"
+          :class="['size-4 shrink-0', item.icon]"
+          aria-hidden="true"
+        />
+        <span>{{ item.label }}</span>
+      </button>
+    </template>
+  </div>
+</template>

--- a/src/molecules/editor/components/font-color/ColorSwatchGrid.vue
+++ b/src/molecules/editor/components/font-color/ColorSwatchGrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mt-1 grid grid-cols-6 gap-1">
+  <div class="mt-2 grid grid-cols-6 gap-2">
     <Tooltip
       v-for="swatch in swatches"
       :key="swatch.label"
@@ -10,13 +10,11 @@
         type="button"
         :aria-label="swatch.label"
         :aria-pressed="swatch.value === active"
-        class="flex h-5 w-5 items-center justify-center rounded border text-base"
+        class="flex h-6 w-6 items-center justify-center rounded-sm border text-base focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3"
         :class="[
           swatch.class,
           variant === 'highlight' ? 'text-ink-gray-9' : '',
-          swatch.value === active
-            ? 'ring-2 ring-outline-gray-3 ring-offset-1'
-            : '',
+          swatch.value === active ? 'ring-2 ring-outline-gray-4' : '',
         ]"
         @click="emit('select', swatch.value)"
       >

--- a/src/molecules/editor/components/font-color/fontColorController.ts
+++ b/src/molecules/editor/components/font-color/fontColorController.ts
@@ -2,6 +2,7 @@ import { defineComponent, h } from 'vue'
 import type { Editor } from '@tiptap/core'
 import { useFloatingPopup } from '#molecules/editor/composables/useFloatingPopup'
 import { useNamedColorState } from '#molecules/editor/composables/useNamedColorState'
+import EditorPopover from '#molecules/editor/components/EditorPopover.vue'
 import ColorSwatchGrid from './ColorSwatchGrid.vue'
 import { highlightSwatches, textSwatches } from './swatches'
 
@@ -28,31 +29,32 @@ const FontColorPanel = defineComponent({
 
     return () =>
       h(
-        'div',
+        EditorPopover,
+        { dialogLabel: 'Text and background color', contentClass: 'p-2' },
         {
-          'data-slot': 'font-color-panel',
-          class: 'rounded-lg bg-surface-white p-2 shadow-2xl',
+          default: () => [
+            h('div', { 'data-slot': 'font-color-panel' }, [
+              h('div', { class: 'text-sm text-ink-gray-7' }, 'Text Color'),
+              h(ColorSwatchGrid, {
+                swatches: textSwatches,
+                active: activeTextColor.value,
+                variant: 'text',
+                onSelect: selectText,
+              }),
+              h(
+                'div',
+                { class: 'mt-2 text-sm text-ink-gray-7' },
+                'Background Color',
+              ),
+              h(ColorSwatchGrid, {
+                swatches: highlightSwatches,
+                active: activeHighlightColor.value,
+                variant: 'highlight',
+                onSelect: selectHighlight,
+              }),
+            ]),
+          ],
         },
-        [
-          h('div', { class: 'text-sm text-ink-gray-7' }, 'Text Color'),
-          h(ColorSwatchGrid, {
-            swatches: textSwatches,
-            active: activeTextColor.value,
-            variant: 'text',
-            onSelect: selectText,
-          }),
-          h(
-            'div',
-            { class: 'mt-2 text-sm text-ink-gray-7' },
-            'Background Color',
-          ),
-          h(ColorSwatchGrid, {
-            swatches: highlightSwatches,
-            active: activeHighlightColor.value,
-            variant: 'highlight',
-            onSelect: selectHighlight,
-          }),
-        ],
       )
   },
 })

--- a/src/molecules/editor/components/font-color/fontColorController.ts
+++ b/src/molecules/editor/components/font-color/fontColorController.ts
@@ -30,7 +30,10 @@ const FontColorPanel = defineComponent({
     return () =>
       h(
         EditorPopover,
-        { dialogLabel: 'Text and background color', contentClass: 'rounded-md p-2' },
+        {
+          dialogLabel: 'Text and background color',
+          contentClass: 'rounded-md p-2.5',
+        },
         {
           default: () => [
             h('div', { 'data-slot': 'font-color-panel' }, [
@@ -43,7 +46,7 @@ const FontColorPanel = defineComponent({
               }),
               h(
                 'div',
-                { class: 'mt-2 text-sm text-ink-gray-7' },
+                { class: 'mt-4 text-sm text-ink-gray-7' },
                 'Background Color',
               ),
               h(ColorSwatchGrid, {

--- a/src/molecules/editor/components/font-color/fontColorController.ts
+++ b/src/molecules/editor/components/font-color/fontColorController.ts
@@ -30,7 +30,7 @@ const FontColorPanel = defineComponent({
     return () =>
       h(
         EditorPopover,
-        { dialogLabel: 'Text and background color', contentClass: 'p-2' },
+        { dialogLabel: 'Text and background color', contentClass: 'rounded-md p-2' },
         {
           default: () => [
             h('div', { 'data-slot': 'font-color-panel' }, [

--- a/src/molecules/editor/components/table-color/tableCellColorController.ts
+++ b/src/molecules/editor/components/table-color/tableCellColorController.ts
@@ -1,0 +1,80 @@
+import { defineComponent, h } from 'vue'
+import type { Editor } from '@tiptap/core'
+import { useFloatingPopup } from '#molecules/editor/composables/useFloatingPopup'
+import { useTableCellColorState } from '#molecules/editor/composables/useTableCellColorState'
+import EditorPopover from '#molecules/editor/components/EditorPopover.vue'
+import ColorSwatchGrid from '../font-color/ColorSwatchGrid.vue'
+import { highlightSwatches, textSwatches } from '../font-color/swatches'
+
+let activePopup: ReturnType<typeof useFloatingPopup> | null = null
+
+const TableCellColorPanel = defineComponent({
+  props: {
+    editor: { type: Object, required: true },
+    onClose: { type: Function, required: true },
+  },
+  setup(props) {
+    const { activeBackground, activeTextColor, setBackground, setTextColor } =
+      useTableCellColorState(props.editor as Editor)
+
+    const pickBackground = (value: string | null) => {
+      setBackground(value)
+      props.onClose()
+    }
+    const pickText = (value: string | null) => {
+      setTextColor(value)
+      props.onClose()
+    }
+
+    return () =>
+      h(
+        EditorPopover,
+        { dialogLabel: 'Cell color', contentClass: 'rounded-md p-2.5' },
+        {
+          default: () => [
+            h('div', { 'data-slot': 'table-cell-color-panel' }, [
+              h('div', { class: 'text-sm text-ink-gray-7' }, 'Cell color'),
+              h(ColorSwatchGrid, {
+                swatches: highlightSwatches,
+                active: activeBackground.value,
+                variant: 'highlight',
+                onSelect: pickBackground,
+              }),
+              h('div', { class: 'mt-4 text-sm text-ink-gray-7' }, 'Text color'),
+              h(ColorSwatchGrid, {
+                swatches: textSwatches,
+                active: activeTextColor.value,
+                variant: 'text',
+                onSelect: pickText,
+              }),
+            ]),
+          ],
+        },
+      )
+  },
+})
+
+/**
+ * Open the cell color picker anchored to a trigger button.
+ *
+ * The trigger rect is snapshotted into a virtual reference because the table
+ * context-menu button is removed from the DOM when the menu closes on run —
+ * anchoring to the live element would leave Floating UI tracking a detached node.
+ */
+export function openTableCellColorPicker(args: {
+  editor: Editor
+  anchor: HTMLElement
+}): void {
+  activePopup?.destroy()
+  const rect = args.anchor.getBoundingClientRect()
+  activePopup = useFloatingPopup({
+    anchor: args.anchor,
+    component: TableCellColorPanel,
+    props: {
+      editor: args.editor,
+      onClose: () => activePopup?.destroy(),
+    },
+    virtualReference: { getBoundingClientRect: () => rect },
+    floatingOptions: { placement: 'bottom-start' },
+  })
+}

--- a/src/molecules/editor/composables/useEditorFileDrop.ts
+++ b/src/molecules/editor/composables/useEditorFileDrop.ts
@@ -1,0 +1,99 @@
+import { onBeforeUnmount, ref, watch, type Ref } from 'vue'
+import { useWindowFileDragging } from './useWindowFileDragging'
+
+/**
+ * File drop tracking for a single editor drop zone.
+ *
+ * Exposes two signals so the zone can show a two-stage affordance:
+ *  - `isWindowDragging` — a file is being dragged anywhere over the window; the
+ *    zone reveals itself as a hint so the user can see where to drop.
+ *  - `isOverZone` — the file is over THIS zone specifically; the zone emphasises
+ *    itself as the active target.
+ *
+ * `onFiles` fires only for file drops that land inside `root` (the surrounding
+ * editor chrome). Drops on the prose itself are handled by the media ProseMirror
+ * plugin, which stop-propagates them — so our drop handler never runs for those,
+ * and `isOverZone` is instead cleared by watching the window signal (which flips
+ * false on any drop, captured before the inner `stopPropagation`).
+ *
+ * @param root  Ref to the zone element. May be null until mounted.
+ * @param onFiles Called with dropped `File[]` for drops inside `root`.
+ */
+export function useEditorFileDrop(
+  root: Ref<HTMLElement | null>,
+  onFiles: (files: File[]) => void,
+): { isWindowDragging: Ref<boolean>; isOverZone: Ref<boolean> } {
+  const isWindowDragging = useWindowFileDragging()
+  const isOverZone = ref(false)
+  let depth = 0
+
+  const hasFiles = (event: DragEvent): boolean =>
+    !!event.dataTransfer && Array.from(event.dataTransfer.types).includes('Files')
+
+  const reset = () => {
+    depth = 0
+    isOverZone.value = false
+  }
+
+  const onDragEnter = (event: DragEvent) => {
+    if (!hasFiles(event)) return
+    depth += 1
+    isOverZone.value = true
+  }
+
+  const onDragOver = (event: DragEvent) => {
+    if (!hasFiles(event)) return
+    event.preventDefault()
+  }
+
+  const onDragLeave = () => {
+    depth = Math.max(0, depth - 1)
+    if (depth === 0) isOverZone.value = false
+  }
+
+  const onDrop = (event: DragEvent) => {
+    reset()
+    const files = Array.from(event.dataTransfer?.files ?? [])
+    if (files.length === 0) return
+    event.preventDefault()
+    event.stopPropagation()
+    onFiles(files)
+  }
+
+  // The window signal flips false on any drop (capture phase) or when the drag
+  // leaves the window. Mirror that here so a prose drop — whose event never
+  // reaches our handler — can't leave the zone stuck highlighted.
+  watch(isWindowDragging, (dragging) => {
+    if (!dragging) reset()
+  })
+
+  const bind = (el: HTMLElement) => {
+    el.addEventListener('dragenter', onDragEnter)
+    el.addEventListener('dragover', onDragOver)
+    el.addEventListener('dragleave', onDragLeave)
+    el.addEventListener('drop', onDrop)
+  }
+
+  const unbind = (el: HTMLElement) => {
+    el.removeEventListener('dragenter', onDragEnter)
+    el.removeEventListener('dragover', onDragOver)
+    el.removeEventListener('dragleave', onDragLeave)
+    el.removeEventListener('drop', onDrop)
+  }
+
+  watch(
+    root,
+    (el, prev) => {
+      if (prev) unbind(prev)
+      reset()
+      if (el) bind(el)
+    },
+    { immediate: true },
+  )
+
+  onBeforeUnmount(() => {
+    if (root.value) unbind(root.value)
+  })
+
+  return { isWindowDragging, isOverZone }
+}

--- a/src/molecules/editor/composables/useFloatingPopup.ts
+++ b/src/molecules/editor/composables/useFloatingPopup.ts
@@ -19,6 +19,12 @@ export interface FloatingPopupOptions<P extends Record<string, unknown>> {
   props: P
   virtualReference?: VirtualReference
   closeOnAnchorPointerDown?: boolean
+  /**
+   * Close the popup when Escape is pressed. Defaults to `true`.
+   * Set `false` when the mounted component needs to handle Escape itself
+   * (e.g. a multi-step popup where Escape first steps back, then closes).
+   */
+  closeOnEscape?: boolean
   floatingOptions?: {
     placement?: Placement
     strategy?: Strategy
@@ -103,7 +109,7 @@ export function useFloatingPopup<P extends Record<string, unknown>>(
   }
 
   function onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') handle.destroy()
+    if (event.key === 'Escape' && options.closeOnEscape !== false) handle.destroy()
   }
 
   cleanupAutoUpdate = autoUpdate(reference, floating, update)

--- a/src/molecules/editor/composables/useFloatingPopup.ts
+++ b/src/molecules/editor/composables/useFloatingPopup.ts
@@ -25,6 +25,13 @@ export interface FloatingPopupOptions<P extends Record<string, unknown>> {
    * (e.g. a multi-step popup where Escape first steps back, then closes).
    */
   closeOnEscape?: boolean
+  /**
+   * Play a fast origin-aware appear animation on the floating wrapper (scales
+   * out from the edge nearest the anchor, using the *resolved* placement). Leave
+   * off for popups that wrap their content in `EditorPopover`, which animates
+   * itself. Defaults to `false`.
+   */
+  animate?: boolean
   floatingOptions?: {
     placement?: Placement
     strategy?: Strategy
@@ -62,6 +69,7 @@ export function useFloatingPopup<P extends Record<string, unknown>>(
 
   let cleanupAutoUpdate: (() => void) | null = null
   let destroyed = false
+  let animated = false
 
   const update = () => {
     if (destroyed) return
@@ -73,13 +81,21 @@ export function useFloatingPopup<P extends Record<string, unknown>>(
         flip(),
         shift({ padding: 8 }),
       ],
-    }).then(({ x, y, strategy }) => {
+    }).then(({ x, y, strategy, placement }) => {
       if (destroyed) return
       Object.assign(floating.style, {
         position: strategy,
         left: `${x}px`,
         top: `${y}px`,
       })
+      // First positioned frame: set the origin from the resolved placement and
+      // trigger the enter animation once (so it scales from the edge nearest the
+      // anchor, not from 0,0 before positioning).
+      if (options.animate && !animated) {
+        animated = true
+        floating.style.transformOrigin = transformOriginFor(placement)
+        floating.classList.add('editor-floating-pop')
+      }
     })
   }
 
@@ -125,4 +141,25 @@ export function useFloatingPopup<P extends Record<string, unknown>>(
 function normalizeOffset(value: number | [number, number] | undefined) {
   if (Array.isArray(value)) return { mainAxis: value[1], crossAxis: value[0] }
   return value ?? 4
+}
+
+/**
+ * CSS `transform-origin` for a popup at the given (resolved) placement: the
+ * point on the floating box nearest the anchor. A menu placed `right-start`
+ * grows from its `left top` corner; `top` grows from `center bottom`, etc.
+ */
+function transformOriginFor(placement: Placement): string {
+  const [side, align] = placement.split('-')
+  const opposite: Record<string, string> = {
+    top: 'bottom',
+    bottom: 'top',
+    left: 'right',
+    right: 'left',
+  }
+  if (side === 'top' || side === 'bottom') {
+    const x = align === 'start' ? 'left' : align === 'end' ? 'right' : 'center'
+    return `${x} ${opposite[side]}`
+  }
+  const y = align === 'start' ? 'top' : align === 'end' ? 'bottom' : 'center'
+  return `${opposite[side]} ${y}`
 }

--- a/src/molecules/editor/composables/useTableCellColorState.ts
+++ b/src/molecules/editor/composables/useTableCellColorState.ts
@@ -1,0 +1,78 @@
+import type { Editor } from '@tiptap/core'
+import { onBeforeUnmount, onMounted, ref, type Ref } from 'vue'
+import { CellSelection, isInTable, selectionCell } from '@tiptap/pm/tables'
+import { PALETTE_NAMES } from '#molecules/editor/extensions/shared/color-palette'
+
+export interface TableCellColorState {
+  /** Named background of the anchor cell, or `null` when none / not in a table. */
+  activeBackground: Ref<string | null>
+  /** Named text color active across the selection, or `null`. */
+  activeTextColor: Ref<string | null>
+  /** Fill the selected cell(s); `null` clears the fill. */
+  setBackground: (name: string | null) => void
+  /** Color all text in the selected cell(s); `null` clears it. */
+  setTextColor: (name: string | null) => void
+}
+
+/**
+ * Reactive active-color state + setters for the table cell-color picker. Mirrors
+ * `useNamedColorState`'s leak-free subscription pattern (attach in `onMounted`,
+ * detach in `onBeforeUnmount`) and guards every read/write against a destroyed
+ * editor.
+ */
+export function useTableCellColorState(editor: Editor): TableCellColorState {
+  const activeBackground = ref<string | null>(null)
+  const activeTextColor = ref<string | null>(null)
+
+  const readBackground = (): string | null => {
+    const { state } = editor
+    if (!isInTable(state)) return null
+    const { selection } = state
+    // The anchor cell's value: for a uniform selection it's the shared color,
+    // otherwise just the anchor's — enough to drive the active swatch.
+    const $cell =
+      selection instanceof CellSelection
+        ? selection.$anchorCell
+        : selectionCell(state)
+    const value = $cell?.nodeAfter?.attrs?.backgroundColor
+    return typeof value === 'string' ? value : null
+  }
+
+  const readTextColor = (): string | null => {
+    for (const name of PALETTE_NAMES) {
+      if (editor.isActive('textStyle', { color: name })) return name
+    }
+    return null
+  }
+
+  const sync = () => {
+    if (!editor || editor.isDestroyed) return
+    activeBackground.value = readBackground()
+    activeTextColor.value = readTextColor()
+  }
+
+  onMounted(() => {
+    sync()
+    if (!editor || editor.isDestroyed) return
+    editor.on('transaction', sync)
+    editor.on('selectionUpdate', sync)
+  })
+
+  onBeforeUnmount(() => {
+    if (!editor) return
+    editor.off('transaction', sync)
+    editor.off('selectionUpdate', sync)
+  })
+
+  const setBackground = (name: string | null) => {
+    if (!editor || editor.isDestroyed) return
+    editor.chain().focus().setCellBackground(name).run()
+  }
+
+  const setTextColor = (name: string | null) => {
+    if (!editor || editor.isDestroyed) return
+    editor.chain().focus().setCellTextColor(name).run()
+  }
+
+  return { activeBackground, activeTextColor, setBackground, setTextColor }
+}

--- a/src/molecules/editor/composables/useWindowFileDragging.ts
+++ b/src/molecules/editor/composables/useWindowFileDragging.ts
@@ -1,0 +1,68 @@
+import { onBeforeUnmount, onMounted, ref, type Ref } from 'vue'
+
+/**
+ * Shared, reference-counted signal that is `true` while the user is dragging
+ * file(s) anywhere over the window.
+ *
+ * Editor drop zones use it to reveal themselves the moment a file enters the
+ * page — not only once it is over the editor — so the drop targets are
+ * discoverable instead of invisible until hovered.
+ *
+ * Listeners are bound in the CAPTURE phase so the `drop`/`dragend` resets still
+ * fire when an inner handler (the media ProseMirror plugin, a scoped drop zone)
+ * calls `stopPropagation()` on the bubbling event. A single set of listeners is
+ * shared across all callers via the ref count.
+ *
+ * Detection only — it never calls `preventDefault`, so it does not turn the
+ * window into a drop target or otherwise change drop handling.
+ */
+const isWindowFileDragging = ref(false)
+let refCount = 0
+// Depth counter: dragenter on a child fires before dragleave on its parent, so
+// the count stays > 0 while the pointer is anywhere inside the window and only
+// hits 0 when the drag truly leaves it.
+let depth = 0
+
+const hasFiles = (event: DragEvent): boolean =>
+  !!event.dataTransfer && Array.from(event.dataTransfer.types).includes('Files')
+
+const reset = () => {
+  depth = 0
+  isWindowFileDragging.value = false
+}
+
+const onDragEnter = (event: DragEvent) => {
+  if (!hasFiles(event)) return
+  depth += 1
+  isWindowFileDragging.value = true
+}
+
+const onDragLeave = () => {
+  depth = Math.max(0, depth - 1)
+  if (depth === 0) isWindowFileDragging.value = false
+}
+
+export function useWindowFileDragging(): Ref<boolean> {
+  onMounted(() => {
+    if (refCount === 0) {
+      window.addEventListener('dragenter', onDragEnter, true)
+      window.addEventListener('dragleave', onDragLeave, true)
+      window.addEventListener('drop', reset, true)
+      window.addEventListener('dragend', reset, true)
+    }
+    refCount += 1
+  })
+
+  onBeforeUnmount(() => {
+    refCount = Math.max(0, refCount - 1)
+    if (refCount === 0) {
+      window.removeEventListener('dragenter', onDragEnter, true)
+      window.removeEventListener('dragleave', onDragLeave, true)
+      window.removeEventListener('drop', reset, true)
+      window.removeEventListener('dragend', reset, true)
+      reset()
+    }
+  })
+
+  return isWindowFileDragging
+}

--- a/src/molecules/editor/extensions.ts
+++ b/src/molecules/editor/extensions.ts
@@ -10,9 +10,14 @@ import { ExtendedCode, ExtendedCodeBlock } from './extensions/code-block'
 import {
   Table as TiptapTable,
   TableRow,
-  TableCell,
-  TableHeader,
+  TableCell as TiptapTableCell,
+  TableHeader as TiptapTableHeader,
 } from '@tiptap/extension-table'
+import {
+  cellBackgroundAttributes,
+  TableCellColor as TableCellColorExtension,
+} from './extensions/table/table-cell-color'
+import { TableSelectionOverlay as TableSelectionOverlayExtension } from './extensions/table/table-selection-overlay'
 import TaskListExtension from '@tiptap/extension-task-list'
 import TaskItemExtension from '@tiptap/extension-task-item'
 import TypographyExtension from '@tiptap/extension-typography'
@@ -105,10 +110,26 @@ export const Link = LinkExtension
 export const Code = ExtendedCode
 export const CodeBlock = ExtendedCodeBlock
 export const Table = TiptapTable.configure({ resizable: true })
-export { TableRow, TableCell, TableHeader }
+// Cell nodes carry a named `backgroundColor` attribute (rendered via
+// `--prose-highlight-*`); see `extensions/table/table-cell-color`.
+export const TableCell = TiptapTableCell.extend({
+  addAttributes() {
+    return { ...this.parent?.(), ...cellBackgroundAttributes }
+  },
+})
+export const TableHeader = TiptapTableHeader.extend({
+  addAttributes() {
+    return { ...this.parent?.(), ...cellBackgroundAttributes }
+  },
+})
+export { TableRow }
 // Spreadsheet-style cell navigation (active-cell highlight, Enter to edit, Esc
 // to exit, arrow keys to move). Loaded alongside Table in the kits.
 export { TableNavigation } from './extensions/table/table-navigation'
+// First-class named cell background + text color commands, and the single-box
+// multi-cell selection overlay. Both loaded alongside Table.
+export const TableCellColor = TableCellColorExtension
+export const TableSelectionOverlay = TableSelectionOverlayExtension
 export const TaskList = TaskListExtension
 export const TaskItem = TaskItemExtension.configure({ nested: true })
 export const Typography = TypographyExtension

--- a/src/molecules/editor/extensions.ts
+++ b/src/molecules/editor/extensions.ts
@@ -106,6 +106,9 @@ export const Code = ExtendedCode
 export const CodeBlock = ExtendedCodeBlock
 export const Table = TiptapTable.configure({ resizable: true })
 export { TableRow, TableCell, TableHeader }
+// Spreadsheet-style cell navigation (active-cell highlight, Enter to edit, Esc
+// to exit, arrow keys to move). Loaded alongside Table in the kits.
+export { TableNavigation } from './extensions/table/table-navigation'
 export const TaskList = TaskListExtension
 export const TaskItem = TaskItemExtension.configure({ nested: true })
 export const Typography = TypographyExtension

--- a/src/molecules/editor/extensions.ts
+++ b/src/molecules/editor/extensions.ts
@@ -26,6 +26,7 @@ import { ImageExtension } from './extensions/image'
 import { ImageGroup as ImageGroupExtension } from './extensions/image-group'
 import ImageViewerExtension from './extensions/image-viewer'
 import { VideoExtension } from './extensions/video'
+import { MediaDrop as MediaDropExtension } from './extensions/media-drop/media-drop-extension'
 import { IframeExtension } from './extensions/iframe'
 import {
   MentionExtension,
@@ -126,6 +127,7 @@ export const Image = ImageExtension
 export const ImageGroup = ImageGroupExtension
 export const ImageViewer = ImageViewerExtension
 export const Video = VideoExtension
+export const MediaDrop = MediaDropExtension
 export const Iframe = IframeExtension
 export const Mention = MentionExtension
 

--- a/src/molecules/editor/extensions/code-block/CodeBlockComponent.css
+++ b/src/molecules/editor/extensions/code-block/CodeBlockComponent.css
@@ -1,29 +1,9 @@
-/* CodeBlock styles */
-.code-block {
-  position: relative;
-}
-
-.code-block-container {
-  position: relative;
-}
-
-.language-selector {
-  position: absolute;
-  top: 0.25rem;
-  right: 0.25rem;
-  padding-top: 0;
-  padding-bottom: 0;
-}
-
-.language-label {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.75rem;
-  font-size: 12px;
-  color: var(--ink-gray-4);
-  pointer-events: none;
-  user-select: none;
-}
+/* CodeBlock styles
+ *
+ * Layout (container/toolbar/gutter/copy button) lives as Tailwind utilities in
+ * CodeBlockComponent.vue. Only the `pre` shell + highlight.js theme stay here —
+ * they target ProseMirror-rendered descendants (`.hljs-*` spans) and theme
+ * variants that can't be expressed as element-level utility classes. */
 
 /* ── pre shell ────────────────────────────────────────────────── */
 .ProseMirror pre {

--- a/src/molecules/editor/extensions/code-block/CodeBlockComponent.vue
+++ b/src/molecules/editor/extensions/code-block/CodeBlockComponent.vue
@@ -1,32 +1,56 @@
 <template>
   <node-view-wrapper>
-    <div class="code-block-container">
-      <pre><code><node-view-content /></code></pre>
-      <select
-        v-if="isEditable"
-        class="language-selector form-select py-0"
+    <div class="code-block-container group relative">
+      <pre
+        class="flex items-start gap-5 !pl-3"
+      ><span class="flex flex-none select-none flex-col items-end border-outline-gray-2 text-ink-gray-4" aria-hidden="true" contenteditable="false"><span v-for="n in lineCount" :key="n" class="block">{{ n }}</span></span><code class="min-w-0 flex-1 overflow-x-auto"><node-view-content /></code></pre>
+      <div
+        class="absolute right-0 top-0 pr-2 pt-1.5 flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 [@media(hover:none)]:opacity-100"
+        :class="{ 'opacity-100': languageMenuOpen || props.selected }"
         contenteditable="false"
-        v-model="selectedLanguage"
       >
-        <option :value="null">auto</option>
-        <option disabled>—</option>
-        <option
-          v-for="language in languages"
-          :value="language.value"
-          :key="language.value"
-        >
-          {{ language.label }}
-        </option>
-      </select>
-      <span v-else class="language-label">{{ selectedLanguage || 'auto' }}</span>
+        <Combobox
+          v-if="isEditable"
+          v-model="selectedLanguage"
+          :options="languageOptions"
+          trigger="button"
+          variant="ghost"
+          size="sm"
+          placeholder="auto"
+          @update:open="languageMenuOpen = $event"
+        />
+        <span v-else class="select-none px-1 text-xs text-ink-gray-4">{{
+          props.node.attrs.language || 'auto'
+        }}</span>
+        <TooltipProvider :delay-duration="500">
+          <TooltipRoot disable-closing-trigger>
+            <TooltipTrigger as-child>
+              <Button
+                size="xs"
+                variant="ghost"
+                label="Copy code"
+                :icon="copied ? 'lucide-check' : 'lucide-copy'"
+                @mousedown.prevent
+                @click.stop="copyCode"
+              />
+            </TooltipTrigger>
+            <TooltipBubble :text="copied ? 'Copied!' : 'Copy code'" />
+          </TooltipRoot>
+        </TooltipProvider>
+      </div>
     </div>
   </node-view-wrapper>
 </template>
 
 <script setup lang="ts">
-import { computed, toRaw } from 'vue'
+import { computed, ref, toRaw, onBeforeUnmount } from 'vue'
 import { NodeViewContent, nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3'
 import { createLowlight } from 'lowlight'
+import { TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui'
+import Button from '#components/Button/Button.vue'
+import Combobox from '#components/Combobox/Combobox.vue'
+import type { ComboboxOption } from '#components/Combobox/types'
+import TooltipBubble from '#components/Tooltip/TooltipBubble.vue'
 import { useNodeViewEditable } from '#molecules/editor/composables/useNodeViewEditable'
 import { listEditorLanguages } from '#molecules/editor/extensions/shared/lowlight-languages'
 import './CodeBlockComponent.css'
@@ -41,15 +65,76 @@ const editor = toRaw(props.editor)
 
 const isEditable = useNodeViewEditable(editor)
 
+// The combobox value is a string, but the node stores `null` for "auto". Map the
+// two: `''` is the sentinel the "auto" option carries, round-tripped to `null`.
 const selectedLanguage = computed<string | null>({
-  get: () => props.node.attrs.language as string | null,
+  get: () => (props.node.attrs.language as string | null) ?? '',
   set: (language) => {
-    props.updateAttributes({ language })
+    props.updateAttributes({ language: language || null })
   },
 })
 
-const languages = computed(() => {
+const languageOptions = computed<ComboboxOption[]>(() => {
   const lowlight = props.extension.options.lowlight as Lowlight
-  return listEditorLanguages(lowlight)
+  return [
+    { label: 'auto', value: '' },
+    ...listEditorLanguages(lowlight).map(({ label, value }) => ({
+      label,
+      value,
+    })),
+  ]
 })
+
+const languageMenuOpen = ref(false)
+
+// One gutter number per `\n`-delimited line. Rendered as discrete block lines
+// (not a `\n`-joined string) so stacking never depends on `white-space`.
+const lineCount = computed(() => props.node.textContent.split('\n').length)
+
+const copied = ref(false)
+let resetTimer: ReturnType<typeof setTimeout> | undefined
+
+const copyCode = async () => {
+  const text = props.node.textContent
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+    } else {
+      copyViaExecCommand(text)
+    }
+    markCopied()
+  } catch (error) {
+    // Async Clipboard API can reject in insecure contexts or when the document
+    // lost focus; fall back to the legacy path before giving up.
+    try {
+      copyViaExecCommand(text)
+      markCopied()
+    } catch {
+      console.error('Failed to copy code block', error)
+    }
+  }
+}
+
+function markCopied() {
+  copied.value = true
+  clearTimeout(resetTimer)
+  resetTimer = setTimeout(() => (copied.value = false), 2000)
+}
+
+/**
+ * Legacy clipboard path for contexts where `navigator.clipboard` is missing
+ * (non-HTTPS origins, older webviews). Selects a detached textarea and copies.
+ */
+function copyViaExecCommand(text: string) {
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  document.execCommand('copy')
+  document.body.removeChild(textarea)
+}
+
+onBeforeUnmount(() => clearTimeout(resetTimer))
 </script>

--- a/src/molecules/editor/extensions/image/image-extension.ts
+++ b/src/molecules/editor/extensions/image/image-extension.ts
@@ -209,6 +209,14 @@ export const ImageExtension = NodeExtension.create<ImageExtensionOptions>({
           return true
         },
 
+      uploadImageFiles:
+        (files: File[], pos: number | null = null) =>
+        ({ editor }) => {
+          if (files.length === 0) return false
+          void imageEngine.processMultiple(files, editor, pos, resolve(editor))
+          return true
+        },
+
       selectAndUploadImage:
         () =>
         ({ editor }) => {

--- a/src/molecules/editor/extensions/image/image-extension.ts
+++ b/src/molecules/editor/extensions/image/image-extension.ts
@@ -209,14 +209,6 @@ export const ImageExtension = NodeExtension.create<ImageExtensionOptions>({
           return true
         },
 
-      uploadImageFiles:
-        (files: File[], pos: number | null = null) =>
-        ({ editor }) => {
-          if (files.length === 0) return false
-          void imageEngine.processMultiple(files, editor, pos, resolve(editor))
-          return true
-        },
-
       selectAndUploadImage:
         () =>
         ({ editor }) => {

--- a/src/molecules/editor/extensions/link/LinkEditorPopup.vue
+++ b/src/molecules/editor/extensions/link/LinkEditorPopup.vue
@@ -1,7 +1,7 @@
 <template>
   <EditorPopover
     dialog-label="Edit link"
-    content-class="flex min-w-60 max-w-80 items-center gap-1 p-1"
+    content-class="flex min-w-60 max-w-80 items-center gap-1 rounded-md p-1"
     :autofocus="false"
   >
     <template v-if="edit">

--- a/src/molecules/editor/extensions/link/LinkEditorPopup.vue
+++ b/src/molecules/editor/extensions/link/LinkEditorPopup.vue
@@ -1,74 +1,80 @@
 <template>
-  <div
-    class="p-2 w-72 flex items-center gap-2 bg-surface-white shadow-xl rounded"
+  <EditorPopover
+    dialog-label="Edit link"
+    content-class="flex min-w-60 max-w-80 items-center gap-1 p-1"
+    :autofocus="false"
   >
-    <TextInput
-      v-if="edit"
-      ref="input"
-      type="text"
-      class="w-full"
-      placeholder="https://example.com"
-      v-model="_href"
-      @keydown.enter="submitLink"
-      @keydown.esc="$emit('close')"
-    />
-    <a
-      v-else
-      class="text-ink-gray-700 underline text-sm flex-1 truncate pl-1"
-      :title="_href"
-      :href="_href"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {{ _href }}
-    </a>
-    <div class="shrink-0 flex items-center gap-1.5 ml-auto">
-      <template v-if="edit">
-        <Button
-          @click="submitLink"
-          tooltip="Submit"
-          :icon="'lucide-check'"
-          variant="subtle"
+    <template v-if="edit">
+      <div
+        class="flex-1"
+        :class="{ 'editor-link-shake': shake }"
+        @animationend="shake = false"
+      >
+        <TextInput
+          ref="input"
+          type="text"
+          class="w-full"
+          placeholder="https://example.com"
+          v-model="_href"
+          @keydown.enter="submitLink"
         />
-        <Button
-          @click="props.href ? (edit = false) : $emit('updateHref', '')"
-          tooltip="Exit"
-          :icon="'lucide-x'"
-          variant="subtle"
-        />
-      </template>
-      <template v-else>
-        <Button
-          @click="copyLink"
-          tooltip="Copy"
-          :icon="'lucide-copy'"
-          variant="subtle"
-        />
-        <Button
-          @click="edit = true"
-          tooltip="Edit"
-          :icon="'lucide-pencil'"
-          variant="subtle"
-        />
-        <Button
-          tooltip="Remove"
-          variant="subtle"
-          @click="$emit('updateHref', '')"
-          :icon="'lucide-link-2-off'"
-        />
-      </template>
-    </div>
-  </div>
+      </div>
+      <Button
+        v-if="href"
+        size="xs"
+        variant="ghost"
+        tooltip="Remove link"
+        :icon="'lucide-link-2-off'"
+        @click="$emit('updateHref', '')"
+      />
+      <Button
+        size="xs"
+        variant="ghost"
+        tooltip="Apply"
+        :icon="'lucide-check'"
+        @click="submitLink"
+      />
+    </template>
+
+    <template v-else>
+      <span
+        class="lucide-globe ml-1.5 size-4 shrink-0 text-ink-gray-5"
+        aria-hidden="true"
+      />
+      <div class="pl-1.5 flex-1 min-w-0 flex">
+        <a
+          class="truncate text-sm text-ink-gray-8 border-b border-outline-gray-2 hover:border-outline-gray-3"
+          :title="_href"
+          :href="_href"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ _href }}
+        </a>
+      </div>
+      <Button
+        size="xs"
+        variant="ghost"
+        tooltip="Copy link"
+        :icon="'lucide-copy'"
+        @click="copyLink"
+      />
+      <Button size="xs" variant="ghost" @click="enterEditMode">Edit</Button>
+    </template>
+  </EditorPopover>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, useTemplateRef, nextTick } from 'vue'
+import { onBeforeUnmount, onMounted, ref, useTemplateRef, nextTick } from 'vue'
 import Button from '#components/Button/Button.vue'
 import TextInput from '#components/TextInput/TextInput.vue'
+import EditorPopover from '#molecules/editor/components/EditorPopover.vue'
 import { isSafeUrl } from '#molecules/editor/extensions/shared/url-safety'
 
 const props = defineProps<{
   href: string
+  /** Open directly in edit mode. Defaults to "edit when there is no href". */
+  startInEdit?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -76,15 +82,65 @@ const emit = defineEmits<{
   (e: 'close'): void
 }>()
 
+const ALLOWED_SCHEMES = ['http', 'https', 'mailto', 'tel']
+
 const _href = ref(props.href)
 const input = useTemplateRef('input')
-const edit = ref(!props.href)
+// New links open straight into edit mode; existing links open in the view —
+// unless the caller forces it (e.g. ⌘K on a selected link → edit mode).
+const edit = ref(props.startInEdit ?? !props.href)
+const shake = ref(false)
+
+/**
+ * Make a bare entry usable as a link: `github.com` → `https://github.com`.
+ * Anything that already carries a scheme (`http:`, `mailto:`, `tel:`, …) or is
+ * empty is left untouched, matching the extension's `defaultProtocol: 'https'`.
+ */
+const normalizeHref = (value: string): string => {
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return trimmed
+  return `https://${trimmed}`
+}
+
+/**
+ * Stricter than {@link isSafeUrl} alone: the URL parser accepts bare tokens
+ * (`asdf` → `https://asdf`) as valid hostnames, so for http(s) links we also
+ * require a dotted host (or localhost). Keeps "not a link" text from being
+ * accepted once auto-prefixed.
+ */
+const isValidLinkHref = (href: string): boolean => {
+  if (!isSafeUrl(href, { allowedSchemes: ALLOWED_SCHEMES })) return false
+  let url: URL
+  try {
+    url = new URL(href)
+  } catch {
+    return false
+  }
+  if (url.protocol === 'http:' || url.protocol === 'https:') {
+    return url.hostname === 'localhost' || url.hostname.includes('.')
+  }
+  return true
+}
+
+const triggerShake = () => {
+  // Restart the animation even if it is mid-flight.
+  shake.value = false
+  requestAnimationFrame(() => {
+    shake.value = true
+  })
+}
 
 const submitLink = () => {
-  // Empty submits through as the "remove link" action; otherwise require a
-  // well-formed http(s) URL (shared url-safety, not the legacy isValidUrl).
-  if (_href.value === '' || isSafeUrl(_href.value, { allowedSchemes: ['http', 'https', 'mailto', 'tel'] })) {
-    emit('updateHref', _href.value)
+  const normalized = normalizeHref(_href.value)
+  // Empty submits through as the "remove link" action; otherwise the URL must
+  // be well-formed and look like a real link (see isValidLinkHref).
+  if (normalized === '') {
+    emit('updateHref', '')
+  } else if (isValidLinkHref(normalized)) {
+    emit('updateHref', normalized)
+  } else {
+    triggerShake()
   }
 }
 
@@ -97,14 +153,101 @@ const copyLink = async () => {
   }
 }
 
-onMounted(async () => {
+const focusInput = async () => {
   await nextTick()
-  if (input.value?.el) {
-    // preventScroll: the popup is teleported to <body> and positioned async by
-    // floating-ui, so at focus time the input may still be at the top of the
-    // document — a plain focus() would scroll the page up to it.
-    input.value.el.focus({ preventScroll: true })
-    input.value.el.select()
+  const el = input.value?.el
+  if (!el) return
+  // preventScroll: the popup is teleported to <body> and positioned async by
+  // floating-ui, so at focus time the input may still be at the top of the
+  // document — a plain focus() would scroll the page up to it.
+  el.focus({ preventScroll: true })
+  el.select()
+}
+
+const enterEditMode = () => {
+  edit.value = true
+  focusInput()
+}
+
+/**
+ * When creating a brand-new link, offer a URL already on the clipboard as the
+ * default — the common "copy a URL, select some text, ⌘K" flow. The value is
+ * left selected so a keystroke replaces it.
+ */
+const maybePrefillFromClipboard = async () => {
+  if (props.href || _href.value) return
+  // Clipboard read needs a secure context (https/localhost); it is unavailable
+  // over plain http (e.g. *.frappe.test dev), where this simply no-ops.
+  if (!navigator.clipboard?.readText) return
+  let text = ''
+  try {
+    text = (await navigator.clipboard.readText()).trim()
+  } catch {
+    return // No permission / not focused.
+  }
+  const normalized = normalizeHref(text)
+  if (!isValidLinkHref(normalized)) return
+  _href.value = normalized
+  await nextTick()
+  input.value?.el?.select()
+}
+
+/**
+ * Escape is owned here (the floating popup is created with `closeOnEscape:
+ * false`). When editing an existing link the first Escape discards the edit
+ * and steps back to the view; in every other case it closes the popup.
+ */
+const handleEscape = () => {
+  if (edit.value && props.href) {
+    _href.value = props.href
+    edit.value = false
+    return
+  }
+  emit('close')
+}
+
+const onDocumentKeydown = (event: KeyboardEvent) => {
+  if (event.key !== 'Escape') return
+  // Consume it so a single Escape doesn't also close a surrounding dialog.
+  event.preventDefault()
+  event.stopPropagation()
+  handleEscape()
+}
+
+onMounted(async () => {
+  document.addEventListener('keydown', onDocumentKeydown, true)
+  if (edit.value) {
+    focusInput()
+    await maybePrefillFromClipboard()
   }
 })
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onDocumentKeydown, true)
+})
 </script>
+
+<style scoped>
+.editor-link-shake {
+  animation: editor-link-shake 160ms ease-in-out;
+}
+
+@keyframes editor-link-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-3px);
+  }
+  75% {
+    transform: translateX(3px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .editor-link-shake {
+    animation: none;
+  }
+}
+</style>

--- a/src/molecules/editor/extensions/link/link-commands.ts
+++ b/src/molecules/editor/extensions/link/link-commands.ts
@@ -4,10 +4,23 @@ import { mapStoredRange } from '#molecules/editor/extensions/shared/node-view'
 import { openLinkPopup } from './link-popup-controller'
 import type { VirtualReference } from '#molecules/editor/composables/useFloatingPopup'
 
+/** Options accepted by the `openLinkEditor` command. */
+export interface OpenLinkEditorOptions {
+  /**
+   * Force the popup to open in edit mode. When omitted it defaults to edit mode
+   * for new links and view mode for existing links. The ⌘K shortcut passes
+   * `true` for an explicit (non-collapsed) selection so editing a link's URL is
+   * one keystroke, while a plain click on a link stays in view mode.
+   */
+  startInEdit?: boolean
+}
+
 /**
- * A TipTap command factory: `() => ({ editor }) => boolean`.
+ * A TipTap command factory: `(options?) => ({ editor }) => boolean`.
  */
-type LinkEditorCommand = () => (props: { editor: Editor }) => boolean
+type LinkEditorCommand = (
+  options?: OpenLinkEditorOptions,
+) => (props: { editor: Editor }) => boolean
 
 /**
  * Build the `openLinkEditor` command for the given link mark type.
@@ -24,7 +37,7 @@ type LinkEditorCommand = () => (props: { editor: Editor }) => boolean
  * after the `await` is guarded by `editor.isDestroyed`.
  */
 export function buildOpenLinkEditor(markType: MarkType): LinkEditorCommand {
-  return () =>
+  return (options?: OpenLinkEditorOptions) =>
     ({ editor }: { editor: Editor }): boolean => {
       const { state } = editor
       const { from, to } = state.selection
@@ -51,8 +64,16 @@ export function buildOpenLinkEditor(markType: MarkType): LinkEditorCommand {
       const show = () => {
         void openLinkPopup({
           href: existingHref,
+          startInEdit: options?.startInEdit ?? !existingHref,
           anchor: editor.view.dom,
           virtualReference: selectionReference(editor, range),
+          onEscape: () => {
+            // Escape leaves focus on <body>; return it to the editor so the
+            // user can keep typing where they left off.
+            if (!editor.isDestroyed) {
+              editor.commands.focus(null, { scrollIntoView: false })
+            }
+          },
         }).then((href) => {
           // Cancelled, or the editor went away while the popup was open.
           if (href === null || editor.isDestroyed) return

--- a/src/molecules/editor/extensions/link/link-extension.ts
+++ b/src/molecules/editor/extensions/link/link-extension.ts
@@ -1,5 +1,5 @@
 import Link from '@tiptap/extension-link'
-import { buildOpenLinkEditor } from './link-commands'
+import { buildOpenLinkEditor, type OpenLinkEditorOptions } from './link-commands'
 import { linkPastePlugin } from './link-paste-plugin'
 import { clearLinkOnBoundaryPlugin } from './clear-link-on-boundary-plugin'
 import { linkClickPlugin } from './link-click-plugin'
@@ -9,7 +9,7 @@ declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     linkEditor: {
       /** Opens the link editor bubble menu. */
-      openLinkEditor: () => ReturnType
+      openLinkEditor: (options?: OpenLinkEditorOptions) => ReturnType
     }
   }
 }

--- a/src/molecules/editor/extensions/link/link-popup-controller.ts
+++ b/src/molecules/editor/extensions/link/link-popup-controller.ts
@@ -10,10 +10,17 @@ import LinkEditorPopup from './LinkEditorPopup.vue'
 export interface OpenLinkPopupOptions {
   /** Existing href to seed the editor with (`null` when creating a new link). */
   href: string | null
+  /** Open straight into edit mode (vs. the read-only view). */
+  startInEdit?: boolean
   /** Anchor element used for popup ownership and outside-click containment. */
   anchor: HTMLElement
   /** Optional positioning reference. Defaults to the editor selection. */
   virtualReference?: VirtualReference
+  /**
+   * Called when the user dismisses the popup with Escape (not on apply or
+   * click-outside). Used to return focus to the editor.
+   */
+  onEscape?: () => void
 }
 
 /**
@@ -35,6 +42,16 @@ export function openLinkPopup(
 ): Promise<string | null> {
   const { href, anchor } = options
 
+  // Lock the page's scroll container while the popup is open so the anchored
+  // editor can't scroll away underneath it. The app scrolls an inner
+  // overflow-auto element (not <body>), so we lock the nearest such ancestor.
+  const scrollParent = getScrollParent(anchor)
+  const previousOverflow = scrollParent?.style.overflow ?? ''
+  if (scrollParent) scrollParent.style.overflow = 'hidden'
+  const unlockScroll = () => {
+    if (scrollParent) scrollParent.style.overflow = previousOverflow
+  }
+
   return new Promise<string | null>((resolve) => {
     let settled = false
     const settle = (value: string | null) => {
@@ -47,16 +64,21 @@ export function openLinkPopup(
       anchor,
       component: LinkEditorPopup,
       closeOnAnchorPointerDown: true,
+      // The popup owns Escape: in view mode it closes; in edit mode the first
+      // Escape steps back to view mode and only a second one closes.
+      closeOnEscape: false,
       virtualReference: options.virtualReference ?? {
         getBoundingClientRect: () => selectionRect(anchor),
       },
       floatingOptions: { placement: 'top' },
       props: {
         href: href ?? '',
+        startInEdit: options.startInEdit ?? !href,
         onClose: () => {
-          // Cancel: resolve null, then tear down.
+          // Cancel via Escape: resolve null, tear down, then hand focus back.
           settle(null)
           popup.destroy()
+          options.onEscape?.()
         },
         onUpdateHref: (newHref: string) => {
           settle(newHref)
@@ -69,12 +91,34 @@ export function openLinkPopup(
     // else settled the promise by the time the popup is gone.
     const originalDestroy = popup.destroy
     popup.destroy = () => {
+      unlockScroll()
       settle(null)
       originalDestroy()
     }
 
-    if (!popup.floating) settle(null)
+    if (!popup.floating) {
+      unlockScroll()
+      settle(null)
+    }
   })
+}
+
+/**
+ * Nearest scrollable ancestor of `el` (the element that actually scrolls), used
+ * to lock scrolling while editing. The app's scroll container is an inner
+ * `overflow-auto` div, not `document.body`, so locking the body is a no-op —
+ * we must lock this element instead. Returns `null` if nothing scrolls.
+ */
+function getScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let node: HTMLElement | null = el
+  while (node && node !== document.body) {
+    const { overflowY } = getComputedStyle(node)
+    if (/(auto|scroll|overlay)/.test(overflowY) && node.scrollHeight > node.clientHeight) {
+      return node
+    }
+    node = node.parentElement
+  }
+  return null
 }
 
 /**

--- a/src/molecules/editor/extensions/link/link-shortcut-plugin.ts
+++ b/src/molecules/editor/extensions/link/link-shortcut-plugin.ts
@@ -24,7 +24,7 @@ export function linkShortcutPlugin(options: LinkShortcutPluginOptions): Plugin {
   return new Plugin({
     key: new PluginKey('linkShortcut'),
     props: {
-      handleKeyDown: (_view, event): boolean => {
+      handleKeyDown: (view, event): boolean => {
         const isModK =
           (event.metaKey || event.ctrlKey) &&
           !event.shiftKey &&
@@ -34,7 +34,12 @@ export function linkShortcutPlugin(options: LinkShortcutPluginOptions): Plugin {
 
         event.preventDefault()
         event.stopPropagation()
-        editor.commands.openLinkEditor()
+        // An explicit selection (e.g. selecting a link) → edit its URL straight
+        // away; a bare cursor in a link → the default read-only view.
+        const hasSelection = !view.state.selection.empty
+        editor.commands.openLinkEditor(
+          hasSelection ? { startInEdit: true } : undefined,
+        )
         return true
       },
     },

--- a/src/molecules/editor/extensions/media-drop/media-drop-extension.ts
+++ b/src/molecules/editor/extensions/media-drop/media-drop-extension.ts
@@ -1,0 +1,136 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, Selection } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
+import { openImageGroupUploadDialog } from '#molecules/editor/extensions/image-group/imageGroupDialogController'
+
+/**
+ * The single drop pipeline.
+ *
+ * One place decides what a set of dropped files becomes, so every entry point
+ * behaves identically: the precise in-prose drop (this extension's ProseMirror
+ * plugin, which drops at the cursor) and the generous editor-area drop zone
+ * (`EditorDropZone`, which calls `dropFiles` directly).
+ *
+ * Routing by type/count:
+ *   - exactly one image  -> insert it inline (`uploadImage`)
+ *   - several images     -> open the image group dialog (matches the toolbar's
+ *                           multi-image pick, instead of stacking them inline)
+ *   - any video(s)       -> upload inline (`uploadVideoFiles`)
+ *   - anything else      -> reserved for attachments (not yet supported)
+ *
+ * Type routing is feature-detected via the editor's commands, so a kit without
+ * the image or video extension simply skips that branch.
+ */
+
+const IMAGE_RE = /^image\//i
+const VIDEO_RE = /^video\//i
+
+/** Pull every `File` out of a drag `DataTransfer`, regardless of MIME. */
+function collectFiles(dataTransfer: DataTransfer | null | undefined): File[] {
+  const items = dataTransfer?.items
+  if (!items || items.length === 0) return []
+  const files: File[] = []
+  for (let i = 0; i < items.length; i++) {
+    if (items[i].kind === 'file') {
+      const file = items[i].getAsFile()
+      if (file) files.push(file)
+    }
+  }
+  return files
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    mediaDrop: {
+      /**
+       * Route dropped/provided files by type and count (the single drop
+       * pipeline). Inserts at the current selection — callers that want a
+       * precise position should move the selection first.
+       */
+      dropFiles: (files: File[]) => ReturnType
+    }
+  }
+}
+
+export const MediaDrop = Extension.create({
+  name: 'mediaDrop',
+
+  addCommands() {
+    return {
+      dropFiles:
+        (files: File[]) =>
+        ({ editor }) => {
+          if (files.length === 0) return false
+
+          const images = files.filter((f) => IMAGE_RE.test(f.type))
+          const videos = files.filter((f) => VIDEO_RE.test(f.type))
+          // Files that are neither image nor video are left for attachment
+          // support (not yet implemented).
+
+          const can = (name: string): boolean =>
+            typeof (editor.commands as Record<string, unknown>)[name] ===
+            'function'
+
+          let handled = false
+
+          if (images.length === 1 && can('uploadImage')) {
+            editor.commands.uploadImage(images[0])
+            handled = true
+          } else if (images.length > 1 && can('uploadImage')) {
+            openImageGroupUploadDialog({ editor, files: images })
+            handled = true
+          }
+
+          if (videos.length > 0 && can('uploadVideoFiles')) {
+            editor.commands.uploadVideoFiles(videos)
+            handled = true
+          }
+
+          return handled
+        },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        props: {
+          handleDOMEvents: {
+            drop: (view: EditorView, event: DragEvent): boolean => {
+              const files = collectFiles(event.dataTransfer)
+              if (files.length === 0) return false
+              // Only claim drops we can actually route; let ProseMirror handle
+              // the rest (and, later, attachments).
+              const isMedia = files.some(
+                (f) => IMAGE_RE.test(f.type) || VIDEO_RE.test(f.type),
+              )
+              if (!isMedia) return false
+
+              event.preventDefault()
+              event.stopPropagation()
+
+              // Drop at the cursor: move the selection to the drop point so the
+              // single-image insert lands where the file was released.
+              const coords = view.posAtCoords({
+                left: event.clientX,
+                top: event.clientY,
+              })
+              if (coords) {
+                view.dispatch(
+                  view.state.tr.setSelection(
+                    Selection.near(view.state.doc.resolve(coords.pos)),
+                  ),
+                )
+              }
+
+              this.editor.commands.dropFiles(files)
+              return true
+            },
+          },
+        },
+      }),
+    ]
+  },
+})
+
+export default MediaDrop

--- a/src/molecules/editor/extensions/shared/media-plugin.ts
+++ b/src/molecules/editor/extensions/shared/media-plugin.ts
@@ -8,7 +8,7 @@
  * is handled under `props.handlePaste` (NOT `handleDOMEvents.paste`), per the
  * conventions §1.6 contract.
  */
-import { Plugin, Selection } from '@tiptap/pm/state'
+import { Plugin } from '@tiptap/pm/state'
 import type { Transaction, EditorState } from '@tiptap/pm/state'
 import type { EditorView } from '@tiptap/pm/view'
 import type { Editor } from '@tiptap/core'
@@ -61,46 +61,11 @@ export function createMediaPlugin(
 
   return new Plugin({
     props: {
-      handleDOMEvents: {
-        drop: (view: EditorView, event: DragEvent): boolean => {
-          const editor = host.editor
-          const options = resolve()
-          if (
-            !editor ||
-            !event.dataTransfer?.files?.length ||
-            !options.uploadFunction
-          ) {
-            return false
-          }
-          const files = collectFiles(event.dataTransfer, config.accept)
-          if (files.length === 0) return false
-
-          event.preventDefault()
-          // Drops on the prose are authoritative (precise insert at the cursor):
-          // stop the event so an ancestor editor-area drop zone (which inserts at
-          // the doc end) does not also handle the same files.
-          event.stopPropagation()
-
-          let pos: number | null = null
-          const coords = view.posAtCoords({
-            left: event.clientX,
-            top: event.clientY,
-          })
-          if (coords) {
-            pos = coords.pos
-            view.dispatch(
-              view.state.tr.setSelection(
-                Selection.near(view.state.doc.resolve(pos)),
-              ),
-            )
-          }
-
-          void engine.processMultiple(files, editor, pos, options)
-          return true
-        },
-      },
-
-      handlePaste: (view: EditorView, event: ClipboardEvent): boolean => {
+      // NOTE: drop is NOT handled here. The single drop pipeline lives in the
+      // `MediaDrop` extension (`media-drop-extension.ts`), which routes a whole
+      // drop by type/count. This per-node plugin owns only paste + the
+      // intrinsic-dimension back-fill below.
+      handlePaste: (_view: EditorView, event: ClipboardEvent): boolean => {
         const editor = host.editor
         const options = resolve()
         if (!editor || !options.uploadFunction) return false

--- a/src/molecules/editor/extensions/shared/media-plugin.ts
+++ b/src/molecules/editor/extensions/shared/media-plugin.ts
@@ -76,6 +76,10 @@ export function createMediaPlugin(
           if (files.length === 0) return false
 
           event.preventDefault()
+          // Drops on the prose are authoritative (precise insert at the cursor):
+          // stop the event so an ancestor editor-area drop zone (which inserts at
+          // the doc end) does not also handle the same files.
+          event.stopPropagation()
 
           let pos: number | null = null
           const coords = view.posAtCoords({

--- a/src/molecules/editor/extensions/shared/media-upload-types.ts
+++ b/src/molecules/editor/extensions/shared/media-upload-types.ts
@@ -11,19 +11,18 @@ import type { UploadedFile as FrappeUploadedFile } from '#utils/useFileUpload'
 import type { MediaDimensions } from '#molecules/editor/extensions/shared/media-dimensions'
 
 /**
- * Drop/programmatic upload commands, declared once in a dedicated `mediaUpload`
+ * Programmatic upload commands, declared once in a dedicated `mediaUpload`
  * group (tiptap flattens every group into `RawCommands`, so callers still use
- * the flat `editor.commands.uploadImageFiles` / `uploadVideoFiles`).
+ * the flat `editor.commands.uploadVideoFiles`).
  *
- * Kept out of the `image`/`video` groups on purpose: the legacy TextEditor
- * extension also augments `Commands.image`, and a divergent second declaration
- * of the same group is a TS2717 error. A separate group sidesteps that.
+ * Kept out of the `video` group only for symmetry with the legacy-conflict
+ * rationale on images: the legacy TextEditor augments `Commands.image`, so a
+ * divergent second declaration of a shared group is a TS2717 error. A separate
+ * group sidesteps that.
  */
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     mediaUpload: {
-      /** Upload and insert already-provided image files (e.g. from a drop). */
-      uploadImageFiles: (files: File[], pos?: number | null) => ReturnType
       /** Upload and insert already-provided video files (e.g. from a drop). */
       uploadVideoFiles: (files: File[], pos?: number | null) => ReturnType
     }

--- a/src/molecules/editor/extensions/shared/media-upload-types.ts
+++ b/src/molecules/editor/extensions/shared/media-upload-types.ts
@@ -10,6 +10,26 @@ import type { Editor } from '@tiptap/core'
 import type { UploadedFile as FrappeUploadedFile } from '#utils/useFileUpload'
 import type { MediaDimensions } from '#molecules/editor/extensions/shared/media-dimensions'
 
+/**
+ * Drop/programmatic upload commands, declared once in a dedicated `mediaUpload`
+ * group (tiptap flattens every group into `RawCommands`, so callers still use
+ * the flat `editor.commands.uploadImageFiles` / `uploadVideoFiles`).
+ *
+ * Kept out of the `image`/`video` groups on purpose: the legacy TextEditor
+ * extension also augments `Commands.image`, and a divergent second declaration
+ * of the same group is a TS2717 error. A separate group sidesteps that.
+ */
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    mediaUpload: {
+      /** Upload and insert already-provided image files (e.g. from a drop). */
+      uploadImageFiles: (files: File[], pos?: number | null) => ReturnType
+      /** Upload and insert already-provided video files (e.g. from a drop). */
+      uploadVideoFiles: (files: File[], pos?: number | null) => ReturnType
+    }
+  }
+}
+
 /** Result of a successful upload. Must carry a `file_url`. */
 export interface UploadedFile extends Partial<FrappeUploadedFile> {
   file_url: string

--- a/src/molecules/editor/extensions/shared/suggestion-helpers.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-helpers.ts
@@ -1,4 +1,5 @@
 import type { Editor, Range } from '@tiptap/core'
+import type { EditorState } from '@tiptap/pm/state'
 
 /**
  * Shared helpers for slash/emoji/mention/tag suggesters: DRY node-insertion,
@@ -44,6 +45,25 @@ export function filterByQuery<T>(items: T[], query: string, key: keyof T): T[] {
     const value = item[key]
     return typeof value === 'string' && value.toLowerCase().includes(needle)
   })
+}
+
+/**
+ * True when `pos` sits inside a code context — either a code-block node or text
+ * carrying the inline `code` mark. Suggesters (`@`/`#`/`:`) use this to stay
+ * inert inside code, where a `:emoji`/`#tag`/`@mention` trigger would otherwise
+ * corrupt the literal source the author is typing.
+ *
+ * Detection is structural: code-block nodes carry `spec.code === true`, and
+ * inline code is a mark — so we walk the resolved ancestors for the former and
+ * test the position's mark set for the latter.
+ */
+export function isInCode(state: EditorState, pos: number): boolean {
+  const $pos = state.doc.resolve(pos)
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    if ($pos.node(depth).type.spec.code) return true
+  }
+  const codeMark = state.schema.marks.code
+  return codeMark ? codeMark.isInSet($pos.marks()) != null : false
 }
 
 /**

--- a/src/molecules/editor/extensions/suggestion/SuggestionList.vue
+++ b/src/molecules/editor/extensions/suggestion/SuggestionList.vue
@@ -1,9 +1,14 @@
 <template>
-  <div
+  <EditorPopover
     v-if="items.length || showNoResults"
-    ref="container"
-    class="relative max-h-[300px] min-w-40 overflow-y-auto rounded-lg bg-surface-white p-1 text-base shadow-lg"
-    :class="containerClass"
+    dialog-label="Suggestions"
+    :autofocus="false"
+    :trapped="false"
+    :loop="false"
+    :content-class="[
+      'relative max-h-[300px] min-w-40 overflow-y-auto rounded-lg p-1 text-base',
+      containerClass,
+    ]"
   >
     <template v-if="items.length">
       <SuggestionListItem
@@ -18,13 +23,15 @@
       >
         <template #default="{ item: slotItem }">
           <slot :item="slotItem" :index="index">
-            <span>{{ slotItem.display || slotItem.title || slotItem.name }}</span>
+            <span>{{
+              slotItem.display || slotItem.title || slotItem.name
+            }}</span>
           </slot>
         </template>
       </SuggestionListItem>
     </template>
     <div v-else class="px-3 py-1.5 text-sm text-ink-gray-5">No results</div>
-  </div>
+  </EditorPopover>
 </template>
 
 <script setup lang="ts">
@@ -39,6 +46,7 @@ import {
 import type { BaseSuggestionItem } from '#molecules/editor/extensions/shared/suggestion-types'
 import { useSuggestionList } from '#molecules/editor/composables/useSuggestionList'
 import SuggestionListItem from './SuggestionListItem.vue'
+import EditorPopover from '#molecules/editor/components/EditorPopover.vue'
 
 const props = defineProps({
   items: {
@@ -63,7 +71,6 @@ const props = defineProps({
   },
 })
 
-const container = ref<HTMLDivElement | null>(null)
 const itemRefs = ref<HTMLElement[]>([])
 
 const { selectedIndex, onKeyDown } = useSuggestionList<BaseSuggestionItem>(
@@ -79,7 +86,8 @@ function setItemRef(
   el: Element | ComponentPublicInstance | null,
   index: number,
 ): void {
-  const node = (el as ComponentPublicInstance | null)?.$el ?? (el as Element | null)
+  const node =
+    (el as ComponentPublicInstance | null)?.$el ?? (el as Element | null)
   if (node instanceof HTMLElement) itemRefs.value[index] = node
 }
 

--- a/src/molecules/editor/extensions/suggestion/SuggestionListItem.vue
+++ b/src/molecules/editor/extensions/suggestion/SuggestionListItem.vue
@@ -2,7 +2,7 @@
   <button
     type="button"
     :class="[
-      'flex w-full items-center whitespace-nowrap rounded-md px-2 py-1.5 text-sm text-ink-gray-9',
+      'flex w-full items-center whitespace-nowrap rounded px-2 py-1.5 text-sm text-ink-gray-9',
       selected ? 'bg-surface-gray-2' : '',
       itemClass,
     ]"

--- a/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
+++ b/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
@@ -7,6 +7,7 @@ import {
   createSuggestionRenderer,
   type SuggestionFloatingOptions,
 } from '#molecules/editor/extensions/shared/suggestion-renderer'
+import { isInCode } from '#molecules/editor/extensions/shared/suggestion-helpers'
 
 // Re-export for back-compat: several extensions still import the base item type
 // from this module path. The canonical home is `suggestion-types`.
@@ -59,6 +60,9 @@ export function createSuggestionExtension<TItem extends BaseSuggestionItem>(
           pluginKey: options.pluginKey,
           items: options.items,
           command: options.command,
+          // Stay inert inside code blocks / inline code, where a trigger char
+          // (`:`/`#`/`@`) is literal source the author is typing — not a cue.
+          allow: ({ state, range }) => !isInCode(state, range.from),
           allowSpaces: options.allowSpaces,
           startOfLine: options.startOfLine,
           decorationTag: options.decorationTag || 'span',

--- a/src/molecules/editor/extensions/table/table-cell-color.ts
+++ b/src/molecules/editor/extensions/table/table-cell-color.ts
@@ -1,0 +1,113 @@
+/**
+ * First-class named colors for table cells, mirroring the inline named-color /
+ * highlight extensions:
+ *
+ *  - **Cell background** — a `backgroundColor` attribute on the cell nodes
+ *    (added in `extensions.ts` via `cellBackgroundAttributes`), storing a
+ *    palette name and rendering as `background-color: var(--prose-highlight-NAME)`
+ *    (the same tints the highlight mark uses, so cell fills track light/dark).
+ *  - **Cell text color** — the `textStyle` mark applied across the whole content
+ *    of the selected cell(s), so a bare cursor colors the entire cell rather
+ *    than only newly-typed text.
+ *
+ * Setting the background uses the Table extension's built-in `setCellAttribute`
+ * (which already targets either the cursor's cell or every cell in a
+ * `CellSelection`); the text-color command reproduces that targeting for marks.
+ */
+import { Extension } from '@tiptap/core'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import { CellSelection, isInTable, selectionCell } from '@tiptap/pm/tables'
+import { PALETTE_NAMES } from '../shared/color-palette'
+import {
+  extractHighlightColorFromStyle,
+  highlightColorStyle,
+} from '../shared/color-style'
+
+/**
+ * The `backgroundColor` attribute spec, spread into both `TableCell` and
+ * `TableHeader` (see `extensions.ts`). Kept as a plain object — not a node of
+ * its own — so the command extension below can declare the commands exactly
+ * once (two nodes declaring the same command would collide).
+ */
+export const cellBackgroundAttributes = {
+  backgroundColor: {
+    default: null as string | null,
+    parseHTML: (element: HTMLElement) => {
+      const style = element.getAttribute('style')
+      if (!style) return null
+      // Normalize a pasted inline `background-color` back to a palette name.
+      return extractHighlightColorFromStyle(style, PALETTE_NAMES)
+    },
+    renderHTML: (attributes: Record<string, unknown>) => {
+      const name = attributes.backgroundColor
+      if (typeof name !== 'string' || !PALETTE_NAMES.includes(name)) return {}
+      return { style: highlightColorStyle(name) }
+    },
+  },
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    tableCellColor: {
+      /** Fill the selected cell(s) with a named background; `null` clears it. */
+      setCellBackground: (colorName: string | null) => ReturnType
+      /** Color all text in the selected cell(s) by name; `null` clears it. */
+      setCellTextColor: (colorName: string | null) => ReturnType
+    }
+  }
+}
+
+export const TableCellColor = Extension.create({
+  name: 'tableCellColor',
+
+  addCommands() {
+    return {
+      setCellBackground:
+        (colorName) =>
+        ({ chain }) => {
+          if (colorName !== null && !PALETTE_NAMES.includes(colorName)) {
+            return false
+          }
+          return chain().setCellAttribute('backgroundColor', colorName).run()
+        },
+
+      setCellTextColor:
+        (colorName) =>
+        ({ state, tr, dispatch }) => {
+          if (colorName !== null && !PALETTE_NAMES.includes(colorName)) {
+            return false
+          }
+          if (!isInTable(state)) return false
+          const markType = state.schema.marks.textStyle
+          if (!markType) return false
+
+          // Collect the content range of every targeted cell: each cell in a
+          // CellSelection, else just the cell holding the cursor.
+          const ranges: Array<{ from: number; to: number }> = []
+          const addCell = (cell: PMNode | null, pos: number) => {
+            if (!cell) return
+            ranges.push({ from: pos + 1, to: pos + cell.nodeSize - 1 })
+          }
+          const { selection } = state
+          if (selection instanceof CellSelection) {
+            selection.forEachCell((cell, pos) => addCell(cell, pos))
+          } else {
+            const $cell = selectionCell(state)
+            if ($cell) addCell($cell.nodeAfter, $cell.pos)
+          }
+          if (!ranges.length) return false
+
+          for (const { from, to } of ranges) {
+            // textStyle only carries `color` in this editor, so replacing the
+            // whole mark in-range is equivalent to setting the color.
+            tr.removeMark(from, to, markType)
+            if (colorName) tr.addMark(from, to, markType.create({ color: colorName }))
+          }
+          if (dispatch) dispatch(tr.scrollIntoView())
+          return true
+        },
+    }
+  },
+})
+
+export { TableCellColor as default }

--- a/src/molecules/editor/extensions/table/table-navigation.ts
+++ b/src/molecules/editor/extensions/table/table-navigation.ts
@@ -109,6 +109,27 @@ function moveCell(editor: Editor, axis: Axis, dir: number): boolean {
 }
 
 /**
+ * Grow/shrink the cell selection one step along an axis (spreadsheet-style
+ * Shift-Arrow): keep the anchor cell fixed, move only the head cell. The
+ * selection is always rectangular, so moving the head fills in the block.
+ * No-op (but consumed) at an edge.
+ */
+function extendCell(editor: Editor, axis: Axis, dir: number): boolean {
+  const { state, view } = editor
+  const sel = state.selection
+  if (!(sel instanceof CellSelection)) return false
+  const $next = nextCell(sel.$headCell, axis, dir)
+  if ($next) {
+    view.dispatch(
+      state.tr
+        .setSelection(new CellSelection(sel.$anchorCell, $next))
+        .scrollIntoView(),
+    )
+  }
+  return true
+}
+
+/**
  * Tab / Shift-Tab: move to the next/previous cell and land in navigate mode
  * (highlight, no caret), exiting edit mode. Wraps across rows via the table's
  * own `goToNextCell`, then converts its text selection to a cell selection.
@@ -143,6 +164,8 @@ export const TableNavigation = Extension.create({
       new Plugin({
         props: {
           handleKeyDown(view, event) {
+            // Read-only: leave caret/selection to the default. No cell nav.
+            if (!editor.isEditable) return false
             const { state } = view
             if (!isInTable(state)) return false
             const navigating = state.selection instanceof CellSelection
@@ -153,6 +176,29 @@ export const TableNavigation = Extension.create({
             if (event.key === 'Tab') {
               tabToCell(editor, event.shiftKey ? -1 : 1)
               return true
+            }
+
+            // Shift+Arrow grows the cell selection (spreadsheet-style), anchor
+            // fixed. Only once a CellSelection exists (navigate mode); in edit
+            // mode let the default extend the text selection within the cell.
+            if (
+              event.shiftKey &&
+              !event.metaKey &&
+              !event.ctrlKey &&
+              !event.altKey &&
+              (ARROWS as readonly string[]).includes(event.key)
+            ) {
+              if (!navigating) return false
+              switch (event.key) {
+                case 'ArrowRight':
+                  return extendCell(editor, 'horiz', 1)
+                case 'ArrowLeft':
+                  return extendCell(editor, 'horiz', -1)
+                case 'ArrowDown':
+                  return extendCell(editor, 'vert', 1)
+                case 'ArrowUp':
+                  return extendCell(editor, 'vert', -1)
+              }
             }
 
             // In edit mode, keep arrows inside the cell (no escaping to the next
@@ -196,6 +242,8 @@ export const TableNavigation = Extension.create({
           // the default (caret) to start editing.
           handleDOMEvents: {
             mousedown(view, event) {
+              // Read-only: don't hijack clicks into cell selection.
+              if (!editor.isEditable) return false
               if (
                 event.button !== 0 ||
                 event.shiftKey ||
@@ -252,6 +300,7 @@ export const TableNavigation = Extension.create({
           // Typing while a cell is selected starts editing (append) instead of
           // letting a CellSelection swallow the input.
           handleTextInput(view, _from, _to, text) {
+            if (!editor.isEditable) return false
             const { selection } = view.state
             if (!(selection instanceof CellSelection)) return false
             const $cell = selection.$headCell

--- a/src/molecules/editor/extensions/table/table-navigation.ts
+++ b/src/molecules/editor/extensions/table/table-navigation.ts
@@ -190,15 +190,63 @@ export const TableNavigation = Extension.create({
             }
           },
 
-          handleClick(view, pos) {
-            const $cell = cellAround(view.state.doc.resolve(pos))
-            if (!$cell) return false
-            // Second click on the already-selected cell starts editing at the
-            // click point; first click selects the cell (navigate).
-            if (isOnCell(view.state.selection, $cell)) {
-              return editCell(editor, $cell, pos)
-            }
-            return selectCell(editor, $cell.pos)
+          // Select the cell on mousedown — before the browser places a text
+          // caret — so a click lands straight in navigate mode with no caret
+          // flash. A second click on the already-active cell falls through to
+          // the default (caret) to start editing.
+          handleDOMEvents: {
+            mousedown(view, event) {
+              if (
+                event.button !== 0 ||
+                event.shiftKey ||
+                event.ctrlKey ||
+                event.metaKey ||
+                event.altKey
+              ) {
+                return false
+              }
+              const coords = view.posAtCoords({
+                left: event.clientX,
+                top: event.clientY,
+              })
+              if (!coords) return false
+              const $cell = cellAround(view.state.doc.resolve(coords.pos))
+              if (!$cell) return false
+              // Clicking the active cell again → let the default place the caret.
+              if (isOnCell(view.state.selection, $cell)) return false
+
+              event.preventDefault()
+              const anchorPos = $cell.pos
+              view.dispatch(
+                view.state.tr.setSelection(
+                  CellSelection.create(view.state.doc, anchorPos),
+                ),
+              )
+              if (!view.hasFocus()) view.focus()
+
+              // Drag to extend into a multi-cell selection (e.g. for merge).
+              const onMove = (e: MouseEvent) => {
+                const c = view.posAtCoords({ left: e.clientX, top: e.clientY })
+                if (!c) return
+                const $c = cellAround(view.state.doc.resolve(c.pos))
+                if (!$c) return
+                const next = CellSelection.create(
+                  view.state.doc,
+                  anchorPos,
+                  $c.pos,
+                )
+                if (!view.state.selection.eq(next)) {
+                  view.dispatch(view.state.tr.setSelection(next))
+                }
+              }
+              const onUp = () => {
+                document.removeEventListener('mousemove', onMove)
+                document.removeEventListener('mouseup', onUp, true)
+              }
+              document.addEventListener('mousemove', onMove)
+              document.addEventListener('mouseup', onUp, true)
+              return true
+            },
           },
 
           // Typing while a cell is selected starts editing (append) instead of

--- a/src/molecules/editor/extensions/table/table-navigation.ts
+++ b/src/molecules/editor/extensions/table/table-navigation.ts
@@ -1,0 +1,149 @@
+/**
+ * Spreadsheet-style cell navigation for tables.
+ *
+ * Two modes, distinguished purely by the selection type (no extra state):
+ *  - **Navigate** — the selection is a single-cell `CellSelection`. The cell is
+ *    highlighted (prosemirror-tables draws `.selectedCell`; styled in style.css),
+ *    there's no caret, and arrow keys move between cells.
+ *  - **Edit** — a normal `TextSelection` inside the cell. Arrows move the caret
+ *    as usual; Escape returns to navigate.
+ *
+ * Flow: click a cell → navigate (highlight). Enter (or a second click, or
+ * typing) → edit. Escape → navigate. Arrow keys in navigate mode → move the
+ * active cell.
+ *
+ * Runs at a high priority so its `handleKeyDown` precedes the Table extension's
+ * built-in arrow handling (which would otherwise collapse a CellSelection to a
+ * caret on arrow press).
+ */
+import { Extension } from '@tiptap/core'
+import type { Editor } from '@tiptap/core'
+import { Plugin } from '@tiptap/pm/state'
+import { TextSelection } from '@tiptap/pm/state'
+import type { ResolvedPos } from '@tiptap/pm/model'
+import {
+  CellSelection,
+  cellAround,
+  isInTable,
+  nextCell,
+  selectionCell,
+} from '@tiptap/pm/tables'
+
+type Axis = 'horiz' | 'vert'
+
+/** Select a whole cell (navigate mode), highlighting it. */
+function selectCell(editor: Editor, pos: number): boolean {
+  const { state, view } = editor
+  view.dispatch(
+    state.tr
+      .setSelection(CellSelection.create(state.doc, pos))
+      .scrollIntoView(),
+  )
+  return true
+}
+
+/** Drop the caret into a cell (edit mode), at the end of its content. */
+function editCell(editor: Editor, $cell: ResolvedPos, at?: number): boolean {
+  const { state, view } = editor
+  const cell = $cell.nodeAfter
+  if (!cell) return false
+  const pos = at ?? $cell.pos + cell.nodeSize - 1
+  const selection = TextSelection.near(state.doc.resolve(pos), -1)
+  view.dispatch(state.tr.setSelection(selection).scrollIntoView())
+  return true
+}
+
+/** Move the active cell one step along an axis; no-op (but consumed) at an edge. */
+function moveCell(editor: Editor, axis: Axis, dir: number): boolean {
+  const { state } = editor
+  const $next = nextCell(selectionCell(state), axis, dir)
+  if ($next) selectCell(editor, $next.pos)
+  return true
+}
+
+/** A single-cell CellSelection sitting on exactly the given cell. */
+function isOnCell(selection: unknown, $cell: ResolvedPos): boolean {
+  return (
+    selection instanceof CellSelection &&
+    selection.$anchorCell.pos === $cell.pos &&
+    selection.$headCell.pos === $cell.pos
+  )
+}
+
+export const TableNavigation = Extension.create({
+  name: 'tableNavigation',
+  // Beat the Table extension's own arrow/keymap handling.
+  priority: 200,
+
+  addProseMirrorPlugins() {
+    const editor = this.editor
+
+    return [
+      new Plugin({
+        props: {
+          handleKeyDown(view, event) {
+            const { state } = view
+            if (!isInTable(state)) return false
+            const navigating = state.selection instanceof CellSelection
+
+            switch (event.key) {
+              case 'ArrowRight':
+                return navigating ? moveCell(editor, 'horiz', 1) : false
+              case 'ArrowLeft':
+                return navigating ? moveCell(editor, 'horiz', -1) : false
+              case 'ArrowDown':
+                return navigating ? moveCell(editor, 'vert', 1) : false
+              case 'ArrowUp':
+                return navigating ? moveCell(editor, 'vert', -1) : false
+              case 'Enter':
+                if (navigating) {
+                  return editCell(
+                    editor,
+                    (state.selection as CellSelection).$headCell,
+                  )
+                }
+                return false
+              case 'Escape':
+                if (!navigating)
+                  return selectCell(editor, selectionCell(state).pos)
+                return false
+              default:
+                return false
+            }
+          },
+
+          handleClick(view, pos) {
+            const $cell = cellAround(view.state.doc.resolve(pos))
+            if (!$cell) return false
+            // Second click on the already-selected cell starts editing at the
+            // click point; first click selects the cell (navigate).
+            if (isOnCell(view.state.selection, $cell)) {
+              return editCell(editor, $cell, pos)
+            }
+            return selectCell(editor, $cell.pos)
+          },
+
+          // Typing while a cell is selected starts editing (append) instead of
+          // letting a CellSelection swallow the input.
+          handleTextInput(view, _from, _to, text) {
+            const { selection } = view.state
+            if (!(selection instanceof CellSelection)) return false
+            const $cell = selection.$headCell
+            const cell = $cell.nodeAfter
+            if (!cell) return false
+            const end = $cell.pos + cell.nodeSize - 1
+            view.dispatch(
+              view.state.tr
+                .setSelection(
+                  TextSelection.near(view.state.doc.resolve(end), -1),
+                )
+                .insertText(text)
+                .scrollIntoView(),
+            )
+            return true
+          },
+        },
+      }),
+    ]
+  },
+})

--- a/src/molecules/editor/extensions/table/table-navigation.ts
+++ b/src/molecules/editor/extensions/table/table-navigation.ts
@@ -24,6 +24,7 @@ import type { ResolvedPos } from '@tiptap/pm/model'
 import {
   CellSelection,
   cellAround,
+  columnResizingPluginKey,
   goToNextCell,
   isInTable,
   nextCell,
@@ -244,6 +245,12 @@ export const TableNavigation = Extension.create({
             mousedown(view, event) {
               // Read-only: don't hijack clicks into cell selection.
               if (!editor.isEditable) return false
+              // Pointer is over a column-resize border (the resize plugin set its
+              // active handle on the preceding mousemove). Bail so its own,
+              // lower-priority mousedown can start the drag instead of us
+              // swallowing it as a cell selection.
+              const resizeState = columnResizingPluginKey.getState(view.state)
+              if (resizeState && resizeState.activeHandle > -1) return false
               if (
                 event.button !== 0 ||
                 event.shiftKey ||

--- a/src/molecules/editor/extensions/table/table-navigation.ts
+++ b/src/molecules/editor/extensions/table/table-navigation.ts
@@ -18,8 +18,8 @@
  */
 import { Extension } from '@tiptap/core'
 import type { Editor } from '@tiptap/core'
-import { Plugin } from '@tiptap/pm/state'
-import { TextSelection } from '@tiptap/pm/state'
+import { Plugin, Selection, TextSelection } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
 import type { ResolvedPos } from '@tiptap/pm/model'
 import {
   CellSelection,
@@ -30,6 +30,52 @@ import {
 } from '@tiptap/pm/tables'
 
 type Axis = 'horiz' | 'vert'
+
+const ARROWS = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'] as const
+
+/**
+ * In edit mode, true when a plain arrow press would move the caret out of the
+ * current cell (so we can swallow it — the cell is a sandbox; leave via Escape or
+ * Tab). Caret movement that stays inside the cell is left to the default.
+ */
+function arrowLeavesCell(view: EditorView, event: KeyboardEvent): boolean {
+  if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+    return false
+  }
+  const { state } = view
+  if (!state.selection.empty) return false
+  const $head = state.selection.$head
+  const $cell = cellAround($head)
+  if (!$cell) return false
+  const cell = $cell.nodeAfter
+  if (!cell) return false
+  // First / last caret positions inside the cell, and their textblocks.
+  const firstPos = Selection.near(state.doc.resolve($cell.pos + 1), 1).from
+  const lastPos = Selection.near(
+    state.doc.resolve($cell.pos + cell.nodeSize - 1),
+    -1,
+  ).from
+  switch (event.key) {
+    case 'ArrowLeft':
+      return $head.pos <= firstPos
+    case 'ArrowRight':
+      return $head.pos >= lastPos
+    case 'ArrowUp':
+      // At the top line of the cell's first block.
+      return (
+        view.endOfTextblock('up') &&
+        $head.start() === state.doc.resolve(firstPos).start()
+      )
+    case 'ArrowDown':
+      // At the bottom line of the cell's last block.
+      return (
+        view.endOfTextblock('down') &&
+        $head.start() === state.doc.resolve(lastPos).start()
+      )
+    default:
+      return false
+  }
+}
 
 /** Select a whole cell (navigate mode), highlighting it. */
 function selectCell(editor: Editor, pos: number): boolean {
@@ -85,6 +131,15 @@ export const TableNavigation = Extension.create({
             const { state } = view
             if (!isInTable(state)) return false
             const navigating = state.selection instanceof CellSelection
+
+            // In edit mode, keep arrows inside the cell (no escaping to the next
+            // cell or out of the table); leave the cell via Escape or Tab.
+            if (
+              !navigating &&
+              (ARROWS as readonly string[]).includes(event.key)
+            ) {
+              return arrowLeavesCell(view, event)
+            }
 
             switch (event.key) {
               case 'ArrowRight':

--- a/src/molecules/editor/extensions/table/table-navigation.ts
+++ b/src/molecules/editor/extensions/table/table-navigation.ts
@@ -24,6 +24,7 @@ import type { ResolvedPos } from '@tiptap/pm/model'
 import {
   CellSelection,
   cellAround,
+  goToNextCell,
   isInTable,
   nextCell,
   selectionCell,
@@ -107,6 +108,20 @@ function moveCell(editor: Editor, axis: Axis, dir: number): boolean {
   return true
 }
 
+/**
+ * Tab / Shift-Tab: move to the next/previous cell and land in navigate mode
+ * (highlight, no caret), exiting edit mode. Wraps across rows via the table's
+ * own `goToNextCell`, then converts its text selection to a cell selection.
+ */
+function tabToCell(editor: Editor, dir: 1 | -1): boolean {
+  const { state, view } = editor
+  if (!isInTable(state)) return false
+  if (!goToNextCell(dir)(state, view.dispatch)) return false
+  const $cell = cellAround(editor.state.selection.$head)
+  if ($cell) selectCell(editor, $cell.pos)
+  return true
+}
+
 /** A single-cell CellSelection sitting on exactly the given cell. */
 function isOnCell(selection: unknown, $cell: ResolvedPos): boolean {
   return (
@@ -131,6 +146,14 @@ export const TableNavigation = Extension.create({
             const { state } = view
             if (!isInTable(state)) return false
             const navigating = state.selection instanceof CellSelection
+
+            // Tab moves to the next/previous cell in navigate mode, exiting edit
+            // mode (works from either mode). Consume it in a table either way so
+            // focus never leaves the cell grid.
+            if (event.key === 'Tab') {
+              tabToCell(editor, event.shiftKey ? -1 : 1)
+              return true
+            }
 
             // In edit mode, keep arrows inside the cell (no escaping to the next
             // cell or out of the table); leave the cell via Escape or Tab.

--- a/src/molecules/editor/extensions/table/table-selection-overlay.ts
+++ b/src/molecules/editor/extensions/table/table-selection-overlay.ts
@@ -1,0 +1,114 @@
+/**
+ * Draws ONE rounded box around a multi-cell selection instead of ringing each
+ * cell on its own.
+ *
+ * prosemirror-tables flags every selected cell with `.selectedCell`, which by
+ * default we paint with a translucent fill + a per-cell ring (see style.css).
+ * For a 2+ cell selection that reads as a grid of boxes. Here we instead:
+ *  - add a `table-cell-range` class to the editor so the per-cell ring is
+ *    suppressed (the fill stays, so the region reads as one block), and
+ *  - overlay a single element spanning the union of the selected cells' rects,
+ *    appended to the `.tableWrapper` (a positioned, scrollable ancestor) so it
+ *    tracks horizontal scroll for free.
+ *
+ * A single selected cell (navigate mode) is left untouched — it keeps its ring.
+ */
+import { Extension } from '@tiptap/core'
+import { Plugin } from '@tiptap/pm/state'
+import { CellSelection } from '@tiptap/pm/tables'
+import type { EditorView } from '@tiptap/pm/view'
+
+interface Rect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+class SelectionOverlay {
+  private el: HTMLElement | null = null
+
+  constructor(private view: EditorView) {
+    this.update(view)
+  }
+
+  update(view: EditorView): void {
+    const { selection } = view.state
+    const isRange =
+      selection instanceof CellSelection &&
+      selection.$anchorCell.pos !== selection.$headCell.pos
+    view.dom.classList.toggle('table-cell-range', isRange)
+    if (!isRange) {
+      this.remove()
+      return
+    }
+    this.draw(view, selection as CellSelection)
+  }
+
+  private draw(view: EditorView, selection: CellSelection): void {
+    let union: Rect | null = null
+    selection.forEachCell((_cell, pos) => {
+      const dom = view.nodeDOM(pos)
+      if (!(dom instanceof HTMLElement)) return
+      const r = dom.getBoundingClientRect()
+      union = union
+        ? {
+            left: Math.min(union.left, r.left),
+            top: Math.min(union.top, r.top),
+            right: Math.max(union.right, r.right),
+            bottom: Math.max(union.bottom, r.bottom),
+          }
+        : { left: r.left, top: r.top, right: r.right, bottom: r.bottom }
+    })
+    if (!union) {
+      this.remove()
+      return
+    }
+
+    const anchorDom = view.nodeDOM(selection.$anchorCell.pos)
+    const host =
+      (anchorDom instanceof HTMLElement
+        ? (anchorDom.closest('.tableWrapper') as HTMLElement | null)
+        : null) ?? (view.dom as HTMLElement)
+    const hostRect = host.getBoundingClientRect()
+
+    // Convert viewport rect → host content coordinates (so the box scrolls with
+    // the wrapper's horizontal overflow).
+    const box: Rect = union
+    const el = this.ensure(host)
+    el.style.left = `${box.left - hostRect.left + host.scrollLeft}px`
+    el.style.top = `${box.top - hostRect.top + host.scrollTop}px`
+    el.style.width = `${box.right - box.left}px`
+    el.style.height = `${box.bottom - box.top}px`
+  }
+
+  private ensure(host: HTMLElement): HTMLElement {
+    if (this.el && this.el.parentElement === host) return this.el
+    this.remove()
+    const el = document.createElement('div')
+    el.className = 'table-selection-box'
+    el.setAttribute('aria-hidden', 'true')
+    host.appendChild(el)
+    this.el = el
+    return el
+  }
+
+  private remove(): void {
+    this.el?.remove()
+    this.el = null
+  }
+
+  destroy(): void {
+    this.view.dom.classList.remove('table-cell-range')
+    this.remove()
+  }
+}
+
+export const TableSelectionOverlay = Extension.create({
+  name: 'tableSelectionOverlay',
+  addProseMirrorPlugins() {
+    return [new Plugin({ view: (view) => new SelectionOverlay(view) })]
+  },
+})
+
+export { TableSelectionOverlay as default }

--- a/src/molecules/editor/extensions/video/video-extension.ts
+++ b/src/molecules/editor/extensions/video/video-extension.ts
@@ -193,6 +193,14 @@ export const VideoExtension = NodeExtension.create<VideoExtensionOptions>({
           return true
         },
 
+      uploadVideoFiles:
+        (files: File[], pos: number | null = null) =>
+        ({ editor }) => {
+          if (files.length === 0) return false
+          void videoEngine.processMultiple(files, editor, pos, resolve())
+          return true
+        },
+
       selectAndUploadVideo:
         () =>
         ({ editor }) => {

--- a/src/molecules/editor/index.ts
+++ b/src/molecules/editor/index.ts
@@ -1,3 +1,8 @@
+// Editor styles ship with the package: importing from `frappe-ui/editor` pulls
+// in the ProseMirror/prose-v3 rules so the editor is self-contained and does not
+// rely on any other component's stylesheet being loaded.
+import './style.css'
+
 // Engine
 export {
   useEditor,

--- a/src/molecules/editor/index.ts
+++ b/src/molecules/editor/index.ts
@@ -18,6 +18,7 @@ export { default as Editor } from './Editor.vue'
 
 // Building blocks (compose without <Editor>)
 export { default as EditorContent } from './EditorContent.vue'
+export { default as EditorDropZone } from './components/EditorDropZone.vue'
 export { default as EditorFixedMenu } from './EditorFixedMenu.vue'
 export { default as EditorBubbleMenu } from './EditorBubbleMenu.vue'
 export { default as EditorFloatingMenu } from './EditorFloatingMenu.vue'

--- a/src/molecules/editor/index.ts
+++ b/src/molecules/editor/index.ts
@@ -21,6 +21,7 @@ export { default as EditorContent } from './EditorContent.vue'
 export { default as EditorDropZone } from './components/EditorDropZone.vue'
 export { default as EditorFixedMenu } from './EditorFixedMenu.vue'
 export { default as EditorBubbleMenu } from './EditorBubbleMenu.vue'
+export { default as EditorTableMenu } from './EditorTableMenu.vue'
 export { default as EditorFloatingMenu } from './EditorFloatingMenu.vue'
 
 // Kits — configurable extension bundles (StarterKit is re-exported from extensions)

--- a/src/molecules/editor/kits.ts
+++ b/src/molecules/editor/kits.ts
@@ -13,6 +13,7 @@ import {
   ImageGroup,
   ImageViewer,
   Video,
+  MediaDrop,
   ContentPaste,
   Emoji,
   Mention,
@@ -135,6 +136,8 @@ function commentMembers(options: CommentKitOptions): Extensions {
   if (options.image !== false)
     pushMember(list, ImageViewer, options.imageViewer)
   pushMember(list, Video, options.video)
+  // The single drop pipeline; only useful when there's a media node to route to.
+  if (options.image !== false || options.video !== false) list.push(MediaDrop)
   pushMember(list, ContentPaste, options.contentPaste)
   pushMember(list, Emoji, options.emoji)
   pushMember(list, Mention, options.mention)

--- a/src/molecules/editor/kits.ts
+++ b/src/molecules/editor/kits.ts
@@ -22,6 +22,7 @@ import {
   TableRow,
   TableCell,
   TableHeader,
+  TableNavigation,
   TaskList,
   TaskItem,
   Iframe,
@@ -193,13 +194,15 @@ export const RichTextKit = Extension.create<RichTextKitOptions>({
     const options = this.options
     const list: Extensions = commentMembers(options)
 
-    // Table needs its row/cell/header companions.
+    // Table needs its row/cell/header companions; TableNavigation adds the
+    // spreadsheet-style cell navigation on top.
     if (options.table !== false) {
       list.push(
         Table.configure(options.table),
         TableRow,
         TableCell,
         TableHeader,
+        TableNavigation,
       )
     }
     // Task list needs its item companion.

--- a/src/molecules/editor/kits.ts
+++ b/src/molecules/editor/kits.ts
@@ -103,6 +103,9 @@ export interface CommentKitOptions {
   imageGroup: CustomMember
   imageViewer: CustomMember
   video: CustomMember
+  // Tables. Off by default for CommentKit (the lighter stack); RichTextKit turns
+  // it on. Opt in with `CommentKit.configure({ table: {} })`.
+  table: CustomMember
   contentPaste: CustomMember
   emoji: CustomMember
   mention: MentionMember
@@ -118,6 +121,7 @@ const commentKitDefaults = (): CommentKitOptions => ({
   imageGroup: {},
   imageViewer: {},
   video: {},
+  table: false,
   contentPaste: {},
   emoji: {},
   mention: {},
@@ -139,6 +143,18 @@ function commentMembers(options: CommentKitOptions): Extensions {
   pushMember(list, Video, options.video)
   // The single drop pipeline; only useful when there's a media node to route to.
   if (options.image !== false || options.video !== false) list.push(MediaDrop)
+  // Table needs its row/cell/header companions; TableNavigation adds the
+  // spreadsheet-style cell navigation. Shared so both kits get it (off by
+  // default for CommentKit, on for RichTextKit).
+  if (options.table !== false) {
+    list.push(
+      Table.configure(options.table),
+      TableRow,
+      TableCell,
+      TableHeader,
+      TableNavigation,
+    )
+  }
   pushMember(list, ContentPaste, options.contentPaste)
   pushMember(list, Emoji, options.emoji)
   pushMember(list, Mention, options.mention)
@@ -192,19 +208,10 @@ export const RichTextKit = Extension.create<RichTextKitOptions>({
   },
   addExtensions() {
     const options = this.options
+    // Table is handled by commentMembers (shared, on for RichTextKit via the
+    // `table: {}` default below).
     const list: Extensions = commentMembers(options)
 
-    // Table needs its row/cell/header companions; TableNavigation adds the
-    // spreadsheet-style cell navigation on top.
-    if (options.table !== false) {
-      list.push(
-        Table.configure(options.table),
-        TableRow,
-        TableCell,
-        TableHeader,
-        TableNavigation,
-      )
-    }
     // Task list needs its item companion.
     if (options.taskList !== false) {
       list.push(TaskList.configure(options.taskList), TaskItem)

--- a/src/molecules/editor/kits.ts
+++ b/src/molecules/editor/kits.ts
@@ -23,6 +23,8 @@ import {
   TableCell,
   TableHeader,
   TableNavigation,
+  TableCellColor,
+  TableSelectionOverlay,
   TaskList,
   TaskItem,
   Iframe,
@@ -153,6 +155,8 @@ function commentMembers(options: CommentKitOptions): Extensions {
       TableCell,
       TableHeader,
       TableNavigation,
+      TableCellColor,
+      TableSelectionOverlay,
     )
   }
   pushMember(list, ContentPaste, options.contentPaste)

--- a/src/molecules/editor/menu.ts
+++ b/src/molecules/editor/menu.ts
@@ -7,6 +7,7 @@ import {
   type EditorCommandMeta,
 } from './commands'
 import { openFontColorPicker } from './components/font-color/fontColorController'
+import { openTableCellColorPicker } from './components/table-color/tableCellColorController'
 
 export type MenuActionContext = EditorCommandContext
 
@@ -232,32 +233,32 @@ function tableCommand(
 
 export const TableAddColumnBefore = tableCommand(
   'Insert column left',
-  'lucide-between-vertical-start',
+  'lucide-arrow-left-to-line',
   (editor) => editor.chain().focus().addColumnBefore().run(),
 )
 export const TableAddColumnAfter = tableCommand(
   'Insert column right',
-  'lucide-between-vertical-end',
+  'lucide-arrow-right-to-line',
   (editor) => editor.chain().focus().addColumnAfter().run(),
 )
 export const TableDeleteColumn = tableCommand(
   'Delete column',
-  'lucide-fold-horizontal',
+  'lucide-square-x',
   (editor) => editor.chain().focus().deleteColumn().run(),
 )
 export const TableAddRowBefore = tableCommand(
   'Insert row above',
-  'lucide-between-horizontal-start',
+  'lucide-arrow-up-to-line',
   (editor) => editor.chain().focus().addRowBefore().run(),
 )
 export const TableAddRowAfter = tableCommand(
   'Insert row below',
-  'lucide-between-horizontal-end',
+  'lucide-arrow-down-to-line',
   (editor) => editor.chain().focus().addRowAfter().run(),
 )
 export const TableDeleteRow = tableCommand(
   'Delete row',
-  'lucide-fold-vertical',
+  'lucide-square-x',
   (editor) => editor.chain().focus().deleteRow().run(),
 )
 // Active when the cursor sits in a header cell, so the toggle reflects the
@@ -280,6 +281,18 @@ export const TableDelete = tableCommand(
   'lucide-trash-2',
   (editor) => editor.chain().focus().deleteTable().run(),
 )
+// Opens an imperative picker (cell background + text color), so it owns no
+// can()-probe (which would invoke the action). `isAvailable` self-prunes it when
+// the Table extension is absent, matching the other table controls.
+export const CellColor: CommandMenuItem = {
+  label: 'Cell color',
+  icon: 'lucide-paint-bucket',
+  action: (editor, context) => {
+    if (!context?.trigger) return
+    openTableCellColorPicker({ editor, anchor: context.trigger })
+  },
+  isAvailable: tableLoaded,
+}
 
 /** Contextual table toolbar, consumed by `EditorTableMenu`. */
 export const tableToolbar: MenuItem[] = [
@@ -293,6 +306,7 @@ export const tableToolbar: MenuItem[] = [
   Separator,
   TableToggleHeaderRow,
   TableMergeOrSplit,
+  CellColor,
   Separator,
   TableDelete,
 ]

--- a/src/molecules/editor/menu.ts
+++ b/src/molecules/editor/menu.ts
@@ -199,6 +199,104 @@ export const Redo: CommandMenuItem = {
 
 export const Separator: MenuItem = { type: 'separator' }
 
+// ---------------------------------------------------------------------------
+// Table controls
+//
+// Surfaced in a contextual toolbar (`EditorTableMenu`) that appears only while
+// the selection is inside a table. Each item disables itself through the
+// editor's `can()` chain (via `canRun`), and the whole set self-prunes when the
+// Table extension isn't loaded — `isAvailable` checks the live schema, so the
+// same `tableToolbar` is inert in a comment editor and live in a doc editor.
+// ---------------------------------------------------------------------------
+
+/** True when the Table extension's node is present in the active schema. */
+function tableLoaded(editor: Editor): boolean {
+  return !!editor.schema.nodes.table
+}
+
+function tableCommand(
+  label: string,
+  icon: string,
+  action: CommandMenuItem['action'],
+  isActive?: (editor: Editor) => boolean,
+): CommandMenuItem {
+  return {
+    label,
+    icon,
+    action,
+    isActive,
+    isDisabled: (editor) => !canRun(editor, action),
+    isAvailable: tableLoaded,
+  }
+}
+
+export const TableAddColumnBefore = tableCommand(
+  'Insert column left',
+  'lucide-between-vertical-start',
+  (editor) => editor.chain().focus().addColumnBefore().run(),
+)
+export const TableAddColumnAfter = tableCommand(
+  'Insert column right',
+  'lucide-between-vertical-end',
+  (editor) => editor.chain().focus().addColumnAfter().run(),
+)
+export const TableDeleteColumn = tableCommand(
+  'Delete column',
+  'lucide-fold-horizontal',
+  (editor) => editor.chain().focus().deleteColumn().run(),
+)
+export const TableAddRowBefore = tableCommand(
+  'Insert row above',
+  'lucide-between-horizontal-start',
+  (editor) => editor.chain().focus().addRowBefore().run(),
+)
+export const TableAddRowAfter = tableCommand(
+  'Insert row below',
+  'lucide-between-horizontal-end',
+  (editor) => editor.chain().focus().addRowAfter().run(),
+)
+export const TableDeleteRow = tableCommand(
+  'Delete row',
+  'lucide-fold-vertical',
+  (editor) => editor.chain().focus().deleteRow().run(),
+)
+// Active when the cursor sits in a header cell, so the toggle reflects the
+// state of the row it would flip.
+export const TableToggleHeaderRow = tableCommand(
+  'Toggle header row',
+  'lucide-panel-top',
+  (editor) => editor.chain().focus().toggleHeaderRow().run(),
+  (editor) => editor.isActive('tableHeader'),
+)
+// One button for both directions: merges a multi-cell selection, splits a
+// merged cell. `can()` disables it when neither applies.
+export const TableMergeOrSplit = tableCommand(
+  'Merge or split cells',
+  'lucide-table-cells-merge',
+  (editor) => editor.chain().focus().mergeOrSplit().run(),
+)
+export const TableDelete = tableCommand(
+  'Delete table',
+  'lucide-trash-2',
+  (editor) => editor.chain().focus().deleteTable().run(),
+)
+
+/** Contextual table toolbar, consumed by `EditorTableMenu`. */
+export const tableToolbar: MenuItem[] = [
+  TableAddColumnBefore,
+  TableAddColumnAfter,
+  TableDeleteColumn,
+  Separator,
+  TableAddRowBefore,
+  TableAddRowAfter,
+  TableDeleteRow,
+  Separator,
+  TableToggleHeaderRow,
+  TableMergeOrSplit,
+  Separator,
+  TableDelete,
+]
+
 export const minimalToolbar: MenuItem[] = [Bold, Italic, InsertLink]
 export const commentToolbar: MenuItem[] = [
   Bold,

--- a/src/molecules/editor/style.css
+++ b/src/molecules/editor/style.css
@@ -131,8 +131,17 @@ img.ProseMirror-selectednode {
   background-color: var(--surface-gray-2);
 }
 
-.ProseMirror a span[style] {
-  text-decoration: underline;
+/* Links underline via `border-bottom` (see prose-v3 `a` in tailwind/plugin.js),
+   whose color is fixed and ignores the text `color`. When a link wraps named-
+   color text, drop that gray border (incl. on hover) and let the colored span
+   carry the underline in `currentColor`, so the line matches the text color. */
+.ProseMirror a:has(span[style*='--prose-color-']),
+.ProseMirror a:has(span[style*='--prose-color-']):hover {
+  border-bottom-color: transparent;
+}
+
+.ProseMirror a span[style*='--prose-color-'] {
+  border-bottom: 1px solid currentColor;
 }
 
 .ProseMirror .tableWrapper {

--- a/src/molecules/editor/style.css
+++ b/src/molecules/editor/style.css
@@ -131,6 +131,20 @@ img.ProseMirror-selectednode {
   background-color: var(--surface-gray-2);
 }
 
+/* Spreadsheet-style active cell: a CellSelection (incl. a single navigated
+   cell) is decorated with `.selectedCell` by prosemirror-tables. Overlay a
+   subtle gray fill + ring so the active cell reads as "selected" in navigate
+   mode. `::after` rides the cell's `position: relative` above. */
+.ProseMirror .selectedCell::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-color: var(--surface-gray-3);
+  box-shadow: inset 0 0 0 2px var(--outline-gray-4);
+  z-index: 2;
+}
+
 /* Links underline via `border-bottom` (see prose-v3 `a` in tailwind/plugin.js),
    whose color is fixed and ignores the text `color`. When a link wraps named-
    color text, drop that gray border (incl. on hover) and let the colored span

--- a/src/molecules/editor/style.css
+++ b/src/molecules/editor/style.css
@@ -131,21 +131,26 @@ img.ProseMirror-selectednode {
   background-color: var(--surface-gray-2);
 }
 
-/* Spreadsheet-style active cell: a CellSelection (incl. a single navigated
-   cell) is decorated with `.selectedCell` by prosemirror-tables. Overlay a
-   subtle gray fill + ring so the active cell reads as "selected" in navigate
-   mode. `::after` rides the cell's `position: relative` above. */
-.ProseMirror .selectedCell::after {
+/* Spreadsheet-style active cell. The overlay lives on *every* cell at opacity 0
+   and only fades in when prosemirror-tables adds `.selectedCell` (for a single
+   navigated cell or a multi-cell selection), so activating a cell animates in
+   smoothly instead of snapping on. Translucent fill keeps text readable; the
+   ring carries the emphasis. `::after` rides the cell's `position: relative`. */
+.ProseMirror td::after,
+.ProseMirror th::after {
   content: '';
   position: absolute;
   inset: 0;
   pointer-events: none;
-  /* Translucent so cell text stays readable; the ring carries the emphasis.
-     Solid rgba fallback first, themed color-mix when supported. */
-  background-color: rgba(0, 0, 0, 0.04);
-  background-color: color-mix(in srgb, var(--surface-gray-5) 18%, transparent);
-  box-shadow: inset 0 0 0 2px var(--outline-gray-4);
   z-index: 2;
+  opacity: 0;
+  background-color: color-mix(in srgb, var(--surface-gray-2) 10%, transparent);
+  box-shadow: inset 0 0 0 1px var(--outline-gray-4);
+  transition: opacity 150ms ease;
+}
+
+.ProseMirror .selectedCell::after {
+  opacity: 1;
 }
 
 /* Links underline via `border-bottom` (see prose-v3 `a` in tailwind/plugin.js),

--- a/src/molecules/editor/style.css
+++ b/src/molecules/editor/style.css
@@ -131,26 +131,18 @@ img.ProseMirror-selectednode {
   background-color: var(--surface-gray-2);
 }
 
-/* Spreadsheet-style active cell. The overlay lives on *every* cell at opacity 0
-   and only fades in when prosemirror-tables adds `.selectedCell` (for a single
-   navigated cell or a multi-cell selection), so activating a cell animates in
-   smoothly instead of snapping on. Translucent fill keeps text readable; the
-   ring carries the emphasis. `::after` rides the cell's `position: relative`. */
-.ProseMirror td::after,
-.ProseMirror th::after {
+/* Spreadsheet-style active cell: prosemirror-tables adds `.selectedCell` to the
+   navigated cell (or a multi-cell selection). Overlay a translucent fill (keeps
+   text readable) + ring, applied instantly — no transition. `::after` rides the
+   cell's `position: relative`. */
+.ProseMirror .selectedCell::after {
   content: '';
   position: absolute;
   inset: 0;
   pointer-events: none;
   z-index: 2;
-  opacity: 0;
   background-color: color-mix(in srgb, var(--surface-gray-2) 10%, transparent);
   box-shadow: inset 0 0 0 1px var(--outline-gray-4);
-  transition: opacity 150ms ease;
-}
-
-.ProseMirror .selectedCell::after {
-  opacity: 1;
 }
 
 /* Links underline via `border-bottom` (see prose-v3 `a` in tailwind/plugin.js),

--- a/src/molecules/editor/style.css
+++ b/src/molecules/editor/style.css
@@ -134,13 +134,17 @@ img.ProseMirror-selectednode {
 /* Links underline via `border-bottom` (see prose-v3 `a` in tailwind/plugin.js),
    whose color is fixed and ignores the text `color`. When a link wraps named-
    color text, drop that gray border (incl. on hover) and let the colored span
-   carry the underline in `currentColor`, so the line matches the text color. */
-.ProseMirror a:has(span[style*='--prose-color-']),
-.ProseMirror a:has(span[style*='--prose-color-']):hover {
+   carry the underline in `currentColor`, so the line matches the text color.
+   Compound `.prose-v3.ProseMirror` (both classes are on the editor element) so
+   these win over the legacy TextEditor's `a span[style]` underline, which may
+   still be loaded alongside this stylesheet. */
+.prose-v3.ProseMirror a:has(span[style*='--prose-color-']),
+.prose-v3.ProseMirror a:has(span[style*='--prose-color-']):hover {
   border-bottom-color: transparent;
 }
 
-.ProseMirror a span[style*='--prose-color-'] {
+.prose-v3.ProseMirror a span[style*='--prose-color-'] {
+  text-decoration: none;
   border-bottom: 1px solid currentColor;
 }
 

--- a/src/molecules/editor/style.css
+++ b/src/molecules/editor/style.css
@@ -28,6 +28,29 @@ img.ProseMirror-selectednode {
   padding: 0 10px;
 }
 
+/* Fast origin-aware appear for imperatively-mounted popups (useFloatingPopup).
+ * `transform-origin` is set inline from the resolved placement. */
+.editor-floating-pop {
+  animation: editor-floating-pop-in 90ms ease-out;
+}
+
+@keyframes editor-floating-pop-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .editor-floating-pop {
+    animation: none;
+  }
+}
+
 .table-of-contents-node li p {
   width: fit-content;
   padding: 0 3px;
@@ -138,11 +161,28 @@ img.ProseMirror-selectednode {
 .ProseMirror .selectedCell::after {
   content: '';
   position: absolute;
-  inset: 0;
+  inset: -1px;
+  border-radius: 2px;
   pointer-events: none;
   z-index: 2;
   background-color: color-mix(in srgb, var(--surface-gray-2) 10%, transparent);
-  box-shadow: inset 0 0 0 1px var(--outline-gray-4);
+  box-shadow: inset 0 0 0 1px var(--surface-gray-7);
+}
+
+/* Multi-cell selection: drop the per-cell ring (keep the fill, so adjacent
+   cells merge into one tinted region) and let `.table-selection-box` draw a
+   single box around the whole selection (see table-selection-overlay.ts). */
+.ProseMirror.table-cell-range .selectedCell::after {
+  box-shadow: none;
+}
+
+.ProseMirror .table-selection-box {
+  position: absolute;
+  pointer-events: none;
+  z-index: 3;
+  border-radius: 2px;
+  inset: -1px;
+  box-shadow: inset 0 0 0 1px var(--surface-gray-7);
 }
 
 /* Links underline via `border-bottom` (see prose-v3 `a` in tailwind/plugin.js),
@@ -164,6 +204,8 @@ img.ProseMirror-selectednode {
 
 .ProseMirror .tableWrapper {
   overflow-x: scroll;
+  /* Positioning context for the single-box multi-cell selection overlay. */
+  position: relative;
 }
 
 .prose-v3.ProseMirror[contenteditable='false']

--- a/src/molecules/editor/style.css
+++ b/src/molecules/editor/style.css
@@ -140,7 +140,10 @@ img.ProseMirror-selectednode {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background-color: var(--surface-gray-3);
+  /* Translucent so cell text stays readable; the ring carries the emphasis.
+     Solid rgba fallback first, themed color-mix when supported. */
+  background-color: rgba(0, 0, 0, 0.04);
+  background-color: color-mix(in srgb, var(--surface-gray-5) 18%, transparent);
   box-shadow: inset 0 0 0 2px var(--outline-gray-4);
   z-index: 2;
 }


### PR DESCRIPTION
## What this does

This PR improves the editor in a few areas.

### Link popup
- Cleaner link bubble: a view mode (URL with Copy and Edit) and an edit mode (URL input with Apply, and Remove for existing links).
- Escape works in two steps when editing an existing link — first goes back to view, second closes.
- ⌘K on a selected link jumps straight to editing.
- Adds `https://` automatically when you leave it out, and rejects invalid input with a small shake.

<img width="2880" height="1064" alt="link-popup" src="https://github.com/user-attachments/assets/c02b49e4-42e2-4cbe-9107-57837e6bacf1" />


### Shared popover
- A reusable popover (`EditorPopover`) for editor popups, with a proper dialog role, label, animation, and focus handling.
- Now used by the link popup, the color picker, and the slash/mention suggestion lists.

### Tables
- Spreadsheet-style cell navigation: click a cell to select it (navigate mode, no caret), Enter or typing drops into edit mode, Escape goes back. Arrow keys move between cells in navigate mode and stay confined to the cell in edit mode.
- Tab / Shift-Tab move to the next/previous cell (wrapping across rows); Shift-Arrow grows a rectangular multi-cell selection.
- Multi-cell selections render as a single rounded box spanning the region instead of a ring around each cell.
- Per-cell background colors.
- A contextual toolbar anchored to the table (not the caret), plus a right-click context menu for row/column/table actions.
- Column resizing now wins over cell selection: dragging a column border resizes instead of starting a selection.
- Tables are an opt-in `CommentKit` member (on by default in `RichTextKit`).

<img width="2880" height="1064" alt="tables" src="https://github.com/user-attachments/assets/a99ef8cb-bb19-47f5-9a09-5c4c0816aaa4" />

### File drop
- You can drop files anywhere on the editor now, not just into the text.
- The drop area lights up the moment you drag a file over the window, so it's easy to see where to drop.
- One handler decides what to do based on the files: a single image goes inline, multiple images open the group dialog, and videos are uploaded. (Attachments can slot in here later.)
- The drop area's look can be customized with an `#overlay` slot.

### Other fixes
- Better code block experience.
- Hover tooltips on menu buttons, grouped under a single `TooltipProvider`.
- The editor ships its own stylesheet, so its styles apply without relying on the old editor.
- A link's underline now matches its text color.
- `Button` gets a new extra-small (`xs`) size.

## Testing
- 97/97 editor unit tests pass.
- Verified in a running app: link popup modes and shortcuts, focus trap, scroll lock, all three file-drop cases (single image, multiple images, video), and table navigation/selection/resizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-752/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 56.02% (-0.11% vs `main`)
<!-- coverage-report:end -->
