### PR TITLE
feat!: Tree component rework

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -146,6 +146,7 @@ declare module 'vue' {
     TooltipBubble: typeof import('./src/components/Tooltip/TooltipBubble.vue')['default']
     TooltipProvider: typeof import('./src/components/Tooltip/TooltipProvider.vue')['default']
     Tree: typeof import('./src/components/Tree/Tree.vue')['default']
+    TreeItem: typeof import('./src/components/Tree/TreeItem.vue')['default']
     WeekIcon: typeof import('./src/components/Calendar/Icon/WeekIcon.vue')['default']
   }
 }

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -5,31 +5,31 @@ pageClass: migration-page
 # Migration from v0
 
 A guide for moving an existing app onto `frappe-ui` v1. Work through one
-component family at a time. Each section opens with a before/after table.
-For the full change list see the
+component family at a time. Each section opens with a before/after table. For
+the full change list see the
 [changelog](https://github.com/frappe/frappe-ui/blob/main/v1-release/changelog.md);
 for the rationale behind each API see the
 [v1 release specs](https://github.com/frappe/frappe-ui/tree/main/v1-release).
 
-After each pass, `grep` for the old prop or slot name to catch anything
-missed, then test the flows you touched. Type-checking won't catch focus,
-slot renames, or visual regressions.
+After each pass, `grep` for the old prop or slot name to catch anything missed,
+then test the flows you touched. Type-checking won't catch focus, slot renames,
+or visual regressions.
 
 ## Dialog
 
 The `options` blob is flattened into top-level props. See the
 [Dialog](./components/dialog) component page for the full API.
 
-| Before                                 | After                            |
-| -------------------------------------- | -------------------------------- |
-| `v-model="show"`                       | `v-model:open="show"`            |
-| `:options="{ title, size, actions }"`  | `title` / `size` / `:actions`    |
-| `disableOutsideClickToClose`           | `:dismissible="false"`           |
-| `<template #body-content>`             | default slot                     |
-| `<template #body-title>`               | `<template #title>`              |
-| `<template #body>`                     | `bare` prop + default slot       |
-| `onClick: (close) => …`                | `onClick: ({ close }) => …`      |
-| manual focus hacks / `v-focus`         | `autofocus` attr on a descendant |
+| Before                                | After                            |
+| ------------------------------------- | -------------------------------- |
+| `v-model="show"`                      | `v-model:open="show"`            |
+| `:options="{ title, size, actions }"` | `title` / `size` / `:actions`    |
+| `disableOutsideClickToClose`          | `:dismissible="false"`           |
+| `<template #body-content>`            | default slot                     |
+| `<template #body-title>`              | `<template #title>`              |
+| `<template #body>`                    | `bare` prop + default slot       |
+| `onClick: (close) => …`               | `onClick: ({ close }) => …`      |
+| manual focus hacks / `v-focus`        | `autofocus` attr on a descendant |
 
 ```vue
 <!-- Before -->
@@ -52,24 +52,24 @@ The `options` blob is flattened into top-level props. See the
 ```
 
 For reactive `:options` objects, spread them: `<Dialog v-bind="opts || {}" />`.
-For the imperative API, use `dialog.confirm` / `dialog.danger` /
-`dialog.prompt` from `frappe-ui` (callback-based: `onConfirm` resolves to
-close, throws to stay open) and wrap your app root in `<FrappeUIProvider>`.
+For the imperative API, use `dialog.confirm` / `dialog.danger` / `dialog.prompt`
+from `frappe-ui` (callback-based: `onConfirm` resolves to close, throws to stay
+open) and wrap your app root in `<FrappeUIProvider>`.
 
 ## DatePicker / TimePicker family
 
-Covers `DatePicker`, `DateRangePicker`, `DateTimePicker`, and `TimePicker`.
-They share the popover-trigger vocabulary.
+Covers `DatePicker`, `DateRangePicker`, `DateTimePicker`, and `TimePicker`. They
+share the popover-trigger vocabulary.
 
-| Before                          | After                            |
-| ------------------------------- | -------------------------------- |
-| `:value` prop                   | `v-model`                        |
-| `@change`                       | `@update:modelValue`             |
-| `placement="bottom-start"`      | `side` + `align` + `offset`      |
-| `:autoClose`                    | `:keepOpen` (inverted)           |
-| `allowCustom` / `readonly`      | `typeable`                       |
-| `minDate`/`maxDate`/`minTime`/`maxTime` | `min` / `max`            |
-| `#target`                       | `#trigger`                       |
+| Before                                  | After                       |
+| --------------------------------------- | --------------------------- |
+| `:value` prop                           | `v-model`                   |
+| `@change`                               | `@update:modelValue`        |
+| `placement="bottom-start"`              | `side` + `align` + `offset` |
+| `:autoClose`                            | `:keepOpen` (inverted)      |
+| `allowCustom` / `readonly`              | `typeable`                  |
+| `minDate`/`maxDate`/`minTime`/`maxTime` | `min` / `max`               |
+| `#target`                               | `#trigger`                  |
 
 Behavior changes that apply even if you don't touch your code:
 
@@ -84,12 +84,12 @@ Behavior changes that apply even if you don't touch your code:
 
 ## Selection family (Dropdown / Select / Combobox / MultiSelect)
 
-| Before                          | After                            |
-| ------------------------------- | -------------------------------- |
-| Dropdown `{ group, items }`     | `{ group, options }`             |
-| Select `#item-*` slot prop `option` | slot prop `item`             |
-| chevron / trailing content      | `#suffix` slot (replaces chevron)|
-| Combobox `createOption`         | `type: 'custom'` option + `condition` |
+| Before                              | After                                 |
+| ----------------------------------- | ------------------------------------- |
+| Dropdown `{ group, items }`         | `{ group, options }`                  |
+| Select `#item-*` slot prop `option` | slot prop `item`                      |
+| chevron / trailing content          | `#suffix` slot (replaces chevron)     |
+| Combobox `createOption`             | `type: 'custom'` option + `condition` |
 
 For the deprecated `Autocomplete`, see
 [Autocomplete (deprecated)](#autocomplete-deprecated).
@@ -97,19 +97,19 @@ For the deprecated `Autocomplete`, see
 ## Inputs
 
 Covers `TextInput`, `Textarea`, `Password`, `Checkbox`, `Switch`, `Rating`,
-`Slider`. All share the labeling contract (`label` / `description` / `error`
-/ `required`).
+`Slider`. All share the labeling contract (`label` / `description` / `error` /
+`required`).
 
-| Before                          | After                            |
-| ------------------------------- | -------------------------------- |
-| `Rating` `:rating_from`         | `:max`                           |
-| `Rating` `:readonly`            | `:disabled`                      |
-| `Switch` `@change`              | `@update:modelValue`             |
-| `Switch.labelClasses` / `Checkbox.padding` | `data-*` styling hooks|
-| `Password` `:value` + `@input` workaround | `v-model` (now works)  |
+| Before                                     | After                  |
+| ------------------------------------------ | ---------------------- |
+| `Rating` `:rating_from`                    | `:max`                 |
+| `Rating` `:readonly`                       | `:disabled`            |
+| `Switch` `@change`                         | `@update:modelValue`   |
+| `Switch.labelClasses` / `Checkbox.padding` | `data-*` styling hooks |
+| `Password` `:value` + `@input` workaround  | `v-model` (now works)  |
 
-`Slider` no longer hardcodes `aria-label="Volume"`. Pass `label` explicitly
-so the control is announced correctly.
+`Slider` no longer hardcodes `aria-label="Volume"`. Pass `label` explicitly so
+the control is announced correctly.
 
 The legacy `Input` component is deprecated. Use
 [`TextInput`](./components/textinput) for text-like modes, or `Textarea` /
@@ -117,9 +117,46 @@ The legacy `Input` component is deprecated. Use
 
 ## Divider
 
-| Before                  | After                   |
-| ----------------------- | ----------------------- |
-| `action.handler`        | `action.onClick`        |
+| Before           | After            |
+| ---------------- | ---------------- |
+| `action.handler` | `action.onClick` |
+
+## Tree
+
+The Tree was rebuilt from a single recursive `node` renderer into a stateful
+forest. It takes a `nodes` array, drives expansion through `v-model:expanded`,
+and scopes its per-row slots as `#item-*`. The `options` blob and the per-node
+internal collapse state are gone and sizing moves to CSS variables. Keyboard
+navigation, `role="tree"` ARIA, and opt-in drag-and-drop are new.
+
+| Before                                           | After                                          |
+| ------------------------------------------------ | ---------------------------------------------- |
+| `:node="root"` (single root object)              | `:nodes="[root]"` (array of roots)             |
+| internal per-node collapse                       | `v-model:expanded` (array of keys)             |
+| `:options="{ rowHeight, indentWidth }"`          | `--tree-row-height` / `--tree-indent` CSS vars |
+| `:options="{ showIndentationGuides }"`           | `guides="connectors" \| "lines" \| "none"`     |
+| `:options="{ defaultCollapsed: true }"`          | `defaultExpanded` (inverted)                   |
+| `#node="{ node, isCollapsed, toggleCollapsed }"` | `#item="{ node, expanded, toggle, … }"`        |
+| `#label`                                         | `#item-label`                                  |
+| `#icon`                                          | built-in chevron; override via `#item`         |
+
+```vue
+<!-- Before -->
+<Tree :node="root" node-key="name" :options="{ defaultCollapsed: false }">
+  <template #label="{ node }">{{ node.title }}</template>
+</Tree>
+
+<!-- After -->
+<Tree :nodes="[root]" node-key="name" default-expanded>
+  <template #item-label="{ node }">{{ node.title }}</template>
+</Tree>
+```
+
+Drag-and-drop is opt-in: set `draggable`, gate drops with
+`:move="({ node, target, position }) => …"`, and persist from
+`@drag-end="(info) => …"` — `info` is
+`{ node, from, to, position, oldIndex, newIndex }`, or `null` when the drag is
+cancelled.
 
 ## Icons
 
@@ -127,8 +164,10 @@ Replace `FeatherIcon` and Feather-name strings with `lucide-*` strings or a
 `Component`:
 
 ```vue
-<!-- Before -->        <Button icon="plus" />
-<!-- After -->         <Button icon="lucide-plus" />
+<!-- Before -->
+<Button icon="plus" />
+<!-- After -->
+<Button icon="lucide-plus" />
 ```
 
 Same for icon-name strings in `Dropdown` options:
@@ -155,10 +194,10 @@ Review the output, then run it without `--dry-run`:
 npx --package frappe-ui@beta tokens-v2 .
 ```
 
-The codemod renames espresso color tokens like `bg-surface-white` to `bg-surface-base`
-and merges static text size + weight class pairs, for example `text-base font-medium`
-to `text-base-medium`. Run it once per codebase; the token migration is not idempotent
-because some v2 names overlap with v0 names.
+The codemod renames espresso color tokens like `bg-surface-white` to
+`bg-surface-base` and merges static text size + weight class pairs, for example
+`text-base font-medium` to `text-base-medium`. Run it once per codebase; the
+token migration is not idempotent because some v2 names overlap with v0 names.
 
 ## Editor
 
@@ -174,41 +213,54 @@ and recipes.
 // Before
 import { TextEditor, TextEditorFixedMenu } from 'frappe-ui'
 // After
-import { Editor, EditorFixedMenu, RichTextKit, articleToolbar } from 'frappe-ui/editor'
+import {
+  Editor,
+  EditorFixedMenu,
+  RichTextKit,
+  articleToolbar,
+} from 'frappe-ui/editor'
 ```
 
-| Before                                          | After                                                            |
-| ----------------------------------------------- | ---------------------------------------------------------------- |
-| `import … from 'frappe-ui'`                     | `import … from 'frappe-ui/editor'`                               |
-| `<TextEditor>`                                  | `<Editor>`                                                       |
-| `:content="x" @change="x = $event"`             | `v-model="x"` (`@change` still emitted)                          |
-| HTML string only                                | `v-model` + `format="json"` for a JSON value                     |
-| `:starterkit-options="{ heading: { levels } }"` | `RichTextKit.configure({ heading: { levels } })` in `:extensions`|
+| Before                                          | After                                                                    |
+| ----------------------------------------------- | ------------------------------------------------------------------------ |
+| `import … from 'frappe-ui'`                     | `import … from 'frappe-ui/editor'`                                       |
+| `<TextEditor>`                                  | `<Editor>`                                                               |
+| `:content="x" @change="x = $event"`             | `v-model="x"` (`@change` still emitted)                                  |
+| HTML string only                                | `v-model` + `format="json"` for a JSON value                             |
+| `:starterkit-options="{ heading: { levels } }"` | `RichTextKit.configure({ heading: { levels } })` in `:extensions`        |
 | auto-loaded extension set (no opt-out)          | explicit `:extensions` — pick `CommentKit` / `RichTextKit` / `InlineKit` |
-| `:mentions` / `:tags` props                     | `kit.configure({ mention: { items, component }, tag: { items } })` |
-| `:bubble-menu="true"`                           | `<EditorBubbleMenu :items="articleToolbar">` in the default slot |
-| `:floating-menu="true"`                         | `<EditorFloatingMenu :items>`                                    |
-| `<TextEditorFixedMenu :buttons>`                | `<EditorFixedMenu :items>`                                       |
-| `<TextEditorContent>`                           | `<EditorContent>`                                                |
-| menu `:buttons`                                 | menu `:items`                                                    |
-| hand-rolled `textEditorMenuButtons` array       | `commentToolbar` / `articleToolbar` / `minimalToolbar` presets   |
-| `#top` / `#bottom` / `#editor` slots            | one default slot — you render `EditorContent` + menus yourself   |
-| `:uploadFunction` (optional, frappe default)    | `:upload-function` (required to enable uploads)                  |
+| `:mentions` / `:tags` props                     | `kit.configure({ mention: { items, component }, tag: { items } })`       |
+| `:bubble-menu="true"`                           | `<EditorBubbleMenu :items="articleToolbar">` in the default slot         |
+| `:floating-menu="true"`                         | `<EditorFloatingMenu :items>`                                            |
+| `<TextEditorFixedMenu :buttons>`                | `<EditorFixedMenu :items>`                                               |
+| `<TextEditorContent>`                           | `<EditorContent>`                                                        |
+| menu `:buttons`                                 | menu `:items`                                                            |
+| hand-rolled `textEditorMenuButtons` array       | `commentToolbar` / `articleToolbar` / `minimalToolbar` presets           |
+| `#top` / `#bottom` / `#editor` slots            | one default slot — you render `EditorContent` + menus yourself           |
+| `:uploadFunction` (optional, frappe default)    | `:upload-function` (required to enable uploads)                          |
 
 ### Compose, don't configure
 
 v0 took every option as a prop on `<TextEditor>` and auto-loaded every
-extension. v1 renders no chrome of its own — you place the building blocks inside
-its default slot and they pick up the editor from context (the `:editor` prop is
-only needed when composing primitives without `<Editor>`):
+extension. v1 renders no chrome of its own — you place the building blocks
+inside its default slot and they pick up the editor from context (the `:editor`
+prop is only needed when composing primitives without `<Editor>`):
 
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Editor, EditorContent, EditorBubbleMenu, RichTextKit, articleToolbar } from 'frappe-ui/editor'
+import {
+  Editor,
+  EditorContent,
+  EditorBubbleMenu,
+  RichTextKit,
+  articleToolbar,
+} from 'frappe-ui/editor'
 
 const content = ref('')
-const extensions = [RichTextKit.configure({ heading: { levels: [2, 3, 4, 5, 6] } })]
+const extensions = [
+  RichTextKit.configure({ heading: { levels: [2, 3, 4, 5, 6] } }),
+]
 </script>
 
 <template>
@@ -219,11 +271,11 @@ const extensions = [RichTextKit.configure({ heading: { levels: [2, 3, 4, 5, 6] }
 </template>
 ```
 
-Pick the kit per surface: `CommentKit` (light — no table/toc/slash), `RichTextKit`
-(full document), `InlineKit` (single-line). Configure kit members in place rather
-than via props — e.g. mentions/tags through `kit.configure({ mention: {...}, tag: {...} })`.
-To keep the mention/tag nodes rendering but disable the live popups, pass
-`mention: { items: null }`.
+Pick the kit per surface: `CommentKit` (light — no table/toc/slash),
+`RichTextKit` (full document), `InlineKit` (single-line). Configure kit members
+in place rather than via props — e.g. mentions/tags through
+`kit.configure({ mention: {...}, tag: {...} })`. To keep the mention/tag nodes
+rendering but disable the live popups, pass `mention: { items: null }`.
 
 For a fully custom layout (e.g. a title `<textarea>` as a sibling of the body),
 skip `<Editor>` and drive `useEditor` yourself — see
@@ -239,8 +291,8 @@ skip `<Editor>` and drive `useEditor` yourself — see
 - **Uploads need an explicit handler.** v0 silently invoked the Frappe upload;
   v1 requires `:upload-function`. In a Frappe app:
   `(file) => useFileUpload().upload(file, {})`.
-- **TipTap must be v3.** The v1 editor is built on TipTap 3 — pin `@tiptap/core`,
-  `@tiptap/pm`, and `@tiptap/vue-3` to `^3`.
+- **TipTap must be v3.** The v1 editor is built on TipTap 3 — pin
+  `@tiptap/core`, `@tiptap/pm`, and `@tiptap/vue-3` to `^3`.
 
 ## Autocomplete (deprecated)
 
@@ -249,24 +301,24 @@ removed in a future major release. It merged single- and multi-select via the
 `multiple` boolean; v1 splits them: [`Combobox`](./components/combobox) for
 single, [`MultiSelect`](./components/multiselect) for multiple.
 
-The model value changes shape. `Autocomplete` took and emitted the full
-option object; the new components model the value only. `Combobox` is
-`string | null` and `MultiSelect` is `string[]`. To read the full option,
-listen to `Combobox`'s `@update:selected-option`.
+The model value changes shape. `Autocomplete` took and emitted the full option
+object; the new components model the value only. `Combobox` is `string | null`
+and `MultiSelect` is `string[]`. To read the full option, listen to `Combobox`'s
+`@update:selected-option`.
 
-| Before (`Autocomplete`)         | After                                   |
-| ------------------------------- | --------------------------------------- |
-| `:multiple="false"` (default)   | use `Combobox`                          |
-| `:multiple="true"`              | use `MultiSelect`                        |
-| `v-model` (option or value)     | `v-model` (value / value array)         |
-| `@change`                       | `@update:modelValue`                    |
-| grouped `{ group, items }`      | grouped `{ group, options }`            |
-| `placement` (string)            | `side` + `align`                        |
-| `:showFooter`                   | `#footer` slot (MultiSelect has built-in)|
-| `:bodyClasses`                  | `data-slot` CSS                         |
-| `:maxOptions`                   | no equivalent                           |
-| `#target`                       | `#trigger`                              |
-| `#prefix` / `#suffix` / `#item-*`| same (`#suffix` now replaces chevron)  |
+| Before (`Autocomplete`)           | After                                     |
+| --------------------------------- | ----------------------------------------- |
+| `:multiple="false"` (default)     | use `Combobox`                            |
+| `:multiple="true"`                | use `MultiSelect`                         |
+| `v-model` (option or value)       | `v-model` (value / value array)           |
+| `@change`                         | `@update:modelValue`                      |
+| grouped `{ group, items }`        | grouped `{ group, options }`              |
+| `placement` (string)              | `side` + `align`                          |
+| `:showFooter`                     | `#footer` slot (MultiSelect has built-in) |
+| `:bodyClasses`                    | `data-slot` CSS                           |
+| `:maxOptions`                     | no equivalent                             |
+| `#target`                         | `#trigger`                                |
+| `#prefix` / `#suffix` / `#item-*` | same (`#suffix` now replaces chevron)     |
 
 ```vue
 <!-- Before -->
@@ -274,7 +326,11 @@ listen to `Combobox`'s `@update:selected-option`.
 <!-- country === { label: 'India', value: 'in' } -->
 
 <!-- After -->
-<Combobox v-model="country" :options="countries" @update:model-value="onChange" />
+<Combobox
+  v-model="country"
+  :options="countries"
+  @update:model-value="onChange"
+/>
 <!-- country === 'in' -->
 ```
 
@@ -285,15 +341,15 @@ grep -rln '<Autocomplete\b' src --include='*.vue'   # find usages
 grep -rln ':multiple' src --include='*.vue'         # these become MultiSelect
 ```
 
-`FormControl` itself is not deprecated, but its `type="autocomplete"` value
-is. Switch to `type="combobox"`, or use the standalone
+`FormControl` itself is not deprecated, but its `type="autocomplete"` value is.
+Switch to `type="combobox"`, or use the standalone
 [`Combobox`](./components/combobox).
 
 ## FAQ
 
-**Will my CSS break?** Where structure changed, components expose `data-*`
-hooks (`data-slot`, `data-state`, `data-size`, `data-variant`). Audit
-selectors that targeted tags or classes.
+**Will my CSS break?** Where structure changed, components expose `data-*` hooks
+(`data-slot`, `data-state`, `data-size`, `data-variant`). Audit selectors that
+targeted tags or classes.
 
 **Report bugs:** [file an issue](https://github.com/frappe/frappe-ui/issues/new)
 with the `v1-beta` label. Include the component name, before/after code,

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -124,21 +124,22 @@ The legacy `Input` component is deprecated. Use
 ## Tree
 
 The Tree was rebuilt from a single recursive `node` renderer into a stateful
-forest. It takes a `nodes` array, drives expansion through `v-model:expanded`,
-and scopes its per-row slots as `#item-*`. The `options` blob and the per-node
-internal collapse state are gone and sizing moves to CSS variables. Keyboard
-navigation, `role="tree"` ARIA, and opt-in drag-and-drop are new.
+forest. It takes a `nodes` array and scopes its per-row slots as `#item-*`. Each
+node still owns its expansion via an `expanded` field, now defaulting to open —
+set `expanded: false` to collapse one (v0 used `defaultCollapsed`). The
+`options` blob is gone — sizing moves to CSS variables. Keyboard navigation,
+`role="tree"` ARIA, and opt-in drag-and-drop are new.
 
-| Before                                           | After                                          |
-| ------------------------------------------------ | ---------------------------------------------- |
-| `:node="root"` (single root object)              | `:nodes="[root]"` (array of roots)             |
-| internal per-node collapse                       | `v-model:expanded` (array of keys)             |
-| `:options="{ rowHeight, indentWidth }"`          | `--tree-row-height` / `--tree-indent` CSS vars |
-| `:options="{ showIndentationGuides }"`           | `guides="connectors" \| "lines" \| "none"`     |
-| `:options="{ defaultCollapsed: true }"`          | `defaultExpanded` (inverted)                   |
-| `#node="{ node, isCollapsed, toggleCollapsed }"` | `#item="{ node, expanded, toggle, … }"`        |
-| `#label`                                         | `#item-label`                                  |
-| `#icon`                                          | built-in chevron; override via `#item`         |
+| Before                                           | After                                                           |
+| ------------------------------------------------ | --------------------------------------------------------------- |
+| `:node="root"` (single root object)              | `:nodes="[root]"` (array of roots)                              |
+| `node.collapsed` / internal collapse             | `node.expanded` (inverted, on each node)                        |
+| `:options="{ rowHeight, indentWidth }"`          | `--tree-row-height` / `--tree-indent` CSS vars                  |
+| `:options="{ showIndentationGuides }"`           | `guides="connectors" \| "lines" \| "none"`                      |
+| `:options="{ defaultCollapsed: true }"`          | `expanded: false` per node, or `v-model:expanded` to toggle all |
+| `#node="{ node, isCollapsed, toggleCollapsed }"` | `#item="{ node, expanded, toggle, … }"`                         |
+| `#label`                                         | `#item-label`                                                   |
+| `#icon`                                          | built-in chevron; override via `#item`                          |
 
 ```vue
 <!-- Before -->
@@ -147,10 +148,13 @@ navigation, `role="tree"` ARIA, and opt-in drag-and-drop are new.
 </Tree>
 
 <!-- After -->
-<Tree :nodes="[root]" node-key="name" default-expanded>
+<Tree :nodes="[root]" node-key="name">
   <template #item-label="{ node }">{{ node.title }}</template>
 </Tree>
 ```
+
+`v-model:expanded` is a boolean expand/collapse-all switch (bind it to a
+button), not a per-node value.
 
 Drag-and-drop is opt-in: set `draggable`, gate drops with
 `:move="({ node, target, position }) => …"`, and persist from

--- a/src/components/Tree/Tree.api.md
+++ b/src/components/Tree/Tree.api.md
@@ -39,13 +39,6 @@
     default: '"connectors"'
   },
   {
-    name: 'defaultExpanded',
-    description: 'Start with every node expanded. A one-shot convenience that seeds the open\nset on first load (async-safe — it waits for `nodes` to arrive). To open\nspecific nodes or track expansion, use `v-model:expanded` instead; this is\nignored once you provide your own keys.',
-    required: false,
-    type: 'boolean',
-    default: 'false'
-  },
-  {
     name: 'disabled',
     description: 'Disable all interaction — expand/collapse and drag.',
     required: false,
@@ -54,10 +47,10 @@
   },
   {
     name: 'expanded',
-    description: 'The keys of the currently expanded nodes — the live source of truth for\nwhich rows are open. Controlled or uncontrolled. Use `defaultExpanded` only\nfor the simple "start fully expanded" case.',
+    description: 'Expand/collapse-all switch. Toggling it writes that value into every node\'s\n`expanded` field. Two-way: it also reflects whether all collapsible nodes are\ncurrently open, so a bound button stays in sync. Per-node state lives on the\nnodes themselves (`node.expanded`).',
     required: false,
-    type: 'TreeKey[]',
-    default: '[]'
+    type: 'boolean',
+    default: 'false'
   }
 ]
 
@@ -93,7 +86,7 @@
   {
     name: 'update:expanded',
     description: 'Fired when the expanded changes.',
-    type: '[value: TreeKey[]]'
+    type: '[value: boolean]'
   },
   {
     name: 'drag-start',

--- a/src/components/Tree/Tree.api.md
+++ b/src/components/Tree/Tree.api.md
@@ -20,23 +20,16 @@
   },
   {
     name: 'draggable',
-    description: 'Enable drag-and-drop. Each node becomes draggable and can be dropped onto\nanother node to reparent it.',
+    description: 'Enable drag-and-drop. Nodes can be dragged onto one another to reparent, or\nbetween siblings to reorder.',
     required: false,
     type: 'boolean',
     default: 'false'
   },
   {
-    name: 'canDrop',
-    description: 'Gate every drop. Receives the drag context and returns whether the drop is\nallowed. Built-in guards (drop-on-self, drop-into-descendant) run first.',
+    name: 'move',
+    description: 'Gate a drop while dragging. Receives the live drag context and returns\nwhether the drop is allowed — a rejected target shows the no-drop cursor and\nhides the drop indicator. Built-in guards (drop-on-self, drop-into-own-\ndescendant) run first, so this only carries your domain rules.',
     required: false,
-    type: '((ctx: DropContext) => boolean)'
-  },
-  {
-    name: 'reorderable',
-    description: 'Allow dropping `before`/`after` a sibling to reorder, in addition to\ndropping `inside` to reparent.',
-    required: false,
-    type: 'boolean',
-    default: 'false'
+    type: '((ctx: MoveContext) => boolean)'
   },
   {
     name: 'guides',
@@ -54,7 +47,7 @@
   },
   {
     name: 'disabled',
-    description: 'Disable all interaction — expand/collapse, selection and drag.',
+    description: 'Disable all interaction — expand/collapse and drag.',
     required: false,
     type: 'boolean',
     default: 'false'
@@ -65,13 +58,6 @@
     required: false,
     type: 'TreeKey[]',
     default: '[]'
-  },
-  {
-    name: 'selected',
-    description: '',
-    required: false,
-    type: 'TreeKey | null',
-    default: 'null'
   }
 ]
 
@@ -84,7 +70,7 @@
   {
     name: 'label',
     description: '',
-    type: 'Omit<TreeNodeSlotProps, "disabled" | "toggle" | "select" | "focused">'
+    type: 'Omit<TreeNodeSlotProps, "disabled" | "toggle" | "focused">'
   },
   {
     name: 'prefix',
@@ -94,7 +80,7 @@
   {
     name: 'suffix',
     description: '',
-    type: '{ node: TreeNode; selected: boolean; }'
+    type: '{ node: TreeNode; }'
   },
   {
     name: 'empty',
@@ -110,14 +96,14 @@
     type: '[value: TreeKey[]]'
   },
   {
-    name: 'update:selected',
-    description: 'Fired when the selected changes.',
-    type: '[value: TreeKey | null]'
+    name: 'drag-start',
+    description: '',
+    type: '[node: TreeNode]'
   },
   {
-    name: 'move',
+    name: 'drag-end',
     description: '',
-    type: '[move: MoveEvent]'
+    type: '[info: DropInfo | null]'
   }
 ]
 </script>

--- a/src/components/Tree/Tree.api.md
+++ b/src/components/Tree/Tree.api.md
@@ -6,41 +6,146 @@
 
   const propsData = [
   {
-    name: 'node',
-    description: 'Root tree node to render.\nCan contain nested children to form the tree structure.',
+    name: 'nodes',
+    description: 'Forest roots to render. Each node may contain nested children to form the\ntree structure.',
     required: true,
-    type: 'TreeNode'
+    type: 'TreeNode[]'
   },
   {
     name: 'nodeKey',
-    description: 'Unique key used to identify each node.\nUsually an id-like property present on every node.',
-    required: true,
-    type: 'string'
+    description: 'Name of the field that uniquely identifies each node.',
+    required: false,
+    type: 'string',
+    default: '"key"'
   },
   {
-    name: 'options',
-    description: 'Optional configuration for tree layout and behavior.',
+    name: 'labelKey',
+    description: 'Name of the field holding the node\'s display label.',
     required: false,
-    type: 'TreeOptions',
-    default: '{\n    rowHeight: "25px",\n    indentWidth: "20px",\n    showIndentationGuides: true,\n    defaultCollapsed: true,\n}'
+    type: 'string',
+    default: '"label"'
+  },
+  {
+    name: 'childrenKey',
+    description: 'Name of the field holding the node\'s children array.',
+    required: false,
+    type: 'string',
+    default: '"children"'
+  },
+  {
+    name: 'draggable',
+    description: 'Enable drag-and-drop. Each node becomes draggable and can be dropped onto\nanother node to reparent it.',
+    required: false,
+    type: 'boolean',
+    default: 'false'
+  },
+  {
+    name: 'canDrop',
+    description: 'Gate every drop. Receives the drag context and returns whether the drop is\nallowed. Built-in guards (drop-on-self, drop-into-descendant) run first.',
+    required: false,
+    type: '((ctx: DropContext) => boolean)'
+  },
+  {
+    name: 'reorderable',
+    description: 'Allow dropping `before`/`after` a sibling to reorder, in addition to\ndropping `inside` to reparent.',
+    required: false,
+    type: 'boolean',
+    default: 'false'
+  },
+  {
+    name: 'guides',
+    description: 'Visual style of the indentation guides.',
+    required: false,
+    type: '"connectors" | "lines" | "none"',
+    default: '"connectors"'
+  },
+  {
+    name: 'rowHeight',
+    description: 'Height of each tree row, e.g. "32px".',
+    required: false,
+    type: 'string',
+    default: '"32px"'
+  },
+  {
+    name: 'indent',
+    description: 'Horizontal indentation per tree level, e.g. "28px".',
+    required: false,
+    type: 'string',
+    default: '"28px"'
+  },
+  {
+    name: 'defaultExpanded',
+    description: 'Initial expansion state of nodes when `v-model:expanded` is not bound.',
+    required: false,
+    type: 'boolean',
+    default: 'false'
+  },
+  {
+    name: 'disabled',
+    description: 'Disable all interaction — expand/collapse, selection and drag.',
+    required: false,
+    type: 'boolean',
+    default: 'false'
+  },
+  {
+    name: 'expanded',
+    description: '',
+    required: false,
+    type: 'TreeKey[]',
+    default: '[]'
+  },
+  {
+    name: 'selected',
+    description: '',
+    required: false,
+    type: 'TreeKey | null',
+    default: 'null'
   }
 ]
 
   const slotsData = [
   {
     name: 'node',
-    description: 'Slot to fully override how a tree node renders',
-    type: 'any'
-  },
-  {
-    name: 'icon',
-    description: 'Slot to override only the node expand/collapse icon',
-    type: 'any'
+    description: '',
+    type: 'TreeNodeSlotProps'
   },
   {
     name: 'label',
-    description: 'Slot to override only the node label/content',
+    description: '',
+    type: 'Omit<TreeNodeSlotProps, "disabled" | "toggle" | "select" | "focused">'
+  },
+  {
+    name: 'prefix',
+    description: '',
+    type: '{ node: TreeNode; expanded: boolean; hasChildren: boolean; }'
+  },
+  {
+    name: 'suffix',
+    description: '',
+    type: '{ node: TreeNode; selected: boolean; }'
+  },
+  {
+    name: 'empty',
+    description: '',
     type: 'any'
+  }
+]
+
+  const emitsData = [
+  {
+    name: 'update:expanded',
+    description: 'Fired when the expanded changes.',
+    type: '[value: TreeKey[]]'
+  },
+  {
+    name: 'update:selected',
+    description: 'Fired when the selected changes.',
+    type: '[value: TreeKey | null]'
+  },
+  {
+    name: 'move',
+    description: '',
+    type: '[move: MoveEvent]'
   }
 ]
 </script>
@@ -49,4 +154,6 @@
 <PropsTable name="Tree" :data="propsData"/> 
 
 <SlotsTable :data="slotsData"/> 
+
+<EmitsTable :data="emitsData"/> 
 

--- a/src/components/Tree/Tree.api.md
+++ b/src/components/Tree/Tree.api.md
@@ -63,24 +63,24 @@
 
   const slotsData = [
   {
-    name: 'node',
+    name: 'item',
     description: '',
     type: 'TreeNodeSlotProps'
   },
   {
-    name: 'label',
+    name: 'item-prefix',
     description: '',
-    type: 'Omit<TreeNodeSlotProps, "disabled" | "toggle" | "focused">'
+    type: 'Omit<TreeNodeSlotProps, "toggle">'
   },
   {
-    name: 'prefix',
+    name: 'item-label',
     description: '',
-    type: '{ node: TreeNode; expanded: boolean; hasChildren: boolean; }'
+    type: 'Omit<TreeNodeSlotProps, "toggle">'
   },
   {
-    name: 'suffix',
+    name: 'item-suffix',
     description: '',
-    type: '{ node: TreeNode; }'
+    type: 'Omit<TreeNodeSlotProps, "toggle">'
   },
   {
     name: 'empty',

--- a/src/components/Tree/Tree.api.md
+++ b/src/components/Tree/Tree.api.md
@@ -40,7 +40,7 @@
   },
   {
     name: 'defaultExpanded',
-    description: 'Initial expansion state of nodes when `v-model:expanded` is not bound.',
+    description: 'Start with every node expanded. A one-shot convenience that seeds the open\nset on first load (async-safe — it waits for `nodes` to arrive). To open\nspecific nodes or track expansion, use `v-model:expanded` instead; this is\nignored once you provide your own keys.',
     required: false,
     type: 'boolean',
     default: 'false'
@@ -54,7 +54,7 @@
   },
   {
     name: 'expanded',
-    description: '',
+    description: 'The keys of the currently expanded nodes — the live source of truth for\nwhich rows are open. Controlled or uncontrolled. Use `defaultExpanded` only\nfor the simple "start fully expanded" case.',
     required: false,
     type: 'TreeKey[]',
     default: '[]'

--- a/src/components/Tree/Tree.api.md
+++ b/src/components/Tree/Tree.api.md
@@ -19,20 +19,6 @@
     default: '"key"'
   },
   {
-    name: 'labelKey',
-    description: 'Name of the field holding the node\'s display label.',
-    required: false,
-    type: 'string',
-    default: '"label"'
-  },
-  {
-    name: 'childrenKey',
-    description: 'Name of the field holding the node\'s children array.',
-    required: false,
-    type: 'string',
-    default: '"children"'
-  },
-  {
     name: 'draggable',
     description: 'Enable drag-and-drop. Each node becomes draggable and can be dropped onto\nanother node to reparent it.',
     required: false,
@@ -58,20 +44,6 @@
     required: false,
     type: '"connectors" | "lines" | "none"',
     default: '"connectors"'
-  },
-  {
-    name: 'rowHeight',
-    description: 'Height of each tree row, e.g. "32px".',
-    required: false,
-    type: 'string',
-    default: '"32px"'
-  },
-  {
-    name: 'indent',
-    description: 'Horizontal indentation per tree level, e.g. "28px".',
-    required: false,
-    type: 'string',
-    default: '"28px"'
   },
   {
     name: 'defaultExpanded',

--- a/src/components/Tree/Tree.md
+++ b/src/components/Tree/Tree.md
@@ -10,12 +10,22 @@ The simplest tree — pass `nodes` and tell it which field is the key.
 
 <ComponentPreview name="Tree-Example" />
 
+## Indentation guides
+
+`guides` controls how nesting is drawn: `connectors` (elbow lines), `lines`
+(plain vertical rules), or `none`. The indentation itself stays either way —
+`guides` only changes the lines.
+
+<ComponentPreview name="Tree-Guides" />
+
 ## Drag and drop
 
 Set `draggable` to let nodes be dragged onto one another to reparent, or between
 siblings to reorder. A `move` predicate gates where drops are allowed (here,
 only into folders), and `@drag-end` hands you the committed move to persist.
 This example is fully working — drag a file into a folder and it stays there.
+Flip **Disable interaction** to see the `disabled` state freeze drag and
+expand/collapse.
 
 <ComponentPreview name="Tree-DragDrop" />
 
@@ -65,9 +75,14 @@ remapping.
 
 ## Expansion
 
-`v-model:expanded` holds the array of expanded node keys (controlled or
-uncontrolled). When unbound, `defaultExpanded` seeds the initial state. Leave it
-unbound and the tree manages expansion internally.
+Two inputs affect which rows are open — reach for **one**:
+
+- **`v-model:expanded`** — the array of open node keys, and the source of truth.
+  Bind it to control or observe expansion; leave it unbound and the tree tracks
+  the set internally. This is the one you want in most cases.
+- **`defaultExpanded`** — a boolean shortcut for "start with everything open."
+  It seeds `expanded` once on first load (and waits for async `nodes`), then
+  steps aside — it does nothing once you provide your own `expanded` keys.
 
 Clicking a row, or pressing `Enter`/`Space` on it, toggles expansion.
 

--- a/src/components/Tree/Tree.md
+++ b/src/components/Tree/Tree.md
@@ -7,7 +7,8 @@ guides visually link parents to their children.
 ## Default
 
 The simplest tree — pass `nodes` and tell it which field is the key. Nodes are
-expanded by default; set `expanded: false` on one to start it collapsed.
+expanded by default; here **Documents** carries `expanded: false` to start
+collapsed.
 
 <ComponentPreview name="Tree-Example" />
 

--- a/src/components/Tree/Tree.md
+++ b/src/components/Tree/Tree.md
@@ -6,9 +6,18 @@ guides visually link parents to their children.
 
 ## Default
 
-The simplest tree — pass `nodes` and tell it which field is the key.
+The simplest tree — pass `nodes` and tell it which field is the key. Nodes are
+expanded by default; set `expanded: false` on one to start it collapsed.
 
 <ComponentPreview name="Tree-Example" />
+
+## Expand / collapse all
+
+Bind `v-model:expanded` to a boolean for a master switch — toggling it opens or
+closes every node. It's two-way, so it also reflects whether all nodes are
+currently open as the user toggles rows individually.
+
+<ComponentPreview name="Tree-ExpandAll" />
 
 ## Indentation guides
 
@@ -55,11 +64,10 @@ const nodes = ref([
     ],
   },
 ])
-const expanded = ref(['src'])
 </script>
 
 <template>
-  <Tree :nodes="nodes" node-key="name" v-model:expanded="expanded" />
+  <Tree :nodes="nodes" node-key="name" />
 </template>
 ```
 
@@ -75,16 +83,16 @@ remapping.
 
 ## Expansion
 
-Two inputs affect which rows are open — reach for **one**:
+Each node owns its own state via an `expanded` field — the source of truth the
+tree reads and writes as rows toggle, so expansion travels with your data. Nodes
+are **expanded by default**; set `expanded: false` to start one collapsed.
 
-- **`v-model:expanded`** — the array of open node keys, and the source of truth.
-  Bind it to control or observe expansion; leave it unbound and the tree tracks
-  the set internally. This is the one you want in most cases.
-- **`defaultExpanded`** — a boolean shortcut for "start with everything open."
-  It seeds `expanded` once on first load (and waits for async `nodes`), then
-  steps aside — it does nothing once you provide your own `expanded` keys.
+`v-model:expanded` is a separate, optional boolean **switch** for the whole
+tree: toggle it to open or close everything at once (see
+[Expand / collapse all](#expand-collapse-all)). It's two-way, reflecting whether
+all nodes are currently open.
 
-Clicking a row, or pressing `Enter`/`Space` on it, toggles expansion.
+Clicking a row, or pressing `Enter`/`Space` on it, toggles that node.
 
 ## Keyboard
 

--- a/src/components/Tree/Tree.md
+++ b/src/components/Tree/Tree.md
@@ -21,9 +21,10 @@ This example is fully working — drag a file into a folder and it stays there.
 
 ## List view with avatars and row actions
 
-Use the `#prefix`, `#label`, and `#suffix` slots to turn the tree into a rich
-list — an avatar on the left, a two-line label, and a row action (an add button)
-on the right. `guides="none"` drops the connector lines for a plain list look.
+Use the `#item-prefix`, `#item-label`, and `#item-suffix` slots to turn the tree
+into a rich list — an avatar on the left, a two-line label, and a row action (an
+add button) on the right. `guides="none"` drops the connector lines for a plain
+list look.
 
 <ComponentPreview name="Tree-ListView" />
 
@@ -59,7 +60,7 @@ Each node is a plain object with a `label` (display text) and optional
 `name`). A node is a leaf when `children` is missing or empty. Extra fields are
 passed through to the slots, so you can render avatars, roles, badges, etc.
 
-To display a field other than `label`, use the `#label` slot rather than
+To display a field other than `label`, use the `#item-label` slot rather than
 remapping.
 
 ## Expansion
@@ -107,10 +108,10 @@ final index within its new parent, already accounting for its removal.
 
 ## Customizing rows
 
-Use the `#node` slot to fully replace a row (you receive `toggle` plus state),
-or the lighter `#label`, `#prefix`, and `#suffix` slots to keep the default
-layout. Style via the `data-slot`, `data-state`, `data-drop` and `data-level`
-attributes rather than class props.
+Use the `#item` slot to fully replace a row (you receive `toggle` plus state),
+or the lighter `#item-label`, `#item-prefix`, and `#item-suffix` slots to keep
+the default layout. Style via the `data-slot`, `data-state`, `data-drop` and
+`data-level` attributes rather than class props.
 
 Row height and indentation are CSS variables — override them in CSS rather than
 through props:

--- a/src/components/Tree/Tree.md
+++ b/src/components/Tree/Tree.md
@@ -1,9 +1,8 @@
 # Tree
 
 Displays hierarchical data as a collapsible tree. Renders a forest of roots with
-keyboard navigation, optional single-selection, and optional drag-and-drop
-reparenting/reordering. Connector guides visually link parents to their
-children.
+keyboard navigation and optional drag-and-drop reparenting/reordering. Connector
+guides visually link parents to their children.
 
 ## Default
 
@@ -13,18 +12,18 @@ The simplest tree — pass `nodes` and tell it which field is the key.
 
 ## Drag and drop
 
-Set `draggable` to let nodes be dragged onto one another to reparent. A
-`canDrop` validator gates where drops are allowed, and `@move` reports the
-change for you to persist.
+Set `draggable` to let nodes be dragged onto one another to reparent, or between
+siblings to reorder. A `move` predicate gates where drops are allowed (here,
+only into folders), and `@drag-end` hands you the committed move to persist.
+This example is fully working — drag a file into a folder and it stays there.
 
 <ComponentPreview name="Tree-DragDrop" />
 
 ## List view with avatars and row actions
 
 Use the `#prefix`, `#label`, and `#suffix` slots to turn the tree into a rich
-list — an avatar on the left, a two-line label, and a row action (an add
-button) on the right. `guides="none"` drops the connector lines for a plain
-list look.
+list — an avatar on the left, a two-line label, and a row action (an add button)
+on the right. `guides="none"` drops the connector lines for a plain list look.
 
 <ComponentPreview name="Tree-ListView" />
 
@@ -46,16 +45,10 @@ const nodes = ref([
   },
 ])
 const expanded = ref(['src'])
