### PR TITLE
fix: remove default shadow from Card component

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col rounded-lg border bg-white px-6 py-5 shadow">
+  <div class="flex flex-col rounded-lg border bg-white px-6 py-5">
     <div class="flex items-baseline justify-between">
       <div class="flex items-baseline space-x-2">
         <div class="flex items-center space-x-2" v-if="$slots['actions-left']">


### PR DESCRIPTION
## Summary

`Card` no longer hardcodes the `shadow` class on its root element. The card keeps its border, rounding, and background; the drop shadow that made it look inconsistent next to flat-styled cards is gone, as requested in #735 ("But it does ship with one, just remove the shadow?").

No prop was added - the directive in the issue is removal. An opt-in `shadow` prop can follow later if review wants one.

Fixes #735

<!-- coverage-report:start -->
Coverage: 56.48% (±0.00% vs `main`)
<!-- coverage-report:end -->
