### PR TITLE
Default <p> to relaxed line-height

### DIFF
--- a/docs/components/Home/Hero.vue
+++ b/docs/components/Home/Hero.vue
@@ -15,7 +15,7 @@ import { withBase } from 'vitepress'
       </h1>
 
       <p
-        class="text-base sm:text-xl text-ink-gray-5 leading-relaxed sm:w-3/4 mx-auto"
+        class="text-p-base sm:text-p-xl text-ink-gray-5 sm:w-3/4 mx-auto"
       >
         Beautifully crafted components built for real world applications. Better
         defaults helping you ship faster.

--- a/docs/components/Home/Showcase/col2.vue
+++ b/docs/components/Home/Showcase/col2.vue
@@ -71,7 +71,7 @@ const resetState = () => {
               </Button>
             </div>
 
-            <p class="text-sm text-ink-gray-7 mb-4 leading-relaxed">
+            <p class="text-p-sm text-ink-gray-7 mb-4">
               {{ state.about }}
             </p>
 
@@ -118,7 +118,7 @@ const resetState = () => {
           <LucideTag class="size-5" />
         </span>
 
-        <p class="leading-relaxed">
+        <p class="text-p-base">
           Prize: 25% discount coupon <br />
           <span class="text-ink-gray-6"> for all software courses</span>
         </p>
@@ -167,7 +167,7 @@ const resetState = () => {
       >
         <div class="grid gap-1 flex-1">
           <span>Balanced </span>
-          <span class="text-ink-gray-4">
+          <span class="text-p-sm text-ink-gray-4">
             Automatically balances performance with energy consumption
           </span>
         </div>
@@ -187,7 +187,7 @@ const resetState = () => {
       >
         <div class="grid gap-1 flex-1">
           <span> Power Saving</span>
-          <span class="text-ink-gray-4">
+          <span class="text-p-sm text-ink-gray-4">
             Saves energy by reducing performance where possible
           </span>
         </div>
@@ -203,7 +203,7 @@ const resetState = () => {
       <label class="flex gap-3 p-3 has-[:checked]:bg-surface-gray-1" for="perf">
         <div class="grid gap-1 flex-1">
           <span> Performance</span>
-          <span class="text-ink-gray-4">
+          <span class="text-p-sm text-ink-gray-4">
             High performance but uses more energy
           </span>
         </div>

--- a/docs/components/Home/Showcase/col3.vue
+++ b/docs/components/Home/Showcase/col3.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref } from 'vue'
 import {
   Avatar,
   Badge,
@@ -9,67 +9,64 @@ import {
   Select,
   Slider,
   Switch,
-} from "frappe-ui";
-import LucideCoins from "~icons/lucide/circle-dollar-sign";
-import LucideUsers from "~icons/lucide/users";
-import LucideVideo from "~icons/lucide/video";
-import LucideMapPin from "~icons/lucide/map-pin";
-import LucideClock from "~icons/lucide/clock";
-import LucideCalendar from "~icons/lucide/calendar";
-import LucideX from "~icons/lucide/x";
-import LucideLink from "~icons/lucide/send";
+} from 'frappe-ui'
+import LucideCoins from '~icons/lucide/circle-dollar-sign'
+import LucideUsers from '~icons/lucide/users'
+import LucideVideo from '~icons/lucide/video'
+import LucideMapPin from '~icons/lucide/map-pin'
+import LucideClock from '~icons/lucide/clock'
+import LucideCalendar from '~icons/lucide/calendar'
+import LucideX from '~icons/lucide/x'
+import LucideLink from '~icons/lucide/send'
 
 const imgs = [
-  "https://avatars.githubusercontent.com/u/499550?s=60&v=4",
+  'https://avatars.githubusercontent.com/u/499550?s=60&v=4',
   'https://avatars.githubusercontent.com/u/2798204?s=70&v=4',
   'https://avatars.githubusercontent.com/u/28706372?s=96&v=4',
   'https://avatars.githubusercontent.com/u/1493221?s=70&v=4',
-];
+]
 
-const progressVal = ref(1);
-const checkboxVal = ref(true);
+const progressVal = ref(1)
+const checkboxVal = ref(true)
 
 const incProgress = () => {
   if (progressVal.value < 3) {
-    progressVal.value += 1;
+    progressVal.value += 1
   }
-};
+}
 
 const decProgress = () => {
   if (progressVal.value > 1) {
-    progressVal.value -= 1;
+    progressVal.value -= 1
   }
-};
+}
 
-const themes = ["green", "red", "blue", "yellow", "gray"];
+const themes = ['green', 'red', 'blue', 'yellow', 'gray']
 
-const slider2Val = ref([20, 50]);
-const switchVal = ref(true);
+const slider2Val = ref([20, 50])
+const switchVal = ref(true)
 
 const progressData = [
   {
-    title: "Objection Handling",
-    desc:
-      "In this objection handling role-play scenario, participants will engage in a simulated sales interaction.",
-    tags: ["Communication", "Negotiation"],
+    title: 'Objection Handling',
+    desc: 'In this objection handling role-play scenario, participants will engage in a simulated sales interaction.',
+    tags: ['Communication', 'Negotiation'],
   },
 
   {
-    title: "Business Development",
-    desc:
-      "In this business development role-play scenario, participants will engage in a simulated sales interaction.",
-    tags: ["Strategy", "Customer support"],
+    title: 'Business Development',
+    desc: 'In this business development role-play scenario, participants will engage in a simulated sales interaction.',
+    tags: ['Strategy', 'Customer support'],
   },
 
   {
-    title: "Marketing Strategy",
-    desc:
-      "In this marketing strategy role-play scenario, participants will engage in a simulated sales interaction.",
-    tags: ["Strategy", "Analytics"],
+    title: 'Marketing Strategy',
+    desc: 'In this marketing strategy role-play scenario, participants will engage in a simulated sales interaction.',
+    tags: ['Strategy', 'Analytics'],
   },
-];
+]
 