-const selected = ref(null)
 </script>
 
 <template>
-  <Tree
-    :nodes="nodes"
-    node-key="name"
-    v-model:expanded="expanded"
-    v-model:selected="selected"
-  />
+  <Tree :nodes="nodes" node-key="name" v-model:expanded="expanded" />
 </template>
 ```
 
@@ -69,45 +62,55 @@ passed through to the slots, so you can render avatars, roles, badges, etc.
 To display a field other than `label`, use the `#label` slot rather than
 remapping.
 
-## Expansion & selection
+## Expansion
 
-- `v-model:expanded` holds the array of expanded node keys (controlled or
-  uncontrolled). When unbound, `defaultExpanded` seeds the initial state.
-- `v-model:selected` holds the single selected key, or `null`.
+`v-model:expanded` holds the array of expanded node keys (controlled or
+uncontrolled). When unbound, `defaultExpanded` seeds the initial state. Leave it
+unbound and the tree manages expansion internally.
 
-Both are optional — leave them unbound and the tree manages state internally.
+Clicking a row, or pressing `Enter`/`Space` on it, toggles expansion.
 
 ## Keyboard
 
-Following the WAI-ARIA Tree View pattern: `↑`/`↓` move between visible rows,
-`→` expands or steps into children, `←` collapses or steps to the parent,
-`Home`/`End` jump to the first/last row, `Enter`/`Space` select, and typing
-letters jumps to the next matching label.
+Following the WAI-ARIA Tree View pattern: `↑`/`↓` move between visible rows, `→`
+expands or steps into children, `←` collapses or steps to the parent,
+`Home`/`End` jump to the first/last row, `Enter`/`Space` toggle expansion, and
+typing letters jumps to the next matching label.
 
 ## Drag and drop
 
-Set `draggable` to let nodes be dragged onto one another to reparent. Provide a
-`canDrop(ctx)` validator to gate drops — built-in guards already reject
-drop-on-self and drop-into-own-descendant. Enable `reorderable` to also allow
-`before`/`after` sibling drops. A valid drop emits `move`; the consumer persists
-the change and updates `nodes`.
+Set `draggable` to enable dragging. The tree resolves the drop position from the
+cursor (`before` / `inside` / `after`) and shows a live indicator.
+
+- `move(ctx)` — an optional predicate called as you hover. Return `false` to
+  reject a target (it shows the no-drop cursor and hides the indicator).
+  Built-in guards already reject drop-on-self and drop-into-own-descendant, so
+  `move` only carries your domain rules. `ctx` is `{ node, target, position }`.
+- `@drag-start(node)` — fires when a drag is picked up.
+- `@drag-end(info)` — fires when the drag ends. `info` is a `DropInfo` on a
+  committed move, or `null` if the drag was cancelled. Apply it to your data and
+  update `nodes`.
 
 ```vue
 <Tree
   :nodes="nodes"
   node-key="name"
   draggable
-  :can-drop="({ node, target }) => target.name !== 'locked'"
-  @move="onMove"
+  :move="({ node, target, position }) => Array.isArray(target.children)"
+  @drag-end="onDragEnd"
 />
 ```
 
+`DropInfo` is `{ node, from, to, position, oldIndex, newIndex }` — `from`/`to`
+are the old/new parent keys (`null` at root level) and `newIndex` is the node's
+final index within its new parent, already accounting for its removal.
+
 ## Customizing rows
 
-Use the `#node` slot to fully replace a row (you receive `toggle` and `select`
-plus state), or the lighter `#label`, `#prefix`, and `#suffix` slots to keep the
-default layout. Style via the `data-slot`, `data-state`, `data-selected`,
-`data-drop` and `data-level` attributes rather than class props.
+Use the `#node` slot to fully replace a row (you receive `toggle` plus state),
+or the lighter `#label`, `#prefix`, and `#suffix` slots to keep the default
+layout. Style via the `data-slot`, `data-state`, `data-drop` and `data-level`
+attributes rather than class props.
 
 Row height and indentation are CSS variables — override them in CSS rather than
 through props:
