### PR TITLE
feat(docs): automatically copy icon name when user clicks on it

### DIFF
--- a/docs/components/LucideGallery.vue
+++ b/docs/components/LucideGallery.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import * as LucideIcons from 'lucide-static'
-import { TextInput } from 'frappe-ui'
+import { TextInput, toast } from 'frappe-ui'
 import { TooltipBubble } from 'frappe-ui'
 import { TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui'
 
@@ -26,6 +26,15 @@ const icons = [...iconsByName.entries()]
   .sort((a, b) => a.name.localeCompare(b.name))
 
 const query = ref('')
+
+async function copyName(name: string) {
+  try {
+    await navigator.clipboard.writeText(name)
+    toast.success(`Copied "${name}"`)
+  } catch {
+    toast.error('Failed to copy')
+  }
+}
 
 const filteredIcons = computed(() => {
   const q = query.value.trim().toLowerCase()
@@ -69,7 +78,8 @@ const filteredIcons = computed(() => {
           <TooltipRoot v-for="icon in filteredIcons" :key="icon.name">
             <TooltipTrigger as-child>
               <div
-                class="flex size-14 items-center justify-center rounded text-ink-gray-7 hover:bg-surface-gray-2"
+                class="flex size-14 cursor-pointer items-center justify-center rounded text-ink-gray-7 hover:bg-surface-gray-2"
+                @click="copyName(icon.name)"
               >
                 <span class="size-6 [&>svg]:size-full" v-html="icon.svg" />
               </div>


### PR DESCRIPTION
shows a toast with icon name when Icon from https://ui.frappe.io/docs/other/icons is clicked. Current popover on icons is not very helpful. 

<img width="1420" height="831" alt="Screenshot 2026-06-10 at 7 02 14 PM" src="https://github.com/user-attachments/assets/882a290f-31ad-469f-bc0a-830d1b7f195e" />

<!-- coverage-report:start -->
Coverage: 56.89% (±0.00% vs `main`)
<!-- coverage-report:end -->
