### PR TITLE
feat(slider)!: support bidirectional fill

### DIFF
--- a/src/components/Slider/Slider.api.md
+++ b/src/components/Slider/Slider.api.md
@@ -21,7 +21,7 @@
   },
   {
     name: 'min',
-    description: 'Minimum allowed slider value.',
+    description: 'Minimum allowed slider value. Negative values enable bidirectional fill from zero.',
     required: false,
     type: 'number',
     default: '0'

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -103,13 +103,6 @@ describe('Slider', () => {
     })
   })
 
-  it('emits value-commit once when interaction ends, not on every step', () => {
-    const onValueCommit = cy.stub().as('valueCommit')
-    cy.mount(Slider, { props: { modelValue: [25], onValueCommit } })
-    cy.get('[role="slider"]').focus().type('{rightarrow}{rightarrow}{rightarrow}')
-    cy.get('@valueCommit').should('have.been.calledThrice')
-  })
-
   describe('bidirectional fill', () => {
     // Targets the range element: the only absolutely-positioned element inside the control.
     const range = () => cy.get('[data-slot="control"] .absolute')

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -102,4 +102,40 @@ describe('Slider', () => {
       cy.get('#sl-err').should('have.attr', 'data-state', 'invalid')
     })
   })
+
+  it('emits value-commit once when interaction ends, not on every step', () => {
+    const onValueCommit = cy.stub().as('valueCommit')
+    cy.mount(Slider, { props: { modelValue: [25], onValueCommit } })
+    cy.get('[role="slider"]').focus().type('{rightarrow}{rightarrow}{rightarrow}')
+    cy.get('@valueCommit').should('have.been.calledThrice')
+  })
+
+  describe('bidirectional fill', () => {
+    // Targets the range element: the only absolutely-positioned element inside the control.
+    const range = () => cy.get('[data-slot="control"] .absolute')
+
+    it('fills from zero-crossing to a positive value', () => {
+      cy.mount(Slider, { props: { modelValue: [50], min: -100, max: 100 } })
+      range()
+        .should('have.attr', 'style')
+        .and('include', 'left: 50%')
+        .and('include', 'right: 25%')
+    })
+
+    it('fills from a negative value to the zero-crossing', () => {
+      cy.mount(Slider, { props: { modelValue: [-50], min: -100, max: 100 } })
+      range()
+        .should('have.attr', 'style')
+        .and('include', 'left: 25%')
+        .and('include', 'right: 50%')
+    })
+
+    it('renders zero-width fill when value is at zero', () => {
+      cy.mount(Slider, { props: { modelValue: [0], min: -100, max: 100 } })
+      range()
+        .should('have.attr', 'style')
+        .and('include', 'left: 50%')
+        .and('include', 'right: 50%')
+    })
+  })
 })

--- a/src/components/Slider/Slider.md
+++ b/src/components/Slider/Slider.md
@@ -14,6 +14,12 @@ Use a two-element `modelValue` to render two thumbs.
 
 <ComponentPreview name="Slider-Range" />
 
+## Negative Values
+
+When `min` is negative the slider fills bidirectionally from the zero-crossing, so positive and negative values are visually distinct.
+
+<ComponentPreview name="Slider-NegativeValues" />
+
 ## Labeling
 
 <ComponentPreview name="Slider-Labeling" />

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -53,6 +53,20 @@ const {
   disabled: () => props.disabled,
 })
 
