### PR TITLE
fix: sync shadow tokens with Figma and remove dark elevation utilities

### DIFF
--- a/docs/components/foundations/ElevationPreview.vue
+++ b/docs/components/foundations/ElevationPreview.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { TabButtons } from 'frappe-ui'
 import { useTheme, setTheme } from '../../composables/useTheme'
+import effects from '../../../tailwind/generated/effects.json'
 
 // The six shadow steps, all sat on one elevated surface so the scale reads as
 // shadow-only. In light mode `surface-elevation-2` is white, so depth comes
@@ -9,6 +10,11 @@ import { useTheme, setTheme } from '../../composables/useTheme'
 // lift the (faded) shadow can't. Real per-component pairings live in the
 // Surface pairing table.
 const STEPS = ['sm', 'base', 'md', 'lg', 'xl', '2xl'] as const
+
+const rows = STEPS.map((step) => ({
+  name: step,
+  value: effects.elevation.light[step],
+}))
 
 // The switcher drives the global theme, so the page and these cards swap
 // together, with no detached preview, and `bg-surface-*` resolves straight from
@@ -31,16 +37,29 @@ const modeButtons = [
       <TabButtons :buttons="modeButtons" v-model="previewTheme" class="w-fit" />
     </div>
 
-    <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-8 py-4">
-      <div v-for="step in STEPS" :key="step" class="grid gap-3">
+    <div class="grid divide-y divide-outline-gray-1">
+      <div
+        v-for="row in rows"
+        :key="row.name"
+        class="flex w-full items-center gap-4 py-4 text-left"
+      >
         <div
-          class="h-24 rounded-lg bg-surface-elevation-2"
-          :class="`shadow-${step}`"
+          class="size-16 shrink-0 rounded-lg bg-surface-elevation-2"
+          :class="`shadow-${row.name}`"
         ></div>
-        <div class="grid gap-0.5">
-          <span class="text-2xs font-mono text-ink-gray-7">shadow-{{ step }}</span>
-          <span class="text-2xs font-mono text-ink-gray-5">--elevation-{{ step }}</span>
+        <div class="grid gap-0.5 min-w-0 flex-1">
+          <span class="text-sm font-mono text-ink-gray-8 truncate">
+            shadow-{{ row.name }}
+          </span>
+          <span class="text-xs font-mono text-ink-gray-5 truncate">
+            --elevation-{{ row.name }}
+          </span>
         </div>
+        <span
+          class="max-w-[56%] shrink-0 break-words text-right text-xs font-mono leading-relaxed text-ink-gray-5"
+        >
+          {{ row.value }}
+        </span>
       </div>
     </div>
   </div>

--- a/espresso-v2-design-tokens/effect.styles.tokens.json
+++ b/espresso-v2-design-tokens/effect.styles.tokens.json
@@ -28,14 +28,14 @@
             "offsetY": "0px",
             "blur": "1px",
             "spread": "0px",
-            "color": "#00000024"
+            "color": "#00000033"
           },
           {
             "offsetX": "0px",
             "offsetY": "0.25px",
             "blur": "1.5px",
             "spread": "0px",
-            "color": "#ffffff14",
+            "color": "#ffffff29",
             "inset": true
           }
         ]
@@ -62,7 +62,7 @@
             "offsetY": "0.25px",
             "blur": "1.5px",
             "spread": "0px",
-            "color": "#ffffff14",
+            "color": "#ffffff29",
             "inset": true
           }
         ]
@@ -75,14 +75,14 @@
             "offsetY": "6px",
             "blur": "12px",
             "spread": "-2px",
-            "color": "#0000001f"
+            "color": "#00000014"
           },
           {
             "offsetX": "0px",
             "offsetY": "0px",
             "blur": "6px",
             "spread": "2px",
-            "color": "#00000008"
+            "color": "#0000000a"
           },
           {
             "offsetX": "0px",
@@ -96,7 +96,7 @@
             "offsetY": "0.25px",
             "blur": "1.5px",
             "spread": "0px",
-            "color": "#ffffff14",
+            "color": "#ffffff29",
             "inset": true
           }
         ]
@@ -124,6 +124,14 @@
             "blur": "1.5px",
             "spread": "0px",
             "color": "#0000002e"
+          },
+          {
+            "offsetX": "0px",
+            "offsetY": "0.25px",
+            "blur": "1.5px",
+            "spread": "0px",
+            "color": "#ffffff29",
+            "inset": true
           }
         ]
       },
