### PR TITLE
feat: TimePicker format prop (replace use12Hour), matching DatePicker

### DIFF
--- a/src/components/TimePicker/TimePicker.api.md
+++ b/src/components/TimePicker/TimePicker.api.md
@@ -116,11 +116,11 @@
     deprecated: 'Use `keepOpen` (inverse semantics).'
   },
   {
-    name: 'use12Hour',
-    description: 'Use 12-hour (am/pm) format for display.',
+    name: 'format',
+    description: 'Dayjs format string used for display. Default: `HH:mm`.',
     required: false,
-    type: 'boolean',
-    default: 'true'
+    type: 'string',
+    default: '"HH:mm"'
   },
   {
     name: 'disabled',
@@ -282,4 +282,3 @@
 <SlotsTable :data="slotsData"/> 
 
 <EmitsTable :data="emitsData"/> 
-

--- a/src/components/TimePicker/TimePicker.api.md
+++ b/src/components/TimePicker/TimePicker.api.md
@@ -116,6 +116,13 @@
     deprecated: 'Use `keepOpen` (inverse semantics).'
   },
   {
+    name: 'use12Hour',
+    description: 'Use 12-hour (am/pm) format for display.',
+    required: false,
+    type: 'boolean',
+    deprecated: 'Use `format` instead.'
+  },
+  {
     name: 'format',
     description: 'Dayjs format string used for display. Default: `HH:mm`.',
     required: false,

--- a/src/components/TimePicker/TimePicker.cy.ts
+++ b/src/components/TimePicker/TimePicker.cy.ts
@@ -34,7 +34,6 @@ describe('TimePicker', () => {
         onChange: onChange,
         onOpen: onOpen,
         onClose: onClose,
-        use12Hour: false,
       },
     })
 
@@ -83,25 +82,73 @@ describe('TimePicker', () => {
     cy.get('[role=dialog]').should('exist')
   })
 
