### PR TITLE
fix(build): preserve CSS/Vue side-effects in consumer tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0-beta.5",
   "description": "A set of components and utilities for rapid UI development",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.vue"
+  ],
   "imports": {
     "#components/*": "./src/components/*",
     "#molecules/*": "./src/molecules/*",


### PR DESCRIPTION
## Problem

`package.json` declares `"sideEffects": false`, which promises bundlers that **no file in the package has import-time side effects** — licensing them to delete side-effect-only imports during production tree-shaking.

But the editor ships its styles as exactly such an import:

```ts
// src/molecules/editor/index.ts
import './style.css'   // bindingless — its whole purpose is the side effect
```

So when a consumer app imports only named bindings:

```ts
import { RichTextKit, EditorContent } from 'frappe-ui/editor'
```

the production build tree-shakes `import './style.css'` away. The editor loses its **table borders, taskList, and cell-selection styles** (e.g. `.ProseMirror td { border: 1px solid var(--outline-gray-2) }` — with the rule gone, no border renders at all).

This is **build-only**: dev servers never tree-shake, so the styles load fine in `yarn dev` and only vanish after `yarn build`. That makes it an easy-to-miss regression. Confirmed reproducing in Gameplan after adopting the beta.

## Fix

Scope `sideEffects` to the file types that actually have side effects:

```jsonc
"sideEffects": ["**/*.css", "**/*.vue"]
```

- **`.css`** — always preserved, so bindingless stylesheet imports survive tree-shaking. Covers all 12 such imports in `src` (`style.css` ×6, `popoverMotion.css` ×5, `CodeBlockComponent.css` ×1).
- **`.vue`** — defensively preserved (SFC `<style>` injection + import-time global registration).
- Pure JS modules still match neither glob, so unused exports remain tree-shakeable — **no bundle-size regression** for consumers.

## Consumer-side note

Apps currently on the beta can unblock themselves by importing the editor stylesheet explicitly (`@import 'frappe-ui/editor-style.css'`), but that's a per-app workaround for what is a package-level mis-declaration. This fixes it at the source for every consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-774/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 56.48% (±0.00% vs `main`)
<!-- coverage-report:end -->
