### PR TITLE
chore(tokens): expose v2 migration bin

### DIFF
--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -141,6 +141,26 @@ const options = [{ label: 'Edit', icon: 'edit' }]
 const options = [{ label: 'Edit', icon: 'lucide-pen' }]
 ```
 
+## Tokens
+
+Run the v2 token codemod from the app you are migrating:
+
+```sh
+npx --package frappe-ui tokens-v2 --dry-run .
+```
+
+Review the output, then run it without `--dry-run`:
+
+```sh
+npx --package frappe-ui tokens-v2 .
+```
+
+The codemod renames espresso color tokens and merges static text size + weight
+class pairs, for example `text-base font-medium` to `text-base-medium`. Run it
+once per codebase; the token migration is not idempotent because some v2 names
+overlap with v0 names. If `frappe-ui` is already installed locally, you can use
+`npx tokens-v2` instead.
+
 ## Editor
 
 The v0 monolith `<TextEditor>` (imported from `frappe-ui`) is replaced by the

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -146,13 +146,13 @@ const options = [{ label: 'Edit', icon: 'lucide-pen' }]
 Run the v2 token codemod from the app you are migrating:
 
 ```sh
-npx --package frappe-ui tokens-v2 --dry-run .
+npx --package frappe-ui@beta tokens-v2 --dry-run .
 ```
 
 Review the output, then run it without `--dry-run`:
 
 ```sh
-npx --package frappe-ui tokens-v2 .
+npx --package frappe-ui@beta tokens-v2 .
 ```
 
 The codemod renames espresso color tokens like `bg-surface-white` to `bg-surface-base`

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -155,11 +155,10 @@ Review the output, then run it without `--dry-run`:
 npx --package frappe-ui tokens-v2 .
 ```
 
-The codemod renames espresso color tokens and merges static text size + weight
-class pairs, for example `text-base font-medium` to `text-base-medium`. Run it
-once per codebase; the token migration is not idempotent because some v2 names
-overlap with v0 names. If `frappe-ui` is already installed locally, you can use
-`npx tokens-v2` instead.
+The codemod renames espresso color tokens like `bg-surface-white` to `bg-surface-base`
+and merges static text size + weight class pairs, for example `text-base font-medium`
+to `text-base-medium`. Run it once per codebase; the token migration is not idempotent
+because some v2 names overlap with v0 names.
 
 ## Editor
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "#composables/*": "./src/composables/*",
     "#utils/*": "./src/utils/*"
   },
+  "bin": {
+    "tokens-v2": "./tailwind/migrate-tokens-v2.js"
+  },
   "scripts": {
     "test": "vitest --run",
     "test:coverage": "vitest --run --coverage",

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * Espresso v2 token migration codemod.
  *
@@ -13,7 +14,7 @@
  * class, which carries the correct per-weight letter-spacing (see
  * `mergeWeightClasses`).
  *
- *   Usage:  node tailwind/migrate-tokens-v2.js [--dry-run] [--force] <dir-or-file...>
+ *   Usage:  tokens-v2 [--dry-run] [--force] <dir-or-file...>
  *
  * IMPORTANT: the token replacement is single-pass/simultaneous. Several renames
  * chain (outline red-2→3, red-3→4, red-4→5); applying them sequentially would
@@ -27,6 +28,8 @@
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
+
+const USAGE = 'Usage: tokens-v2 [--dry-run] [--force] <dir-or-file...>'
 
 // ---------- MAPPING ----------
 
@@ -322,12 +325,18 @@ function* walk(target) {
 
 function main() {
   const args = process.argv.slice(2)
+  const help = args.includes('--help') || args.includes('-h')
   const dryRun = args.includes('--dry-run')
   const force = args.includes('--force')
   const targets = args.filter((a) => !a.startsWith('--'))
 
+  if (help) {
+    console.log(USAGE)
+    return
+  }
+
   if (targets.length === 0) {
-    console.error('Usage: node tailwind/migrate-tokens-v2.js [--dry-run] [--force] <dir-or-file...>')
+    console.error(USAGE)
     process.exit(1)
   }
 
@@ -387,5 +396,7 @@ function main() {
   }
 }
 
-const isCLI = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+const scriptPath = fileURLToPath(import.meta.url)
+const invokedPath = process.argv[1]
+const isCLI = invokedPath && fs.realpathSync(invokedPath) === fs.realpathSync(scriptPath)
 if (isCLI) main()


### PR DESCRIPTION
## Summary
- expose the espresso v2 token migration codemod as the `tokens-v2` package bin
- add a shebang, help output, and symlink-safe CLI detection for package-manager execution

## Testing
- `node tailwind/migrate-tokens-v2.js --help`
- `npm pkg get bin`

<!-- coverage-report:start -->
Coverage: 56.48% (±0.00% vs `main`)
<!-- coverage-report:end -->

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-775/
<!-- docs-preview:end -->