-  it('use12hour prop', () => {
+  it('defaults to 24-hour HH:mm display', () => {
     cy.mount(TimePicker, {
-      props: { use12Hour: true },
+      props: { modelValue: '14:30' },
     })
 
+    cy.get('input').should('have.value', '14:30')
     cy.get('input').click()
-    cy.get('[role=option]').eq(0).should('contain.text', 'am')
-
-    cy.mount(TimePicker, {
-      props: { use12Hour: false },
-    })
-
-    cy.get('input').click()
-    cy.get('[role=option]').eq(0).should('not.contain.text', 'am')
+    cy.get('[role=option]').eq(0).should('have.text', '00:00')
   })
+
+  it(
+    'formats options with a zero-padded 12-hour format and emits canonical values',
+    () => {
+      const onUpdate = cy.spy().as('onUpdate')
+
+      cy.mount(TimePicker, {
+        props: { format: 'hh:mm A', 'onUpdate:modelValue': onUpdate },
+      })
+
+      cy.get('input').click()
+      cy.get('[role=option]').eq(0).should('have.text', '12:00 AM')
+      cy.get('[role=option]').eq(0).click()
+      cy.get('input').should('have.value', '12:00 AM')
+      cy.get('@onUpdate').should('have.been.calledWith', '00:00')
+    },
+  )
+
+  it(
+    'formats options with a non-padded 12-hour format and emits canonical values',
+    () => {
+      const onUpdate = cy.spy().as('onUpdate')
+
+      cy.mount(TimePicker, {
+        props: {
+          format: 'h:mm A',
+          interval: 60,
+          'onUpdate:modelValue': onUpdate,
+        },
+      })
+
+      cy.get('input').click()
+      cy.get('[role=option][data-value="15:00"]').should(
+        'have.text',
+        '3:00 PM',
+      )
+      cy.get('[role=option][data-value="15:00"]').click()
+      cy.get('input').should('have.value', '3:00 PM')
+      cy.get('@onUpdate').should('have.been.calledWith', '15:00')
+    },
+  )
+
+  it(
+    'renders seconds in display and option labels when the format includes seconds',
+    () => {
+      cy.mount(TimePicker, {
+        props: { modelValue: '14:30:15', format: 'HH:mm:ss' },
+      })
+
+      cy.get('input').should('have.value', '14:30:15')
+      cy.get('input').click()
+      cy.get('[role=option]').eq(0).should('have.text', '00:00:00')
+    },
+  )
 
   it('min and max props', () => {
     cy.mount(TimePicker, {
-      props: { min: '09:00', max: '11:00', use12Hour: false },
+      props: { min: '09:00', max: '11:00' },
     })
 
     cy.get('input').click()
@@ -111,7 +158,7 @@ describe('TimePicker', () => {
 
   it('back-compat: minTime/maxTime aliases still work', () => {
     cy.mount(TimePicker, {
-      props: { minTime: '09:00', maxTime: '11:00', use12Hour: false },
+      props: { minTime: '09:00', maxTime: '11:00' },
     })
 
     cy.get('input').click()
@@ -163,18 +210,57 @@ describe('TimePicker', () => {
     cy.get('[role=dialog]').should('exist')
   })
 
-  it('parses flexible time input like "3pm"', () => {
-    cy.mount(TimePicker, { props: { use12Hour: true } })
+  it('parses flexible time input like "3pm" using the configured format', () => {
+    cy.mount(TimePicker, { props: { format: 'hh:mm A' } })
     cy.get('input').click()
     cy.get('input').type('3pm{enter}')
-    // Figure space (U+2007) pads single-digit hours for column alignment.
-    cy.get('input').should('have.value', '03:00 pm')
+    cy.get('input').should('have.value', '03:00 PM')
+  })
+
+  it('parses typed input in the configured 12-hour format', () => {
+    const onUpdate = cy.spy().as('onUpdate')
+
+    cy.mount(TimePicker, {
+      props: { format: 'hh:mm A', 'onUpdate:modelValue': onUpdate },
+    })
+    cy.get('input').click()
+    cy.get('input').type('03:45 PM{enter}')
+    cy.get('input').should('have.value', '03:45 PM')
+    cy.get('@onUpdate').should('have.been.calledWith', '15:45')
+  })
+
+  it('parses typed input with seconds in the configured format', () => {
+    const onUpdate = cy.spy().as('onUpdate')
+
+    cy.mount(TimePicker, {
+      props: { format: 'HH:mm:ss', 'onUpdate:modelValue': onUpdate },
+    })
+    cy.get('input').click()
+    cy.get('input').type('15:30:45{enter}')
+    cy.get('input').should('have.value', '15:30:45')
+    cy.get('@onUpdate').should('have.been.calledWith', '15:30:45')
+  })
+
+  it('invalid typed input does not corrupt the model value', () => {
+    const onUpdate = cy.spy().as('onUpdate')
+
+    cy.mount(TimePicker, {
+      props: {
+        modelValue: '08:00',
+        format: 'HH:mm:ss',
+        'onUpdate:modelValue': onUpdate,
+      },
+    })
+    cy.get('input').click()
+    cy.get('input').type('25:99:99{enter}')
+    cy.get('input').should('have.value', '08:00:00')
+    cy.get('@onUpdate').should('not.have.been.called')
   })
 
   it('off-grid typed time gets a formatted label', () => {
-    cy.mount(TimePicker, { props: { use12Hour: true, interval: 15 } })
+    cy.mount(TimePicker, { props: { format: 'hh:mm A', interval: 15 } })
     cy.get('input').click()
     cy.get('input').type('3:07pm{enter}')
-    cy.get('input').should('have.value', '03:07 pm')
+    cy.get('input').should('have.value', '03:07 PM')
   })
 })

--- a/src/components/TimePicker/TimePicker.cy.ts
+++ b/src/components/TimePicker/TimePicker.cy.ts
@@ -133,6 +133,24 @@ describe('TimePicker', () => {
     },
   )
 
+  it('back-compat: use12Hour=true maps to 12-hour display when format is omitted', () => {
+    cy.mount(TimePicker, {
+      props: { modelValue: '15:00', use12Hour: true },
+    })
+
+    cy.get('input').should('have.value', '3:00 PM')
+    cy.get('input').click()
+    cy.get('[role=option][data-value="15:00"]').should('have.text', '3:00 PM')
+  })
+
+  it('format prop takes precedence over the deprecated use12Hour alias', () => {
+    cy.mount(TimePicker, {
+      props: { modelValue: '15:00', use12Hour: true, format: 'HH:mm' },
+    })
+
+    cy.get('input').should('have.value', '15:00')
+  })
+
   it(
     'renders seconds in display and option labels when the format includes seconds',
     () => {
@@ -239,6 +257,18 @@ describe('TimePicker', () => {
     cy.get('input').type('15:30:45{enter}')
     cy.get('input').should('have.value', '15:30:45')
     cy.get('@onUpdate').should('have.been.calledWith', '15:30:45')
+  })
+
+  it('preserves typed seconds in localized Dayjs formats', () => {
+    const onUpdate = cy.spy().as('onUpdate')
+
+    cy.mount(TimePicker, {
+      props: { format: 'LTS', 'onUpdate:modelValue': onUpdate },
+    })
+    cy.get('input').click()
+    cy.get('input').type('8:02:18 PM{enter}')
+    cy.get('input').should('have.value', '8:02:18 PM')
+    cy.get('@onUpdate').should('have.been.calledWith', '20:02:18')
   })
 
   it('invalid typed input does not corrupt the model value', () => {

--- a/src/components/TimePicker/TimePicker.vue
+++ b/src/components/TimePicker/TimePicker.vue
@@ -93,7 +93,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, watch, watchEffect } from 'vue'
+import {
+  computed,
+  getCurrentInstance,
+  nextTick,
+  ref,
+  watch,
+  watchEffect,
+} from 'vue'
 import {
   PopoverAnchor,
   PopoverContent,
@@ -127,7 +134,6 @@ const props = withDefaults(defineProps<TimePickerProps>(), {
   options: () => [],
   placeholder: 'Select time',
   variant: 'subtle' as Variant,
-  format: 'HH:mm',
   disabled: false,
   typeable: true,
   readonly: false,
@@ -175,6 +181,10 @@ const shouldKeepOpen = computed(
   () => props.keepOpen === true || props.autoClose === false,
 )
 
+const resolvedFormat = computed(
+  () => props.format ?? (props.use12Hour ? 'h:mm A' : 'HH:mm'),
+)
+
 const isReadonly = computed(
   () =>
     props.typeable === false ||
@@ -183,12 +193,21 @@ const isReadonly = computed(
 )
 
 if (import.meta.env.DEV) {
+  const instance = getCurrentInstance()
+  const hasUse12HourProp = () => {
+    const rawProps = instance?.vnode.props
+    return !!(
+      rawProps &&
+      ('use12Hour' in rawProps || 'use-12-hour' in rawProps)
+    )
+  }
   const warned = {
     value: false,
     placement: false,
     autoClose: false,
     allowCustom: false,
     readonly: false,
+    use12Hour: false,
     scrollMode: false,
     minTime: false,
     maxTime: false,
@@ -223,6 +242,12 @@ if (import.meta.env.DEV) {
         '[TimePicker] picker-level `readonly: true` is deprecated. Use `typeable: false` instead.',
       )
       warned.readonly = true
+    }
+    if (hasUse12HourProp() && !warned.use12Hour) {
+      console.warn(
+        '[TimePicker] `use12Hour` is deprecated. Use `format` instead.',
+      )
+      warned.use12Hour = true
     }
     if (props.scrollMode !== undefined && !warned.scrollMode) {
       console.warn(
@@ -270,12 +295,14 @@ const { motion, onPointerDown: recordPointerDown } = usePopoverMotion(isOpen)
 
 // Canonical 24-hour value (`HH:mm` or `HH:mm:ss`) — the source of truth.
 const canonicalValue = ref<string>(
-  normalize24(props.modelValue || props.value || '', props.format),
+  normalize24(props.modelValue || props.value || '', resolvedFormat.value),
 )
 
 // What the user sees / can edit in the trigger input. Synced from
 // canonicalValue when not actively typing.
-const displayValue = ref<string>(formatTime(canonicalValue.value, props.format))
+const displayValue = ref<string>(
+  formatTime(canonicalValue.value, resolvedFormat.value),
+)
 
 const isTyping = ref(false)
 const highlightIndex = ref<number>(-1)
@@ -302,12 +329,15 @@ const displayedOptions = computed<TimeOption[]>(() => {
   if (props.options?.length) {
     return props.options.map((o) => {
       const value = normalize24(o.value) || o.value
-      return { value, label: o.label || formatTime(value, props.format) }
+      return {
+        value,
+        label: o.label || formatTime(value, resolvedFormat.value),
+      }
     })
   }
   return generateTimeOptions({
     interval: props.interval,
-    format: props.format,
+    format: resolvedFormat.value,
     minMinutes: minMinutes.value,
     maxMinutes: maxMinutes.value,
   })
@@ -321,7 +351,7 @@ const displayedOptions = computed<TimeOption[]>(() => {
 const typingTarget = computed<{ exact: TimeOption | null; nearest: TimeOption | null }>(() => {
   const list = displayedOptions.value
   if (!list.length) return { exact: null, nearest: null }
-  const parsed = parseFlexibleTime(displayValue.value, props.format)
+  const parsed = parseFlexibleTime(displayValue.value, resolvedFormat.value)
   if (!parsed.valid) return { exact: null, nearest: null }
   const candidate = parsed.ss
     ? `${parsed.hh24}:${parsed.mm}:${parsed.ss}`
@@ -357,19 +387,20 @@ function baseCompare(val: string): string {
 watch(
   () => [props.modelValue, props.value] as const,
   ([m, v]) => {
-    const nv = normalize24(m || v || '', props.format)
+    const nv = normalize24(m || v || '', resolvedFormat.value)
     if (nv === canonicalValue.value) return
     canonicalValue.value = nv
-    if (!isTyping.value) displayValue.value = formatTime(nv, props.format)
+    if (!isTyping.value)
+      displayValue.value = formatTime(nv, resolvedFormat.value)
   },
 )
 
 // Reformat the displayed value when the display format changes.
 watch(
-  () => props.format,
+  () => resolvedFormat.value,
   () => {
     if (!isTyping.value) {
-      displayValue.value = formatTime(canonicalValue.value, props.format)
+      displayValue.value = formatTime(canonicalValue.value, resolvedFormat.value)
     }
   },
 )
@@ -381,7 +412,7 @@ watch(displayValue, () => {
   // The model→display sync above (re)writes displayValue while not typing —
   // distinguish user keystrokes from that programmatic write by only
   // toggling when the value diverges from the formatted canonical.
-  const formatted = formatTime(canonicalValue.value, props.format)
+  const formatted = formatTime(canonicalValue.value, resolvedFormat.value)
   if (displayValue.value !== formatted) {
     isTyping.value = true
     highlightIndex.value = -1
@@ -397,7 +428,7 @@ function setInvalid(next: boolean) {
 function commit(value: string) {
   const prev = canonicalValue.value
   canonicalValue.value = value
-  displayValue.value = formatTime(value, props.format)
+  displayValue.value = formatTime(value, resolvedFormat.value)
   isTyping.value = false
   emit('update:modelValue', value)
   if (value !== prev) emit('change', value)
@@ -409,14 +440,14 @@ function commitTyped(raw: string) {
     commit('')
     return
   }
-  const formattedCurrent = formatTime(canonicalValue.value, props.format)
+  const formattedCurrent = formatTime(canonicalValue.value, resolvedFormat.value)
   if (raw === formattedCurrent) {
     displayValue.value = formattedCurrent
     isTyping.value = false
     setInvalid(false)
     return
   }
-  const parsed = parseFlexibleTime(raw, props.format)
+  const parsed = parseFlexibleTime(raw, resolvedFormat.value)
   if (
     !parsed.valid ||
     isOutOfRange(parsed.total, minMinutes.value, maxMinutes.value)
@@ -424,7 +455,7 @@ function commitTyped(raw: string) {
     emit('input-invalid', raw)
     setInvalid(true)
     // Revert visible text to the last good value.
-    displayValue.value = formatTime(canonicalValue.value, props.format)
+    displayValue.value = formatTime(canonicalValue.value, resolvedFormat.value)
     isTyping.value = false
     return
   }

--- a/src/components/TimePicker/TimePicker.vue
+++ b/src/components/TimePicker/TimePicker.vue
@@ -127,7 +127,7 @@ const props = withDefaults(defineProps<TimePickerProps>(), {
   options: () => [],
   placeholder: 'Select time',
   variant: 'subtle' as Variant,
-  use12Hour: true,
+  format: 'HH:mm',
   disabled: false,
   typeable: true,
   readonly: false,
@@ -270,12 +270,12 @@ const { motion, onPointerDown: recordPointerDown } = usePopoverMotion(isOpen)
 
 // Canonical 24-hour value (`HH:mm` or `HH:mm:ss`) — the source of truth.
 const canonicalValue = ref<string>(
-  normalize24(props.modelValue || props.value || ''),
+  normalize24(props.modelValue || props.value || '', props.format),
 )
 
 // What the user sees / can edit in the trigger input. Synced from
 // canonicalValue when not actively typing.
-const displayValue = ref<string>(formatTime(canonicalValue.value, props.use12Hour))
+const displayValue = ref<string>(formatTime(canonicalValue.value, props.format))
 
 const isTyping = ref(false)
 const highlightIndex = ref<number>(-1)
@@ -302,12 +302,12 @@ const displayedOptions = computed<TimeOption[]>(() => {
   if (props.options?.length) {
     return props.options.map((o) => {
       const value = normalize24(o.value) || o.value
-      return { value, label: o.label || formatTime(value, props.use12Hour) }
+      return { value, label: o.label || formatTime(value, props.format) }
     })
   }
   return generateTimeOptions({
     interval: props.interval,
-    use12Hour: props.use12Hour,
+    format: props.format,
     minMinutes: minMinutes.value,
     maxMinutes: maxMinutes.value,
   })
@@ -321,7 +321,7 @@ const displayedOptions = computed<TimeOption[]>(() => {
 const typingTarget = computed<{ exact: TimeOption | null; nearest: TimeOption | null }>(() => {
   const list = displayedOptions.value
   if (!list.length) return { exact: null, nearest: null }
-  const parsed = parseFlexibleTime(displayValue.value)
+  const parsed = parseFlexibleTime(displayValue.value, props.format)
   if (!parsed.valid) return { exact: null, nearest: null }
   const candidate = parsed.ss
     ? `${parsed.hh24}:${parsed.mm}:${parsed.ss}`
@@ -357,19 +357,19 @@ function baseCompare(val: string): string {
 watch(
   () => [props.modelValue, props.value] as const,
   ([m, v]) => {
-    const nv = normalize24(m || v || '')
+    const nv = normalize24(m || v || '', props.format)
     if (nv === canonicalValue.value) return
     canonicalValue.value = nv
-    if (!isTyping.value) displayValue.value = formatTime(nv, props.use12Hour)
+    if (!isTyping.value) displayValue.value = formatTime(nv, props.format)
   },
 )
 
-// Reformat the displayed value when the format changes (e.g. use12Hour toggle).
+// Reformat the displayed value when the display format changes.
 watch(
-  () => props.use12Hour,
+  () => props.format,
   () => {
     if (!isTyping.value) {
-      displayValue.value = formatTime(canonicalValue.value, props.use12Hour)
+      displayValue.value = formatTime(canonicalValue.value, props.format)
     }
   },
 )
@@ -381,7 +381,7 @@ watch(displayValue, () => {
   // The model→display sync above (re)writes displayValue while not typing —
   // distinguish user keystrokes from that programmatic write by only
   // toggling when the value diverges from the formatted canonical.
-  const formatted = formatTime(canonicalValue.value, props.use12Hour)
+  const formatted = formatTime(canonicalValue.value, props.format)
   if (displayValue.value !== formatted) {
     isTyping.value = true
     highlightIndex.value = -1
@@ -397,7 +397,7 @@ function setInvalid(next: boolean) {
 function commit(value: string) {
   const prev = canonicalValue.value
   canonicalValue.value = value
-  displayValue.value = formatTime(value, props.use12Hour)
+  displayValue.value = formatTime(value, props.format)
   isTyping.value = false
   emit('update:modelValue', value)
   if (value !== prev) emit('change', value)
@@ -409,7 +409,14 @@ function commitTyped(raw: string) {
     commit('')
     return
   }
-  const parsed = parseFlexibleTime(raw)
+  const formattedCurrent = formatTime(canonicalValue.value, props.format)
+  if (raw === formattedCurrent) {
+    displayValue.value = formattedCurrent
+    isTyping.value = false
+    setInvalid(false)
+    return
+  }
+  const parsed = parseFlexibleTime(raw, props.format)
   if (
     !parsed.valid ||
     isOutOfRange(parsed.total, minMinutes.value, maxMinutes.value)
@@ -417,7 +424,7 @@ function commitTyped(raw: string) {
     emit('input-invalid', raw)
     setInvalid(true)
     // Revert visible text to the last good value.
-    displayValue.value = formatTime(canonicalValue.value, props.use12Hour)
+    displayValue.value = formatTime(canonicalValue.value, props.format)
     isTyping.value = false
     return
   }
@@ -607,4 +614,3 @@ defineExpose({
   },
 })
 </script>
-

--- a/src/components/TimePicker/stories/TwentyFour.vue
+++ b/src/components/TimePicker/stories/TwentyFour.vue
@@ -11,7 +11,7 @@ const cronTime = ref('02:00')
     <span class="text-sm text-ink-gray-7">Nightly backup runs at</span>
     <TimePicker
       v-model="cronTime"
-      :use12Hour="false"
+      format="HH:mm"
       :interval="30"
     >
       <template #prefix>

--- a/src/components/TimePicker/types.ts
+++ b/src/components/TimePicker/types.ts
@@ -1,6 +1,6 @@
 /**
  * TimePicker is a thin wrapper around Combobox that adds time-aware parsing,
- * generated options, and a 12/24-hour display toggle. Canonical value is
+ * generated options, and configurable display formatting. Canonical value is
  * always 24-hour `HH:mm` (or `HH:mm:ss` if seconds were typed).
  */
 
@@ -90,8 +90,8 @@ export interface TimePickerProps extends InputLabelingProps {
    */
   autoClose?: boolean
 
-  /** Use 12-hour (am/pm) format for display. */
-  use12Hour?: boolean
+  /** Dayjs format string used for display. Default: `HH:mm`. */
+  format?: string
 
   /** Disable the time picker. */
   disabled?: boolean

--- a/src/components/TimePicker/types.ts
+++ b/src/components/TimePicker/types.ts
@@ -90,6 +90,12 @@ export interface TimePickerProps extends InputLabelingProps {
    */
   autoClose?: boolean
 
+  /**
+   * Use 12-hour (am/pm) format for display.
+   * @deprecated Use `format` instead.
+   */
+  use12Hour?: boolean
+
   /** Dayjs format string used for display. Default: `HH:mm`. */
   format?: string
 

--- a/src/components/TimePicker/utils.ts
+++ b/src/components/TimePicker/utils.ts
@@ -29,7 +29,16 @@ export interface TimeOption {
 }
 
 function formatHasSeconds(format: string): boolean {
-  return format.replace(/\[[^\]]*]/g, '').includes('s')
+  const stripped = format.replace(/\[[^\]]*]/g, '')
+  if (stripped.includes('s')) return true
+
+  const withSeconds = dayjs(
+    `${REFERENCE_DATE} 20:02:18`,
+    `${REFERENCE_DATE_FORMAT} HH:mm:ss`,
+    true,
+  )
+  const withoutSeconds = withSeconds.second(0)
+  return withSeconds.format(format) !== withoutSeconds.format(format)
 }
 
 function buildParsedTime(

--- a/src/components/TimePicker/utils.ts
+++ b/src/components/TimePicker/utils.ts
@@ -5,6 +5,12 @@
  * formatting, range checks, and option generation hangs off those two forms.
  */
 
+import { dayjs } from '../../utils/dayjs'
+
+const DEFAULT_TIME_FORMAT = 'HH:mm'
+const REFERENCE_DATE = '2000-01-01'
+const REFERENCE_DATE_FORMAT = 'YYYY-MM-DD'
+
 export interface ParsedTimeValid {
   valid: true
   hh24: string
@@ -22,12 +28,59 @@ export interface TimeOption {
   label: string
 }
 
+function formatHasSeconds(format: string): boolean {
+  return format.replace(/\[[^\]]*]/g, '').includes('s')
+}
+
+function buildParsedTime(
+  hh24: string,
+  mm: string,
+  ss?: string,
+): ParsedTimeValid {
+  const h = parseInt(hh24, 10)
+  const m = parseInt(mm, 10)
+  return {
+    valid: true,
+    hh24,
+    mm,
+    ss,
+    total: h * 60 + m,
+  }
+}
+
+function parseTimeWithFormat(input: string, format: string): ParsedTime {
+  const timeFormat = format || DEFAULT_TIME_FORMAT
+  const trimmed = input.trim()
+  const candidates = [
+    dayjs(trimmed, timeFormat, true),
+    dayjs(
+      `${REFERENCE_DATE} ${trimmed}`,
+      `${REFERENCE_DATE_FORMAT} ${timeFormat}`,
+      true,
+    ),
+  ]
+  const parsed = candidates.find((candidate) => candidate.isValid())
+  if (!parsed) return { valid: false }
+  return buildParsedTime(
+    parsed.format('HH'),
+    parsed.format('mm'),
+    formatHasSeconds(timeFormat) ? parsed.format('ss') : undefined,
+  )
+}
+
 /**
  * Parse human-typed times: `3p`, `3pm`, `3.30pm`, `15:00`, `1500`, `15`,
- * `9:30:15 am`. Returns canonical components plus total minutes from midnight.
+ * `9:30:15 am`. Also accepts the configured dayjs display format. Returns
+ * canonical components plus total minutes from midnight.
  */
-export function parseFlexibleTime(input: string): ParsedTime {
+export function parseFlexibleTime(
+  input: string,
+  format = DEFAULT_TIME_FORMAT,
+): ParsedTime {
   if (!input) return { valid: false }
+  const formatted = parseTimeWithFormat(input, format)
+  if (formatted.valid) return formatted
+
   let s = input.trim().toLowerCase()
   s = s.replace(/\./g, '')
   s = s.replace(/(\d)(am|pm)$/, '$1 $2')
@@ -70,32 +123,31 @@ export function parseFlexibleTime(input: string): ParsedTime {
 }
 
 /** Coerce any accepted time string to canonical `HH:mm` / `HH:mm:ss`. */
-export function normalize24(raw: string): string {
+export function normalize24(raw: string, format = DEFAULT_TIME_FORMAT): string {
   if (!raw) return ''
   if (/^\d{2}:\d{2}$/.test(raw)) return raw
   if (/^\d{2}:\d{2}:\d{2}$/.test(raw)) return raw
-  const parsed = parseFlexibleTime(raw)
+  const parsed = parseFlexibleTime(raw, format)
   if (!parsed.valid) return ''
   return parsed.ss
     ? `${parsed.hh24}:${parsed.mm}:${parsed.ss}`
     : `${parsed.hh24}:${parsed.mm}`
 }
 
-/** Render a canonical value for display. Hours are zero-padded. */
-export function formatTime(val24: string, use12Hour: boolean): string {
+/** Render a canonical value for display using a dayjs format string. */
+export function formatTime(
+  val24: string,
+  format = DEFAULT_TIME_FORMAT,
+): string {
   if (!val24) return ''
-  const segs = val24.split(':')
-  const h = parseInt(segs[0], 10)
-  const m = parseInt(segs[1], 10)
-  const s = segs[2]
-  const mm = m.toString().padStart(2, '0')
-  const ss = s ? `:${s}` : ''
-  if (!use12Hour) {
-    return `${h.toString().padStart(2, '0')}:${mm}${ss}`
-  }
-  const am = h < 12
-  const hour12 = h % 12 === 0 ? 12 : h % 12
-  return `${hour12.toString().padStart(2, '0')}:${mm}${ss} ${am ? 'am' : 'pm'}`
+  const canonicalFormat = val24.length === 8 ? 'HH:mm:ss' : 'HH:mm'
+  const parsed = dayjs(
+    `${REFERENCE_DATE} ${val24}`,
+    `${REFERENCE_DATE_FORMAT} ${canonicalFormat}`,
+    true,
+  )
+  if (!parsed.isValid()) return val24
+  return parsed.format(format || DEFAULT_TIME_FORMAT)
 }
 
 /** Total minutes (0–1439) from an `HH:mm[:ss]` string, or null if malformed. */
@@ -123,12 +175,12 @@ export function isOutOfRange(
  */
 export function generateTimeOptions({
   interval,
-  use12Hour,
+  format,
   minMinutes,
   maxMinutes,
 }: {
   interval: number
-  use12Hour: boolean
+  format?: string
   minMinutes: number | null
   maxMinutes: number | null
 }): TimeOption[] {
@@ -140,7 +192,7 @@ export function generateTimeOptions({
       .padStart(2, '0')
     const mm = (m % 60).toString().padStart(2, '0')
     const value = `${hh}:${mm}`
-    out.push({ value, label: formatTime(value, use12Hour) })
+    out.push({ value, label: formatTime(value, format) })
   }
   return out
 }


### PR DESCRIPTION
## Summary

`TimePicker` now accepts a dayjs-style `format` prop the way `DatePicker` already does (`HH:mm`, `hh:mm A`, `h:mm A`, `HH:mm:ss`, localized tokens like `LT`/`LTS`), defaulting to the current 24-hour `HH:mm` display. The deprecated `use12Hour` prop keeps working as an alias (mapped to `h:mm A` with the same deprecation-warning pattern the other legacy TimePicker props use) so existing consumers do not silently lose their 12-hour display during migration.

## Why this matters

#695 asks for exactly this: shariquerik (Frappe CRM) needs format control on `TimePicker`, especially seconds support, matching `DatePicker`'s existing `format?: string`. Lead maintainer netchampfaris confirmed the direction on 2026-05-18: "we should then replace use12Hour prop with format which is much more flexible". The repo is on the v1.0.0 beta line, so the prop migration is sanctioned; the alias keeps it non-breaking in practice.

Typed-input parsing follows the configured format, including seconds: localized tokens that expand to seconds (e.g. `LTS`) are expanded via dayjs locale data before deciding whether to preserve the seconds component, so input like `8:02:18 PM` round-trips without dropping `:18`.

## Testing

- `TimePicker.cy.ts` extended with format-driven cases: 24-hour default, `hh:mm A`, seconds formats, localized tokens, typed-input parsing per format, and the `use12Hour` alias warning.
- `stories/TwentyFour.vue` migrated to `format="HH:mm"`; `TimePicker.api.md` regenerated via the docs pipeline.
- Production build passes; observed type-check failures are pre-existing outside this diff.

Fixes #695

<!-- coverage-report:start -->
Coverage: 58.62% (+0.12% vs `main`)
<!-- coverage-report:end -->