-const toggledDiv = ref(false);
+const toggledDiv = ref(false)
 </script>
 
 <template>
@@ -89,7 +86,7 @@ const toggledDiv = ref(false);
         {{ progressData[progressVal - 1].title }}
       </h3>
 
-      <p class="leading-relaxed">
+      <p>
         {{ progressData[progressVal - 1].desc }}
       </p>
 
@@ -97,7 +94,7 @@ const toggledDiv = ref(false);
         <Badge
           v-for="(tag, tagIndex) in progressData[progressVal - 1].tags"
           :key="tag"
-          :theme='themes[tagIndex] || "gray"'
+          :theme="themes[tagIndex] || 'gray'"
           size="lg"
           class="rounded-sm"
         >
@@ -114,14 +111,10 @@ const toggledDiv = ref(false);
           class="border-2 border-surface-base -ml-2"
         />
 
-        <span class="ml-3 text-sm !text-ink-gray-9">
-          + 5 more
-        </span>
+        <span class="ml-3 text-sm !text-ink-gray-9"> + 5 more </span>
       </div>
 
-      <div
-        class="grid grid-cols-2 mt-3 gap-3 *:py-4 border-t rounded pt-3"
-      >
+      <div class="grid grid-cols-2 mt-3 gap-3 *:py-4 border-t rounded pt-3">
         <Button @click="decProgress">Back</Button>
         <Button @click="incProgress" variant="solid">Next</Button>
       </div>
@@ -133,7 +126,7 @@ const toggledDiv = ref(false);
           <LucideCoins class="size-4" />
           Price range
         </span>
-        <Badge size="lg" class='rounded-sm'>
+        <Badge size="lg" class="rounded-sm">
           ${{ slider2Val[0] * 10 }} - ${{ slider2Val[1] * 10 }}
         </Badge>
       </div>
@@ -150,9 +143,7 @@ const toggledDiv = ref(false);
       <div class="flex gap-3 justify-between">
         <div class="grid gap-2">
           <span class="text-ink-gray-9">Smart compose</span>
-          <p class="text-ink-gray-5">
-            Enable predictive suggestions
-          </p>
+          <p class="text-ink-gray-5">Enable predictive suggestions</p>
         </div>
         <Switch v-model="switchVal" />
       </div>
@@ -162,9 +153,7 @@ const toggledDiv = ref(false);
       <div class="flex gap-2 justify-between">
         <div class="grid gap-2">
           <span class="text-ink-gray-9">Inline completions</span>
-          <p class="text-ink-gray-5">
-            Auto completions as you type
-          </p>
+          <p class="text-ink-gray-5">Auto completions as you type</p>
         </div>
         <Switch />
       </div>
@@ -172,7 +161,7 @@ const toggledDiv = ref(false);
 
     <div
       class="p-5 transition-all duration-200"
-      :class='{ "border-outline-gray-7": checkboxVal }'
+      :class="{ 'border-outline-gray-7': checkboxVal }"
     >
       <Checkbox
         v-model="checkboxVal"
@@ -184,15 +173,15 @@ const toggledDiv = ref(false);
 
     <div
       class="p-4 grid"
-      :class='{ "animate-bounce bg-surface-base shadow-lg": toggledDiv }'
+      :class="{ 'animate-bounce bg-surface-base shadow-lg': toggledDiv }"
     >
       <h3 class="text-xl mb-2 font-semibold flex gap-3 justify-between">
         Schedule an event
         <LucideX class="size-5" @click="toggledDiv = !toggledDiv" />
       </h3>
 
-      <span class="leading-relaxed mb-1">Product marketing</span>
-      <p class="leading-relaxed text-ink-gray-5 mb-2">
+      <span class="mb-1">Product marketing</span>
+      <p class="text-p-sm text-ink-gray-5 mb-2">
         Discussion of new marketing strategies and pricing for the new project
       </p>
 

--- a/tailwind/plugin.js
+++ b/tailwind/plugin.js
@@ -169,6 +169,14 @@ let globalStyles = (theme) => ({
     backgroundSize: '1.13em',
     backgroundPosition: 'right 0.44rem center',
   },
+  // A bare `<p>` reads as body copy, so it defaults to a relaxed line-height
+  // instead of the tight value baked into the `text-<size>` utilities. Kept at
+  // element specificity (0,0,1) with `:where()` (which adds none) so any explicit
+  // `text-*` / `text-p-*` line-height wins, and scoped out of rich text so the
+  // `prose` / editor line-heights are untouched.
+  'p:not(:where(.prose, .ProseMirror) *)': {
+    lineHeight: '1.5',
+  },
   // Global keyboard focus indicator (espresso v2 focus/default token).
   // Lives in the base layer so any utility on the element can override it:
   // suppress with `focus-visible:outline-none`, retheme with


### PR DESCRIPTION
## What

A bare `<p>` now defaults to `line-height: 1.5`, so multiline body text (descriptions, paragraphs) isn't cramped with the tight line-height baked into the `text-<size>` utilities.

The rule is kept at element specificity and `:where()` adds none, so any explicit `text-*`, `text-p-*`, `leading-*` or `prose-*` line-height still wins. It's also scoped out of `.prose` / `.ProseMirror`, so rich-text and editor line-heights are untouched.

## Commits

1. `fix:` the `<p>` default line-height rule in the Tailwind plugin
2. `docs:` update homepage demos to use `<p>` / `text-p-*` for multiline text and drop redundant `leading-relaxed` overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-782/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 56.52% (±0.00% vs `main`)
<!-- coverage-report:end -->
