### PR TITLE
fix(docs): resolve color token values so swatches render in docs pages

### DIFF
--- a/docs/content/docs/design-system/[token].paths.ts
+++ b/docs/content/docs/design-system/[token].paths.ts
@@ -3,6 +3,15 @@ import config from '../../../../tailwind.config'
 
 const designTokens = resolveConfig(config).theme
 
+/**
+ * Semantic color tokens resolve to Tailwind strings with the internal `<alpha-value>` placeholder,
+ * e.g. `color-mix(in srgb, var(--surface-gray-2, #F3F3F3) calc(<alpha-value> * 100%), transparent)`,
+ * which is invalid as an inline style. Extract the theme-aware `var(--token, fallback)`
+ * part so swatches render (and follow dark mode).
+ */
+const resolveColorValue = (value: string): string =>
+  value.match(/var\([^)]*\)/)?.[0] ?? value.replace(/<alpha-value>/g, '1')
+
 const getBgColors = () => {
   let colors: { name: string; value?: string }[] = []
   const list = designTokens.backgroundColor.surface
@@ -16,7 +25,7 @@ const getBgColors = () => {
       if (lastcolor !== curColor) colors.push({ name: curColor })
     }
 
-    colors.push({ name: classname, value })
+    colors.push({ name: classname, value: resolveColorValue(value) })
   }
 
   return colors
@@ -37,7 +46,7 @@ const getTextColors = () => {
       if (lastcolor !== curColor) colors.push({ name: curColor })
     }
 
-    colors.push({ name: classname, value })
+    colors.push({ name: classname, value: resolveColorValue(value) })
   }
 
   return colors
@@ -58,7 +67,7 @@ const getBorderColors = () => {
       if (lastcolor !== curColor) colors.push({ name: curColor })
     }
 
-    colors.push({ name: classname, value })
+    colors.push({ name: classname, value: resolveColorValue(value) })
   }
 
   return colors


### PR DESCRIPTION
Fixes #760

## Problem

  On the docs Design System pages (`yarn docs:dev` → Background Color, Border Color,
  Text Design › Text Color), all color swatches render transparent/empty — the colors
  don't show up.

  ## Root cause

  The semantic color tokens generated in `tailwind/colorPalette.js` resolve to Tailwind
  strings containing the internal `<alpha-value>` placeholder, e.g.:

  ```
  color-mix(in srgb, var(--surface-gray-2, #F3F3F3) calc(<alpha-value> * 100%), transparent)
  ```

  That placeholder is only substituted by Tailwind when generating utility classes.
  `docs/content/docs/design-system/[token].paths.ts` was passing this raw value to the
  token components, which use it as an inline style (`backgroundColor` / `color` /
  `borderColor`) — invalid CSS, so the swatches rendered transparent.

  ## Fix

  Added a small resolver in `[token].paths.ts` that extracts the theme-aware
  `var(--token, fallback)` portion of the value and applied it in the three color
  getters (`getBgColors`, `getTextColors`, `getBorderColors`). Since the CSS variables
  are defined on `:root` / `[data-theme="dark"]` by the theme plugin, the swatches also
  follow dark mode correctly.

  ## Before / After

<img width="800" height="1900" alt="06-before-after-background-color" src="https://github.com/user-attachments/assets/2efed250-4578-4776-ad9f-1e9b446a8dab" />
 
 Dark mode (swatches follow the theme):
<img width="1440" height="3406" alt="05-after-background-color-dark" src="https://github.com/user-attachments/assets/c5cd5fa0-ebb6-464b-988f-b9321fba7906" />

 Also fixes Border Color and Text Design › Text Color, which used the same data:
 
<img width="1440" height="1740" alt="03-after-border-color" src="https://github.com/user-attachments/assets/fa49120d-647b-424b-9d88-b9decef5b852" />
<img width="1440" height="3066" alt="04-after-text-design" src="https://github.com/user-attachments/assets/e32073a6-ac60-4ff1-bbd8-2ae3701f0095" />