@@ -115,7 +118,7 @@ through props:
 ```css
 .my-tree {
   --tree-row-height: 40px;
-  --tree-indent: 20px;
+  --tree-indent: 24px;
 }
 ```
 

--- a/src/components/Tree/Tree.md
+++ b/src/components/Tree/Tree.md
@@ -7,7 +7,17 @@ children.
 
 ## Default
 
+The simplest tree — pass `nodes` and tell it which field is the key.
+
 <ComponentPreview name="Tree-Example" />
+
+## Drag and drop
+
+Set `draggable` to let nodes be dragged onto one another to reparent. A
+`canDrop` validator gates where drops are allowed, and `@move` reports the
+change for you to persist.
+
+<ComponentPreview name="Tree-DragDrop" />
 
 ## List view with avatars and row actions
 

--- a/src/components/Tree/Tree.md
+++ b/src/components/Tree/Tree.md
@@ -12,9 +12,9 @@ children.
 ## List view with avatars and row actions
 
 Use the `#prefix`, `#label`, and `#suffix` slots to turn the tree into a rich
-list — an avatar on the left, a two-line label, and row actions (an add button
-and a navigate chevron) on the right. `guides="none"` drops the connector lines
-for a plain list look.
+list — an avatar on the left, a two-line label, and a row action (an add
+button) on the right. `guides="none"` drops the connector lines for a plain
+list look.
 
 <ComponentPreview name="Tree-ListView" />
 

--- a/src/components/Tree/Tree.md
+++ b/src/components/Tree/Tree.md
@@ -61,10 +61,13 @@ const selected = ref(null)
 
 ## Node shape
 
-Each node is a plain object. The field names for its **id**, **label** and
-**children** are configurable via the `nodeKey`, `labelKey` and `childrenKey`
-props, so existing records can be rendered without remapping. A node is a leaf
-when its children field is missing or empty.
+Each node is a plain object with a `label` (display text) and optional
+`children`. Its unique id lives under the field named by `nodeKey` (e.g.
+`name`). A node is a leaf when `children` is missing or empty. Extra fields are
+passed through to the slots, so you can render avatars, roles, badges, etc.
+
+To display a field other than `label`, use the `#label` slot rather than
+remapping.
 
 ## Expansion & selection
 
@@ -105,5 +108,15 @@ Use the `#node` slot to fully replace a row (you receive `toggle` and `select`
 plus state), or the lighter `#label`, `#prefix`, and `#suffix` slots to keep the
 default layout. Style via the `data-slot`, `data-state`, `data-selected`,
 `data-drop` and `data-level` attributes rather than class props.
+
+Row height and indentation are CSS variables — override them in CSS rather than
+through props:
+
+```css
+.my-tree {
+  --tree-row-height: 40px;
+  --tree-indent: 20px;
+}
+```
 
 <!-- @include: ./Tree.api.md -->

--- a/src/components/Tree/Tree.md
+++ b/src/components/Tree/Tree.md
@@ -1,8 +1,99 @@
 # Tree
 
-Displays hierarchical data in a collapsible tree structure. Makes it easy to navigate nested items and manage complex relationships.
+Displays hierarchical data as a collapsible tree. Renders a forest of roots with
+keyboard navigation, optional single-selection, and optional drag-and-drop
+reparenting/reordering. Connector guides visually link parents to their
+children.
 
-## Default 
+## Default
+
 <ComponentPreview name="Tree-Example" />
+
+## List view with avatars and row actions
+
+Use the `#prefix`, `#label`, and `#suffix` slots to turn the tree into a rich
+list — an avatar on the left, a two-line label, and row actions (an add button
+and a navigate chevron) on the right. `guides="none"` drops the connector lines
+for a plain list look.
+
+<ComponentPreview name="Tree-ListView" />
+
+## Usage
+
+```vue
+<script setup>
+import { ref } from 'vue'
+import { Tree } from 'frappe-ui'
+
+const nodes = ref([
+  {
+    name: 'src',
+    label: 'src',
+    children: [
+      { name: 'index.ts', label: 'index.ts' },
+      { name: 'app.vue', label: 'app.vue' },
+    ],
+  },
+])
+const expanded = ref(['src'])
+const selected = ref(null)
+</script>
+
+<template>
+  <Tree
+    :nodes="nodes"
+    node-key="name"
+    v-model:expanded="expanded"
+    v-model:selected="selected"
+  />
+</template>
+```
+
+## Node shape
+
+Each node is a plain object. The field names for its **id**, **label** and
+**children** are configurable via the `nodeKey`, `labelKey` and `childrenKey`
+props, so existing records can be rendered without remapping. A node is a leaf
+when its children field is missing or empty.
+
+## Expansion & selection
+
+- `v-model:expanded` holds the array of expanded node keys (controlled or
+  uncontrolled). When unbound, `defaultExpanded` seeds the initial state.
+- `v-model:selected` holds the single selected key, or `null`.
+
+Both are optional — leave them unbound and the tree manages state internally.
+
+## Keyboard
+
+Following the WAI-ARIA Tree View pattern: `↑`/`↓` move between visible rows,
+`→` expands or steps into children, `←` collapses or steps to the parent,
+`Home`/`End` jump to the first/last row, `Enter`/`Space` select, and typing
+letters jumps to the next matching label.
+
+## Drag and drop
+
+Set `draggable` to let nodes be dragged onto one another to reparent. Provide a
+`canDrop(ctx)` validator to gate drops — built-in guards already reject
+drop-on-self and drop-into-own-descendant. Enable `reorderable` to also allow
+`before`/`after` sibling drops. A valid drop emits `move`; the consumer persists
+the change and updates `nodes`.
+
+```vue
+<Tree
+  :nodes="nodes"
+  node-key="name"
+  draggable
+  :can-drop="({ node, target }) => target.name !== 'locked'"
+  @move="onMove"
+/>
+```
+
+## Customizing rows
+
+Use the `#node` slot to fully replace a row (you receive `toggle` and `select`
+plus state), or the lighter `#label`, `#prefix`, and `#suffix` slots to keep the
+default layout. Style via the `data-slot`, `data-state`, `data-selected`,
+`data-drop` and `data-level` attributes rather than class props.
 
 <!-- @include: ./Tree.api.md -->

--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -10,13 +10,13 @@
     @focusin="onFocusin"
   >
     <TreeItem
-      v-for="(node, index) in nodes"
+      v-for="(node, index) in roots"
       :key="keyOf(node)"
       :node="node"
       :parent="null"
       :level="1"
       :index="index"
-      :set-size="nodes.length"
+      :set-size="roots.length"
     >
       <template v-if="$slots.node" #node="p"
         ><slot name="node" v-bind="p"
@@ -32,7 +32,7 @@
       /></template>
     </TreeItem>
 
-    <li v-if="!nodes.length" role="none" data-slot="empty">
+    <li v-if="!roots.length" role="none" data-slot="empty">
       <slot name="empty" />
     </li>
   </ul>
@@ -127,11 +127,15 @@ const liveMessage = ref('')
 const itemEls = new Map<TreeKey, HTMLElement>()
 
 // --- node field accessors -------------------------------------------------
+const roots = computed(() => props.nodes ?? [])
 const keyOf = (node: TreeNode) => node[props.nodeKey] as TreeKey
 const labelOf = (node: TreeNode) => (node[props.labelKey] as string) ?? ''
 const childrenOf = (node: TreeNode) =>
   (node[props.childrenKey] as TreeNode[]) ?? []
 const hasChildren = (node: TreeNode) => childrenOf(node).length > 0
+// Siblings of a node: a parent's children, or the roots for top-level nodes.
+const siblingsOf = (parent: TreeNode | null) =>
+  parent ? childrenOf(parent) : roots.value
 
 // --- expansion ------------------------------------------------------------
 const expandedSet = computed(() => new Set(expanded.value))
@@ -172,8 +176,8 @@ function focus(key: TreeKey) {
 }
 
 function onFocusin() {
-  if (focusedKey.value == null && props.nodes.length)
-    focusedKey.value = keyOf(props.nodes[0])
+  if (focusedKey.value == null && roots.value.length)
+    focusedKey.value = keyOf(roots.value[0])
 }
 
 const registerItem = (key: TreeKey, el: HTMLElement) => itemEls.set(key, el)
@@ -201,7 +205,7 @@ const flat = computed(() => {
         walk(childrenOf(node), keyOf(node), level + 1)
     }
   }
-  walk(props.nodes, null, 1)
+  walk(roots.value, null, 1)
   return out
 })
 