@@ -154,9 +162,9 @@
           {
             "offsetX": "0px",
             "offsetY": "0.25px",
-            "blur": "2px",
+            "blur": "1.5px",
             "spread": "0px",
-            "color": "#ffffff26",
+            "color": "#ffffff29",
             "inset": true
           }
         ]
@@ -187,10 +195,10 @@
           },
           {
             "offsetX": "0px",
-            "offsetY": "0.1px",
+            "offsetY": "0.25px",
             "blur": "2px",
             "spread": "0px",
-            "color": "#ffffff14",
+            "color": "#ffffff29",
             "inset": true
           }
         ]

--- a/tailwind/colorPalette.js
+++ b/tailwind/colorPalette.js
@@ -131,10 +131,9 @@ function generateSemanticColors() {
 // Emit `--elevation-*` and `--focus-*` CSS variables. Elevation uses the
 // Figma `light/*` values in both modes (matches how Espresso 2.0 actually
 // applies shadows in dark mode — see the dark-mode page in Figma, which
-// references `elevation/light/*` exclusively). The Figma `dark/*` set is
-// exposed as `--dark-elevation-*` for opt-in use via `shadow-dark-*`.
-// Focus rings still mode-swap. Theme-independent entries (e.g.
-// `elevation.custom.status`) land in `:root` only.
+// references `elevation/light/*` exclusively). Focus rings still mode-swap.
+// Theme-independent entries (e.g. `elevation.custom.status`) land in
+// `:root` only.
 function generateEffectVariables() {
   const output = {
     ':root': {},
@@ -143,9 +142,6 @@ function generateEffectVariables() {
 
   for (const [step, value] of Object.entries(effectsData.elevation.light)) {
     output[':root'][`--elevation-${step}`] = value
-  }
-  for (const [step, value] of Object.entries(effectsData.elevation.dark)) {
-    output[':root'][`--dark-elevation-${step}`] = value
   }
   for (const [name, value] of Object.entries(effectsData.elevation.custom)) {
     output[':root'][`--elevation-${name}`] = value

--- a/tailwind/figma-tokens-to-theme.js
+++ b/tailwind/figma-tokens-to-theme.js
@@ -316,8 +316,13 @@ function buildEffects() {
   return out
 }
 
+// Figma paints its effect array back-to-front (index 0 = bottom of the stack),
+// while CSS box-shadow paints front-to-back (first listed = on top). Reverse the
+// layers so the composed CSS string matches Figma's visual stacking order.
 function shadowToCss(layers) {
   return layers
+    .slice()
+    .reverse()
     .map((layer) => {
       const parts = [
         layer.inset ? 'inset' : null,

--- a/tailwind/generated/effects.json
+++ b/tailwind/generated/effects.json
@@ -1,20 +1,20 @@
 {
   "elevation": {
     "light": {
-      "sm": "0px 1px 3px 0px #00000024, 0px 0px 1px 0px #00000024, inset 0px 0.25px 1.5px 0px #ffffff14",
-      "base": "0px 2px 5px 0px #00000024, 0px 0px 1.5px 0px #00000029, inset 0px 0.25px 1.5px 0px #ffffff14",
-      "md": "0px 6px 12px -2px #0000001f, 0px 0px 6px 2px #00000008, 0px 0px 1.5px 0px #00000026, inset 0px 0.25px 1.5px 0px #ffffff14",
-      "lg": "0px 18px 22px -6px #0000001a, 0px 0px 6px 3px #00000008, 0px 0px 1.5px 0px #0000002e",
-      "xl": "0px 24px 30px -8px #0000001a, 0px 0px 10px 2px #0000000a, 0px 0px 1px 0px #00000033, inset 0px 0.25px 2px 0px #ffffff26",
-      "2xl": "0px 44px 52px -10px #0000001a, 0px 0px 10px 2px #00000008, 0px 0px 1.5px 0px #00000040, inset 0px 0.1px 2px 0px #ffffff14"
+      "sm": "inset 0px 0.25px 1.5px 0px #ffffff29, 0px 0px 1px 0px #00000033, 0px 1px 3px 0px #00000024",
+      "base": "inset 0px 0.25px 1.5px 0px #ffffff29, 0px 0px 1.5px 0px #00000029, 0px 2px 5px 0px #00000024",
+      "md": "inset 0px 0.25px 1.5px 0px #ffffff29, 0px 0px 1.5px 0px #00000026, 0px 0px 6px 2px #0000000a, 0px 6px 12px -2px #00000014",
+      "lg": "inset 0px 0.25px 1.5px 0px #ffffff29, 0px 0px 1.5px 0px #0000002e, 0px 0px 6px 3px #00000008, 0px 18px 22px -6px #0000001a",
+      "xl": "inset 0px 0.25px 1.5px 0px #ffffff29, 0px 0px 1px 0px #00000033, 0px 0px 10px 2px #0000000a, 0px 24px 30px -8px #0000001a",
+      "2xl": "inset 0px 0.25px 2px 0px #ffffff29, 0px 0px 1.5px 0px #00000040, 0px 0px 10px 2px #00000008, 0px 44px 52px -10px #0000001a"
     },
     "dark": {
-      "sm": "0px 1px 3px 0px #000000b2, 0px 0px 14px 0px #0000002e, inset 0px 0.5px 0.5px 0.5px #ffffff08",
-      "base": "0px 2px 5px 0px #00000099, 0px 0px 14px 0px #0000002e, inset 0px 0.5px 0.5px 0.5px #ffffff08",
-      "md": "0px 6px 12px -2px #00000099, 0px 0px 16px 2px #00000033, inset 0px 0.5px 0.5px 0.5px #ffffff08",
-      "lg": "0px 18px 20px -8px #00000085, 0px 0px 16px 0px #0000001a, inset 0px 0.5px 1.5px 0.5px #ffffff0a",
-      "xl": "0px 26px 34px -6px #0000006b, 0px 0px 14px 2px #0000001f, inset 0px 0.5px 1.5px 0.5px #ffffff0a",
-      "2xl": "0px 44px 52px -4px #0000006b, 0px 0px 14px 10px #0000001f, inset 0px 0.5px 1.5px 0.5px #ffffff0f"
+      "sm": "inset 0px 0.5px 0.5px 0.5px #ffffff08, 0px 0px 14px 0px #0000002e, 0px 1px 3px 0px #000000b2",
+      "base": "inset 0px 0.5px 0.5px 0.5px #ffffff08, 0px 0px 14px 0px #0000002e, 0px 2px 5px 0px #00000099",
+      "md": "inset 0px 0.5px 0.5px 0.5px #ffffff08, 0px 0px 16px 2px #00000033, 0px 6px 12px -2px #00000099",
+      "lg": "inset 0px 0.5px 1.5px 0.5px #ffffff0a, 0px 0px 16px 0px #0000001a, 0px 18px 20px -8px #00000085",
+      "xl": "inset 0px 0.5px 1.5px 0.5px #ffffff0a, 0px 0px 14px 2px #0000001f, 0px 26px 34px -6px #0000006b",
+      "2xl": "inset 0px 0.5px 1.5px 0.5px #ffffff0f, 0px 0px 14px 10px #0000001f, 0px 44px 52px -4px #0000006b"
     },
     "custom": {
       "status": "0px 0px 0px 1.5px #ffffff"

--- a/tailwind/plugin.js
+++ b/tailwind/plugin.js
@@ -216,12 +216,6 @@ export default plugin(
         xl: 'var(--elevation-xl)',
         '2xl': 'var(--elevation-2xl)',
         status: 'var(--elevation-status)',
-        'dark-sm': 'var(--dark-elevation-sm)',
-        'dark-base': 'var(--dark-elevation-base)',
-        'dark-md': 'var(--dark-elevation-md)',
-        'dark-lg': 'var(--dark-elevation-lg)',
-        'dark-xl': 'var(--dark-elevation-xl)',
-        'dark-2xl': 'var(--dark-elevation-2xl)',
       },
       container: {
         padding: {

--- a/tailwind/tokens.js
+++ b/tailwind/tokens.js
@@ -16,12 +16,6 @@ const boxShadow = {
   ...effectsData.elevation.light,
   DEFAULT: effectsData.elevation.light.base,
   ...effectsData.elevation.custom,
-  ...Object.fromEntries(
-    Object.entries(effectsData.elevation.dark).map(([key, value]) => [
-      `dark-${key}`,
-      value,
-    ]),
-  ),
 }
 
 // lineHeight, letterSpacing and fontWeight are baked into each size tuple by


### PR DESCRIPTION
Syncs shadow tokens with the Figma source of truth and removes unused dark elevation utilities.

- Reverse layer order in `shadowToCss` so CSS paint order matches Figma
- Update light-mode shadow values to match Figma
- Remove unused `shadow-dark-*` utilities and `--dark-elevation-*` vars
- Make elevation preview boxes square

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-781/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 56.52% (+0.01% vs `main`)
<!-- coverage-report:end -->
