### PR TITLE
fix: render safeHTML in toasts

### DIFF
--- a/src/components/Toast/Toast.sanitize.test.ts
+++ b/src/components/Toast/Toast.sanitize.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Sanitization is verified against the REAL DOMPurify (needs a DOM, hence the
+ * jsdom environment) — the allow-list wiring is covered separately in
+ * Toast.test.ts with a stubbed DOMPurify.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { VNode } from 'vue'
+
+const sonnerSpy = Object.assign(vi.fn(), {
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+})
+
+vi.mock('vue-sonner', () => ({ toast: sonnerSpy }))
+
+const { toast } = await import('./toast')
+
+// renderSafeHTML returns `() => h('span', { innerHTML })`. Pull that render
+// function off the sonner spy, invoke it, and read the sanitized markup back.
+function sanitizedHTML(): string {
+  const [message] = sonnerSpy.success.mock.calls[0]!
+  const vnode = (message as () => VNode)()
+  return (vnode.props as { innerHTML: string }).innerHTML
+}
+
+beforeEach(() => sonnerSpy.success.mockClear())
+
+describe('Toast v1 — DOMPurify stripping', () => {
+  it('strips tags outside the allow-list while keeping their text content', () => {
+    toast.success('<strong>safe</strong><div>nested</div>')
+    const html = sanitizedHTML()
+    expect(html).toContain('<strong>safe</strong>')
+    expect(html).not.toContain('<div>')
+    expect(html).toContain('nested')
+  })
+
+  it('removes script and event-handler payloads to prevent XSS', () => {
+    toast.success('<b>ok</b><img src=x onerror=alert(1)><script>alert(2)<\/script>')
+    const html = sanitizedHTML()
+    expect(html).toContain('<b>ok</b>')
+    expect(html).not.toContain('<img')
+    expect(html).not.toContain('onerror')
+    expect(html).not.toContain('<script')
+  })
+})