@@ -209,6 +213,7 @@ const flat = computed(() => {
 const dragDrop = useTreeDragDrop({
   keyOf,
   childrenOf,
+  siblingsOf,
   labelOf,
   reorderable: toRef(props, 'reorderable'),
   disabled: toRef(props, 'disabled'),
@@ -242,7 +247,7 @@ const { onKeydown } = useTreeKeyboard({
 let seeded = false
 onMounted(() => {
   if (!seeded && props.defaultExpanded && expanded.value.length === 0) {
-    expanded.value = collectCollapsibleKeys(props.nodes)
+    expanded.value = collectCollapsibleKeys(roots.value)
   }
   seeded = true
 })

--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -91,6 +91,11 @@ defineSlots<{
   empty: () => unknown
 }>()
 
+/**
+ * The keys of the currently expanded nodes — the live source of truth for
+ * which rows are open. Controlled or uncontrolled. Use `defaultExpanded` only
+ * for the simple "start fully expanded" case.
+ */
 const expanded = defineModel<TreeKey[]>('expanded', { default: () => [] })
 
 const treeRef = ref<HTMLElement | null>(null)

--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -1,6 +1,7 @@
 <template>
   <ul
     ref="treeRef"
+    v-bind="$attrs"
     role="tree"
     class="frappe-tree select-none"
     :data-guides="guides"
@@ -66,6 +67,8 @@ import {
   type TreeNodeSlotProps,
   type TreeProps,
 } from './types'
+
+defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<TreeProps>(), {
   nodeKey: 'key',

--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -74,7 +74,6 @@ const props = withDefaults(defineProps<TreeProps>(), {
   nodeKey: 'key',
   draggable: false,
   guides: 'connectors',
-  defaultExpanded: false,
   disabled: false,
 })
 
@@ -92,11 +91,12 @@ defineSlots<{
 }>()
 
 /**
- * The keys of the currently expanded nodes — the live source of truth for
- * which rows are open. Controlled or uncontrolled. Use `defaultExpanded` only
- * for the simple "start fully expanded" case.
+ * Expand/collapse-all switch. Toggling it writes that value into every node's
+ * `expanded` field. Two-way: it also reflects whether all collapsible nodes are
+ * currently open, so a bound button stays in sync. Per-node state lives on the
+ * nodes themselves (`node.expanded`).
  */
-const expanded = defineModel<TreeKey[]>('expanded', { default: () => [] })
+const expanded = defineModel<boolean>('expanded', { default: false })
 
 const treeRef = ref<HTMLElement | null>(null)
 const focusedKey = ref<TreeKey | null>(null)
@@ -114,29 +114,53 @@ const siblingsOf = (parent: TreeNode | null) =>
   parent ? childrenOf(parent) : roots.value
 
 // --- expansion ------------------------------------------------------------
-const expandedSet = computed(() => new Set(expanded.value))
-const isExpanded = (node: TreeNode) => expandedSet.value.has(keyOf(node))
+// Per-node state lives on the node itself. Expanded by default — a node is only
+// closed when it explicitly carries `expanded: false`.
+const isExpanded = (node: TreeNode) => node.expanded !== false
 
 function setExpanded(node: TreeNode, value: boolean) {
   if (props.disabled || !hasChildren(node)) return
-  const key = keyOf(node)
-  const next = new Set(expanded.value)
-  value ? next.add(key) : next.delete(key)
-  expanded.value = [...next]
+  node.expanded = value
+  syncModel()
 }
 
 const toggle = (node: TreeNode) => setExpanded(node, !isExpanded(node))
 const expand = (node: TreeNode) => setExpanded(node, true)
 const collapse = (node: TreeNode) => setExpanded(node, false)
 
-function collectCollapsibleKeys(nodes: TreeNode[], acc: TreeKey[] = []) {
+function eachCollapsible(nodes: TreeNode[], fn: (node: TreeNode) => void) {
   for (const node of nodes) {
     if (hasChildren(node)) {
-      acc.push(keyOf(node))
-      collectCollapsibleKeys(childrenOf(node), acc)
+      fn(node)
+      eachCollapsible(childrenOf(node), fn)
     }
   }
-  return acc
+}
+
+// Write `value` into every collapsible node's `expanded` field.
+function setAll(value: boolean) {
+  eachCollapsible(roots.value, (node) => (node.expanded = value))
+}
+
+// True when every collapsible node is open (drives the two-way switch).
+function allExpanded() {
+  let total = 0
+  let open = 0
+  eachCollapsible(roots.value, (node) => {
+    total++
+    if (isExpanded(node)) open++
+  })
+  return total > 0 ? open === total : expanded.value
+}
+
+// Reflect the per-node state back onto the switch without re-triggering setAll.
+let syncing = false
+function syncModel() {
+  const all = allExpanded()
+  if (expanded.value === all) return
+  syncing = true
+  expanded.value = all
+  syncing = false
 }
 
 // --- focus -----------------------------------------------------------------
@@ -214,17 +238,21 @@ const { onKeydown } = useTreeKeyboard({
 })
 
 // --- lifecycle ------------------------------------------------------------
-// Seed once, on the first non-empty roots — so async-loaded nodes still expand.
-let seeded = false
+// The switch applies to every node when toggled. Skip the initial `false` so a
+// tree's per-node `expanded` data is respected on first render.
 watch(
-  roots,
-  (r) => {
-    if (seeded || !props.defaultExpanded || !r.length) return
-    if (expanded.value.length === 0) expanded.value = collectCollapsibleKeys(r)
-    seeded = true
+  expanded,
+  (value, old) => {
+    if (syncing) return
+    if (old === undefined && value === false) return
+    setAll(value)
   },
-  { immediate: true },
+  { immediate: true, flush: 'sync' },
 )
+
+// Keep the switch reflecting the real per-node state, including initial data
+// and async-loaded nodes.
+watch(roots, syncModel, { immediate: true })
 
 // Keep focus valid if the focused node disappears from the tree.
 watch(flat, (rows) => {

--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -1,122 +1,303 @@
 <template>
-  <!-- Current Tree Node -->
-  <slot
-    name="node"
-    v-bind="{ node, hasChildren, isCollapsed, toggleCollapsed }"
+  <ul
+    ref="treeRef"
+    role="tree"
+    :aria-multiselectable="false"
+    class="frappe-tree select-none"
+    :data-guides="guides"
+    :style="rootStyle"
+    @keydown="onKeydown"
+    @focusin="onFocusin"
   >
-    <div
-      class="flex items-center cursor-pointer gap-1"
-      :style="{ height: options.rowHeight }"
-      @click="toggleCollapsed"
+    <TreeItem
+      v-for="(node, index) in nodes"
+      :key="keyOf(node)"
+      :node="node"
+      :parent="null"
+      :level="1"
+      :index="index"
+      :set-size="nodes.length"
     >
-      <div ref="iconRef">
-        <!-- slot to only override the Icon -->
-        <slot name="icon" v-bind="{ hasChildren, isCollapsed }">
-          <span
-            v-if="hasChildren && !isCollapsed"
-            class="lucide-chevron-down size-3.5"
-            aria-hidden="true"
-          />
-          <span
-            v-else-if="hasChildren"
-            class="lucide-chevron-right size-3.5"
-            aria-hidden="true"
-          />
-        </slot>
-      </div>
+      <template v-if="$slots.node" #node="p"
+        ><slot name="node" v-bind="p"
+      /></template>
+      <template v-if="$slots.label" #label="p"
+        ><slot name="label" v-bind="p"
+      /></template>
+      <template v-if="$slots.prefix" #prefix="p"
+        ><slot name="prefix" v-bind="p"
+      /></template>
+      <template v-if="$slots.suffix" #suffix="p"
+        ><slot name="suffix" v-bind="p"
+      /></template>
+    </TreeItem>
 
-      <!-- slot to only override the label -->
-      <slot name="label" v-bind="{ node, hasChildren, isCollapsed }">
-        <div class="text-base truncate" :class="hasChildren ? '' : 'pl-3.5'">
-          {{ node.label }}
-        </div>
-      </slot>
-    </div>
-  </slot>
+    <li v-if="!nodes.length" role="none" data-slot="empty">
+      <slot name="empty" />
+    </li>
+  </ul>
 
-  <!-- Recursively render the children -->
-  <div v-if="hasChildren && !isCollapsed" class="flex">
+  <!-- Floating drag indicator -->
+  <Teleport to="body">
     <div
-      :style="{ paddingLeft: linePadding }"
-      class="border-r"
-      v-if="options.showIndentationGuides"
-    ></div>
-    <ul class="w-full" :style="{ paddingLeft: options.indentWidth }">
-      <li v-for="child in node.children" :key="child[nodeKey] as string">
-        <Tree :node="child" :nodeKey="nodeKey" :options="options">
-          <!-- Pass the parent slots to the children of current node -->
-          <template #node="{ node, hasChildren, isCollapsed, toggleCollapsed }">
-            <slot
-              name="node"
-              v-bind="{ node, hasChildren, isCollapsed, toggleCollapsed }"
-            />
-          </template>
+      v-if="dragLabel"
+      class="frappe-tree-drag-label pointer-events-none fixed z-[1000] rounded-md bg-surface-gray-7 px-2 py-1 text-xs text-ink-white shadow-lg"
+      :style="{
+        top: `${dragDrop.state.y + 18}px`,
+        left: `${dragDrop.state.x + 12}px`,
+      }"
+    >
+      {{ dragLabel }}
+    </div>
+  </Teleport>
 
-          <template #icon="{ hasChildren, isCollapsed }">
-            <slot name="icon" v-bind="{ hasChildren, isCollapsed }" />
-          </template>
-
-          <template #label="{ node, hasChildren, isCollapsed }">
-            <slot name="label" v-bind="{ node, hasChildren, isCollapsed }" />
-          </template>
-        </Tree>
-      </li>
-    </ul>
-  </div>
+  <!-- Polite live region for drag/drop announcements -->
+  <div class="sr-only" role="status" aria-live="polite">{{ liveMessage }}</div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
-import type { TreeNode, TreeProps } from './types'
+import {
+  computed,
+  getCurrentInstance,
+  nextTick,
+  onMounted,
+  provide,
+  ref,
+  toRef,
+  watch,
+} from 'vue'
+import TreeItem from './TreeItem.vue'
+import { useTreeDragDrop } from './useTreeDragDrop'
+import { useTreeKeyboard, type FlatNode } from './useTreeKeyboard'
+import {
+  TreeContextKey,
+  type MoveEvent,
+  type TreeKey,
+  type TreeNode,
+  type TreeNodeSlotProps,
+  type TreeProps,
+} from './types'
 
 const props = withDefaults(defineProps<TreeProps>(), {
-  options: () => ({
-    rowHeight: '25px',
-    indentWidth: '20px',
-    showIndentationGuides: true,
-    defaultCollapsed: true,
-  }),
+  nodeKey: 'key',
+  labelKey: 'label',
+  childrenKey: 'children',
+  draggable: false,
+  reorderable: false,
+  guides: 'connectors',
+  rowHeight: '32px',
+  indent: '28px',
+  defaultExpanded: false,
+  disabled: false,
 })
 
-const slots = defineSlots<{
-  /** Slot to fully override how a tree node renders */
-  node: {
-    node: TreeNode
-    hasChildren: boolean
-    isCollapsed: boolean
-    toggleCollapsed: (event: MouseEvent) => void
-  }
+const emit = defineEmits<{ move: [move: MoveEvent] }>()
 
-  /** Slot to override only the node expand/collapse icon */
-  icon: {
-    hasChildren: boolean
-    isCollapsed: boolean
-  }
-
-  /** Slot to override only the node label/content */
-  label: {
+defineSlots<{
+  node: (props: TreeNodeSlotProps) => unknown
+  label: (
+    props: Omit<
+      TreeNodeSlotProps,
+      'toggle' | 'select' | 'focused' | 'disabled'
+    >,
+  ) => unknown
+  prefix: (props: {
     node: TreeNode
+    expanded: boolean
     hasChildren: boolean
-    isCollapsed: boolean
-  }
+  }) => unknown
+  suffix: (props: { node: TreeNode; selected: boolean }) => unknown
+  empty: () => unknown
 }>()
 
-const isCollapsed = ref(props.options.defaultCollapsed ?? true)
+const expanded = defineModel<TreeKey[]>('expanded', { default: () => [] })
+const selected = defineModel<TreeKey | null>('selected', { default: null })
 
-const linePadding = ref('')
+// Selection is opt-in: it's only active when the caller binds
+// `v-model:selected`. Without it, clicks neither select nor highlight a row.
+const instance = getCurrentInstance()
+const selectionEnabled = computed(() => {
+  const vnodeProps = instance?.vnode.props ?? {}
+  return 'selected' in vnodeProps || 'onUpdate:selected' in vnodeProps
+})
 
-const hasChildren = computed(() => props.node.children?.length > 0)
+const treeRef = ref<HTMLElement | null>(null)
+const focusedKey = ref<TreeKey | null>(null)
+const liveMessage = ref('')
+const itemEls = new Map<TreeKey, HTMLElement>()
 
-const iconRef = ref<HTMLElement | null>(null)
+// --- node field accessors -------------------------------------------------
+const keyOf = (node: TreeNode) => node[props.nodeKey] as TreeKey
+const labelOf = (node: TreeNode) => (node[props.labelKey] as string) ?? ''
+const childrenOf = (node: TreeNode) =>
+  (node[props.childrenKey] as TreeNode[]) ?? []
+const hasChildren = (node: TreeNode) => childrenOf(node).length > 0
 
-const toggleCollapsed = (event: MouseEvent) => {
-  event.stopPropagation()
-  if (hasChildren.value) isCollapsed.value = !isCollapsed.value
+// --- expansion ------------------------------------------------------------
+const expandedSet = computed(() => new Set(expanded.value))
+const isExpanded = (node: TreeNode) => expandedSet.value.has(keyOf(node))
+
+function setExpanded(node: TreeNode, value: boolean) {
+  if (props.disabled || !hasChildren(node)) return
+  const key = keyOf(node)
+  const next = new Set(expanded.value)
+  value ? next.add(key) : next.delete(key)
+  expanded.value = [...next]
 }
 
+const toggle = (node: TreeNode) => setExpanded(node, !isExpanded(node))
+const expand = (node: TreeNode) => setExpanded(node, true)
+const collapse = (node: TreeNode) => setExpanded(node, false)
+
+function collectCollapsibleKeys(nodes: TreeNode[], acc: TreeKey[] = []) {
+  for (const node of nodes) {
+    if (hasChildren(node)) {
+      acc.push(keyOf(node))
+      collectCollapsibleKeys(childrenOf(node), acc)
+    }
+  }
+  return acc
+}
+
+// --- selection + focus ----------------------------------------------------
+function select(node: TreeNode) {
+  if (props.disabled || !selectionEnabled.value) return
+  selected.value = keyOf(node)
+  focus(keyOf(node))
+}
+
+function focus(key: TreeKey) {
+  focusedKey.value = key
+  nextTick(() => itemEls.get(key)?.focus())
+}
+
+function onFocusin() {
+  if (focusedKey.value == null && props.nodes.length)
+    focusedKey.value = keyOf(props.nodes[0])
+}
+
+const registerItem = (key: TreeKey, el: HTMLElement) => itemEls.set(key, el)
+const unregisterItem = (key: TreeKey) => itemEls.delete(key)
+
+// --- flattened visible list (for keyboard nav) ----------------------------
+const flat = computed(() => {
+  const out: FlatNode[] = []
+  const walk = (
+    nodes: TreeNode[],
+    parentKey: TreeKey | null,
+    level: number,
+  ) => {
+    for (const node of nodes) {
+      const expandedNow = isExpanded(node)
+      out.push({
+        key: keyOf(node),
+        node,
+        parentKey,
+        level,
+        hasChildren: hasChildren(node),
+        expanded: expandedNow,
+      })
+      if (expandedNow && hasChildren(node))
+        walk(childrenOf(node), keyOf(node), level + 1)
+    }
+  }
+  walk(props.nodes, null, 1)
+  return out
+})
+
+// --- drag & drop ----------------------------------------------------------
+const dragDrop = useTreeDragDrop({
+  keyOf,
+  childrenOf,
+  labelOf,
+  reorderable: toRef(props, 'reorderable'),
+  disabled: toRef(props, 'disabled'),
+  canDrop: props.canDrop,
+  onMove: (move) => emit('move', move),
+  announce: (message) => (liveMessage.value = message),
+})
+
+const dragLabel = computed(() => {
+  const { state } = dragDrop
+  const position = dragDrop.dropPosition.value
+  if (!state.source || !state.target || !position) return null
+  const target = labelOf(state.target)
+  return position === 'inside'
+    ? `Move under ${target}`
+    : `Move ${position} ${target}`
+})
+
+// --- keyboard -------------------------------------------------------------
+const { onKeydown } = useTreeKeyboard({
+  flat,
+  focusedKey,
+  labelOf,
+  focus,
+  expand,
+  collapse,
+  select,
+})
+
+// --- lifecycle ------------------------------------------------------------
+let seeded = false
 onMounted(() => {
-  if (iconRef.value?.clientWidth)
-    // Set the padding for the LHS line to align with the center of icon
-    linePadding.value = iconRef.value.clientWidth / 2 + 'px'
+  if (!seeded && props.defaultExpanded && expanded.value.length === 0) {
+    expanded.value = collectCollapsibleKeys(props.nodes)
+  }
+  seeded = true
+})
+
+// Keep focus valid if the focused node disappears from the tree.
+watch(flat, (rows) => {
+  if (focusedKey.value != null && !rows.some((r) => r.key === focusedKey.value))
+    focusedKey.value = rows[0]?.key ?? null
+})
+
+const rootStyle = computed(() => ({
+  '--tree-indent': props.indent,
+  '--tree-row-height': props.rowHeight,
+}))
+
+// --- provide context ------------------------------------------------------
+provide(TreeContextKey, {
+  nodeKey: toRef(props, 'nodeKey'),
+  labelKey: toRef(props, 'labelKey'),
+  childrenKey: toRef(props, 'childrenKey'),
+  guides: toRef(props, 'guides'),
+  rowHeight: toRef(props, 'rowHeight'),
+  indent: toRef(props, 'indent'),
+  draggable: toRef(props, 'draggable'),
+  reorderable: toRef(props, 'reorderable'),
+  disabled: toRef(props, 'disabled'),
+  selected,
+  selectionEnabled,
+  focusedKey,
+  keyOf,
+  labelOf,
+  childrenOf,
+  hasChildren,
+  isExpanded,
+  toggle,
+  select,
+  focus,
+  registerItem,
+  unregisterItem,
+  dragSourceKey: dragDrop.dragSourceKey,
+  dropTargetKey: dragDrop.dropTargetKey,
+  dropPosition: dragDrop.dropPosition,
+  onDragStart: dragDrop.onDragStart,
+  onDragOver: dragDrop.onDragOver,
+  onDragLeave: dragDrop.onDragLeave,
+  onDrop: dragDrop.onDrop,
+  onDragEnd: dragDrop.onDragEnd,
 })
 </script>
+
+<style>
+.frappe-tree,
+.frappe-tree ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -17,17 +17,17 @@
       :index="index"
       :set-size="roots.length"
     >
-      <template v-if="$slots.node" #node="p"
-        ><slot name="node" v-bind="p"
+      <template v-if="$slots.item" #item="p"
+        ><slot name="item" v-bind="p"
       /></template>
-      <template v-if="$slots.label" #label="p"
-        ><slot name="label" v-bind="p"
+      <template v-if="$slots['item-label']" #item-label="p"
+        ><slot name="item-label" v-bind="p"
       /></template>
-      <template v-if="$slots.prefix" #prefix="p"
-        ><slot name="prefix" v-bind="p"
+      <template v-if="$slots['item-prefix']" #item-prefix="p"
+        ><slot name="item-prefix" v-bind="p"
       /></template>
-      <template v-if="$slots.suffix" #suffix="p"
-        ><slot name="suffix" v-bind="p"
+      <template v-if="$slots['item-suffix']" #item-suffix="p"
+        ><slot name="item-suffix" v-bind="p"
       /></template>
     </TreeItem>
 
@@ -55,7 +55,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, provide, ref, toRef, watch } from 'vue'
+import { computed, nextTick, provide, ref, toRef, watch } from 'vue'
 import TreeItem from './TreeItem.vue'
 import { useTreeDragDrop } from './useTreeDragDrop'
 import { useTreeKeyboard, type FlatNode } from './useTreeKeyboard'
@@ -84,16 +84,10 @@ const emit = defineEmits<{
 }>()
 
 defineSlots<{
-  node: (props: TreeNodeSlotProps) => unknown
-  label: (
-    props: Omit<TreeNodeSlotProps, 'toggle' | 'focused' | 'disabled'>,
-  ) => unknown
-  prefix: (props: {
-    node: TreeNode
-    expanded: boolean
-    hasChildren: boolean
-  }) => unknown
-  suffix: (props: { node: TreeNode }) => unknown
+  item: (props: TreeNodeSlotProps) => unknown
+  'item-prefix': (props: Omit<TreeNodeSlotProps, 'toggle'>) => unknown
+  'item-label': (props: Omit<TreeNodeSlotProps, 'toggle'>) => unknown
+  'item-suffix': (props: Omit<TreeNodeSlotProps, 'toggle'>) => unknown
   empty: () => unknown
 }>()
 
@@ -187,7 +181,7 @@ const dragDrop = useTreeDragDrop({
   siblingsOf,
   labelOf,
   disabled: toRef(props, 'disabled'),
-  move: props.move,
+  move: (ctx) => props.move?.(ctx) ?? true,
   emitDragStart: (node) => emit('drag-start', node),
   emitDragEnd: (info) => emit('drag-end', info),
   announce: (message) => (liveMessage.value = message),
@@ -215,13 +209,17 @@ const { onKeydown } = useTreeKeyboard({
 })
 
 // --- lifecycle ------------------------------------------------------------
+// Seed once, on the first non-empty roots — so async-loaded nodes still expand.
 let seeded = false
-onMounted(() => {
-  if (!seeded && props.defaultExpanded && expanded.value.length === 0) {
-    expanded.value = collectCollapsibleKeys(roots.value)
-  }
-  seeded = true
-})
+watch(
+  roots,
+  (r) => {
+    if (seeded || !props.defaultExpanded || !r.length) return
+    if (expanded.value.length === 0) expanded.value = collectCollapsibleKeys(r)
+    seeded = true
+  },
+  { immediate: true },
+)
 
 // Keep focus valid if the focused node disappears from the tree.
 watch(flat, (rows) => {

--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -2,7 +2,6 @@
   <ul
     ref="treeRef"
     role="tree"
-    :aria-multiselectable="false"
     class="frappe-tree select-none"
     :data-guides="guides"
     @keydown="onKeydown"
@@ -55,22 +54,13 @@
 </template>
 
 <script setup lang="ts">
-import {
-  computed,
-  getCurrentInstance,
-  nextTick,
-  onMounted,
-  provide,
-  ref,
-  toRef,
-  watch,
-} from 'vue'
+import { computed, nextTick, onMounted, provide, ref, toRef, watch } from 'vue'
 import TreeItem from './TreeItem.vue'
 import { useTreeDragDrop } from './useTreeDragDrop'
 import { useTreeKeyboard, type FlatNode } from './useTreeKeyboard'
 import {
   TreeContextKey,
-  type MoveEvent,
+  type DropInfo,
   type TreeKey,
   type TreeNode,
   type TreeNodeSlotProps,
@@ -80,41 +70,31 @@ import {
 const props = withDefaults(defineProps<TreeProps>(), {
   nodeKey: 'key',
   draggable: false,
-  reorderable: false,
   guides: 'connectors',
   defaultExpanded: false,
   disabled: false,
 })
 
-const emit = defineEmits<{ move: [move: MoveEvent] }>()
+const emit = defineEmits<{
+  'drag-start': [node: TreeNode]
+  'drag-end': [info: DropInfo | null]
+}>()
 
 defineSlots<{
   node: (props: TreeNodeSlotProps) => unknown
   label: (
-    props: Omit<
-      TreeNodeSlotProps,
-      'toggle' | 'select' | 'focused' | 'disabled'
-    >,
+    props: Omit<TreeNodeSlotProps, 'toggle' | 'focused' | 'disabled'>,
   ) => unknown
   prefix: (props: {
     node: TreeNode
     expanded: boolean
     hasChildren: boolean
   }) => unknown
-  suffix: (props: { node: TreeNode; selected: boolean }) => unknown
+  suffix: (props: { node: TreeNode }) => unknown
   empty: () => unknown
 }>()
 
 const expanded = defineModel<TreeKey[]>('expanded', { default: () => [] })
-const selected = defineModel<TreeKey | null>('selected', { default: null })
-
-// Selection is opt-in: it's only active when the caller binds
-// `v-model:selected`. Without it, clicks neither select nor highlight a row.
-const instance = getCurrentInstance()
-const selectionEnabled = computed(() => {
-  const vnodeProps = instance?.vnode.props ?? {}
-  return 'selected' in vnodeProps || 'onUpdate:selected' in vnodeProps
-})
 
 const treeRef = ref<HTMLElement | null>(null)
 const focusedKey = ref<TreeKey | null>(null)
@@ -157,13 +137,7 @@ function collectCollapsibleKeys(nodes: TreeNode[], acc: TreeKey[] = []) {
   return acc
 }
 
-// --- selection + focus ----------------------------------------------------
-function select(node: TreeNode) {
-  if (props.disabled || !selectionEnabled.value) return
-  selected.value = keyOf(node)
-  focus(keyOf(node))
-}
-
+// --- focus -----------------------------------------------------------------
 function focus(key: TreeKey) {
   focusedKey.value = key
   nextTick(() => itemEls.get(key)?.focus())
@@ -209,10 +183,10 @@ const dragDrop = useTreeDragDrop({
   childrenOf,
   siblingsOf,
   labelOf,
-  reorderable: toRef(props, 'reorderable'),
   disabled: toRef(props, 'disabled'),
-  canDrop: props.canDrop,
-  onMove: (move) => emit('move', move),
+  move: props.move,
+  emitDragStart: (node) => emit('drag-start', node),
+  emitDragEnd: (info) => emit('drag-end', info),
   announce: (message) => (liveMessage.value = message),
 })
 
@@ -234,7 +208,7 @@ const { onKeydown } = useTreeKeyboard({
   focus,
   expand,
   collapse,
-  select,
+  toggle,
 })
 
 // --- lifecycle ------------------------------------------------------------
@@ -257,10 +231,7 @@ provide(TreeContextKey, {
   nodeKey: toRef(props, 'nodeKey'),
   guides: toRef(props, 'guides'),
   draggable: toRef(props, 'draggable'),
-  reorderable: toRef(props, 'reorderable'),
   disabled: toRef(props, 'disabled'),
-  selected,
-  selectionEnabled,
   focusedKey,
   keyOf,
   labelOf,
@@ -268,7 +239,6 @@ provide(TreeContextKey, {
   hasChildren,
   isExpanded,
   toggle,
-  select,
   focus,
   registerItem,
   unregisterItem,
@@ -285,15 +255,13 @@ provide(TreeContextKey, {
 
 <style>
 .frappe-tree {
-  /* Sizing is exposed as CSS variables (P10) — override via CSS, not props:
-     `.my-tree { --tree-row-height: 40px; --tree-indent: 20px; }` */
-  --tree-row-height: 32px;
-  --tree-indent: 28px;
+  --_tree-row-height: var(--tree-row-height, 32px);
+  --_tree-indent: var(--tree-indent, 24px);
+  padding: 0;
 }
 .frappe-tree,
 .frappe-tree ul {
   list-style: none;
   margin: 0;
-  padding: 0;
 }
 </style>

--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -5,7 +5,6 @@
     :aria-multiselectable="false"
     class="frappe-tree select-none"
     :data-guides="guides"
-    :style="rootStyle"
     @keydown="onKeydown"
     @focusin="onFocusin"
   >
@@ -80,13 +79,9 @@ import {
 
 const props = withDefaults(defineProps<TreeProps>(), {
   nodeKey: 'key',
-  labelKey: 'label',
-  childrenKey: 'children',
   draggable: false,
   reorderable: false,
   guides: 'connectors',
-  rowHeight: '32px',
-  indent: '28px',
   defaultExpanded: false,
   disabled: false,
 })
@@ -129,9 +124,8 @@ const itemEls = new Map<TreeKey, HTMLElement>()
 // --- node field accessors -------------------------------------------------
 const roots = computed(() => props.nodes ?? [])
 const keyOf = (node: TreeNode) => node[props.nodeKey] as TreeKey
-const labelOf = (node: TreeNode) => (node[props.labelKey] as string) ?? ''
-const childrenOf = (node: TreeNode) =>
-  (node[props.childrenKey] as TreeNode[]) ?? []
+const labelOf = (node: TreeNode) => node.label ?? ''
+const childrenOf = (node: TreeNode) => node.children ?? []
 const hasChildren = (node: TreeNode) => childrenOf(node).length > 0
 // Siblings of a node: a parent's children, or the roots for top-level nodes.
 const siblingsOf = (parent: TreeNode | null) =>
@@ -258,19 +252,10 @@ watch(flat, (rows) => {
     focusedKey.value = rows[0]?.key ?? null
 })
 
-const rootStyle = computed(() => ({
-  '--tree-indent': props.indent,
-  '--tree-row-height': props.rowHeight,
-}))
-
 // --- provide context ------------------------------------------------------
 provide(TreeContextKey, {
   nodeKey: toRef(props, 'nodeKey'),
-  labelKey: toRef(props, 'labelKey'),
-  childrenKey: toRef(props, 'childrenKey'),
   guides: toRef(props, 'guides'),
-  rowHeight: toRef(props, 'rowHeight'),
-  indent: toRef(props, 'indent'),
   draggable: toRef(props, 'draggable'),
   reorderable: toRef(props, 'reorderable'),
   disabled: toRef(props, 'disabled'),
@@ -299,6 +284,12 @@ provide(TreeContextKey, {
 </script>
 
 <style>
+.frappe-tree {
+  /* Sizing is exposed as CSS variables (P10) — override via CSS, not props:
+     `.my-tree { --tree-row-height: 40px; --tree-indent: 20px; }` */
+  --tree-row-height: 32px;
+  --tree-indent: 28px;
+}
 .frappe-tree,
 .frappe-tree ul {
   list-style: none;

--- a/src/components/Tree/TreeItem.vue
+++ b/src/components/Tree/TreeItem.vue
@@ -1,0 +1,278 @@
+<template>
+  <li
+    ref="el"
+    role="treeitem"
+    data-slot="item"
+    :data-level="level"
+    :data-state="expanded ? 'expanded' : 'collapsed'"
+    :data-has-children="hasChildren"
+    :data-selected="isSelected || undefined"
+    :data-disabled="ctx.disabled.value || undefined"
+    :data-dragging="isDragging || undefined"
+    :data-drop="dropEdge || undefined"
+    :aria-expanded="hasChildren ? expanded : undefined"
+    :aria-selected="ctx.selectionEnabled.value ? isSelected : undefined"
+    :aria-level="level"
+    :aria-setsize="setSize"
+    :aria-posinset="index + 1"
+    :tabindex="tabbable ? 0 : -1"
+    @focus="ctx.focusedKey.value = key"
+  >
+    <div
+      data-slot="row"
+      class="frappe-tree-row group/row relative flex items-center gap-1.5 rounded-md px-1.5"
+      :class="[
+        ctx.draggable.value && !ctx.disabled.value ? 'cursor-grab' : '',
+        isSelected ? 'bg-surface-gray-3' : 'hover:bg-surface-gray-2',
+      ]"
+      :style="{ height: ctx.rowHeight.value }"
+      :draggable="ctx.draggable.value && !ctx.disabled.value"
+      @click="onRowClick"
+      @dragstart="ctx.onDragStart($event, node, parent)"
+      @dragend="ctx.onDragEnd()"
+      @dragover.prevent="ctx.onDragOver($event, node)"
+      @dragleave="ctx.onDragLeave(node)"
+      @drop.prevent="ctx.onDrop(node, parent)"
+    >
+      <!-- Fully-overridden node -->
+      <slot v-if="$slots.node" name="node" v-bind="slotProps" />
+
+      <!-- Default node rendering -->
+      <template v-else>
+        <button
+          v-if="hasChildren"
+          type="button"
+          data-slot="toggle"
+          :data-state="expanded ? 'expanded' : 'collapsed'"
+          class="flex size-5 shrink-0 items-center justify-center rounded text-ink-gray-5 hover:bg-surface-gray-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-outline-gray-3"
+          :aria-label="expanded ? 'Collapse' : 'Expand'"
+          tabindex="-1"
+          @click.stop="ctx.toggle(node)"
+        >
+          <svg
+            class="size-3.5 transition-transform duration-150 motion-reduce:transition-none"
+            :style="{ transform: expanded ? 'rotate(90deg)' : 'none' }"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </button>
+        <span v-else class="size-5 shrink-0" aria-hidden="true" />
+
+        <slot name="prefix" v-bind="{ node, expanded, hasChildren }" />
+
+        <slot
+          name="label"
+          v-bind="{ node, level, expanded, hasChildren, selected: isSelected }"
+        >
+          <span class="truncate text-base text-ink-gray-8">{{ label }}</span>
+        </slot>
+
+        <span class="ml-auto flex items-center">
+          <slot name="suffix" v-bind="{ node, selected: isSelected }" />
+        </span>
+      </template>
+    </div>
+
+    <!-- Children -->
+    <ul
+      v-if="hasChildren && expanded"
+      role="group"
+      :style="{ paddingLeft: ctx.indent.value }"
+    >
+      <TreeItem
+        v-for="(child, childIndex) in children"
+        :key="ctx.keyOf(child)"
+        :node="child"
+        :parent="node"
+        :level="level + 1"
+        :index="childIndex"
+        :set-size="children.length"
+      >
+        <template v-if="$slots.node" #node="p"
+          ><slot name="node" v-bind="p"
+        /></template>
+        <template v-if="$slots.label" #label="p"
+          ><slot name="label" v-bind="p"
+        /></template>
+        <template v-if="$slots.prefix" #prefix="p"
+          ><slot name="prefix" v-bind="p"
+        /></template>
+        <template v-if="$slots.suffix" #suffix="p"
+          ><slot name="suffix" v-bind="p"
+        /></template>
+      </TreeItem>
+    </ul>
+  </li>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, onBeforeUnmount, ref, watch } from 'vue'
+import { TreeContextKey, type TreeNode, type TreeNodeSlotProps } from './types'
+
+const props = defineProps<{
+  node: TreeNode
+  parent: TreeNode | null
+  level: number
+  index: number
+  setSize: number
+}>()
+
+defineSlots<{
+  node: (props: TreeNodeSlotProps) => unknown
+  label: (
+    props: Omit<
+      TreeNodeSlotProps,
+      'toggle' | 'select' | 'focused' | 'disabled'
+    >,
+  ) => unknown
+  prefix: (props: {
+    node: TreeNode
+    expanded: boolean
+    hasChildren: boolean
+  }) => unknown
+  suffix: (props: { node: TreeNode; selected: boolean }) => unknown
+}>()
+
+const injected = inject(TreeContextKey)
+if (!injected) throw new Error('TreeItem must be used inside a Tree')
+const ctx = injected
+
+const el = ref<HTMLElement | null>(null)
+
+const key = computed(() => ctx.keyOf(props.node))
+const label = computed(() => ctx.labelOf(props.node))
+const children = computed(() => ctx.childrenOf(props.node))
+const hasChildren = computed(() => ctx.hasChildren(props.node))
+const expanded = computed(() => ctx.isExpanded(props.node))
+const isSelected = computed(
+  () => ctx.selectionEnabled.value && ctx.selected.value === key.value,
+)
+const isDragging = computed(() => ctx.dragSourceKey.value === key.value)
+
+const dropEdge = computed(() =>
+  ctx.dropTargetKey.value === key.value ? ctx.dropPosition.value : null,
+)
+
+const tabbable = computed(
+  () =>
+    ctx.focusedKey.value === key.value ||
+    (ctx.focusedKey.value == null && props.level === 1 && props.index === 0),
+)
+
+const slotProps = computed(() => ({
+  node: props.node,
+  level: props.level,
+  expanded: expanded.value,
+  hasChildren: hasChildren.value,
+  selected: isSelected.value,
+  focused: ctx.focusedKey.value === key.value,
+  disabled: ctx.disabled.value,
+  toggle: () => ctx.toggle(props.node),
+  select: () => ctx.select(props.node),
+}))
+
+function onRowClick() {
+  if (ctx.disabled.value) return
+  ctx.select(props.node)
+}
+
+watch(
+  el,
+  (node) => {
+    if (node) ctx.registerItem(key.value, node)
+  },
+  { immediate: true },
+)
+onBeforeUnmount(() => ctx.unregisterItem(key.value))
+</script>
+
+<style>
+/* ---- Connector guides (elbow lines) ---- */
+.frappe-tree[data-guides='connectors'] [role='group'] > li {
+  position: relative;
+}
+
+/* vertical line running down siblings */
+.frappe-tree[data-guides='connectors'] [role='group'] > li::before {
+  content: '';
+  position: absolute;
+  left: calc(var(--tree-indent) / -2);
+  top: 0;
+  bottom: 0;
+  border-left: 1px solid var(--outline-gray-2, #e5e7eb);
+}
+
+/* horizontal elbow reaching each node */
+.frappe-tree[data-guides='connectors'] [role='group'] > li::after {
+  content: '';
+  position: absolute;
+  left: calc(var(--tree-indent) / -2);
+  top: calc(var(--tree-row-height) / 2);
+  width: calc(var(--tree-indent) / 2);
+  border-top: 1px solid var(--outline-gray-2, #e5e7eb);
+}
+
+/* last child: stop the vertical at the elbow + round the corner */
+.frappe-tree[data-guides='connectors'] [role='group'] > li:last-child::before {
+  bottom: auto;
+  height: calc(var(--tree-row-height) / 2);
+  border-bottom: 1px solid var(--outline-gray-2, #e5e7eb);
+  border-bottom-left-radius: 6px;
+}
+
+/* ---- Simple vertical lines ---- */
+.frappe-tree[data-guides='lines'] [role='group'] {
+  margin-left: calc(var(--tree-indent) / 2);
+  border-left: 1px solid var(--outline-gray-2, #e5e7eb);
+  padding-left: calc(var(--tree-indent) / 2) !important;
+}
+
+/* ---- Drop indicators ---- */
+.frappe-tree-row {
+  outline-offset: -1px;
+}
+[data-drop='inside'] > .frappe-tree-row {
+  outline: 2px solid var(--outline-blue-3, #2490ef);
+  background: var(--surface-blue-1, rgba(36, 144, 239, 0.08));
+}
+[data-drop='before'] > .frappe-tree-row,
+[data-drop='after'] > .frappe-tree-row {
+  position: relative;
+}
+[data-drop='before'] > .frappe-tree-row::before,
+[data-drop='after'] > .frappe-tree-row::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--outline-blue-3, #2490ef);
+  z-index: 1;
+}
+[data-drop='before'] > .frappe-tree-row::before {
+  top: -1px;
+}
+[data-drop='after'] > .frappe-tree-row::after {
+  bottom: -1px;
+}
+
+[data-dragging] > .frappe-tree-row {
+  opacity: 0.4;
+}
+
+.frappe-tree [role='treeitem']:focus-visible {
+  outline: 2px solid var(--outline-blue-3, #2490ef);
+  outline-offset: -1px;
+  border-radius: 6px;
+}
+.frappe-tree [role='treeitem']:focus {
+  outline: none;
+}
+</style>

--- a/src/components/Tree/TreeItem.vue
+++ b/src/components/Tree/TreeItem.vue
@@ -25,7 +25,6 @@
         ctx.draggable.value && !ctx.disabled.value ? 'cursor-grab' : '',
         isSelected ? 'bg-surface-gray-3' : 'hover:bg-surface-gray-2',
       ]"
-      :style="{ height: ctx.rowHeight.value }"
       :draggable="ctx.draggable.value && !ctx.disabled.value"
       @click="onRowClick"
       @dragstart="ctx.onDragStart($event, node, parent)"
@@ -81,11 +80,7 @@
     </div>
 
     <!-- Children -->
-    <ul
-      v-if="hasChildren && expanded"
-      role="group"
-      :style="{ paddingLeft: ctx.indent.value }"
-    >
+    <ul v-if="hasChildren && expanded" role="group" class="frappe-tree-group">
       <TreeItem
         v-for="(child, childIndex) in children"
         :key="ctx.keyOf(child)"
@@ -194,6 +189,14 @@ onBeforeUnmount(() => ctx.unregisterItem(key.value))
 </script>
 
 <style>
+/* ---- Sizing (override via --tree-row-height / --tree-indent in CSS) ---- */
+.frappe-tree-row {
+  height: var(--tree-row-height);
+}
+.frappe-tree-group {
+  padding-left: var(--tree-indent);
+}
+
 /* ---- Connector guides (elbow lines) ---- */
 .frappe-tree[data-guides='connectors'] [role='group'] > li {
   position: relative;

--- a/src/components/Tree/TreeItem.vue
+++ b/src/components/Tree/TreeItem.vue
@@ -28,8 +28,8 @@
       @dragleave="ctx.onDragLeave(node)"
       @drop.prevent="ctx.onDrop(node, parent)"
     >
-      <!-- Fully-overridden node -->
-      <slot v-if="$slots.node" name="node" v-bind="slotProps" />
+      <!-- Fully-overridden item -->
+      <slot v-if="$slots.item" name="item" v-bind="slotProps" />
 
       <!-- Default node rendering -->
       <template v-else>
@@ -59,14 +59,14 @@
         </button>
         <span v-else class="size-5 shrink-0" aria-hidden="true" />
 
-        <slot name="prefix" v-bind="{ node, expanded, hasChildren }" />
+        <slot name="item-prefix" v-bind="itemSlotProps" />
 
-        <slot name="label" v-bind="{ node, level, expanded, hasChildren }">
+        <slot name="item-label" v-bind="itemSlotProps">
           <span class="truncate text-base text-ink-gray-8">{{ label }}</span>
         </slot>
 
         <span class="ml-auto flex items-center">
-          <slot name="suffix" v-bind="{ node }" />
+          <slot name="item-suffix" v-bind="itemSlotProps" />
         </span>
       </template>
     </div>
@@ -82,17 +82,17 @@
         :index="childIndex"
         :set-size="children.length"
       >
-        <template v-if="$slots.node" #node="p"
-          ><slot name="node" v-bind="p"
+        <template v-if="$slots.item" #item="p"
+          ><slot name="item" v-bind="p"
         /></template>
-        <template v-if="$slots.label" #label="p"
-          ><slot name="label" v-bind="p"
+        <template v-if="$slots['item-label']" #item-label="p"
+          ><slot name="item-label" v-bind="p"
         /></template>
-        <template v-if="$slots.prefix" #prefix="p"
-          ><slot name="prefix" v-bind="p"
+        <template v-if="$slots['item-prefix']" #item-prefix="p"
+          ><slot name="item-prefix" v-bind="p"
         /></template>
-        <template v-if="$slots.suffix" #suffix="p"
-          ><slot name="suffix" v-bind="p"
+        <template v-if="$slots['item-suffix']" #item-suffix="p"
+          ><slot name="item-suffix" v-bind="p"
         /></template>
       </TreeItem>
     </ul>
@@ -112,16 +112,10 @@ const props = defineProps<{
 }>()
 
 defineSlots<{
-  node: (props: TreeNodeSlotProps) => unknown
-  label: (
-    props: Omit<TreeNodeSlotProps, 'toggle' | 'focused' | 'disabled'>,
-  ) => unknown
-  prefix: (props: {
-    node: TreeNode
-    expanded: boolean
-    hasChildren: boolean
-  }) => unknown
-  suffix: (props: { node: TreeNode }) => unknown
+  item: (props: TreeNodeSlotProps) => unknown
+  'item-prefix': (props: Omit<TreeNodeSlotProps, 'toggle'>) => unknown
+  'item-label': (props: Omit<TreeNodeSlotProps, 'toggle'>) => unknown
+  'item-suffix': (props: Omit<TreeNodeSlotProps, 'toggle'>) => unknown
 }>()
 
 const injected = inject(TreeContextKey)
@@ -147,13 +141,17 @@ const tabbable = computed(
     (ctx.focusedKey.value == null && props.level === 1 && props.index === 0),
 )
 
-const slotProps = computed(() => ({
+const itemSlotProps = computed(() => ({
   node: props.node,
   level: props.level,
   expanded: expanded.value,
   hasChildren: hasChildren.value,
   focused: ctx.focusedKey.value === key.value,
   disabled: ctx.disabled.value,
+}))
+
+const slotProps = computed(() => ({
+  ...itemSlotProps.value,
   toggle: () => ctx.toggle(props.node),
 }))
 

--- a/src/components/Tree/TreeItem.vue
+++ b/src/components/Tree/TreeItem.vue
@@ -6,12 +6,10 @@
     :data-level="level"
     :data-state="expanded ? 'expanded' : 'collapsed'"
     :data-has-children="hasChildren"
-    :data-selected="isSelected || undefined"
     :data-disabled="ctx.disabled.value || undefined"
     :data-dragging="isDragging || undefined"
     :data-drop="dropEdge || undefined"
     :aria-expanded="hasChildren ? expanded : undefined"
-    :aria-selected="ctx.selectionEnabled.value ? isSelected : undefined"
     :aria-level="level"
     :aria-setsize="setSize"
     :aria-posinset="index + 1"
@@ -20,11 +18,8 @@
   >
     <div
       data-slot="row"
-      class="frappe-tree-row group/row relative flex items-center gap-1.5 rounded-md px-1.5"
-      :class="[
-        ctx.draggable.value && !ctx.disabled.value ? 'cursor-grab' : '',
-        isSelected ? 'bg-surface-gray-3' : 'hover:bg-surface-gray-2',
-      ]"
+      class="frappe-tree-row group/row relative flex items-center gap-1.5 rounded-md px-1.5 hover:bg-surface-gray-2"
+      :class="ctx.draggable.value && !ctx.disabled.value ? 'cursor-grab' : ''"
       :draggable="ctx.draggable.value && !ctx.disabled.value"
       @click="onRowClick"
       @dragstart="ctx.onDragStart($event, node, parent)"
@@ -66,15 +61,12 @@
 
         <slot name="prefix" v-bind="{ node, expanded, hasChildren }" />
 
-        <slot
-          name="label"
-          v-bind="{ node, level, expanded, hasChildren, selected: isSelected }"
-        >
+        <slot name="label" v-bind="{ node, level, expanded, hasChildren }">
           <span class="truncate text-base text-ink-gray-8">{{ label }}</span>
         </slot>
 
         <span class="ml-auto flex items-center">
-          <slot name="suffix" v-bind="{ node, selected: isSelected }" />
+          <slot name="suffix" v-bind="{ node }" />
         </span>
       </template>
     </div>
@@ -122,17 +114,14 @@ const props = defineProps<{
 defineSlots<{
   node: (props: TreeNodeSlotProps) => unknown
   label: (
-    props: Omit<
-      TreeNodeSlotProps,
-      'toggle' | 'select' | 'focused' | 'disabled'
-    >,
+    props: Omit<TreeNodeSlotProps, 'toggle' | 'focused' | 'disabled'>,
   ) => unknown
   prefix: (props: {
     node: TreeNode
     expanded: boolean
     hasChildren: boolean
   }) => unknown
-  suffix: (props: { node: TreeNode; selected: boolean }) => unknown
+  suffix: (props: { node: TreeNode }) => unknown
 }>()
 
 const injected = inject(TreeContextKey)
@@ -146,9 +135,6 @@ const label = computed(() => ctx.labelOf(props.node))
 const children = computed(() => ctx.childrenOf(props.node))
 const hasChildren = computed(() => ctx.hasChildren(props.node))
 const expanded = computed(() => ctx.isExpanded(props.node))
-const isSelected = computed(
-  () => ctx.selectionEnabled.value && ctx.selected.value === key.value,
-)
 const isDragging = computed(() => ctx.dragSourceKey.value === key.value)
 
 const dropEdge = computed(() =>
@@ -166,16 +152,14 @@ const slotProps = computed(() => ({
   level: props.level,
   expanded: expanded.value,
   hasChildren: hasChildren.value,
-  selected: isSelected.value,
   focused: ctx.focusedKey.value === key.value,
   disabled: ctx.disabled.value,
   toggle: () => ctx.toggle(props.node),
-  select: () => ctx.select(props.node),
 }))
 
 function onRowClick() {
   if (ctx.disabled.value) return
-  ctx.select(props.node)
+  ctx.toggle(props.node)
 }
 
 watch(
@@ -191,10 +175,10 @@ onBeforeUnmount(() => ctx.unregisterItem(key.value))
 <style>
 /* ---- Sizing (override via --tree-row-height / --tree-indent in CSS) ---- */
 .frappe-tree-row {
-  height: var(--tree-row-height);
+  height: var(--_tree-row-height);
 }
 .frappe-tree-group {
-  padding-left: var(--tree-indent);
+  padding-left: var(--_tree-indent);
 }
 
 /* ---- Connector guides (elbow lines) ---- */
@@ -206,7 +190,7 @@ onBeforeUnmount(() => ctx.unregisterItem(key.value))
 .frappe-tree[data-guides='connectors'] [role='group'] > li::before {
   content: '';
   position: absolute;
-  left: calc(var(--tree-indent) / -2);
+  left: calc(var(--_tree-indent) / -2);
   top: 0;
   bottom: 0;
   border-left: 1px solid var(--outline-gray-2, #e5e7eb);
@@ -216,25 +200,25 @@ onBeforeUnmount(() => ctx.unregisterItem(key.value))
 .frappe-tree[data-guides='connectors'] [role='group'] > li::after {
   content: '';
   position: absolute;
-  left: calc(var(--tree-indent) / -2);
-  top: calc(var(--tree-row-height) / 2);
-  width: calc(var(--tree-indent) / 2);
+  left: calc(var(--_tree-indent) / -2);
+  top: calc(var(--_tree-row-height) / 2);
+  width: calc(var(--_tree-indent) / 2);
   border-top: 1px solid var(--outline-gray-2, #e5e7eb);
 }
 
 /* last child: stop the vertical at the elbow + round the corner */
 .frappe-tree[data-guides='connectors'] [role='group'] > li:last-child::before {
   bottom: auto;
-  height: calc(var(--tree-row-height) / 2);
+  height: calc(var(--_tree-row-height) / 2);
   border-bottom: 1px solid var(--outline-gray-2, #e5e7eb);
   border-bottom-left-radius: 6px;
 }
 
 /* ---- Simple vertical lines ---- */
 .frappe-tree[data-guides='lines'] [role='group'] {
-  margin-left: calc(var(--tree-indent) / 2);
+  margin-left: calc(var(--_tree-indent) / 2);
   border-left: 1px solid var(--outline-gray-2, #e5e7eb);
-  padding-left: calc(var(--tree-indent) / 2) !important;
+  padding-left: calc(var(--_tree-indent) / 2) !important;
 }
 
 /* ---- Drop indicators ---- */

--- a/src/components/Tree/index.ts
+++ b/src/components/Tree/index.ts
@@ -5,6 +5,6 @@ export type {
   TreeKey,
   TreeNodeSlotProps,
   DropPosition,
-  DropContext,
-  MoveEvent,
+  MoveContext,
+  DropInfo,
 } from './types'

--- a/src/components/Tree/index.ts
+++ b/src/components/Tree/index.ts
@@ -1,2 +1,10 @@
 export { default as Tree } from './Tree.vue'
-export type { TreeProps } from './types'
+export type {
+  TreeProps,
+  TreeNode,
+  TreeKey,
+  TreeNodeSlotProps,
+  DropPosition,
+  DropContext,
+  MoveEvent,
+} from './types'

--- a/src/components/Tree/stories/DragDrop.vue
+++ b/src/components/Tree/stories/DragDrop.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { Tree } from 'frappe-ui'
-import type { DropContext, MoveEvent, TreeNode } from '../types'
+import type { DropInfo, MoveContext, TreeNode } from '../types'
 
 const nodes = ref<TreeNode[]>([
   {
@@ -13,8 +13,8 @@ const nodes = ref<TreeNode[]>([
         label: 'Downloads',
         children: [
           {
-            name: 'download.zip',
-            label: 'download.zip',
+            name: 'archive',
+            label: 'archive',
             children: [{ name: 'image.png', label: 'image.png' }],
           },
         ],
@@ -23,24 +23,58 @@ const nodes = ref<TreeNode[]>([
         name: 'documents',
         label: 'Documents',
         children: [
-          { name: 'somefile.txt', label: 'somefile.txt' },
-          { name: 'somefile.pdf', label: 'somefile.pdf' },
+          { name: 'resume.pdf', label: 'resume.pdf' },
+          { name: 'notes.txt', label: 'notes.txt' },
         ],
       },
     ],
   },
 ])
 
-const expanded = ref<string[]>(['guest', 'downloads', 'documents'])
+const expanded = ref<string[]>(['guest', 'downloads', 'documents', 'archive'])
 
-// Only allow dropping into a "folder" (a node that can have children).
-function canDrop({ target }: DropContext) {
-  return Array.isArray(target.children)
+// Folders (nodes with a `children` array) can receive drops; files cannot.
+function move({ target, position }: MoveContext) {
+  if (position === 'inside') return Array.isArray(target.children)
+  return true
 }
 
-function onMove(move: MoveEvent) {
-  // In a real app you'd persist the change, then update `nodes`.
-  console.log('move', move)
+// Locate a node by key, returning the array that holds it and its index.
+function locate(
+  list: TreeNode[],
+  key: string,
+): { list: TreeNode[]; index: number } | null {
+  for (let i = 0; i < list.length; i++) {
+    if (list[i].name === key) return { list, index: i }
+    const children = list[i].children
+    if (children) {
+      const found = locate(children, key)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+// Persist a committed move by splicing the node into its new position.
+function onDragEnd(info: DropInfo | null) {
+  if (!info) return
+  const roots = nodes.value
+  const src = locate(roots, info.node.name as string)
+  if (!src) return
+  const [moved] = src.list.splice(src.index, 1)
+
+  let dest = roots
+  if (info.to !== null) {
+    const hit = locate(roots, info.to as string)
+    const parent = hit?.list[hit.index]
+    if (parent) {
+      if (!parent.children) parent.children = []
+      dest = parent.children
+      if (!expanded.value.includes(info.to as string))
+        expanded.value = [...expanded.value, info.to as string]
+    }
+  }
+  dest.splice(info.newIndex, 0, moved)
 }
 </script>
 
@@ -49,11 +83,10 @@ function onMove(move: MoveEvent) {
     <Tree
       :nodes="nodes"
       node-key="name"
-      guides="none"
       v-model:expanded="expanded"
       draggable
-      :can-drop="canDrop"
-      @move="onMove"
+      :move="move"
+      @drag-end="onDragEnd"
     />
   </div>
 </template>

--- a/src/components/Tree/stories/DragDrop.vue
+++ b/src/components/Tree/stories/DragDrop.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Tree } from 'frappe-ui'
+import { Switch, Tree } from 'frappe-ui'
 import type { DropInfo, MoveContext, TreeNode } from '../types'
 
 const nodes = ref<TreeNode[]>([
@@ -32,6 +32,7 @@ const nodes = ref<TreeNode[]>([
 ])
 
 const expanded = ref<string[]>(['guest', 'downloads', 'documents', 'archive'])
+const disabled = ref(false)
 
 // Folders (nodes with a `children` array) can receive drops; files cannot.
 function move({ target, position }: MoveContext) {
@@ -79,14 +80,18 @@ function onDragEnd(info: DropInfo | null) {
 </script>
 
 <template>
-  <div class="w-80">
-    <Tree
-      :nodes="nodes"
-      node-key="name"
-      v-model:expanded="expanded"
-      draggable
-      :move="move"
-      @drag-end="onDragEnd"
-    />
+  <div class="flex flex-col gap-3">
+    <Switch v-model="disabled" label="Disable interaction" />
+    <div class="w-80">
+      <Tree
+        :nodes="nodes"
+        node-key="name"
+        v-model:expanded="expanded"
+        :disabled="disabled"
+        draggable
+        :move="move"
+        @drag-end="onDragEnd"
+      />
+    </div>
   </div>
 </template>

--- a/src/components/Tree/stories/DragDrop.vue
+++ b/src/components/Tree/stories/DragDrop.vue
@@ -31,7 +31,6 @@ const nodes = ref<TreeNode[]>([
   },
 ])
 
-const expanded = ref<string[]>(['guest', 'downloads', 'documents', 'archive'])
 const disabled = ref(false)
 
 // Folders (nodes with a `children` array) can receive drops; files cannot.
@@ -70,9 +69,8 @@ function onDragEnd(info: DropInfo | null) {
     const parent = hit?.list[hit.index]
     if (parent) {
       if (!parent.children) parent.children = []
+      parent.expanded = true
       dest = parent.children
-      if (!expanded.value.includes(info.to as string))
-        expanded.value = [...expanded.value, info.to as string]
     }
   }
   dest.splice(info.newIndex, 0, moved)
@@ -86,7 +84,6 @@ function onDragEnd(info: DropInfo | null) {
       <Tree
         :nodes="nodes"
         node-key="name"
-        v-model:expanded="expanded"
         :disabled="disabled"
         draggable
         :move="move"

--- a/src/components/Tree/stories/DragDrop.vue
+++ b/src/components/Tree/stories/DragDrop.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { Tree } from 'frappe-ui'
-import type { TreeNode } from '../types'
+import type { DropContext, MoveEvent, TreeNode } from '../types'
 
 const nodes = ref<TreeNode[]>([
   {
@@ -30,10 +30,30 @@ const nodes = ref<TreeNode[]>([
     ],
   },
 ])
+
+const expanded = ref<string[]>(['guest', 'downloads', 'documents'])
+
+// Only allow dropping into a "folder" (a node that can have children).
+function canDrop({ target }: DropContext) {
+  return Array.isArray(target.children)
+}
+
+function onMove(move: MoveEvent) {
+  // In a real app you'd persist the change, then update `nodes`.
+  console.log('move', move)
+}
 </script>
 
 <template>
   <div class="w-80">
-    <Tree :nodes="nodes" node-key="name" default-expanded />
+    <Tree
+      :nodes="nodes"
+      node-key="name"
+      guides="none"
+      v-model:expanded="expanded"
+      draggable
+      :can-drop="canDrop"
+      @move="onMove"
+    />
   </div>
 </template>

--- a/src/components/Tree/stories/Example.vue
+++ b/src/components/Tree/stories/Example.vue
@@ -34,6 +34,6 @@ const nodes = ref<TreeNode[]>([
 
 <template>
   <div class="w-80">
-    <Tree :nodes="nodes" node-key="name" default-expanded />
+    <Tree :nodes="nodes" node-key="name" />
   </div>
 </template>

--- a/src/components/Tree/stories/Example.vue
+++ b/src/components/Tree/stories/Example.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
-import { reactive } from 'vue'
+import { ref } from 'vue'
 import { Tree } from 'frappe-ui'
+import type { DropContext, MoveEvent, TreeNode } from '../types'
 
-const state = reactive({
-  showIndentationGuides: true,
-  rowHeight: '25px',
-  indentWidth: '15px',
-  node: {
+const nodes = ref<TreeNode[]>([
+  {
     name: 'guest',
     label: 'Guest',
     children: [
@@ -17,13 +15,7 @@ const state = reactive({
           {
             name: 'download.zip',
             label: 'download.zip',
-            children: [
-              {
-                name: 'image.png',
-                label: 'image.png',
-                children: [],
-              },
-            ],
+            children: [{ name: 'image.png', label: 'image.png' }],
           },
         ],
       },
@@ -31,33 +23,39 @@ const state = reactive({
         name: 'documents',
         label: 'Documents',
         children: [
-          {
-            name: 'somefile.txt',
-            label: 'somefile.txt',
-            children: [],
-          },
-          {
-            name: 'somefile.pdf',
-            label: 'somefile.pdf',
-            children: [],
-          },
+          { name: 'somefile.txt', label: 'somefile.txt' },
+          { name: 'somefile.pdf', label: 'somefile.pdf' },
         ],
       },
     ],
   },
-})
+])
+
+const expanded = ref<string[]>(['guest', 'downloads', 'documents'])
+const selected = ref<string | null>(null)
+
+// Block dropping a node into a "file" (a node without children).
+function canDrop({ target }: DropContext) {
+  return Array.isArray(target.children)
+}
+
+function onMove(move: MoveEvent) {
+  // In a real app you'd persist, then update `nodes`. Here we just log.
+  console.log('move', move)
+}
 </script>
 
 <template>
-  <div>
+  <div class="w-80">
     <Tree
-      :options="{
-        showIndentationGuides: state.showIndentationGuides,
-        rowHeight: state.rowHeight,
-        indentWidth: state.indentWidth,
-      }"
-      nodeKey="name"
-      :node="state.node"
+      :nodes="nodes"
+      node-key="name"
+      v-model:expanded="expanded"
+      v-model:selected="selected"
+      draggable
+      :can-drop="canDrop"
+      guides="connectors"
+      @move="onMove"
     />
   </div>
 </template>

--- a/src/components/Tree/stories/Example.vue
+++ b/src/components/Tree/stories/Example.vue
@@ -22,6 +22,7 @@ const nodes = ref<TreeNode[]>([
       {
         name: 'documents',
         label: 'Documents',
+        expanded: false,
         children: [
           { name: 'somefile.txt', label: 'somefile.txt' },
           { name: 'somefile.pdf', label: 'somefile.pdf' },

--- a/src/components/Tree/stories/ExpandAll.vue
+++ b/src/components/Tree/stories/ExpandAll.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Button, Tree } from 'frappe-ui'
+import type { TreeNode } from '../types'
+
+const nodes = ref<TreeNode[]>([
+  {
+    name: 'guest',
+    label: 'Guest',
+    children: [
+      {
+        name: 'downloads',
+        label: 'Downloads',
+        children: [
+          {
+            name: 'download.zip',
+            label: 'download.zip',
+            children: [{ name: 'image.png', label: 'image.png' }],
+          },
+        ],
+      },
+      {
+        name: 'documents',
+        label: 'Documents',
+        children: [
+          { name: 'somefile.txt', label: 'somefile.txt' },
+          { name: 'somefile.pdf', label: 'somefile.pdf' },
+        ],
+      },
+    ],
+  },
+])
+
+// `expanded` mirrors whether every node is open (nodes start expanded), so the
+// label stays in sync even when rows are toggled individually.
+const expanded = ref(true)
+</script>
+
+<template>
+  <div class="flex flex-col gap-3">
+    <Button class="self-start" @click="expanded = !expanded">
+      {{ expanded ? 'Collapse all' : 'Expand all' }}
+    </Button>
+    <div class="w-80">
+      <Tree :nodes="nodes" node-key="name" v-model:expanded="expanded" />
+    </div>
+  </div>
+</template>

--- a/src/components/Tree/stories/Guides.vue
+++ b/src/components/Tree/stories/Guides.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { TabButtons, Tree } from 'frappe-ui'
+import type { TreeNode } from '../types'
+
+const nodes = ref<TreeNode[]>([
+  {
+    name: 'guest',
+    label: 'Guest',
+    children: [
+      {
+        name: 'downloads',
+        label: 'Downloads',
+        children: [
+          {
+            name: 'download.zip',
+            label: 'download.zip',
+            children: [{ name: 'image.png', label: 'image.png' }],
+          },
+        ],
+      },
+      {
+        name: 'documents',
+        label: 'Documents',
+        children: [
+          { name: 'somefile.txt', label: 'somefile.txt' },
+          { name: 'somefile.pdf', label: 'somefile.pdf' },
+        ],
+      },
+    ],
+  },
+])
+
+const guides = ref<'connectors' | 'lines' | 'none'>('connectors')
+const guideOptions = [
+  { label: 'Connectors', value: 'connectors' },
+  { label: 'Lines', value: 'lines' },
+  { label: 'None', value: 'none' },
+]
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <TabButtons v-model="guides" :options="guideOptions" />
+    <div class="w-80">
+      <Tree :nodes="nodes" node-key="name" :guides="guides" default-expanded />
+    </div>
+  </div>
+</template>

--- a/src/components/Tree/stories/Guides.vue
+++ b/src/components/Tree/stories/Guides.vue
@@ -43,7 +43,7 @@ const guideOptions = [
   <div class="flex flex-col gap-4">
     <TabButtons v-model="guides" :options="guideOptions" />
     <div class="w-80">
-      <Tree :nodes="nodes" node-key="name" :guides="guides" default-expanded />
+      <Tree :nodes="nodes" node-key="name" :guides="guides" />
     </div>
   </div>
 </template>

--- a/src/components/Tree/stories/ListView.vue
+++ b/src/components/Tree/stories/ListView.vue
@@ -34,8 +34,6 @@ const nodes = ref<TreeNode[]>([
   },
 ])
 
-const expanded = ref<string[]>(['james', 'wade'])
-
 function addReport(node: TreeNode) {
   console.log('add report under', node.id)
 }
@@ -43,12 +41,7 @@ function addReport(node: TreeNode) {
 
 <template>
   <div class="w-96" style="--tree-row-height: 48px">
-    <Tree
-      :nodes="nodes"
-      node-key="id"
-      v-model:expanded="expanded"
-      guides="none"
-    >
+    <Tree :nodes="nodes" node-key="id" guides="none">
       <!-- Avatar on the left -->
       <template #item-prefix="{ node }">
         <Avatar

--- a/src/components/Tree/stories/ListView.vue
+++ b/src/components/Tree/stories/ListView.vue
@@ -5,10 +5,10 @@ import type { TreeNode } from '../types'
 
 const nodes = ref<TreeNode[]>([
   {
-    id: 'jane',
-    name: 'Jane Cooper',
+    id: 'james',
+    name: 'James Cooper',
     role: 'Head of Sales',
-    image: 'https://i.pravatar.cc/80?img=5',
+    image: 'https://i.pravatar.cc/80?img=11',
     children: [
       {
         id: 'wade',
@@ -17,10 +17,10 @@ const nodes = ref<TreeNode[]>([
         image: 'https://i.pravatar.cc/80?img=12',
         children: [
           {
-            id: 'esther',
-            name: 'Esther Howard',
+            id: 'ethan',
+            name: 'Ethan Howard',
             role: 'Sales Rep',
-            image: 'https://i.pravatar.cc/80?img=32',
+            image: 'https://i.pravatar.cc/80?img=13',
           },
         ],
       },
@@ -34,7 +34,7 @@ const nodes = ref<TreeNode[]>([
   },
 ])
 
-const expanded = ref<string[]>(['jane', 'wade'])
+const expanded = ref<string[]>(['james', 'wade'])
 
 function addReport(node: TreeNode) {
   console.log('add report under', node.id)
@@ -77,18 +77,6 @@ function addReport(node: TreeNode) {
           :aria-label="`Add report under ${node.name}`"
           @click.stop="addReport(node)"
         />
-        <svg
-          class="size-4 text-ink-gray-4"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="m9 18 6-6-6-6" />
-        </svg>
       </template>
     </Tree>
   </div>

--- a/src/components/Tree/stories/ListView.vue
+++ b/src/components/Tree/stories/ListView.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Avatar, Button, Tree } from 'frappe-ui'
+import type { TreeNode } from '../types'
+
+const nodes = ref<TreeNode[]>([
+  {
+    id: 'jane',
+    name: 'Jane Cooper',
+    role: 'Head of Sales',
+    image: 'https://i.pravatar.cc/80?img=5',
+    children: [
+      {
+        id: 'wade',
+        name: 'Wade Warren',
+        role: 'Account Executive',
+        image: 'https://i.pravatar.cc/80?img=12',
+        children: [
+          {
+            id: 'esther',
+            name: 'Esther Howard',
+            role: 'Sales Rep',
+            image: 'https://i.pravatar.cc/80?img=32',
+          },
+        ],
+      },
+      {
+        id: 'cody',
+        name: 'Cody Fisher',
+        role: 'Account Executive',
+        image: 'https://i.pravatar.cc/80?img=15',
+      },
+    ],
+  },
+])
+
+const expanded = ref<string[]>(['jane', 'wade'])
+
+function addReport(node: TreeNode) {
+  console.log('add report under', node.id)
+}
+</script>
+
+<template>
+  <div class="w-96">
+    <Tree
+      :nodes="nodes"
+      node-key="id"
+      label-key="name"
+      v-model:expanded="expanded"
+      guides="none"
+      row-height="48px"
+    >
+      <!-- Avatar on the left -->
+      <template #prefix="{ node }">
+        <Avatar
+          :image="node.image as string"
+          :label="node.name as string"
+          size="lg"
+        />
+      </template>
+
+      <template #label="{ node }">
+        <div class="flex min-w-0 flex-col">
+          <span class="truncate text-base text-ink-gray-8">{{
+            node.name
+          }}</span>
+          <span class="truncate text-sm text-ink-gray-5">{{ node.role }}</span>
+        </div>
+      </template>
+
+      <!-- Add action -->
+      <template #suffix="{ node }">
+        <Button
+          variant="ghost"
+          icon="plus"
+          :aria-label="`Add report under ${node.name}`"
+          @click.stop="addReport(node)"
+        />
+        <svg
+          class="size-4 text-ink-gray-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="m9 18 6-6-6-6" />
+        </svg>
+      </template>
+    </Tree>
+  </div>
+</template>

--- a/src/components/Tree/stories/ListView.vue
+++ b/src/components/Tree/stories/ListView.vue
@@ -6,19 +6,19 @@ import type { TreeNode } from '../types'
 const nodes = ref<TreeNode[]>([
   {
     id: 'james',
-    name: 'James Cooper',
+    label: 'James Cooper',
     role: 'Head of Sales',
     image: 'https://i.pravatar.cc/80?img=11',
     children: [
       {
         id: 'wade',
-        name: 'Wade Warren',
+        label: 'Wade Warren',
         role: 'Account Executive',
         image: 'https://i.pravatar.cc/80?img=12',
         children: [
           {
             id: 'ethan',
-            name: 'Ethan Howard',
+            label: 'Ethan Howard',
             role: 'Sales Rep',
             image: 'https://i.pravatar.cc/80?img=13',
           },
@@ -26,7 +26,7 @@ const nodes = ref<TreeNode[]>([
       },
       {
         id: 'cody',
-        name: 'Cody Fisher',
+        label: 'Cody Fisher',
         role: 'Account Executive',
         image: 'https://i.pravatar.cc/80?img=15',
       },
@@ -42,20 +42,18 @@ function addReport(node: TreeNode) {
 </script>
 
 <template>
-  <div class="w-96">
+  <div class="w-96" style="--tree-row-height: 48px">
     <Tree
       :nodes="nodes"
       node-key="id"
-      label-key="name"
       v-model:expanded="expanded"
       guides="none"
-      row-height="48px"
     >
       <!-- Avatar on the left -->
       <template #prefix="{ node }">
         <Avatar
           :image="node.image as string"
-          :label="node.name as string"
+          :label="node.label as string"
           size="lg"
         />
       </template>
@@ -63,7 +61,7 @@ function addReport(node: TreeNode) {
       <template #label="{ node }">
         <div class="flex min-w-0 flex-col">
           <span class="truncate text-base text-ink-gray-8">{{
-            node.name
+            node.label
           }}</span>
           <span class="truncate text-sm text-ink-gray-5">{{ node.role }}</span>
         </div>
@@ -74,7 +72,7 @@ function addReport(node: TreeNode) {
         <Button
           variant="ghost"
           icon="plus"
-          :aria-label="`Add report under ${node.name}`"
+          :aria-label="`Add report under ${node.label}`"
           @click.stop="addReport(node)"
         />
       </template>

--- a/src/components/Tree/stories/ListView.vue
+++ b/src/components/Tree/stories/ListView.vue
@@ -50,7 +50,7 @@ function addReport(node: TreeNode) {
       guides="none"
     >
       <!-- Avatar on the left -->
-      <template #prefix="{ node }">
+      <template #item-prefix="{ node }">
         <Avatar
           :image="node.image as string"
           :label="node.label as string"
@@ -58,7 +58,7 @@ function addReport(node: TreeNode) {
         />
       </template>
 
-      <template #label="{ node }">
+      <template #item-label="{ node }">
         <div class="flex min-w-0 flex-col">
           <span class="truncate text-base text-ink-gray-8">{{
             node.label
@@ -68,7 +68,7 @@ function addReport(node: TreeNode) {
       </template>
 
       <!-- Add action -->
-      <template #suffix="{ node }">
+      <template #item-suffix="{ node }">
         <Button
           variant="ghost"
           icon="plus"

--- a/src/components/Tree/tree.cy.ts
+++ b/src/components/Tree/tree.cy.ts
@@ -2,83 +2,100 @@ import Tree from './Tree.vue'
 import { h, ref } from 'vue'
 import type { DropInfo, TreeNode } from './types'
 
-const nodes: TreeNode[] = [
-  {
-    id: 'root',
-    label: 'Root',
-    children: [
-      {
-        id: 'a',
-        label: 'Node A',
-        children: [{ id: 'a-1', label: 'Node A-1' }],
-      },
-      { id: 'b', label: 'Node B' },
-    ],
-  },
-]
+// Fresh data per test — the tree mutates `node.expanded`, so a shared const
+// would leak expansion state between tests.
+function makeNodes(): TreeNode[] {
+  return [
+    {
+      id: 'root',
+      label: 'Root',
+      children: [
+        {
+          id: 'a',
+          label: 'Node A',
+          children: [{ id: 'a-1', label: 'Node A-1' }],
+        },
+        { id: 'b', label: 'Node B' },
+      ],
+    },
+  ]
+}
 
 describe('Tree', () => {
-  it('renders roots collapsed by default', () => {
+  it('renders nodes expanded by default', () => {
+    cy.mount(Tree, { props: { nodes: makeNodes(), nodeKey: 'id' } })
+    cy.contains('Node A').should('exist')
+    cy.contains('Node A-1').should('exist')
+  })
+
+  it('starts a node collapsed when flagged expanded: false', () => {
+    const nodes = makeNodes()
+    nodes[0].expanded = false
     cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
     cy.contains('Root').should('exist')
     cy.contains('Node A').should('not.exist')
   })
 
-  it('expands all when defaultExpanded is set', () => {
-    cy.mount(Tree, { props: { nodes, nodeKey: 'id', defaultExpanded: true } })
-    cy.contains('Root').should('exist')
+  it('expands all via the v-model:expanded switch', () => {
+    const nodes = makeNodes()
+    nodes[0].expanded = false // start collapsed; the switch should override it
+    cy.mount(Tree, { props: { nodes, nodeKey: 'id', expanded: true } })
     cy.contains('Node A').should('exist')
     cy.contains('Node A-1').should('exist')
     cy.contains('Node B').should('exist')
   })
 
-  it('seeds defaultExpanded when nodes arrive asynchronously', () => {
+  it('expands late-arriving nodes while the switch is on', () => {
     const data = ref<TreeNode[]>([])
     cy.mount({
       render: () =>
-        h(Tree, { nodes: data.value, nodeKey: 'id', defaultExpanded: true }),
+        h(Tree, { nodes: data.value, nodeKey: 'id', expanded: true }),
     })
     cy.contains('Node A').should('not.exist')
     cy.then(() => {
-      data.value = nodes
+      data.value = makeNodes()
     })
     cy.contains('Node A').should('exist')
     cy.contains('Node A-1').should('exist')
   })
 
+  it('reflects the switch back to the model when a row toggles', () => {
+    const onUpdate = cy.stub().as('update')
+    cy.mount(Tree, {
+      props: {
+        nodes: makeNodes(),
+        nodeKey: 'id',
+        expanded: true,
+        'onUpdate:expanded': onUpdate,
+      },
+    })
+    // Collapsing one node means "not all expanded" → switch flips to false.
+    cy.contains('[data-slot="row"]', 'Node A').click()
+    cy.get('@update').should('have.been.calledWith', false)
+  })
+
   it('toggles via the chevron', () => {
-    cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
+    cy.mount(Tree, { props: { nodes: makeNodes(), nodeKey: 'id' } })
+    cy.contains('Node A').should('exist')
+    cy.get('[data-slot="toggle"]').first().click()
     cy.contains('Node A').should('not.exist')
     cy.get('[data-slot="toggle"]').first().click()
     cy.contains('Node A').should('exist')
-    cy.contains('Node B').should('exist')
   })
 
   it('toggles expansion by clicking the row', () => {
-    cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
-    cy.contains('Node A').should('not.exist')
-    cy.contains('[data-slot="row"]', 'Root').click()
+    cy.mount(Tree, { props: { nodes: makeNodes(), nodeKey: 'id' } })
     cy.contains('Node A').should('exist')
     cy.contains('[data-slot="row"]', 'Root').click()
     cy.contains('Node A').should('not.exist')
-  })
-
-  it('drives expansion through v-model:expanded', () => {
-    const expanded = ref<string[]>(['root'])
-    cy.mount(Tree, {
-      props: {
-        nodes,
-        nodeKey: 'id',
-        expanded: expanded.value,
-        'onUpdate:expanded': (v: string[]) => (expanded.value = v),
-      },
-    })
+    cy.contains('[data-slot="row"]', 'Root').click()
     cy.contains('Node A').should('exist')
-    cy.contains('Node A-1').should('not.exist')
   })
 
   it('exposes ARIA tree semantics', () => {
-    cy.mount(Tree, { props: { nodes, nodeKey: 'id', defaultExpanded: true } })
+    cy.mount(Tree, {
+      props: { nodes: makeNodes(), nodeKey: 'id', expanded: true },
+    })
     cy.get('[role="tree"]').should('exist')
     cy.get('[role="treeitem"]').should('have.length', 4)
     cy.contains('[role="treeitem"]', 'Root')
@@ -92,34 +109,32 @@ describe('Tree', () => {
   })
 
   it('navigates with the keyboard', () => {
-    cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
+    cy.mount(Tree, { props: { nodes: makeNodes(), nodeKey: 'id' } })
     // Root is the only tabbable item initially.
     cy.get('[role="treeitem"]').first().focus()
     cy.focused().should('contain', 'Root')
-    // Right expands, Down moves into children.
-    cy.focused().trigger('keydown', { key: 'ArrowRight' })
+    // Tree starts expanded; Down steps into the first child.
     cy.focused().trigger('keydown', { key: 'ArrowDown' })
     cy.focused().should('contain', 'Node A')
-    // Left on a collapsed leaf-parent collapses; Left again goes to parent.
-    cy.focused().trigger('keydown', { key: 'ArrowRight' }) // expand A
+    // Left collapses the expanded node, Left again steps to the parent.
     cy.focused().trigger('keydown', { key: 'ArrowLeft' }) // collapse A
     cy.focused().trigger('keydown', { key: 'ArrowLeft' }) // -> Root
     cy.focused().should('contain', 'Root')
   })
 
   it('toggles expansion with Enter/Space', () => {
-    cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
+    cy.mount(Tree, { props: { nodes: makeNodes(), nodeKey: 'id' } })
     cy.get('[role="treeitem"]').first().focus()
     cy.focused().should('contain', 'Root')
     cy.focused().trigger('keydown', { key: 'Enter' })
-    cy.contains('Node A').should('exist')
-    cy.focused().trigger('keydown', { key: 'Enter' })
     cy.contains('Node A').should('not.exist')
+    cy.focused().trigger('keydown', { key: 'Enter' })
+    cy.contains('Node A').should('exist')
   })
 
   it('renders custom item-label and item-prefix/item-suffix slots', () => {
     cy.mount(Tree, {
-      props: { nodes, nodeKey: 'id', defaultExpanded: true },
+      props: { nodes: makeNodes(), nodeKey: 'id', expanded: true },
       slots: {
         'item-label': ({ node }: any) =>
           h('span', { 'data-cy': `label-${node.id}` }, `label-${node.label}`),
@@ -134,7 +149,7 @@ describe('Tree', () => {
   it('forwards class and style to the tree element', () => {
     cy.mount(Tree, {
       props: {
-        nodes,
+        nodes: makeNodes(),
         nodeKey: 'id',
         class: 'my-tree',
         style: '--tree-indent: 40px',
@@ -149,7 +164,9 @@ describe('Tree', () => {
   })
 
   it('indents nested groups', () => {
-    cy.mount(Tree, { props: { nodes, nodeKey: 'id', defaultExpanded: true } })
+    cy.mount(Tree, {
+      props: { nodes: makeNodes(), nodeKey: 'id', expanded: true },
+    })
     cy.get('[role="group"]')
       .first()
       .should(($ul) => {
@@ -160,9 +177,9 @@ describe('Tree', () => {
   it('renders connector guides', () => {
     cy.mount(Tree, {
       props: {
-        nodes,
+        nodes: makeNodes(),
         nodeKey: 'id',
-        defaultExpanded: true,
+        expanded: true,
         guides: 'connectors',
       },
     })
@@ -173,9 +190,9 @@ describe('Tree', () => {
   describe('drag and drop', () => {
     function dndProps(onDragEnd: (info: DropInfo | null) => void, extra = {}) {
       return {
-        nodes,
+        nodes: makeNodes(),
         nodeKey: 'id',
-        defaultExpanded: true,
+        expanded: true,
         draggable: true,
         onDragEnd,
         ...extra,

--- a/src/components/Tree/tree.cy.ts
+++ b/src/components/Tree/tree.cy.ts
@@ -1,144 +1,194 @@
 import Tree from './Tree.vue'
-import { h } from 'vue'
-import type { TreeNode } from './types'
+import { h, ref } from 'vue'
+import type { MoveEvent, TreeNode } from './types'
 
-const data: TreeNode = {
-  id: 'root',
-  label: 'Root',
-  children: [
-    {
-      id: 'a',
-      label: 'Node A',
-      children: [
-        {
-          id: 'a-1',
-          label: 'Node A-1',
-          children: [],
-        },
-      ],
-    },
-    {
-      id: 'b',
-      label: 'Node B',
-      children: [],
-    },
-  ],
-}
+const nodes: TreeNode[] = [
+  {
+    id: 'root',
+    label: 'Root',
+    children: [
+      {
+        id: 'a',
+        label: 'Node A',
+        children: [{ id: 'a-1', label: 'Node A-1' }],
+      },
+      { id: 'b', label: 'Node B' },
+    ],
+  },
+]
 
 describe('Tree', () => {
-  it('renders root node', () => {
-    cy.mount(Tree, {
-      props: {
-        node: data,
-        nodeKey: 'id',
-      },
-    })
-
+  it('renders roots collapsed by default', () => {
+    cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
     cy.contains('Root').should('exist')
     cy.contains('Node A').should('not.exist')
   })
 
-  it('expand / collapse', () => {
-    cy.mount(Tree, {
-      props: {
-        node: data,
-        nodeKey: 'id',
-        options: {
-          defaultCollapsed: true,
-        },
-      },
-    })
+  it('expands all when defaultExpanded is set', () => {
+    cy.mount(Tree, { props: { nodes, nodeKey: 'id', defaultExpanded: true } })
+    cy.contains('Root').should('exist')
+    cy.contains('Node A').should('exist')
+    cy.contains('Node A-1').should('exist')
+    cy.contains('Node B').should('exist')
+  })
 
-    // collapse nodes
+  it('toggles via the chevron', () => {
+    cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
     cy.contains('Node A').should('not.exist')
-
-    cy.contains('Root').click()
+    cy.get('[data-slot="toggle"]').first().click()
     cy.contains('Node A').should('exist')
     cy.contains('Node B').should('exist')
+  })
 
-    cy.contains('Node A').click()
-    cy.contains('Node A-1').should('exist')
-
-    cy.contains('Node A').click()
+  it('drives expansion through v-model:expanded', () => {
+    const expanded = ref<string[]>(['root'])
+    cy.mount(Tree, {
+      props: {
+        nodes,
+        nodeKey: 'id',
+        expanded: expanded.value,
+        'onUpdate:expanded': (v: string[]) => (expanded.value = v),
+      },
+    })
+    cy.contains('Node A').should('exist')
     cy.contains('Node A-1').should('not.exist')
   })
 
-  it('renders recursively', () => {
+  it('selects a node (aria-selected) and emits update:selected', () => {
+    const onUpdate = cy.stub().as('select')
     cy.mount(Tree, {
       props: {
-        node: data,
+        nodes,
         nodeKey: 'id',
-        options: {
-          defaultCollapsed: false,
-        },
+        defaultExpanded: true,
+        'onUpdate:selected': onUpdate,
       },
     })
-
-    cy.contains('Root').should('exist')
-    cy.contains('Node A').should('exist')
-    cy.contains('Node A-1').should('exist')
-    cy.contains('Node B').should('exist')
+    cy.contains('Node A').click()
+    cy.get('[role="treeitem"][aria-selected="true"]').should(
+      'contain',
+      'Node A',
+    )
+    cy.get('@select').should('have.been.calledWith', 'a')
   })
 
-  it('options: rowHeight & indentation guides', () => {
-    cy.mount(Tree, {
-      props: {
-        node: data,
-        nodeKey: 'id',
-        options: {
-          rowHeight: '40px',
-          showIndentationGuides: true,
-          defaultCollapsed: false,
-        },
-      },
-    })
-
-    cy.contains('Root')
-      .parent()
-      .should('have.css', 'height', '40px')
-
-    // indentation line
-    cy.get('.border-r').should('exist')
+  it('does not select or highlight when v-model:selected is unbound', () => {
+    cy.mount(Tree, { props: { nodes, nodeKey: 'id', defaultExpanded: true } })
+    cy.contains('Node A').click()
+    cy.get('[data-selected]').should('not.exist')
+    cy.get('[role="treeitem"][aria-selected]').should('not.exist')
   })
 
-  it('slots', () => {
+  it('exposes ARIA tree semantics', () => {
+    cy.mount(Tree, { props: { nodes, nodeKey: 'id', defaultExpanded: true } })
+    cy.get('[role="tree"]').should('exist')
+    cy.get('[role="treeitem"]').should('have.length', 4)
+    cy.contains('[role="treeitem"]', 'Root')
+      .should('have.attr', 'aria-expanded', 'true')
+      .and('have.attr', 'aria-level', '1')
+    cy.contains('[role="treeitem"]', 'Node A-1').should(
+      'have.attr',
+      'aria-level',
+      '3',
+    )
+  })
+
+  it('navigates with the keyboard', () => {
+    cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
+    // Root is the only tabbable item initially.
+    cy.get('[role="treeitem"]').first().focus()
+    cy.focused().should('contain', 'Root')
+    // Right expands, Down moves into children.
+    cy.focused().trigger('keydown', { key: 'ArrowRight' })
+    cy.focused().trigger('keydown', { key: 'ArrowDown' })
+    cy.focused().should('contain', 'Node A')
+    // Left on a collapsed leaf-parent collapses; Left again goes to parent.
+    cy.focused().trigger('keydown', { key: 'ArrowRight' }) // expand A
+    cy.focused().trigger('keydown', { key: 'ArrowLeft' }) // collapse A
+    cy.focused().trigger('keydown', { key: 'ArrowLeft' }) // -> Root
+    cy.focused().should('contain', 'Root')
+  })
+
+  it('renders custom label and prefix/suffix slots', () => {
     cy.mount(Tree, {
-      props: {
-        node: data,
-        nodeKey: 'id',
-        options: { defaultCollapsed: false },
-      },
+      props: { nodes, nodeKey: 'id', defaultExpanded: true },
       slots: {
         label: ({ node }: any) =>
-          h(
-            'span',
-            {
-              'data-cy': `label-${node.id}`,
-            },
-            `label-${node.label}`,
-          ),
-
-        icon: () =>
-          h('span', { 'data-cy': 'icon' }, 'icon'),
+          h('span', { 'data-cy': `label-${node.id}` }, `label-${node.label}`),
+        suffix: ({ node }: any) =>
+          h('span', { 'data-cy': `suffix-${node.id}` }, '★'),
       },
     })
-
     cy.get('[data-cy="label-root"]').should('exist')
-    cy.get('[data-cy="label-a"]').should('exist')
-    cy.get('[data-cy="label-b"]').should('exist')
-    cy.get('[data-cy="icon"]').should('exist')
+    cy.get('[data-cy="suffix-a"]').should('exist')
   })
 
-  it('does not toggle when node has no children', () => {
+  it('renders connector guides', () => {
     cy.mount(Tree, {
       props: {
-        node: data,
+        nodes,
         nodeKey: 'id',
-        options: { defaultCollapsed: false },
+        defaultExpanded: true,
+        guides: 'connectors',
       },
     })
+    cy.get('[role="tree"]').should('have.attr', 'data-guides', 'connectors')
+    cy.get('[role="group"]').should('exist')
+  })
 
-    cy.contains('Node B').click()
-    cy.contains('Node B').should('exist')
+  describe('drag and drop', () => {
+    function dndProps(onMove: (m: MoveEvent) => void, extra = {}) {
+      return {
+        nodes,
+        nodeKey: 'id',
+        defaultExpanded: true,
+        draggable: true,
+        onMove,
+        ...extra,
+      }
+    }
+
+    function drag(sourceLabel: string, targetLabel: string) {
+      const dataTransfer = new DataTransfer()
+      cy.contains('[data-slot="row"]', sourceLabel).trigger('dragstart', {
+        dataTransfer,
+      })
+      cy.contains('[data-slot="row"]', targetLabel).trigger('dragover', {
+        dataTransfer,
+        clientY: 0,
+      })
+      cy.contains('[data-slot="row"]', targetLabel).trigger('drop', {
+        dataTransfer,
+      })
+    }
+
+    it('emits move on a valid reparent', () => {
+      const onMove = cy.stub().as('move')
+      cy.mount(Tree, { props: dndProps(onMove) })
+      drag('Node B', 'Node A')
+      cy.get('@move').should('have.been.calledOnce')
+      cy.get('@move').then((stub: any) => {
+        const move: MoveEvent = stub.firstCall.args[0]
+        expect(move.node.id).to.eq('b')
+        expect(move.to).to.eq('a')
+        expect(move.position).to.eq('inside')
+      })
+    })
+
+    it('blocks dropping a node into its own descendant', () => {
+      const onMove = cy.stub().as('move')
+      cy.mount(Tree, { props: dndProps(onMove) })
+      drag('Node A', 'Node A-1')
+      cy.get('@move').should('not.have.been.called')
+    })
+
+    it('respects the canDrop validator', () => {
+      const onMove = cy.stub().as('move')
+      cy.mount(Tree, {
+        props: dndProps(onMove, { canDrop: () => false }),
+      })
+      drag('Node B', 'Node A')
+      cy.get('@move').should('not.have.been.called')
+    })
   })
 })

--- a/src/components/Tree/tree.cy.ts
+++ b/src/components/Tree/tree.cy.ts
@@ -32,6 +32,20 @@ describe('Tree', () => {
     cy.contains('Node B').should('exist')
   })
 
+  it('seeds defaultExpanded when nodes arrive asynchronously', () => {
+    const data = ref<TreeNode[]>([])
+    cy.mount({
+      render: () =>
+        h(Tree, { nodes: data.value, nodeKey: 'id', defaultExpanded: true }),
+    })
+    cy.contains('Node A').should('not.exist')
+    cy.then(() => {
+      data.value = nodes
+    })
+    cy.contains('Node A').should('exist')
+    cy.contains('Node A-1').should('exist')
+  })
+
   it('toggles via the chevron', () => {
     cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
     cy.contains('Node A').should('not.exist')
@@ -103,13 +117,13 @@ describe('Tree', () => {
     cy.contains('Node A').should('not.exist')
   })
 
-  it('renders custom label and prefix/suffix slots', () => {
+  it('renders custom item-label and item-prefix/item-suffix slots', () => {
     cy.mount(Tree, {
       props: { nodes, nodeKey: 'id', defaultExpanded: true },
       slots: {
-        label: ({ node }: any) =>
+        'item-label': ({ node }: any) =>
           h('span', { 'data-cy': `label-${node.id}` }, `label-${node.label}`),
-        suffix: ({ node }: any) =>
+        'item-suffix': ({ node }: any) =>
           h('span', { 'data-cy': `suffix-${node.id}` }, '★'),
       },
     })

--- a/src/components/Tree/tree.cy.ts
+++ b/src/components/Tree/tree.cy.ts
@@ -1,6 +1,6 @@
 import Tree from './Tree.vue'
 import { h, ref } from 'vue'
-import type { MoveEvent, TreeNode } from './types'
+import type { DropInfo, TreeNode } from './types'
 
 const nodes: TreeNode[] = [
   {
@@ -40,6 +40,15 @@ describe('Tree', () => {
     cy.contains('Node B').should('exist')
   })
 
+  it('toggles expansion by clicking the row', () => {
+    cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
+    cy.contains('Node A').should('not.exist')
+    cy.contains('[data-slot="row"]', 'Root').click()
+    cy.contains('Node A').should('exist')
+    cy.contains('[data-slot="row"]', 'Root').click()
+    cy.contains('Node A').should('not.exist')
+  })
+
   it('drives expansion through v-model:expanded', () => {
     const expanded = ref<string[]>(['root'])
     cy.mount(Tree, {
@@ -52,31 +61,6 @@ describe('Tree', () => {
     })
     cy.contains('Node A').should('exist')
     cy.contains('Node A-1').should('not.exist')
-  })
-
-  it('selects a node (aria-selected) and emits update:selected', () => {
-    const onUpdate = cy.stub().as('select')
-    cy.mount(Tree, {
-      props: {
-        nodes,
-        nodeKey: 'id',
-        defaultExpanded: true,
-        'onUpdate:selected': onUpdate,
-      },
-    })
-    cy.contains('Node A').click()
-    cy.get('[role="treeitem"][aria-selected="true"]').should(
-      'contain',
-      'Node A',
-    )
-    cy.get('@select').should('have.been.calledWith', 'a')
-  })
-
-  it('does not select or highlight when v-model:selected is unbound', () => {
-    cy.mount(Tree, { props: { nodes, nodeKey: 'id', defaultExpanded: true } })
-    cy.contains('Node A').click()
-    cy.get('[data-selected]').should('not.exist')
-    cy.get('[role="treeitem"][aria-selected]').should('not.exist')
   })
 
   it('exposes ARIA tree semantics', () => {
@@ -109,6 +93,16 @@ describe('Tree', () => {
     cy.focused().should('contain', 'Root')
   })
 
+  it('toggles expansion with Enter/Space', () => {
+    cy.mount(Tree, { props: { nodes, nodeKey: 'id' } })
+    cy.get('[role="treeitem"]').first().focus()
+    cy.focused().should('contain', 'Root')
+    cy.focused().trigger('keydown', { key: 'Enter' })
+    cy.contains('Node A').should('exist')
+    cy.focused().trigger('keydown', { key: 'Enter' })
+    cy.contains('Node A').should('not.exist')
+  })
+
   it('renders custom label and prefix/suffix slots', () => {
     cy.mount(Tree, {
       props: { nodes, nodeKey: 'id', defaultExpanded: true },
@@ -121,6 +115,15 @@ describe('Tree', () => {
     })
     cy.get('[data-cy="label-root"]').should('exist')
     cy.get('[data-cy="suffix-a"]').should('exist')
+  })
+
+  it('indents nested groups', () => {
+    cy.mount(Tree, { props: { nodes, nodeKey: 'id', defaultExpanded: true } })
+    cy.get('[role="group"]')
+      .first()
+      .should(($ul) => {
+        expect(parseFloat($ul.css('padding-left'))).to.be.greaterThan(0)
+      })
   })
 
   it('renders connector guides', () => {
@@ -137,81 +140,84 @@ describe('Tree', () => {
   })
 
   describe('drag and drop', () => {
-    function dndProps(onMove: (m: MoveEvent) => void, extra = {}) {
+    function dndProps(onDragEnd: (info: DropInfo | null) => void, extra = {}) {
       return {
         nodes,
         nodeKey: 'id',
         defaultExpanded: true,
         draggable: true,
-        onMove,
+        onDragEnd,
         ...extra,
       }
     }
 
-    function drag(sourceLabel: string, targetLabel: string) {
+    // Drag `sourceLabel` onto a `zone` of `targetLabel` and release.
+    function dragOnto(
+      sourceLabel: string,
+      targetLabel: string,
+      zone: 'before' | 'inside' | 'after',
+    ) {
       const dataTransfer = new DataTransfer()
       cy.contains('[data-slot="row"]', sourceLabel).trigger('dragstart', {
         dataTransfer,
       })
-      cy.contains('[data-slot="row"]', targetLabel).trigger('dragover', {
-        dataTransfer,
-        clientY: 0,
+      cy.contains('[data-slot="row"]', targetLabel).then(($el) => {
+        const rect = $el[0].getBoundingClientRect()
+        const clientY =
+          zone === 'before'
+            ? rect.top + 1
+            : zone === 'after'
+              ? rect.bottom - 1
+              : rect.top + rect.height / 2
+        cy.wrap($el).trigger('dragover', { dataTransfer, clientY })
+        cy.wrap($el).trigger('drop', { dataTransfer })
       })
-      cy.contains('[data-slot="row"]', targetLabel).trigger('drop', {
+      cy.contains('[data-slot="row"]', sourceLabel).trigger('dragend', {
         dataTransfer,
       })
     }
 
-    it('emits move on a valid reparent', () => {
-      const onMove = cy.stub().as('move')
-      cy.mount(Tree, { props: dndProps(onMove) })
-      drag('Node B', 'Node A')
-      cy.get('@move').should('have.been.calledOnce')
-      cy.get('@move').then((stub: any) => {
-        const move: MoveEvent = stub.firstCall.args[0]
-        expect(move.node.id).to.eq('b')
-        expect(move.to).to.eq('a')
-        expect(move.position).to.eq('inside')
+    it('emits drag-end with DropInfo on a valid reparent', () => {
+      const onDragEnd = cy.stub().as('dragEnd')
+      cy.mount(Tree, { props: dndProps(onDragEnd) })
+      dragOnto('Node B', 'Node A', 'inside')
+      cy.get('@dragEnd').should('have.been.calledOnce')
+      cy.get('@dragEnd').then((stub: any) => {
+        const info: DropInfo = stub.firstCall.args[0]
+        expect(info.node.id).to.eq('b')
+        expect(info.to).to.eq('a')
+        expect(info.position).to.eq('inside')
       })
     })
 
-    it('blocks dropping a node into its own descendant', () => {
-      const onMove = cy.stub().as('move')
-      cy.mount(Tree, { props: dndProps(onMove) })
-      drag('Node A', 'Node A-1')
-      cy.get('@move').should('not.have.been.called')
+    it('emits drag-end with null when dropping into a descendant', () => {
+      const onDragEnd = cy.stub().as('dragEnd')
+      cy.mount(Tree, { props: dndProps(onDragEnd) })
+      dragOnto('Node A', 'Node A-1', 'inside')
+      cy.get('@dragEnd').should('have.been.calledOnceWith', null)
     })
 
-    it('respects the canDrop validator', () => {
-      const onMove = cy.stub().as('move')
+    it('respects the move predicate', () => {
+      const onDragEnd = cy.stub().as('dragEnd')
       cy.mount(Tree, {
-        props: dndProps(onMove, { canDrop: () => false }),
+        props: dndProps(onDragEnd, { move: () => false }),
       })
-      drag('Node B', 'Node A')
-      cy.get('@move').should('not.have.been.called')
+      dragOnto('Node B', 'Node A', 'inside')
+      cy.get('@dragEnd').should('have.been.calledOnceWith', null)
     })
 
     it('reports the final post-removal index when reordering down', () => {
-      const onMove = cy.stub().as('move')
-      cy.mount(Tree, { props: dndProps(onMove, { reorderable: true }) })
+      const onDragEnd = cy.stub().as('dragEnd')
+      cy.mount(Tree, { props: dndProps(onDragEnd) })
       // Drag Node A (index 0) to AFTER Node B (index 1) within the same parent.
-      const dataTransfer = new DataTransfer()
-      cy.contains('[data-slot="row"]', 'Node A').trigger('dragstart', {
-        dataTransfer,
-      })
-      cy.contains('[data-slot="row"]', 'Node B').trigger('dragover', {
-        dataTransfer,
-        clientY: 9999, // bottom zone -> 'after'
-      })
-      cy.contains('[data-slot="row"]', 'Node B').trigger('drop', {
-        dataTransfer,
-      })
-      cy.get('@move').then((stub: any) => {
-        const move: MoveEvent = stub.firstCall.args[0]
-        expect(move.node.id).to.eq('a')
-        expect(move.position).to.eq('after')
+      dragOnto('Node A', 'Node B', 'after')
+      cy.get('@dragEnd').then((stub: any) => {
+        const info: DropInfo = stub.firstCall.args[0]
+        expect(info.node.id).to.eq('a')
+        expect(info.position).to.eq('after')
+        expect(info.oldIndex).to.eq(0)
         // Source was before the target, so the final index is 1, not 2.
-        expect(move.index).to.eq(1)
+        expect(info.newIndex).to.eq(1)
       })
     })
   })

--- a/src/components/Tree/tree.cy.ts
+++ b/src/components/Tree/tree.cy.ts
@@ -117,6 +117,23 @@ describe('Tree', () => {
     cy.get('[data-cy="suffix-a"]').should('exist')
   })
 
+  it('forwards class and style to the tree element', () => {
+    cy.mount(Tree, {
+      props: {
+        nodes,
+        nodeKey: 'id',
+        class: 'my-tree',
+        style: '--tree-indent: 40px',
+      },
+    })
+    cy.get('[role="tree"]')
+      .should('have.class', 'my-tree')
+      .and('have.css', 'padding', '0px')
+    cy.get('[role="tree"]').then(($el) => {
+      expect($el[0].style.getPropertyValue('--tree-indent')).to.eq('40px')
+    })
+  })
+
   it('indents nested groups', () => {
     cy.mount(Tree, { props: { nodes, nodeKey: 'id', defaultExpanded: true } })
     cy.get('[role="group"]')

--- a/src/components/Tree/tree.cy.ts
+++ b/src/components/Tree/tree.cy.ts
@@ -190,5 +190,29 @@ describe('Tree', () => {
       drag('Node B', 'Node A')
       cy.get('@move').should('not.have.been.called')
     })
+
+    it('reports the final post-removal index when reordering down', () => {
+      const onMove = cy.stub().as('move')
+      cy.mount(Tree, { props: dndProps(onMove, { reorderable: true }) })
+      // Drag Node A (index 0) to AFTER Node B (index 1) within the same parent.
+      const dataTransfer = new DataTransfer()
+      cy.contains('[data-slot="row"]', 'Node A').trigger('dragstart', {
+        dataTransfer,
+      })
+      cy.contains('[data-slot="row"]', 'Node B').trigger('dragover', {
+        dataTransfer,
+        clientY: 9999, // bottom zone -> 'after'
+      })
+      cy.contains('[data-slot="row"]', 'Node B').trigger('drop', {
+        dataTransfer,
+      })
+      cy.get('@move').then((stub: any) => {
+        const move: MoveEvent = stub.firstCall.args[0]
+        expect(move.node.id).to.eq('a')
+        expect(move.position).to.eq('after')
+        // Source was before the target, so the final index is 1, not 2.
+        expect(move.index).to.eq(1)
+      })
+    })
   })
 })

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -81,7 +81,10 @@ export interface TreeProps {
   guides?: 'connectors' | 'lines' | 'none'
 
   /**
-   * Initial expansion state of nodes when `v-model:expanded` is not bound.
+   * Start with every node expanded. A one-shot convenience that seeds the open
+   * set on first load (async-safe — it waits for `nodes` to arrive). To open
+   * specific nodes or track expansion, use `v-model:expanded` instead; this is
+   * ignored once you provide your own keys.
    * @default false
    */
   defaultExpanded?: boolean

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -1,47 +1,174 @@
+import type { ComputedRef, InjectionKey, Ref } from 'vue'
+
+/** A node key — the value read from `nodeKey` on each node. */
+export type TreeKey = string | number
+
+/**
+ * A tree node. The shape is open: `label` and `children` are the conventional
+ * fields, but the unique-id field (`nodeKey`), label field (`labelKey`) and
+ * children field (`childrenKey`) are all configurable, so any record-like
+ * object can be rendered without remapping.
+ */
 export type TreeNode = {
-  label: string
-  children: TreeNode[]
-  // added TreeNode[] due to enforcement that dynamic key types should accommodate all static key types
-  [nodeKey: string]: string | number | TreeNode[]
+  [key: string]: unknown
+  label?: string
+  children?: TreeNode[]
+}
+
+/** Where a dragged node lands relative to the hovered target. */
+export type DropPosition = 'inside' | 'before' | 'after'
+
+/** Context passed to the `canDrop` validator. */
+export interface DropContext {
+  /** The node being dragged. */
+  node: TreeNode
+  /** The node currently hovered as the drop target. */
+  target: TreeNode
+  /** Resolved drop position relative to `target`. */
+  position: DropPosition
+}
+
+/** Payload emitted on a valid drop. */
+export interface MoveEvent {
+  /** The moved node. */
+  node: TreeNode
+  /** Key of the previous parent, or `null` if it was a root. */
+  from: TreeKey | null
+  /** Key of the new parent, or `null` when moved to root level. */
+  to: TreeKey | null
+  /** Drop position relative to the target node. */
+  position: DropPosition
+  /** Final index of the node within its new parent's children. */
+  index: number
 }
 
 export interface TreeProps {
   /**
-   * Root tree node to render.
-   * Can contain nested children to form the tree structure.
+   * Forest roots to render. Each node may contain nested children to form the
+   * tree structure.
    */
-  node: TreeNode
+  nodes: TreeNode[]
 
   /**
-   * Unique key used to identify each node.
-   * Usually an id-like property present on every node.
+   * Name of the field that uniquely identifies each node.
+   * @default 'key'
    */
-  nodeKey: string
+  nodeKey?: string
 
   /**
-   * Optional configuration for tree layout and behavior.
+   * Name of the field holding the node's display label.
+   * @default 'label'
    */
-  options?: TreeOptions
-}
+  labelKey?: string
 
-export type TreeOptions = {
   /**
-   * Height of each tree row (e.g. "32px").
+   * Name of the field holding the node's children array.
+   * @default 'children'
+   */
+  childrenKey?: string
+
+  /**
+   * Enable drag-and-drop. Each node becomes draggable and can be dropped onto
+   * another node to reparent it.
+   * @default false
+   */
+  draggable?: boolean
+
+  /**
+   * Gate every drop. Receives the drag context and returns whether the drop is
+   * allowed. Built-in guards (drop-on-self, drop-into-descendant) run first.
+   */
+  canDrop?: (ctx: DropContext) => boolean
+
+  /**
+   * Allow dropping `before`/`after` a sibling to reorder, in addition to
+   * dropping `inside` to reparent.
+   * @default false
+   */
+  reorderable?: boolean
+
+  /**
+   * Visual style of the indentation guides.
+   * @default 'connectors'
+   */
+  guides?: 'connectors' | 'lines' | 'none'
+
+  /**
+   * Height of each tree row, e.g. "32px".
+   * @default '32px'
    */
   rowHeight?: string
 
   /**
-   * Horizontal indentation per tree level.
+   * Horizontal indentation per tree level, e.g. "28px".
+   * @default '28px'
    */
-  indentWidth?: string
+  indent?: string
 
   /**
-   * Whether to show vertical indentation guide lines.
+   * Initial expansion state of nodes when `v-model:expanded` is not bound.
+   * @default false
    */
-  showIndentationGuides?: boolean
+  defaultExpanded?: boolean
 
   /**
-   * Whether tree nodes should be collapsed by default.
+   * Disable all interaction — expand/collapse, selection and drag.
+   * @default false
    */
-  defaultCollapsed?: boolean
+  disabled?: boolean
+}
+
+/** State + callbacks shared from `Tree` down to every recursive `TreeItem`. */
+export interface TreeContext {
+  nodeKey: Ref<string>
+  labelKey: Ref<string>
+  childrenKey: Ref<string>
+  guides: Ref<'connectors' | 'lines' | 'none'>
+  rowHeight: Ref<string>
+  indent: Ref<string>
+  draggable: Ref<boolean>
+  reorderable: Ref<boolean>
+  disabled: Ref<boolean>
+
+  selected: Ref<TreeKey | null>
+  /** Whether `v-model:selected` is bound — selection is inert when false. */
+  selectionEnabled: Ref<boolean>
+  focusedKey: Ref<TreeKey | null>
+
+  keyOf: (node: TreeNode) => TreeKey
+  labelOf: (node: TreeNode) => string
+  childrenOf: (node: TreeNode) => TreeNode[]
+  hasChildren: (node: TreeNode) => boolean
+
+  isExpanded: (node: TreeNode) => boolean
+  toggle: (node: TreeNode) => void
+  select: (node: TreeNode) => void
+  focus: (key: TreeKey) => void
+
+  registerItem: (key: TreeKey, el: HTMLElement) => void
+  unregisterItem: (key: TreeKey) => void
+
+  // Drag-and-drop
+  dragSourceKey: ComputedRef<TreeKey | null>
+  dropTargetKey: ComputedRef<TreeKey | null>
+  dropPosition: ComputedRef<DropPosition | null>
+  onDragStart: (e: DragEvent, node: TreeNode, parent: TreeNode | null) => void
+  onDragOver: (e: DragEvent, node: TreeNode) => void
+  onDragLeave: (node: TreeNode) => void
+  onDrop: (node: TreeNode, parent: TreeNode | null) => void
+  onDragEnd: () => void
+}
+
+export const TreeContextKey: InjectionKey<TreeContext> = Symbol('TreeContext')
+
+export interface TreeNodeSlotProps {
+  node: TreeNode
+  level: number
+  expanded: boolean
+  hasChildren: boolean
+  selected: boolean
+  focused: boolean
+  disabled: boolean
+  toggle: () => void
+  select: () => void
 }

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -17,8 +17,8 @@ export type TreeNode = {
 /** Where a dragged node lands relative to the hovered target. */
 export type DropPosition = 'inside' | 'before' | 'after'
 
-/** Context passed to the `canDrop` validator. */
-export interface DropContext {
+/** Context passed to the `move` predicate while dragging. */
+export interface MoveContext {
   /** The node being dragged. */
   node: TreeNode
   /** The node currently hovered as the drop target. */
@@ -27,8 +27,11 @@ export interface DropContext {
   position: DropPosition
 }
 
-/** Payload emitted on a valid drop. */
-export interface MoveEvent {
+/**
+ * The committed move handed to `@drag-end`. `null` is emitted instead when a
+ * drag is cancelled (Escape, or released without a valid landing).
+ */
+export interface DropInfo {
   /** The moved node. */
   node: TreeNode
   /** Key of the previous parent, or `null` if it was a root. */
@@ -37,8 +40,10 @@ export interface MoveEvent {
   to: TreeKey | null
   /** Drop position relative to the target node. */
   position: DropPosition
+  /** Index the node occupied in its previous parent. */
+  oldIndex: number
   /** Final index of the node within its new parent's children. */
-  index: number
+  newIndex: number
 }
 
 export interface TreeProps {
@@ -55,24 +60,19 @@ export interface TreeProps {
   nodeKey?: string
 
   /**
-   * Enable drag-and-drop. Each node becomes draggable and can be dropped onto
-   * another node to reparent it.
+   * Enable drag-and-drop. Nodes can be dragged onto one another to reparent, or
+   * between siblings to reorder.
    * @default false
    */
   draggable?: boolean
 
   /**
-   * Gate every drop. Receives the drag context and returns whether the drop is
-   * allowed. Built-in guards (drop-on-self, drop-into-descendant) run first.
+   * Gate a drop while dragging. Receives the live drag context and returns
+   * whether the drop is allowed — a rejected target shows the no-drop cursor and
+   * hides the drop indicator. Built-in guards (drop-on-self, drop-into-own-
+   * descendant) run first, so this only carries your domain rules.
    */
-  canDrop?: (ctx: DropContext) => boolean
-
-  /**
-   * Allow dropping `before`/`after` a sibling to reorder, in addition to
-   * dropping `inside` to reparent.
-   * @default false
-   */
-  reorderable?: boolean
+  move?: (ctx: MoveContext) => boolean
 
   /**
    * Visual style of the indentation guides.
@@ -87,7 +87,7 @@ export interface TreeProps {
   defaultExpanded?: boolean
 
   /**
-   * Disable all interaction — expand/collapse, selection and drag.
+   * Disable all interaction — expand/collapse and drag.
    * @default false
    */
   disabled?: boolean
@@ -98,12 +98,8 @@ export interface TreeContext {
   nodeKey: Ref<string>
   guides: Ref<'connectors' | 'lines' | 'none'>
   draggable: Ref<boolean>
-  reorderable: Ref<boolean>
   disabled: Ref<boolean>
 
-  selected: Ref<TreeKey | null>
-  /** Whether `v-model:selected` is bound — selection is inert when false. */
-  selectionEnabled: Ref<boolean>
   focusedKey: Ref<TreeKey | null>
 
   keyOf: (node: TreeNode) => TreeKey
@@ -113,7 +109,6 @@ export interface TreeContext {
 
   isExpanded: (node: TreeNode) => boolean
   toggle: (node: TreeNode) => void
-  select: (node: TreeNode) => void
   focus: (key: TreeKey) => void
 
   registerItem: (key: TreeKey, el: HTMLElement) => void
@@ -137,9 +132,7 @@ export interface TreeNodeSlotProps {
   level: number
   expanded: boolean
   hasChildren: boolean
-  selected: boolean
   focused: boolean
   disabled: boolean
   toggle: () => void
-  select: () => void
 }

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -12,6 +12,11 @@ export type TreeNode = {
   [key: string]: unknown
   label?: string
   children?: TreeNode[]
+  /**
+   * Whether this node is expanded — the per-node source of truth. Expanded by
+   * default; set `false` to start it collapsed.
+   */
+  expanded?: boolean
 }
 
 /** Where a dragged node lands relative to the hovered target. */
@@ -79,15 +84,6 @@ export interface TreeProps {
    * @default 'connectors'
    */
   guides?: 'connectors' | 'lines' | 'none'
-
-  /**
-   * Start with every node expanded. A one-shot convenience that seeds the open
-   * set on first load (async-safe — it waits for `nodes` to arrive). To open
-   * specific nodes or track expansion, use `v-model:expanded` instead; this is
-   * ignored once you provide your own keys.
-   * @default false
-   */
-  defaultExpanded?: boolean
 
   /**
    * Disable all interaction — expand/collapse and drag.

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -4,10 +4,9 @@ import type { ComputedRef, InjectionKey, Ref } from 'vue'
 export type TreeKey = string | number
 
 /**
- * A tree node. The shape is open: `label` and `children` are the conventional
- * fields, but the unique-id field (`nodeKey`), label field (`labelKey`) and
- * children field (`childrenKey`) are all configurable, so any record-like
- * object can be rendered without remapping.
+ * A tree node. Carries a display `label`, nested `children`, and a unique id
+ * under the field named by the `nodeKey` prop. Any extra fields are preserved
+ * and passed through to slots.
  */
 export type TreeNode = {
   [key: string]: unknown
@@ -56,18 +55,6 @@ export interface TreeProps {
   nodeKey?: string
 
   /**
-   * Name of the field holding the node's display label.
-   * @default 'label'
-   */
-  labelKey?: string
-
-  /**
-   * Name of the field holding the node's children array.
-   * @default 'children'
-   */
-  childrenKey?: string
-
-  /**
    * Enable drag-and-drop. Each node becomes draggable and can be dropped onto
    * another node to reparent it.
    * @default false
@@ -94,18 +81,6 @@ export interface TreeProps {
   guides?: 'connectors' | 'lines' | 'none'
 
   /**
-   * Height of each tree row, e.g. "32px".
-   * @default '32px'
-   */
-  rowHeight?: string
-
-  /**
-   * Horizontal indentation per tree level, e.g. "28px".
-   * @default '28px'
-   */
-  indent?: string
-
-  /**
    * Initial expansion state of nodes when `v-model:expanded` is not bound.
    * @default false
    */
@@ -121,11 +96,7 @@ export interface TreeProps {
 /** State + callbacks shared from `Tree` down to every recursive `TreeItem`. */
 export interface TreeContext {
   nodeKey: Ref<string>
-  labelKey: Ref<string>
-  childrenKey: Ref<string>
   guides: Ref<'connectors' | 'lines' | 'none'>
-  rowHeight: Ref<string>
-  indent: Ref<string>
   draggable: Ref<boolean>
   reorderable: Ref<boolean>
   disabled: Ref<boolean>

--- a/src/components/Tree/useTreeDragDrop.ts
+++ b/src/components/Tree/useTreeDragDrop.ts
@@ -1,8 +1,8 @@
 import { computed, reactive, type Ref } from 'vue'
 import type {
-  DropContext,
+  DropInfo,
   DropPosition,
-  MoveEvent,
+  MoveContext,
   TreeKey,
   TreeNode,
 } from './types'
@@ -12,14 +12,16 @@ interface DragDropOptions {
   childrenOf: (node: TreeNode) => TreeNode[]
   /** Siblings of a node — a parent's children, or the roots for top level. */
   siblingsOf: (parent: TreeNode | null) => TreeNode[]
-  reorderable: Ref<boolean>
+  labelOf: (node: TreeNode) => string
   disabled: Ref<boolean>
-  canDrop?: (ctx: DropContext) => boolean
-  /** Emit a validated move; the caller owns persistence. */
-  onMove: (move: MoveEvent) => void
+  /** Live predicate gating a hovered drop target. */
+  move?: (ctx: MoveContext) => boolean
+  /** A drag was picked up. */
+  emitDragStart: (node: TreeNode) => void
+  /** A drag finished — `info` on a committed move, `null` on cancel. */
+  emitDragEnd: (info: DropInfo | null) => void
   /** Announce drag state changes to assistive tech. */
   announce: (message: string) => void
-  labelOf: (node: TreeNode) => string
 }
 
 interface DragState {
@@ -33,11 +35,11 @@ interface DragState {
 
 /**
  * Owns the live drag state and resolves + validates drops for the tree.
- * Pure logic — it never mutates `nodes`; it emits a `MoveEvent` and lets the
- * caller persist and update the model.
+ * Pure logic — it never mutates `nodes`; it hands the caller a `DropInfo` via
+ * `drag-end` and lets them persist and update the model.
  */
 export function useTreeDragDrop(options: DragDropOptions) {
-  const { keyOf, childrenOf, reorderable, disabled, canDrop, onMove } = options
+  const { keyOf, childrenOf, siblingsOf, disabled, move } = options
 
   const state = reactive<DragState>({
     source: null,
@@ -47,6 +49,9 @@ export function useTreeDragDrop(options: DragDropOptions) {
     x: 0,
     y: 0,
   })
+
+  // Resolved on a valid drop, emitted on the following `dragend`.
+  let pending: DropInfo | null = null
 
   function isDescendant(node: TreeNode, key: TreeKey): boolean {
     const stack = [...childrenOf(node)]
@@ -60,7 +65,6 @@ export function useTreeDragDrop(options: DragDropOptions) {
 
   /** Resolve where the cursor sits within a row into a drop position. */
   function resolvePosition(e: DragEvent): DropPosition {
-    if (!reorderable.value) return 'inside'
     const row = e.currentTarget as HTMLElement
     const rect = row.getBoundingClientRect()
     const offset = e.clientY - rect.top
@@ -86,7 +90,7 @@ export function useTreeDragDrop(options: DragDropOptions) {
       keyOf(state.sourceParent) === targetKey
     )
       return false
-    if (canDrop && !canDrop({ node: source, target, position })) return false
+    if (move && !move({ node: source, target, position })) return false
     return true
   }
 
@@ -98,10 +102,12 @@ export function useTreeDragDrop(options: DragDropOptions) {
     if (disabled.value) return
     state.source = node
     state.sourceParent = parent
+    pending = null
     if (e.dataTransfer) {
       e.dataTransfer.effectAllowed = 'move'
       e.dataTransfer.setData('text/plain', String(keyOf(node)))
     }
+    options.emitDragStart(node)
     options.announce(`Picked up ${options.labelOf(node)}`)
   }
 
@@ -131,36 +137,34 @@ export function useTreeDragDrop(options: DragDropOptions) {
   function onDrop(target: TreeNode, targetParent: TreeNode | null): void {
     const source = state.source
     const position = state.position
-    if (!source || !position || !state.target) return reset()
-    if (keyOf(state.target) !== keyOf(target)) return reset()
+    if (!source || !position || !state.target) return
+    if (keyOf(state.target) !== keyOf(target)) return
 
     const from = state.sourceParent ? keyOf(state.sourceParent) : null
+    const oldSiblings = siblingsOf(state.sourceParent)
+    const oldIndex = oldSiblings.findIndex((n) => keyOf(n) === keyOf(source))
+
     let to: TreeKey | null
-    let index: number
+    let newIndex: number
 
     if (position === 'inside') {
       to = keyOf(target)
-      index = childrenOf(target).length
+      newIndex = childrenOf(target).length
     } else {
       to = targetParent ? keyOf(targetParent) : null
-      const siblings = options.siblingsOf(targetParent)
+      const siblings = siblingsOf(targetParent)
       const targetIndex = siblings.findIndex((n) => keyOf(n) === keyOf(target))
       let insertIndex = position === 'before' ? targetIndex : targetIndex + 1
       // When reordering within the same parent, the source still occupies a
       // slot in `siblings`. Removing it first shifts later positions down by
-      // one, so the reported `index` is the final post-removal position.
-      if (from === to) {
-        const sourceIndex = siblings.findIndex(
-          (n) => keyOf(n) === keyOf(source),
-        )
-        if (sourceIndex > -1 && sourceIndex < insertIndex) insertIndex -= 1
-      }
-      index = insertIndex
+      // one, so the reported `newIndex` is the final post-removal position.
+      if (from === to && oldIndex > -1 && oldIndex < insertIndex)
+        insertIndex -= 1
+      newIndex = insertIndex
     }
 
+    pending = { node: source, from, to, position, oldIndex, newIndex }
     options.announce(`Moved ${options.labelOf(source)}`)
-    onMove({ node: source, from, to, position, index })
-    reset()
   }
 
   function reset(): void {
@@ -171,7 +175,9 @@ export function useTreeDragDrop(options: DragDropOptions) {
   }
 
   function onDragEnd(): void {
-    if (state.source) options.announce('Cancelled move')
+    if (!pending && state.source) options.announce('Cancelled move')
+    options.emitDragEnd(pending)
+    pending = null
     reset()
   }
 

--- a/src/components/Tree/useTreeDragDrop.ts
+++ b/src/components/Tree/useTreeDragDrop.ts
@@ -10,6 +10,8 @@ import type {
 interface DragDropOptions {
   keyOf: (node: TreeNode) => TreeKey
   childrenOf: (node: TreeNode) => TreeNode[]
+  /** Siblings of a node — a parent's children, or the roots for top level. */
+  siblingsOf: (parent: TreeNode | null) => TreeNode[]
   reorderable: Ref<boolean>
   disabled: Ref<boolean>
   canDrop?: (ctx: DropContext) => boolean
@@ -141,9 +143,19 @@ export function useTreeDragDrop(options: DragDropOptions) {
       index = childrenOf(target).length
     } else {
       to = targetParent ? keyOf(targetParent) : null
-      const siblings = targetParent ? childrenOf(targetParent) : []
+      const siblings = options.siblingsOf(targetParent)
       const targetIndex = siblings.findIndex((n) => keyOf(n) === keyOf(target))
-      index = position === 'before' ? targetIndex : targetIndex + 1
+      let insertIndex = position === 'before' ? targetIndex : targetIndex + 1
+      // When reordering within the same parent, the source still occupies a
+      // slot in `siblings`. Removing it first shifts later positions down by
+      // one, so the reported `index` is the final post-removal position.
+      if (from === to) {
+        const sourceIndex = siblings.findIndex(
+          (n) => keyOf(n) === keyOf(source),
+        )
+        if (sourceIndex > -1 && sourceIndex < insertIndex) insertIndex -= 1
+      }
+      index = insertIndex
     }
 
     options.announce(`Moved ${options.labelOf(source)}`)

--- a/src/components/Tree/useTreeDragDrop.ts
+++ b/src/components/Tree/useTreeDragDrop.ts
@@ -1,0 +1,185 @@
+import { computed, reactive, type Ref } from 'vue'
+import type {
+  DropContext,
+  DropPosition,
+  MoveEvent,
+  TreeKey,
+  TreeNode,
+} from './types'
+
+interface DragDropOptions {
+  keyOf: (node: TreeNode) => TreeKey
+  childrenOf: (node: TreeNode) => TreeNode[]
+  reorderable: Ref<boolean>
+  disabled: Ref<boolean>
+  canDrop?: (ctx: DropContext) => boolean
+  /** Emit a validated move; the caller owns persistence. */
+  onMove: (move: MoveEvent) => void
+  /** Announce drag state changes to assistive tech. */
+  announce: (message: string) => void
+  labelOf: (node: TreeNode) => string
+}
+
+interface DragState {
+  source: TreeNode | null
+  sourceParent: TreeNode | null
+  target: TreeNode | null
+  position: DropPosition | null
+  x: number
+  y: number
+}
+
+/**
+ * Owns the live drag state and resolves + validates drops for the tree.
+ * Pure logic — it never mutates `nodes`; it emits a `MoveEvent` and lets the
+ * caller persist and update the model.
+ */
+export function useTreeDragDrop(options: DragDropOptions) {
+  const { keyOf, childrenOf, reorderable, disabled, canDrop, onMove } = options
+
+  const state = reactive<DragState>({
+    source: null,
+    sourceParent: null,
+    target: null,
+    position: null,
+    x: 0,
+    y: 0,
+  })
+
+  function isDescendant(node: TreeNode, key: TreeKey): boolean {
+    const stack = [...childrenOf(node)]
+    while (stack.length) {
+      const current = stack.pop() as TreeNode
+      if (keyOf(current) === key) return true
+      stack.push(...childrenOf(current))
+    }
+    return false
+  }
+
+  /** Resolve where the cursor sits within a row into a drop position. */
+  function resolvePosition(e: DragEvent): DropPosition {
+    if (!reorderable.value) return 'inside'
+    const row = e.currentTarget as HTMLElement
+    const rect = row.getBoundingClientRect()
+    const offset = e.clientY - rect.top
+    if (offset < rect.height * 0.25) return 'before'
+    if (offset > rect.height * 0.75) return 'after'
+    return 'inside'
+  }
+
+  /** Whether a drop of `source` onto `target` at `position` is permitted. */
+  function isValidDrop(
+    source: TreeNode,
+    target: TreeNode,
+    position: DropPosition,
+  ): boolean {
+    const sourceKey = keyOf(source)
+    const targetKey = keyOf(target)
+    if (sourceKey === targetKey) return false
+    if (isDescendant(source, targetKey)) return false
+    // Re-parenting onto the node's current parent is a no-op.
+    if (
+      position === 'inside' &&
+      state.sourceParent &&
+      keyOf(state.sourceParent) === targetKey
+    )
+      return false
+    if (canDrop && !canDrop({ node: source, target, position })) return false
+    return true
+  }
+
+  function onDragStart(
+    e: DragEvent,
+    node: TreeNode,
+    parent: TreeNode | null,
+  ): void {
+    if (disabled.value) return
+    state.source = node
+    state.sourceParent = parent
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = 'move'
+      e.dataTransfer.setData('text/plain', String(keyOf(node)))
+    }
+    options.announce(`Picked up ${options.labelOf(node)}`)
+  }
+
+  function onDragOver(e: DragEvent, node: TreeNode): void {
+    if (!state.source || disabled.value) return
+    const position = resolvePosition(e)
+    state.x = e.clientX
+    state.y = e.clientY
+    if (isValidDrop(state.source, node, position)) {
+      state.target = node
+      state.position = position
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
+    } else {
+      state.target = null
+      state.position = null
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'none'
+    }
+  }
+
+  function onDragLeave(node: TreeNode): void {
+    if (state.target && keyOf(state.target) === keyOf(node)) {
+      state.target = null
+      state.position = null
+    }
+  }
+
+  function onDrop(target: TreeNode, targetParent: TreeNode | null): void {
+    const source = state.source
+    const position = state.position
+    if (!source || !position || !state.target) return reset()
+    if (keyOf(state.target) !== keyOf(target)) return reset()
+
+    const from = state.sourceParent ? keyOf(state.sourceParent) : null
+    let to: TreeKey | null
+    let index: number
+
+    if (position === 'inside') {
+      to = keyOf(target)
+      index = childrenOf(target).length
+    } else {
+      to = targetParent ? keyOf(targetParent) : null
+      const siblings = targetParent ? childrenOf(targetParent) : []
+      const targetIndex = siblings.findIndex((n) => keyOf(n) === keyOf(target))
+      index = position === 'before' ? targetIndex : targetIndex + 1
+    }
+
+    options.announce(`Moved ${options.labelOf(source)}`)
+    onMove({ node: source, from, to, position, index })
+    reset()
+  }
+
+  function reset(): void {
+    state.source = null
+    state.sourceParent = null
+    state.target = null
+    state.position = null
+  }
+
+  function onDragEnd(): void {
+    if (state.source) options.announce('Cancelled move')
+    reset()
+  }
+
+  const dragSourceKey = computed(() =>
+    state.source ? keyOf(state.source) : null,
+  )
+  const dropTargetKey = computed(() =>
+    state.target ? keyOf(state.target) : null,
+  )
+  const dropPosition = computed(() => state.position)
+
+  return {
+    state,
+    dragSourceKey,
+    dropTargetKey,
+    dropPosition,
+    onDragStart,
+    onDragOver,
+    onDragLeave,
+    onDrop,
+    onDragEnd,
+  }
+}

--- a/src/components/Tree/useTreeKeyboard.ts
+++ b/src/components/Tree/useTreeKeyboard.ts
@@ -1,0 +1,109 @@
+import type { Ref } from 'vue'
+import type { TreeKey, TreeNode } from './types'
+
+/** One visible (un-collapsed) row, in render order. */
+export interface FlatNode {
+  key: TreeKey
+  node: TreeNode
+  parentKey: TreeKey | null
+  level: number
+  hasChildren: boolean
+  expanded: boolean
+}
+
+interface KeyboardOptions {
+  /** Visible rows in render order; recomputed as expansion changes. */
+  flat: Ref<FlatNode[]>
+  focusedKey: Ref<TreeKey | null>
+  labelOf: (node: TreeNode) => string
+  focus: (key: TreeKey) => void
+  expand: (node: TreeNode) => void
+  collapse: (node: TreeNode) => void
+  select: (node: TreeNode) => void
+}
+
+/**
+ * Roving-focus keyboard navigation for the tree, following the WAI-ARIA
+ * Tree View pattern (P12). Operates on the flattened list of visible rows.
+ */
+export function useTreeKeyboard(options: KeyboardOptions) {
+  const { flat, focusedKey, focus, expand, collapse, select } = options
+
+  let typeahead = ''
+  let typeaheadTimer: ReturnType<typeof setTimeout> | null = null
+
+  const indexOfFocused = () =>
+    flat.value.findIndex((f) => f.key === focusedKey.value)
+
+  function focusAt(index: number): void {
+    const item = flat.value[index]
+    if (item) focus(item.key)
+  }
+
+  function moveToParent(current: FlatNode): void {
+    if (current.parentKey == null) return
+    focus(current.parentKey)
+  }
+
+  function typeaheadSearch(char: string): void {
+    if (typeaheadTimer) clearTimeout(typeaheadTimer)
+    typeahead += char.toLowerCase()
+    typeaheadTimer = setTimeout(() => (typeahead = ''), 500)
+
+    const start = Math.max(indexOfFocused(), 0)
+    const ordered = [
+      ...flat.value.slice(start + 1),
+      ...flat.value.slice(0, start + 1),
+    ]
+    const match = ordered.find((f) =>
+      options.labelOf(f.node).toLowerCase().startsWith(typeahead),
+    )
+    if (match) focus(match.key)
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    const index = indexOfFocused()
+    const current = flat.value[index]
+    if (!current && !['Home', 'End'].includes(e.key)) return
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        focusAt(Math.min(index + 1, flat.value.length - 1))
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        focusAt(Math.max(index - 1, 0))
+        break
+      case 'ArrowRight':
+        e.preventDefault()
+        if (current.hasChildren && !current.expanded) expand(current.node)
+        else if (current.hasChildren && current.expanded) focusAt(index + 1)
+        break
+      case 'ArrowLeft':
+        e.preventDefault()
+        if (current.hasChildren && current.expanded) collapse(current.node)
+        else moveToParent(current)
+        break
+      case 'Home':
+        e.preventDefault()
+        focusAt(0)
+        break
+      case 'End':
+        e.preventDefault()
+        focusAt(flat.value.length - 1)
+        break
+      case 'Enter':
+      case ' ':
+        e.preventDefault()
+        select(current.node)
+        break
+      default:
+        if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+          typeaheadSearch(e.key)
+        }
+    }
+  }
+
+  return { onKeydown }
+}

--- a/src/components/Tree/useTreeKeyboard.ts
+++ b/src/components/Tree/useTreeKeyboard.ts
@@ -19,7 +19,7 @@ interface KeyboardOptions {
   focus: (key: TreeKey) => void
   expand: (node: TreeNode) => void
   collapse: (node: TreeNode) => void
-  select: (node: TreeNode) => void
+  toggle: (node: TreeNode) => void
 }
 
 /**
@@ -27,7 +27,7 @@ interface KeyboardOptions {
  * Tree View pattern (P12). Operates on the flattened list of visible rows.
  */
 export function useTreeKeyboard(options: KeyboardOptions) {
-  const { flat, focusedKey, focus, expand, collapse, select } = options
+  const { flat, focusedKey, focus, expand, collapse, toggle } = options
 
   let typeahead = ''
   let typeaheadTimer: ReturnType<typeof setTimeout> | null = null
@@ -96,7 +96,7 @@ export function useTreeKeyboard(options: KeyboardOptions) {
       case 'Enter':
       case ' ':
         e.preventDefault()
-        select(current.node)
+        toggle(current.node)
         break
       default:
         if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {


### PR DESCRIPTION
<!-- coverage-report:start -->
Coverage: 58.82% (+0.20% vs `main`)
<!-- coverage-report:end -->

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-783/
<!-- docs-preview:end -->

The Tree was rebuilt from a single recursive `node` renderer into a stateful forest. It takes a `nodes` array, tracks expansion per node via `node.expanded` (open by default), and scopes its per-row slots as `#item-*`. The `options` blob is gone and sizing moves to CSS variables. Keyboard navigation, `role="tree"` ARIA, and opt-in drag-and-drop are new.

| Before                                           | After                                          |
| ------------------------------------------------ | ---------------------------------------------- |
| `:node="root"` (single root object)              | `:nodes="[root]"` (array of roots)             |
| `node.collapsed` / internal collapse             | `node.expanded` (inverted, open by default)    |
| `:options="{ rowHeight, indentWidth }"`          | `--tree-row-height` / `--tree-indent` CSS vars |
| `:options="{ showIndentationGuides }"`           | `guides="connectors" \| "lines" \| "none"`     |
| `:options="{ defaultCollapsed: true }"`          | `expanded: false` per node, or `v-model:expanded` to toggle all |
| `#node="{ node, isCollapsed, toggleCollapsed }"` | `#item="{ node, expanded, toggle, … }"`        |
| `#label`                                         | `#item-label`                                  |
| `#icon`                                          | built-in chevron; override via `#item`         |

```vue
<!-- Before -->
<Tree :node="root" node-key="name" :options="{ defaultCollapsed: false }">
  <template #label="{ node }">{{ node.title }}</template>
</Tree>

<!-- After -->
<Tree :nodes="[root]" node-key="name">
  <template #item-label="{ node }">{{ node.title }}</template>
</Tree>
```

`v-model:expanded` is a boolean expand/collapse-all switch (bind it to a button), not a per-node value.

Drag-and-drop is opt-in: set `draggable`, gate drops with `:move="({ node, target, position }) => …"`, and persist from `@drag-end="(info) => …"` — `info` is `{ node, from, to, position, oldIndex, newIndex }`, or `null` when the drag is cancelled.