+const isBidirectional = computed(() => props.min < 0)
+
+const bidirectionalRangeStyles = computed(() => {
+  const { min, max } = props
+  const value = sliderValue.value[0] ?? 0
+  const range = max - min
+  const zeroPos = -min / range
+  const valuePos = (value - min) / range
+  return {
+    left: `${Math.min(zeroPos, valuePos) * 100}%`,
+    right: `${(1 - Math.max(zeroPos, valuePos)) * 100}%`,
+  }
+})
+
 const trackClasses = computed(() => {
   return [
     'relative grow rounded',
@@ -85,10 +99,10 @@ const onValueCommit = (value: SliderValue) => {
 const hasLabeling = computed(() => {
   return Boolean(
     props.label ||
-      slots.label ||
-      showDescription.value ||
-      slots.description ||
-      hasError.value,
+    slots.label ||
+    showDescription.value ||
+    slots.description ||
+    hasError.value,
   )
 })
 </script>
@@ -125,7 +139,8 @@ const hasLabeling = computed(() => {
       @value-commit="onValueCommit"
     >
       <SliderTrack :class="trackClasses">
-        <SliderRange :class="rangeClasses" />
+        <SliderRange v-if="!isBidirectional" :class="rangeClasses" />
+        <div v-else :class="rangeClasses" :style="bidirectionalRangeStyles" />
       </SliderTrack>
 
       <SliderThumb

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -53,17 +53,18 @@ const {
   disabled: () => props.disabled,
 })
 
-const isBidirectional = computed(() => props.min < 0)
+const isBidirectional = computed(() => props.min < 0 && props.max > 0)
 
 const bidirectionalRangeStyles = computed(() => {
   const { min, max } = props
-  const value = sliderValue.value[0] ?? 0
   const range = max - min
   const zeroPos = -min / range
-  const valuePos = (value - min) / range
+  const thumbPositions = sliderValue.value.map((v) => (v - min) / range)
+  const allPositions =
+    thumbPositions.length === 1 ? [zeroPos, thumbPositions[0]] : thumbPositions
   return {
-    left: `${Math.min(zeroPos, valuePos) * 100}%`,
-    right: `${(1 - Math.max(zeroPos, valuePos)) * 100}%`,
+    left: `${Math.min(...allPositions) * 100}%`,
+    right: `${(1 - Math.max(...allPositions)) * 100}%`,
   }
 })
 
@@ -147,9 +148,13 @@ const hasLabeling = computed(() => {
     >
       <SliderTrack :class="trackClasses">
         <SliderRange v-if="!isBidirectional" :class="rangeClasses" />
-        <SliderRange v-else as-child>
-          <div :class="rangeClasses" :style="bidirectionalRangeStyles" />
-        </SliderRange>
+        <div
+          v-else
+          :class="rangeClasses"
+          :style="bidirectionalRangeStyles"
+          data-orientation="horizontal"
+          :data-disabled="props.disabled ? '' : undefined"
+        />
       </SliderTrack>
 
       <SliderThumb

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -82,6 +82,13 @@ const rangeClasses = computed(() => {
   ]
 })
 
+const rootClasses = computed(() => {
+  return [
+    'relative flex w-full select-none touch-none items-center',
+    props.size === 'md' ? 'h-5' : 'h-4',
+  ]
+})
+
 const thumbClasses = computed(() => {
   return [
     'rounded-full bg-surface-white shadow-md ring-gray-600/20 transition-shadow duration-200 ease-out hover:ring-[6px] focus:outline-none dark:bg-surface-gray-7 dark:ring-gray-100/20',
@@ -124,7 +131,7 @@ const hasLabeling = computed(() => {
     <SliderRoot
       :id="inputId"
       v-model="sliderValue"
-      class="relative flex w-full select-none touch-none items-center"
+      :class="rootClasses"
       :max="props.max"
       :min="props.min"
       :step="props.step"

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -147,7 +147,9 @@ const hasLabeling = computed(() => {
     >
       <SliderTrack :class="trackClasses">
         <SliderRange v-if="!isBidirectional" :class="rangeClasses" />
-        <div v-else :class="rangeClasses" :style="bidirectionalRangeStyles" />
+        <SliderRange v-else as-child>
+          <div :class="rangeClasses" :style="bidirectionalRangeStyles" />
+        </SliderRange>
       </SliderTrack>
 
       <SliderThumb

--- a/src/components/Slider/stories/NegativeValues.vue
+++ b/src/components/Slider/stories/NegativeValues.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Slider } from 'frappe-ui'
+
+const value = ref([25])
+</script>
+
+<template>
+  <div class="w-full max-w-md">
+    <Slider v-model="value" :min="-50" :max="100" />
+  </div>
+</template>

--- a/src/components/Slider/types.ts
+++ b/src/components/Slider/types.ts
@@ -20,7 +20,7 @@ export interface SliderProps extends InputLabelingProps {
   /** Maximum allowed slider value. */
   max?: number
 
-  /** Minimum allowed slider value. */
+  /** Minimum allowed slider value. Negative values enable bidirectional fill from zero. */
   min?: number
 
   /** Visual size of the slider. */


### PR DESCRIPTION
### Bidirectional fill

When `min` is negative, the slider fill now originates from the zero rather than always from the left edge, making positive and negative values visually distinct.  Added docs and test for the same.

### Fix

`SliderRoot` was missing an explicit height, so the thumb (`size-4` / `size-5`) overflowed the component's bounding box. Added `h-4` for `sm` and `h-5` for `md` to match the thumb dimensions so that we no longer need to compensate for the overflow in our own layouts.

### Breaking change

`Slider` root element now has an explicit `h-4` / `h-5` Tailwind class. Previously the root had no height class and sized naturally to its content. Consumers who applied a custom height to the Slider container or overrode its height via CSS may see a layout shift.

**Migration:** if your Slider container has a fixed height smaller than `h-4` (16px), increase it or remove the constraint.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-764/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 56.10% (+0.01% vs `main`)
<!-- coverage-report:end -->