--- a/src/components/Toast/Toast.test.ts
+++ b/src/components/Toast/Toast.test.ts
@@ -23,6 +23,11 @@ const sonnerSpy = Object.assign(vi.fn(), {
 
 vi.mock('vue-sonner', () => ({ toast: sonnerSpy }))
 
+// Every toast path runs through renderSafeHTML → DOMPurify.sanitize, which
+// needs a DOM. Stub it with a passthrough so this node-environment file doesn't
+// crash; the real sanitization is verified in Toast.sanitize.test.ts (jsdom).
+vi.mock('dompurify', () => ({ default: { sanitize: (html: string) => html } }))
+
 const { toast } = await import('./toast')
 
 beforeEach(() => {

--- a/src/components/Toast/ToastProvider.vue
+++ b/src/components/Toast/ToastProvider.vue
@@ -40,6 +40,15 @@ import { Toaster } from 'vue-sonner'
   height: auto;
 }
 
+/* In the collapsed stack vue-sonner clamps every non-front toast to the front
+   toast's height (--front-toast-height) and hides their content. The content is
+   hidden only on [data-styled='true'] toasts, which `unstyled` strips — so a
+   multiline toast behind a single-line one spills its extra lines out the top.
+   Replicate sonner's intended behavior and fade the collapsed back toasts out. */
+[data-sonner-toast][data-expanded='false'][data-front='false'] > * {
+  opacity: 0;
+}
+
 .sonner-loading-wrapper {
   position: static;
 }

--- a/src/components/Toast/toast.ts
+++ b/src/components/Toast/toast.ts
@@ -1,8 +1,23 @@
+import DOMPurify from 'dompurify'
 import { h, isVNode, type Component, type VNode } from 'vue'
 import { toast as sonnerToast } from 'vue-sonner'
 import { warnDeprecated } from '../../utils/warnDeprecated'
 
 type ToastType = 'success' | 'error' | 'warning' | 'info'
+
+type SonnerData = Parameters<typeof sonnerToast>[1]
+
+// Tags that are safe to render inside a toast message. Anything outside this set is stripped by DOMPurify.
+const ALLOWED_TAGS = ['a', 'em', 'strong', 'i', 'b', 'u']
+
+// Sonner renders a string message as plain text and a VNode via
+// `<component :is>`. To render safe HTML we sanitize the string and return a
+// render function; non-string values (already VNodes/components) pass through.
+function renderSafeHTML<T>(message: T): T | (() => VNode) {
+  if (typeof message !== 'string') return message
+  const html = DOMPurify.sanitize(message, { ALLOWED_TAGS })
+  return () => h('span', { innerHTML: html })
+}
 
 interface LegacyCreateOptions {
   id?: string | number
@@ -62,20 +77,21 @@ function isLegacyObject(arg: unknown): arg is LegacyToastObject {
 
 function dispatch(
   type: ToastType | undefined,
-  message: string,
-  data: Parameters<typeof sonnerToast>[1],
+  message: string | Component | VNode,
+  data: SonnerData,
 ) {
+  const safeMessage = renderSafeHTML(message)
   switch (type) {
     case 'success':
-      return sonnerToast.success(message, data)
+      return sonnerToast.success(safeMessage, data)
     case 'error':
-      return sonnerToast.error(message, data)
+      return sonnerToast.error(safeMessage, data)
     case 'warning':
-      return sonnerToast.warning(message, data)
+      return sonnerToast.warning(safeMessage, data)
     case 'info':
-      return sonnerToast.info(message, data)
+      return sonnerToast.info(safeMessage, data)
     default:
-      return sonnerToast(message, data)
+      return sonnerToast(safeMessage, data)
   }
 }
 
@@ -107,7 +123,7 @@ function toastFn(
   if (isLegacyObject(message)) {
     return callLegacyObject(message)
   }
-  return sonnerToast(message as string, options)
+  return sonnerToast(renderSafeHTML(message as string), options)
 }
 
 function create(options: LegacyCreateOptions) {
@@ -142,6 +158,14 @@ function removeAll() {
 }
 
 export const toast = Object.assign(toastFn, sonnerToast, {
+  success: (message: string | Component | VNode, data?: SonnerData) =>
+    dispatch('success', message, data),
+  error: (message: string | Component | VNode, data?: SonnerData) =>
+    dispatch('error', message, data),
+  warning: (message: string | Component | VNode, data?: SonnerData) =>
+    dispatch('warning', message, data),
+  info: (message: string | Component | VNode, data?: SonnerData) =>
+    dispatch('info', message, data),
   create,
   remove,
   removeAll,


### PR DESCRIPTION
## 1. Render safe HTML inside the toast

Backend-supplied HTML was showing up as escaped text instead of rendering. We now sanitize the message with **DOMPurify** (already in `package.json`) and render it — only the allow-listed tags survive, everything else (scripts, event handlers, unknown tags) is stripped.

**How it works:**

```js
const ALLOWED_TAGS = ['a', 'em', 'strong', 'i', 'b', 'u']

1. toast.success('<b>Saved</b>') — message comes in as a string
2. DOMPurify.sanitize(message, { ALLOWED_TAGS }) — strip unsafe tags
3. () => h('span', { innerHTML: cleanHTML }) — wrap as a render fn (≈ v-html)
4. Pass the render fn to vue-sonner as the title
5. Sonner's Toast.vue renders it via <component :is="toast.title" /> 
```


## 2. Fix the collapsed state with mixed toast heights

When two toasts were stacked in the collapsed state — one multiline, one single-line — the taller toast's content spilled out the top of the card and looked broken.

vue-sonner clamps every non-front toast to the front toast's height and hides their content, but only on [data-styled] toasts — and our unstyled config strips that attribute. We re-add the rule so collapsed back toasts fade their content out, matching sonner's intended stacked look.

<img width="424" height="184" alt="Image" src="https://github.com/user-attachments/assets/9a279d49-7746-411b-a017-309c3f0767c7" />


<img width="403" height="109" alt="Image" src="https://github.com/user-attachments/assets/d79af39c-40bd-46d4-8dff-08412c86cdd0" />



`closes`: https://github.com/frappe/frappe-ui/issues/756

<!-- coverage-report:start -->
Coverage: 56.93% (+0.04% vs `main`)
<!-- coverage-report:end -->
