### PR TITLE
feat(combobox): share control slot props

### DIFF
--- a/src/components/Combobox/Combobox.api.md
+++ b/src/components/Combobox/Combobox.api.md
@@ -16,7 +16,7 @@
     name: 'trigger',
     description: 'Shape of the trigger.\n- `\'input\'` (default): user types directly into the trigger\n- `\'button\'`: render a button trigger; search input moves into the\n  popover header. Label + prefix auto-derive from the selected option.',
     required: false,
-    type: '"button" | "input"',
+    type: '"input" | "button"',
     default: '"input"'
   },
   {
@@ -165,7 +165,7 @@
   {
     name: 'trigger',
     description: 'Fully custom trigger renderer.',
-    type: 'ComboboxTriggerSlotProps'
+    type: 'ComboboxControlSlotProps'
   },
   {
     name: 'label',
@@ -179,13 +179,13 @@
   },
   {
     name: 'prefix',
-    description: 'Content rendered before the default input. Receives the same shape\nas `#trigger` and `#suffix` (`ComboboxSlotProps`).',
-    type: 'ComboboxTriggerSlotProps'
+    description: 'Content rendered before the default input. Receives the same shape\nas the other control slots.',
+    type: 'ComboboxControlSlotProps'
   },
   {
     name: 'suffix',
     description: 'Content rendered after the input (input mode) or label (button mode).\nProviding this slot **replaces the default chevron** — render your\nown fallback (e.g. the chevron) when your slot content is conditional.\nCommon use: an inline clear button. Use `@click.stop` and\n`@pointerdown.stop` so the press doesn\'t toggle the popover.',
-    type: 'ComboboxTriggerSlotProps'
+    type: 'ComboboxControlSlotProps'
   },
   {
     name: 'item-prefix',
@@ -219,31 +219,31 @@
   },
   {
     name: 'footer',
-    description: 'Content rendered after the list. Stays pinned below the scrollable options.',
-    type: 'ComboboxFooterSlotProps'
+    description: 'Content rendered after the list. Stays pinned below the scrollable\noptions.',
+    type: 'ComboboxControlSlotProps'
   }
 ]
 
   const emitsData = [
-  {
-    name: 'update:modelValue',
-    description: 'Fired when the model value changes.',
-    type: '[value: string | null]'
-  },
-  {
-    name: 'update:query',
-    description: 'Fired when the query changes.',
-    type: '[value: string]'
-  },
   {
     name: 'input',
     description: '',
     type: '[value: string]'
   },
   {
+    name: 'update:modelValue',
+    description: 'Fired when the model value changes.',
+    type: '[value: string | null]'
+  },
+  {
     name: 'update:open',
     description: 'Fired when the open state changes.',
     type: '[value: boolean]'
+  },
+  {
+    name: 'update:query',
+    description: 'Fired when the query changes.',
+    type: '[value: string]'
   },
   {
     name: 'update:selectedOption',
@@ -262,11 +262,11 @@
   }
 ]
 </script>
+
 ## API Reference
 
-<PropsTable name="Combobox" :data="propsData"/> 
+<PropsTable name="Combobox" :data="propsData"/>
 
-<SlotsTable :data="slotsData"/> 
+<SlotsTable :data="slotsData"/>
 
-<EmitsTable :data="emitsData"/> 
-
+<EmitsTable :data="emitsData"/>

--- a/src/components/Combobox/Combobox.cy.ts
+++ b/src/components/Combobox/Combobox.cy.ts
@@ -11,8 +11,16 @@ describe('Combobox', () => {
         props: { options: fruits, placeholder: 'Pick fruit' },
       })
 
-      cy.get('[data-slot="trigger"]').should('have.attr', 'data-variant', 'subtle')
-      cy.get('[role="combobox"]').should('have.attr', 'placeholder', 'Pick fruit')
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'data-variant',
+        'subtle',
+      )
+      cy.get('[role="combobox"]').should(
+        'have.attr',
+        'placeholder',
+        'Pick fruit',
+      )
     })
 
     it('forwards `id` to the input element', () => {
@@ -25,13 +33,21 @@ describe('Combobox', () => {
         props: { options: fruits, size: 'lg', variant: 'outline' },
       })
       cy.get('[data-slot="trigger"]').should('have.attr', 'data-size', 'lg')
-      cy.get('[data-slot="trigger"]').should('have.attr', 'data-variant', 'outline')
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'data-variant',
+        'outline',
+      )
     })
 
     it('renders the chevron and rotates it when open', () => {
       cy.mount(Combobox, { props: { options: fruits } })
       cy.get('[data-slot="chevron"]').should('exist')
-      cy.get('[data-slot="trigger"]').should('have.attr', 'data-state', 'closed')
+      cy.get('[data-slot="trigger"]').should(
+        'have.attr',
+        'data-state',
+        'closed',
+      )
 
       cy.get('[data-slot="chevron"]').click()
       cy.get('[data-slot="trigger"]').should('have.attr', 'data-state', 'open')
@@ -151,10 +167,14 @@ describe('Combobox', () => {
         },
       })
       cy.get('[role="combobox"]').type('ENG')
-      cy.get('[role="option"]').should('have.length', 1).and('contain.text', 'Engineering')
+      cy.get('[role="option"]')
+        .should('have.length', 1)
+        .and('contain.text', 'Engineering')
 
       cy.get('[role="combobox"]').clear().type('des')
-      cy.get('[role="option"]').should('have.length', 1).and('contain.text', 'Design')
+      cy.get('[role="option"]')
+        .should('have.length', 1)
+        .and('contain.text', 'Design')
     })
   })
 
@@ -171,7 +191,9 @@ describe('Combobox', () => {
 
       cy.get('[role="combobox"]').focus().type('dragonfruit')
       cy.get('[role="option"]').should('have.length', 1)
-      cy.get('[role="option"]').first().should('contain.text', 'Create "dragonfruit"')
+      cy.get('[role="option"]')
+        .first()
+        .should('contain.text', 'Create "dragonfruit"')
       cy.get('[role="option"]').first().click()
       cy.get('@onUpdate').should('have.been.calledWith', 'dragonfruit')
     })
@@ -233,7 +255,8 @@ describe('Combobox', () => {
               value: 'jane',
               slots: {
                 prefix: () => h('span', { 'data-cy': 'p' }, 'P'),
-                label: ({ item }: any) => h('span', { 'data-cy': 'l' }, item.label),
+                label: ({ item }: any) =>
+                  h('span', { 'data-cy': 'l' }, item.label),
                 suffix: () => h('span', { 'data-cy': 's' }, 'S'),
               },
             },
@@ -254,7 +277,8 @@ describe('Combobox', () => {
               label: 'Custom Row',
               value: 'row',
               slots: {
-                item: () => h('div', { 'data-cy': 'full-row' }, 'Custom Takeover'),
+                item: () =>
+                  h('div', { 'data-cy': 'full-row' }, 'Custom Takeover'),
               },
             },
           ],
@@ -477,14 +501,24 @@ describe('Combobox', () => {
       cy.contains('X').should('not.exist')
     })
 
-    it('renders #footer slot', () => {
+    it('renders #footer slot with control props', () => {
       cy.mount(Combobox, {
         props: { open: true, options: fruits },
         slots: {
-          footer: () => h('div', { 'data-cy': 'footer' }, 'FOOTER'),
+          footer: ({ setOpen }: any) =>
+            h(
+              'button',
+              { 'data-cy': 'footer', onClick: () => setOpen(false) },
+              'FOOTER',
+            ),
         },
       })
-      cy.get('[data-slot="footer"] [data-cy="footer"]').should('contain.text', 'FOOTER')
+      cy.get('[data-slot="footer"] [data-cy="footer"]').should(
+        'contain.text',
+        'FOOTER',
+      )
+      cy.get('[data-cy="footer"]').click()
+      cy.get('[data-slot="content"]').should('not.exist')
     })
   })
 
@@ -508,7 +542,11 @@ describe('Combobox', () => {
       }).then(() => {
         expect(warn).to.have.been.calledWithMatch(/placement.*deprecated/i)
       })
-      cy.get('[data-slot="content"]').should('have.attr', 'data-align', 'center')
+      cy.get('[data-slot="content"]').should(
+        'have.attr',
+        'data-align',
+        'center',
+      )
     })
 
     it('forwards `side` to the popover', () => {
@@ -557,7 +595,9 @@ describe('Combobox', () => {
         .should('be.focused')
         .type('ma')
 
-      cy.get('[role="option"]').should('have.length', 1).and('contain.text', 'Mango')
+      cy.get('[role="option"]')
+        .should('have.length', 1)
+        .and('contain.text', 'Mango')
     })
 
     it('renders built-in button when trigger="button" is set and avoids nested <button>', () => {

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -36,7 +36,7 @@ import type {
   ComboboxProps,
   ComboboxSelectableOption,
   ComboboxSlots,
-  ComboboxTriggerSlotProps,
+  ComboboxControlSlotProps,
 } from './types'
 import {
   buildCustomOptionContext,
@@ -111,10 +111,10 @@ const {
 const hasLabeling = computed(() => {
   return Boolean(
     props.label ||
-      props.description ||
-      hasError.value ||
-      slots.label ||
-      slots.description,
+    props.description ||
+    hasError.value ||
+    slots.label ||
+    slots.description,
   )
 })
 
@@ -248,24 +248,28 @@ function clearSelection() {
   emit('update:selectedOption', null)
 }
 
-function toggleOpen() {
-  if (props.disabled) return
-  open.value = !open.value
+function handleTriggerClick() {
+  setOpen(!open.value)
 }
 
-// Shared shape for the #trigger, #prefix, and #suffix slots. `clearSelection`
-// and `toggleOpen` are exposed alongside the read-only fields so consumers
+function setOpen(value: boolean) {
+  if (props.disabled) return
+  open.value = value
+}
+
+// Shared shape for the #trigger, #prefix, #suffix, and #footer slots. `clearSelection`
+// and `setOpen` are exposed alongside the read-only fields so consumers
 // can wire clear / open affordances (e.g. a custom #trigger or an inline
 // button in #suffix) without hoisting into #trigger or managing the model
 // and open state themselves.
-const triggerSlotProps = computed<ComboboxTriggerSlotProps>(() => ({
+const controlSlotProps = computed<ComboboxControlSlotProps>(() => ({
   open: open.value,
   disabled: Boolean(props.disabled),
   query: typedQuery.value,
   selectedOption: selectedOption.value,
   displayValue: displayValue.value,
   clearSelection,
-  toggleOpen,
+  setOpen,
 }))
 
 function commitSelectableOption(value: string) {
@@ -371,7 +375,9 @@ function reset() {
 }
 
 function focus() {
-  const id = isButtonMode.value ? `${inputId.value}-search-input` : inputId.value
+  const id = isButtonMode.value
+    ? `${inputId.value}-search-input`
+    : inputId.value
   const el = document.getElementById(id) as HTMLInputElement | null
   el?.focus()
 }
@@ -442,27 +448,27 @@ defineSlots<ComboboxSlots>()
       there's no labeling, so bare usage keeps its flattened layout.
     -->
     <div :class="hasLabeling ? null : 'contents'">
-  <ComboboxRoot
-    ref="rootRef"
-    class="contents"
-    :model-value="internalModelValue"
-    :open="open"
-    :disabled="disabled"
-    :ignore-filter="true"
-    :open-on-focus="openOnFocus"
-    :open-on-click="openOnClick"
-    @update:modelValue="handleRootModelValueChange"
-    @update:open="handleRootOpenChange"
-  >
-    <!--
+      <ComboboxRoot
+        ref="rootRef"
+        class="contents"
+        :model-value="internalModelValue"
+        :open="open"
+        :disabled="disabled"
+        :ignore-filter="true"
+        :open-on-focus="openOnFocus"
+        :open-on-click="openOnClick"
+        @update:modelValue="handleRootModelValueChange"
+        @update:open="handleRootOpenChange"
+      >
+        <!--
       Two trigger modes, picked automatically:
         1. Default (`trigger="input"`): the trigger IS the search input.
         2. Button mode (`trigger="button"` or `#trigger` slot provided):
            caller's button — or the built-in auto-wired Button — opens the
            popover; the search input moves into the popover header.
     -->
-    <template v-if="isButtonMode">
-      <!--
+        <template v-if="isButtonMode">
+          <!--
         reka's `ComboboxTrigger` hardcodes `tabindex="-1"` — it assumes
         the ComboboxInput is the tab-stop and the trigger is just a
         mouse-clickable chevron. That's wrong for button mode where
@@ -474,18 +480,18 @@ defineSlots<ComboboxSlots>()
         to the child via `as-child` — this makes consumer-supplied
         `#trigger` elements "just work" without wiring handlers.
       -->
-      <ComboboxAnchor
-        as-child
-        @click="toggleOpen"
-        @pointerdown="markPointerDown"
-      >
-        <slot
-          v-if="$slots.trigger"
-          name="trigger"
-          v-bind="triggerSlotProps"
-        />
+          <ComboboxAnchor
+            as-child
+            @click="handleTriggerClick"
+            @pointerdown="markPointerDown"
+          >
+            <slot
+              v-if="$slots.trigger"
+              name="trigger"
+              v-bind="controlSlotProps"
+            />
 
-        <!--
+            <!--
           Rendered as a raw `<button>` (not the `<Button>` component) so
           the prefix / label / chevron are direct flex children and
           `justify-between` + label `flex-1` align cleanly. Wrapping in
@@ -493,30 +499,30 @@ defineSlots<ComboboxSlots>()
           `<span>`, which is content-sized and would center the label in
           `w-full` buttons.
         -->
-        <button
-          v-else
-          type="button"
-          :class="[
-            triggerClasses,
-            'justify-between',
-            disabled && 'cursor-not-allowed',
-            hasLabeling ? 'w-full' : null,
-            hasLabeling ? null : (attrs.class as any),
-          ]"
-          :style="hasLabeling ? null : (attrs.style as any)"
-          :disabled="disabled"
-          data-slot="trigger"
-          :data-state="open ? 'open' : 'closed'"
-          :data-variant="variant"
-          :data-size="size"
-          :data-invalid="hasError ? 'true' : undefined"
-          :data-required="required ? 'true' : undefined"
-          :id="inputId"
-          aria-haspopup="listbox"
-          :aria-expanded="open"
-          v-bind="inputAriaAttrs"
-        >
-          <!--
+            <button
+              v-else
+              type="button"
+              :class="[
+                triggerClasses,
+                'justify-between',
+                disabled && 'cursor-not-allowed',
+                hasLabeling ? 'w-full' : null,
+                hasLabeling ? null : (attrs.class as any),
+              ]"
+              :style="hasLabeling ? null : (attrs.style as any)"
+              :disabled="disabled"
+              data-slot="trigger"
+              :data-state="open ? 'open' : 'closed'"
+              :data-variant="variant"
+              :data-size="size"
+              :data-invalid="hasError ? 'true' : undefined"
+              :data-required="required ? 'true' : undefined"
+              :id="inputId"
+              aria-haspopup="listbox"
+              :aria-expanded="open"
+              v-bind="inputAriaAttrs"
+            >
+              <!--
             Prefix precedence on the trigger:
               1. selected + `#item-prefix` slot → reuse the list's per-item
                  prefix renderer so the trigger matches the dropdown row
@@ -525,135 +531,125 @@ defineSlots<ComboboxSlots>()
                  string / emoji / component).
               3. not selected + `#prefix` slot → user's placeholder affordance.
           -->
-          <template v-if="selectedOption && $slots['item-prefix']">
-            <slot
-              name="item-prefix"
-              v-bind="{
-                item: selectedOption,
-                query: '',
-                selected: true,
-              }"
-            />
-          </template>
-          <OptionIcon
-            v-else-if="selectedOption?.icon"
-            :icon="selectedOption.icon"
-          />
-          <slot
-            v-else-if="!selectedOption && $slots.prefix"
-            name="prefix"
-            v-bind="triggerSlotProps"
-          />
+              <template v-if="selectedOption && $slots['item-prefix']">
+                <slot
+                  name="item-prefix"
+                  v-bind="{
+                    item: selectedOption,
+                    query: '',
+                    selected: true,
+                  }"
+                />
+              </template>
+              <OptionIcon
+                v-else-if="selectedOption?.icon"
+                :icon="selectedOption.icon"
+              />
+              <slot
+                v-else-if="!selectedOption && $slots.prefix"
+                name="prefix"
+                v-bind="controlSlotProps"
+              />
 
-          <span
+              <span
+                :class="[
+                  'min-w-0 flex-1 truncate text-left font-normal',
+                  !selectedOption && 'text-ink-gray-4',
+                ]"
+              >
+                {{ selectedOption?.label ?? placeholder }}
+              </span>
+
+              <slot name="suffix" v-bind="controlSlotProps">
+                <span
+                  :class="[
+                    'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
+                    open && 'rotate-180',
+                  ]"
+                />
+              </slot>
+            </button>
+          </ComboboxAnchor>
+        </template>
+
+        <template v-else>
+          <ComboboxAnchor
+            data-slot="trigger"
+            :data-state="open ? 'open' : 'closed'"
+            :data-disabled="disabled ? '' : undefined"
+            :data-variant="variant"
+            :data-size="size"
+            :data-invalid="hasError ? 'true' : undefined"
+            :data-required="required ? 'true' : undefined"
             :class="[
-              'min-w-0 flex-1 truncate text-left font-normal',
-              !selectedOption && 'text-ink-gray-4',
+              triggerClasses,
+              hasLabeling ? 'w-full' : null,
+              hasLabeling ? null : (attrs.class as any),
             ]"
+            :style="hasLabeling ? null : (attrs.style as any)"
+            @pointerdown="markPointerDown"
           >
-            {{ selectedOption?.label ?? placeholder }}
-          </span>
-
-          <slot
-            name="suffix"
-            v-bind="triggerSlotProps"
-          >
-            <span
-              :class="[
-                'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
-                open && 'rotate-180',
-              ]"
-            />
-          </slot>
-        </button>
-      </ComboboxAnchor>
-    </template>
-
-    <template v-else>
-      <ComboboxAnchor
-        data-slot="trigger"
-        :data-state="open ? 'open' : 'closed'"
-        :data-disabled="disabled ? '' : undefined"
-        :data-variant="variant"
-        :data-size="size"
-        :data-invalid="hasError ? 'true' : undefined"
-        :data-required="required ? 'true' : undefined"
-        :class="[
-          triggerClasses,
-          hasLabeling ? 'w-full' : null,
-          hasLabeling ? null : (attrs.class as any),
-        ]"
-        :style="hasLabeling ? null : (attrs.style as any)"
-        @pointerdown="markPointerDown"
-      >
-        <!--
+            <!--
           Prefix precedence matches button mode: selected option's
           `#item-prefix` → selected option's icon auto-render →
           user's `#prefix` slot.
         -->
-        <template v-if="selectedOption && $slots['item-prefix']">
-          <slot
-            name="item-prefix"
-            v-bind="{ item: selectedOption, query: '', selected: true }"
-          />
+            <template v-if="selectedOption && $slots['item-prefix']">
+              <slot
+                name="item-prefix"
+                v-bind="{ item: selectedOption, query: '', selected: true }"
+              />
+            </template>
+            <OptionIcon
+              v-else-if="selectedOption?.icon"
+              :icon="selectedOption.icon"
+            />
+            <slot v-else name="prefix" v-bind="controlSlotProps" />
+
+            <ComboboxInput
+              :id="inputId"
+              v-bind="{ ...inputAttrs, ...inputAriaAttrs }"
+              data-slot="input"
+              :data-variant="variant"
+              :data-size="size"
+              :value="query"
+              :disabled="disabled"
+              :placeholder="placeholder"
+              :class="resolvedInputClasses"
+              @input="handleInputChange"
+              @focus="emit('focus', $event)"
+              @blur="emit('blur', $event)"
+              @keydown.enter="handleInputEnter"
+            />
+
+            <slot name="suffix" v-bind="controlSlotProps">
+              <ComboboxTrigger
+                :disabled="disabled"
+                data-slot="chevron"
+                class="inline-flex shrink-0 items-center justify-center text-ink-gray-4 outline-none transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] data-[state=open]:rotate-180"
+              >
+                <span class="lucide-chevron-down size-4 text-ink-gray-6" />
+              </ComboboxTrigger>
+            </slot>
+          </ComboboxAnchor>
         </template>
-        <OptionIcon
-          v-else-if="selectedOption?.icon"
-          :icon="selectedOption.icon"
-        />
-        <slot
-          v-else
-          name="prefix"
-          v-bind="triggerSlotProps"
-        />
 
-        <ComboboxInput
-          :id="inputId"
-          v-bind="{ ...inputAttrs, ...inputAriaAttrs }"
-          data-slot="input"
-          :data-variant="variant"
-          :data-size="size"
-          :value="query"
-          :disabled="disabled"
-          :placeholder="placeholder"
-          :class="resolvedInputClasses"
-          @input="handleInputChange"
-          @focus="emit('focus', $event)"
-          @blur="emit('blur', $event)"
-          @keydown.enter="handleInputEnter"
-        />
-
-        <slot
-          name="suffix"
-          v-bind="triggerSlotProps"
-        >
-          <ComboboxTrigger
-            :disabled="disabled"
-            data-slot="chevron"
-            class="inline-flex shrink-0 items-center justify-center text-ink-gray-4 outline-none transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] data-[state=open]:rotate-180"
+        <ComboboxPortal :to="portalTo">
+          <ComboboxContent
+            data-slot="content"
+            data-selection
+            :data-variant="variant"
+            :data-size="size"
+            :class="[
+              'z-[100]',
+              !isButtonMode && 'min-w-[--reka-combobox-trigger-width]',
+            ]"
+            position="popper"
+            :side="side"
+            :align="resolvedAlign"
+            :side-offset="offset"
           >
-            <span class="lucide-chevron-down size-4 text-ink-gray-6" />
-          </ComboboxTrigger>
-        </slot>
-      </ComboboxAnchor>
-    </template>
-
-    <ComboboxPortal :to="portalTo">
-      <ComboboxContent
-        data-slot="content"
-        data-selection
-        :data-variant="variant"
-        :data-size="size"
-        :class="[
-          'z-[100]',
-          !isButtonMode && 'min-w-[--reka-combobox-trigger-width]',
-        ]"
-        position="popper"
-        :side="side"
-        :align="resolvedAlign"
-        :side-offset="offset"
-      >
-        <!--
+            <!--
           Why FocusScope lives here (inside ComboboxContent) and not around it:
 
           ComboboxContent is a <Presence> wrapper — it renders null when the
@@ -674,66 +670,59 @@ defineSlots<ComboboxSlots>()
           once the dialog trap is paused. In input mode we prevent it so the
           trigger input keeps focus while the list opens.
         -->
-        <FocusScope
-          as-child
-          @mount-auto-focus="handleFocusScopeMountAutoFocus"
-          @unmount-auto-focus.prevent
-        >
-          <div
-            data-slot="content-body"
-            :data-motion="contentMotion"
-            class="overflow-hidden rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5"
-          >
-            <div
-              v-if="isButtonMode"
-              data-slot="content-search"
-              class="flex items-center gap-2 border-b border-outline-gray-1 px-3"
+            <FocusScope
+              as-child
+              @mount-auto-focus="handleFocusScopeMountAutoFocus"
+              @unmount-auto-focus.prevent
             >
-              <ComboboxInput
-                :id="`${inputId}-search-input`"
-                v-bind="inputAttrs"
-                data-slot="input"
-                :value="query"
-                :disabled="disabled"
-                :placeholder="placeholder"
-                class="min-w-0 flex-1 px-0 border-0 bg-transparent py-2 text-base text-ink-gray-8 outline-none placeholder:text-ink-gray-4 focus:ring-0"
-                @input="handleInputChange"
-                @focus="emit('focus', $event)"
-                @blur="emit('blur', $event)"
-                @keydown.enter="handleInputEnter"
-              />
-            </div>
+              <div
+                data-slot="content-body"
+                :data-motion="contentMotion"
+                class="overflow-hidden rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5"
+              >
+                <div
+                  v-if="isButtonMode"
+                  data-slot="content-search"
+                  class="flex items-center gap-2 border-b border-outline-gray-1 px-3"
+                >
+                  <ComboboxInput
+                    :id="`${inputId}-search-input`"
+                    v-bind="inputAttrs"
+                    data-slot="input"
+                    :value="query"
+                    :disabled="disabled"
+                    :placeholder="placeholder"
+                    class="min-w-0 flex-1 px-0 border-0 bg-transparent py-2 text-base text-ink-gray-8 outline-none placeholder:text-ink-gray-4 focus:ring-0"
+                    @input="handleInputChange"
+                    @focus="emit('focus', $event)"
+                    @blur="emit('blur', $event)"
+                    @keydown.enter="handleInputEnter"
+                  />
+                </div>
 
-            <ComboboxResults
-              :groups="filteredGroups"
-              :size="size"
-              :query="typedQuery"
-              :model="model ?? null"
-              :loading="loading"
-              :empty-text="emptyText"
-              :show-create-option="showCreateOption"
-              :show-empty="showEmpty"
-              :slot-fns="slots"
-              :all-selectable-options="allSelectableOptions"
-              @select-custom="handleCustomItemSelect"
-              @select-create="handleCreateOptionSelect"
-            />
+                <ComboboxResults
+                  :groups="filteredGroups"
+                  :size="size"
+                  :query="typedQuery"
+                  :model="model ?? null"
+                  :loading="loading"
+                  :empty-text="emptyText"
+                  :show-create-option="showCreateOption"
+                  :show-empty="showEmpty"
+                  :slot-fns="slots"
+                  :all-selectable-options="allSelectableOptions"
+                  @select-custom="handleCustomItemSelect"
+                  @select-create="handleCreateOptionSelect"
+                />
 
-            <div v-if="$slots.footer" data-slot="footer">
-              <slot
-                name="footer"
-                v-bind="{
-                  query: typedQuery,
-                  selectedOption,
-                  clearSelection,
-                }"
-              />
-            </div>
-          </div>
-        </FocusScope>
-      </ComboboxContent>
-    </ComboboxPortal>
-  </ComboboxRoot>
+                <div v-if="$slots.footer" data-slot="footer">
+                  <slot name="footer" v-bind="controlSlotProps" />
+                </div>
+              </div>
+            </FocusScope>
+          </ComboboxContent>
+        </ComboboxPortal>
+      </ComboboxRoot>
     </div>
     <InputDescription
       v-if="showDescription || $slots.description"

--- a/src/components/Combobox/stories/Footer.vue
+++ b/src/components/Combobox/stories/Footer.vue
@@ -41,12 +41,13 @@ const countries = [
       open-on-focus
       class="w-64"
     >
-      <template #footer="{ query, selectedOption, clearSelection }">
+      <template #footer="{ query, selectedOption, clearSelection, setOpen }">
         <div
           class="flex items-center justify-between border-t border-outline-gray-1 px-3 py-2 text-sm text-ink-gray-5"
         >
           <span v-if="query">
-            Searching “<span class="text-ink-gray-7">{{ query }}</span>”
+            Searching “<span class="text-ink-gray-7">{{ query }}</span
+            >”
           </span>
           <span v-else>{{ countries.length }} countries</span>
           <button
@@ -55,6 +56,13 @@ const countries = [
             @click="clearSelection"
           >
             Clear
+          </button>
+          <button
+            v-else
+            class="text-ink-gray-7 hover:text-ink-gray-8"
+            @click="setOpen(false)"
+          >
+            Close
           </button>
         </div>
       </template>

--- a/src/components/Combobox/types.ts
+++ b/src/components/Combobox/types.ts
@@ -159,7 +159,7 @@ export interface ComboboxProps extends InputLabelingProps {
   placement?: ComboboxPlacement
 }
 
-export interface ComboboxTriggerSlotProps {
+export interface ComboboxControlSlotProps {
   /** Whether the popover is open. */
   open: boolean
 
@@ -178,19 +178,9 @@ export interface ComboboxTriggerSlotProps {
   /** Clears the current selection (sets the model to `null`). */
   clearSelection: () => void
 
-  /** Toggles the popover open state (no-op while disabled). */
-  toggleOpen: () => void
+  /** Sets the popover open state (no-op while disabled). */
+  setOpen: (value: boolean) => void
 }
-
-/**
- * Shared shape for `#trigger`, `#prefix`, and `#suffix`. `selectedOption`
- * is always `null` in `#prefix` because the prefix only renders before a
- * selection — the field is still exposed for slot-prop symmetry across
- * the trio.
- */
-export type ComboboxSlotProps = ComboboxTriggerSlotProps
-export type ComboboxPrefixSlotProps = ComboboxSlotProps
-export type ComboboxSuffixSlotProps = ComboboxSlotProps
 
 export interface ComboboxItemSlotProps {
   /** Item currently being rendered. */
@@ -213,20 +203,9 @@ export interface ComboboxEmptySlotProps {
   query: string
 }
 
-export interface ComboboxFooterSlotProps {
-  /** Current search query — empty when the user hasn't typed since opening. */
-  query: string
-
-  /** Resolved selected option, if any. */
-  selectedOption: ComboboxSelectableOption | null
-
-  /** Clears the current selection (sets the model to `null`). */
-  clearSelection: () => void
-}
-
 export interface ComboboxSlots {
   /** Fully custom trigger renderer. */
-  trigger?: (props: ComboboxTriggerSlotProps) => any
+  trigger?: (props: ComboboxControlSlotProps) => any
 
   /** Overrides the rendered label content. Receives `{ required }`. */
   label?: (props: { required: boolean }) => any
@@ -235,8 +214,8 @@ export interface ComboboxSlots {
   description?: () => any
 
   /** Content rendered before the default input. Receives the same shape
-   * as `#trigger` and `#suffix` (`ComboboxSlotProps`). */
-  prefix?: (props: ComboboxPrefixSlotProps) => any
+   * as the other control slots. */
+  prefix?: (props: ComboboxControlSlotProps) => any
 
   /**
    * Content rendered after the input (input mode) or label (button mode).
@@ -245,7 +224,7 @@ export interface ComboboxSlots {
    * Common use: an inline clear button. Use `@click.stop` and
    * `@pointerdown.stop` so the press doesn't toggle the popover.
    */
-  suffix?: (props: ComboboxSuffixSlotProps) => any
+  suffix?: (props: ComboboxControlSlotProps) => any
 
   /** Shared content rendered before the standard row label. */
   'item-prefix'?: (props: ComboboxItemSlotProps) => any
@@ -267,7 +246,7 @@ export interface ComboboxSlots {
 
   /** Content rendered after the list. Stays pinned below the scrollable
    * options. */
-  footer?: (props: ComboboxFooterSlotProps) => any
+  footer?: (props: ComboboxControlSlotProps) => any
 
   [slotName: string]: ((props: any) => any) | undefined
 }

--- a/src/components/MultiSelect/MultiSelect.api.md
+++ b/src/components/MultiSelect/MultiSelect.api.md
@@ -222,22 +222,22 @@
     type: 'unknown[]'
   },
   {
-    name: 'update:query',
-    description: 'Fired when the query changes.',
-    type: '[value: string]'
-  },
-  {
     name: 'update:open',
     description: 'Fired when the open state changes.',
     type: 'unknown[]'
+  },
+  {
+    name: 'update:query',
+    description: 'Fired when the query changes.',
+    type: '[value: string]'
   }
 ]
 </script>
+
 ## API Reference
 
-<PropsTable name="MultiSelect" :data="propsData"/> 
+<PropsTable name="MultiSelect" :data="propsData"/>
 
-<SlotsTable :data="slotsData"/> 
+<SlotsTable :data="slotsData"/>
 
-<EmitsTable :data="emitsData"/> 
-
+<EmitsTable :data="emitsData"/>

--- a/src/components/MultiSelect/MultiSelect.md
+++ b/src/components/MultiSelect/MultiSelect.md
@@ -1,53 +1,81 @@
 # MultiSelect
 
-Searchable multi-choice picker. Matches the `Combobox` / `Select` item-slot model and provides built-in Clear All / Select All footer controls.
+Searchable multi-choice picker. Matches the `Combobox` / `Select` item-slot
+model and provides built-in Clear All / Select All footer controls.
 
 ## Playground
 
 <ClientOnly><MultiSelectBuilder /></ClientOnly>
 
 ## Default
-A plain picker — button trigger opens a popover with a search input, option list, and default footer.
+
+A plain picker — button trigger opens a popover with a search input, option
+list, and default footer.
 
 <ComponentPreview name="MultiSelect-Example" />
 
 ## Item Prefix
-Use `#item-prefix` to render avatars, icons, or indicators next to each option label.
+
+Use `#item-prefix` to render avatars, icons, or indicators next to each option
+label.
 
 <ComponentPreview name="MultiSelect-Options" />
 
 ## Members
-Use `#prefix` to render an aggregate visual across the current selection — here, a stack of avatars capped at three with a "+N" overflow badge. When `#prefix` is provided it owns the entire prefix area regardless of selection count, so the same template handles 0 / 1 / many.
+
+Use `#prefix` to render an aggregate visual across the current selection — here,
+a stack of avatars capped at three with a "+N" overflow badge. When `#prefix` is
+provided it owns the entire prefix area regardless of selection count, so the
+same template handles 0 / 1 / many.
 
 <ComponentPreview name="MultiSelect-Members" />
 
 ## Grouped Options
-Options can be split into named groups. Group labels render above each group's items.
+
+Options can be split into named groups. Group labels render above each group's
+items.
 
 <ComponentPreview name="MultiSelect-Grouped" />
 
 ## Async Options
-Fetch options from a server as the user types. Listen to `@update:query`, debounce the request, and feed the results back into `:options`. The `:loading` prop swaps the result body for a loading state. Two things to watch for: drop stale responses with a request id so a slower earlier query can't overwrite the latest results, and merge currently-selected items into the options array so chips stay resolvable after the query narrows the list.
+
+Fetch options from a server as the user types. Listen to `@update:query`,
+debounce the request, and feed the results back into `:options`. The `:loading`
+prop swaps the result body for a loading state. Two things to watch for: drop
+stale responses with a request id so a slower earlier query can't overwrite the
+latest results, and merge currently-selected items into the options array so
+chips stay resolvable after the query narrows the list.
 
 <ComponentPreview name="MultiSelect-AsyncOptions" />
 
 ## Custom Footer
-Replace the default Clear All / Select All footer with a custom one. The slot receives `clearAll`, `selectAll`, `selectedOptions`, and `query`.
+
+Replace the default Clear All / Select All footer with a custom one. The slot
+receives `clearAll`, `selectAll`, `selectedOptions`, and `query`.
 
 <ComponentPreview name="MultiSelect-Footer" />
 
 ## Custom Trigger
-Use `#trigger` to fully replace the default button trigger. The slot receives `open`, `disabled`, `selectedOptions`, `displayValue`, `clearAll`, and `toggleOpen`.
+
+Use `#trigger` to fully replace the default button trigger. The slot receives
+`open`, `disabled`, `selectedOptions`, `displayValue`, `clearAll`, and
+`setOpen`.
 
 <ComponentPreview name="MultiSelect-TriggerSlot" />
 
 ## Tags Trigger
-A chips-style trigger: each selected option renders as a removable `Badge`, with inline remove buttons. Authored through `#trigger` using `selectedOptions` and the parent's `v-model`.
+
+A chips-style trigger: each selected option renders as a removable `Badge`, with
+inline remove buttons. Authored through `#trigger` using `selectedOptions` and
+the parent's `v-model`.
 
 <ComponentPreview name="MultiSelect-TagsTrigger" />
 
 ## Label, Description, Error
-`MultiSelect` supports `label`, `description`, `error`, and `required` directly — no `FormControl` wrapper needed. The error suppresses the description and wires `aria-invalid` + `aria-errormessage` onto the trigger.
+
+`MultiSelect` supports `label`, `description`, `error`, and `required` directly
+— no `FormControl` wrapper needed. The error suppresses the description and
+wires `aria-invalid` + `aria-errormessage` onto the trigger.
 
 <ComponentPreview name="MultiSelect-Labeling" />
 

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -26,6 +26,7 @@ import '../shared/selection/popoverMotion.css'
 import type {
   MultiSelectEmits,
   MultiSelectProps,
+  MultiSelectSlotProps,
   MultiSelectSlots,
 } from './types'
 import {
@@ -86,10 +87,10 @@ const {
 const hasLabeling = computed(() => {
   return Boolean(
     props.label ||
-      props.description ||
-      hasError.value ||
-      slots.label ||
-      slots.description,
+    props.description ||
+    hasError.value ||
+    slots.label ||
+    slots.description,
   )
 })
 
@@ -197,10 +198,24 @@ function selectAll() {
     .map((option) => option.value)
 }
 
-function toggleOpen() {
-  if (props.disabled) return
-  open.value = !open.value
+function handleTriggerClick() {
+  setOpen(!open.value)
 }
+
+function setOpen(value: boolean) {
+  if (props.disabled) return
+  open.value = value
+}
+
+const slotProps = computed<MultiSelectSlotProps>(() => ({
+  open: open.value,
+  disabled: Boolean(props.disabled),
+  query: typedQuery.value,
+  selectedOptions: selectedOptions.value,
+  displayValue: displayValue.value,
+  clearAll,
+  setOpen,
+}))
 
 function handleRootModelValueChange(value: string | string[] | undefined) {
   const arr = Array.isArray(value) ? value : value ? [value] : []
@@ -255,69 +270,57 @@ defineSlots<MultiSelectSlots>()
         <slot name="label" v-bind="slotProps" />
       </template>
     </InputLabel>
-  <ComboboxRoot
-    multiple
-    :model-value="internalModel"
-    :open="open"
-    :disabled="disabled"
-    :ignore-filter="true"
-    @update:modelValue="handleRootModelValueChange"
-    @update:open="handleRootOpenChange"
-  >
-    <ComboboxAnchor
-      as-child
-      @click="toggleOpen"
-      @pointerdown="markPointerDown"
+    <ComboboxRoot
+      multiple
+      :model-value="internalModel"
+      :open="open"
+      :disabled="disabled"
+      :ignore-filter="true"
+      @update:modelValue="handleRootModelValueChange"
+      @update:open="handleRootOpenChange"
     >
-      <slot
-        v-if="$slots.trigger"
-        name="trigger"
-        v-bind="{
-          open,
-          disabled: !!disabled,
-          query: typedQuery,
-          selectedOptions,
-          displayValue,
-          clearAll,
-          toggleOpen,
-        }"
-      />
+      <ComboboxAnchor
+        as-child
+        @click="handleTriggerClick"
+        @pointerdown="markPointerDown"
+      >
+        <slot v-if="$slots.trigger" name="trigger" v-bind="slotProps" />
 
-      <!--
+        <!--
         Rendered as a raw `<button>` so prefix / label / chevron are
         direct flex children and `justify-between` + label `flex-1` align
         cleanly. Wrapping in `<Button>` would nest the label inside
         Button's own default-slot `<span>`, which is content-sized and
         would center the label when a width class is applied.
       -->
-      <button
-        v-else
-        type="button"
-        :class="[
-          triggerClasses,
-          'justify-between',
-          disabled && 'cursor-not-allowed',
-          hasLabeling ? 'w-full' : null,
-          hasLabeling ? null : (attrs.class as any),
-        ]"
-        :style="hasLabeling ? null : (attrs.style as any)"
-        :disabled="disabled"
-        data-slot="trigger"
-        :data-state="open ? 'open' : 'closed'"
-        :data-variant="variant"
-        :data-size="size"
-        :data-disabled="disabled ? '' : undefined"
-        :data-invalid="hasError ? 'true' : undefined"
-        :data-required="required ? 'true' : undefined"
-        :id="inputId"
-        aria-haspopup="listbox"
-        :aria-expanded="open"
-        :aria-invalid="hasError || undefined"
-        :aria-errormessage="hasError ? errorMessageId : undefined"
-        :aria-describedby="describedBy"
-        :aria-required="required || undefined"
-      >
-        <!--
+        <button
+          v-else
+          type="button"
+          :class="[
+            triggerClasses,
+            'justify-between',
+            disabled && 'cursor-not-allowed',
+            hasLabeling ? 'w-full' : null,
+            hasLabeling ? null : (attrs.class as any),
+          ]"
+          :style="hasLabeling ? null : (attrs.style as any)"
+          :disabled="disabled"
+          data-slot="trigger"
+          :data-state="open ? 'open' : 'closed'"
+          :data-variant="variant"
+          :data-size="size"
+          :data-disabled="disabled ? '' : undefined"
+          :data-invalid="hasError ? 'true' : undefined"
+          :data-required="required ? 'true' : undefined"
+          :id="inputId"
+          aria-haspopup="listbox"
+          :aria-expanded="open"
+          :aria-invalid="hasError || undefined"
+          :aria-errormessage="hasError ? errorMessageId : undefined"
+          :aria-describedby="describedBy"
+          :aria-required="required || undefined"
+        >
+          <!--
           Prefix precedence on the trigger:
             1. `#prefix` slot, when provided, owns the entire prefix area
                regardless of selection count. Use it for aggregate
@@ -329,101 +332,71 @@ defineSlots<MultiSelectSlots>()
                the icon.
             4. otherwise: nothing.
         -->
-        <slot
-          v-if="$slots.prefix"
-          name="prefix"
-          v-bind="{
-            open,
-            disabled: !!disabled,
-            query: typedQuery,
-            selectedOptions,
-            displayValue,
-            clearAll,
-            toggleOpen,
-          }"
-        />
-        <template
-          v-else-if="singleSelectedOption && $slots['item-prefix']"
-        >
-          <slot
-            name="item-prefix"
-            v-bind="{
-              item: singleSelectedOption,
-              query: '',
-              selected: true,
-            }"
-          />
-        </template>
-        <OptionIcon
-          v-else-if="singleSelectedOption?.icon"
-          :icon="singleSelectedOption.icon"
-        />
-
-        <span class="grid min-w-0 flex-1 text-left font-normal">
-          <span
-            :class="[
-              'col-start-1 row-start-1 max-w-full truncate',
-              !selectedOptions.length && 'text-ink-gray-4',
-            ]"
-          >
+          <slot v-if="$slots.prefix" name="prefix" v-bind="slotProps" />
+          <template v-else-if="singleSelectedOption && $slots['item-prefix']">
             <slot
-              name="summary"
+              name="item-prefix"
               v-bind="{
-                open,
-                disabled: !!disabled,
-                query: typedQuery,
-                selectedOptions,
-                displayValue,
-                clearAll,
-                toggleOpen,
-                summary: triggerSummary,
+                item: singleSelectedOption,
+                query: '',
+                selected: true,
               }"
-            >{{ triggerSummary }}</slot>
+            />
+          </template>
+          <OptionIcon
+            v-else-if="singleSelectedOption?.icon"
+            :icon="singleSelectedOption.icon"
+          />
+
+          <span class="grid min-w-0 flex-1 text-left font-normal">
+            <span
+              :class="[
+                'col-start-1 row-start-1 max-w-full truncate',
+                !selectedOptions.length && 'text-ink-gray-4',
+              ]"
+            >
+              <slot
+                name="summary"
+                v-bind="{
+                  ...slotProps,
+                  summary: triggerSummary,
+                }"
+                >{{ triggerSummary }}</slot
+              >
+            </span>
+            <span
+              v-if="!$slots.summary"
+              aria-hidden="true"
+              class="multi-select-trigger-sizer col-start-1 row-start-1"
+              :data-width-text="triggerSizingText"
+            />
           </span>
-          <span
-            v-if="!$slots.summary"
-            aria-hidden="true"
-            class="multi-select-trigger-sizer col-start-1 row-start-1"
-            :data-width-text="triggerSizingText"
-          />
-        </span>
 
-        <slot
-          name="suffix"
-          v-bind="{
-            open,
-            disabled: !!disabled,
-            query: typedQuery,
-            selectedOptions,
-            displayValue,
-            clearAll,
-            toggleOpen,
-          }"
+          <slot name="suffix" v-bind="slotProps">
+            <span
+              :class="[
+                'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
+                open && 'rotate-180',
+              ]"
+            />
+          </slot>
+        </button>
+      </ComboboxAnchor>
+
+      <ComboboxPortal :to="portalTo">
+        <ComboboxContent
+          data-slot="content"
+          data-selection
+          :data-variant="variant"
+          :data-size="size"
+          :data-loading="loading ? '' : undefined"
+          class="z-[100] min-w-[--reka-combobox-trigger-width]"
+          position="popper"
+          :side="side"
+          :align="align"
+          :side-offset="offset"
         >
-          <span
-            :class="[
-              'lucide-chevron-down size-4 shrink-0 text-ink-gray-4 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]',
-              open && 'rotate-180',
-            ]"
-          />
-        </slot>
-      </button>
-    </ComboboxAnchor>
-
-    <ComboboxPortal :to="portalTo">
-      <ComboboxContent
-        data-slot="content"
-        data-selection
-        :data-variant="variant"
-        :data-size="size"
-        :data-loading="loading ? '' : undefined"
-        class="z-[100] min-w-[--reka-combobox-trigger-width]"
-        position="popper"
-        :side="side"
-        :align="align"
-        :side-offset="offset"
-      >
-        <!--
+          <!--
           FocusScope sits on the always-present content-body div (inside
           ComboboxContent, which is a <Presence> wrapper that renders null
           while closed). Mounting it here pushes a new entry onto reka's
@@ -432,86 +405,86 @@ defineSlots<MultiSelectSlots>()
           popover (e.g. the search input). See Combobox.vue for the same
           fix and a longer rationale.
         -->
-        <FocusScope as-child @unmount-auto-focus.prevent>
-          <div
-            data-slot="content-body"
-            :data-motion="contentMotion"
-            class="overflow-hidden rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5"
-          >
+          <FocusScope as-child @unmount-auto-focus.prevent>
             <div
-              v-if="!hideSearch"
-              data-slot="search"
-              class="flex items-center gap-2 border-b border-outline-gray-1 px-3"
+              data-slot="content-body"
+              :data-motion="contentMotion"
+              class="overflow-hidden rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5"
             >
-              <ComboboxInput
-                data-slot="input"
-                :value="query"
-                :disabled="disabled"
-                :placeholder="placeholder"
-                autocomplete="off"
-                class="min-w-0 flex-1 border-0 bg-transparent px-0 py-2 text-base text-ink-gray-8 outline-none placeholder:text-ink-gray-4 focus:ring-0"
-                @input="handleInputChange"
-              />
-              <LoadingIndicator
-                v-if="loading"
-                class="size-4 shrink-0 text-ink-gray-5"
-              />
-            </div>
-
-            <MultiSelectResults
-              :groups="filteredGroups"
-              :size="size"
-              :query="typedQuery"
-              :selected-values="safeModel"
-              :loading="loading"
-              :hide-search="hideSearch"
-              :empty-text="emptyText"
-              :show-empty="showEmpty"
-              :slot-fns="slots"
-              :all-options="allOptions"
-            />
-
-            <template v-if="$slots.footer">
-              <div data-slot="footer">
-                <slot
-                  name="footer"
-                  v-bind="{
-                    clearAll,
-                    selectAll,
-                    selectedOptions,
-                    query: typedQuery,
-                  }"
+              <div
+                v-if="!hideSearch"
+                data-slot="search"
+                class="flex items-center gap-2 border-b border-outline-gray-1 px-3"
+              >
+                <ComboboxInput
+                  data-slot="input"
+                  :value="query"
+                  :disabled="disabled"
+                  :placeholder="placeholder"
+                  autocomplete="off"
+                  class="min-w-0 flex-1 border-0 bg-transparent px-0 py-2 text-base text-ink-gray-8 outline-none placeholder:text-ink-gray-4 focus:ring-0"
+                  @input="handleInputChange"
+                />
+                <LoadingIndicator
+                  v-if="loading"
+                  class="size-4 shrink-0 text-ink-gray-5"
                 />
               </div>
-            </template>
-            <div
-              v-else
-              data-slot="footer"
-              class="flex items-center justify-between gap-2 border-t border-outline-gray-1 px-2 py-1.5"
-            >
-              <Button
-                v-if="safeModel.length > 0"
-                variant="ghost"
-                size="sm"
-                @click="clearAll"
+
+              <MultiSelectResults
+                :groups="filteredGroups"
+                :size="size"
+                :query="typedQuery"
+                :selected-values="safeModel"
+                :loading="loading"
+                :hide-search="hideSearch"
+                :empty-text="emptyText"
+                :show-empty="showEmpty"
+                :slot-fns="slots"
+                :all-options="allOptions"
+              />
+
+              <template v-if="$slots.footer">
+                <div data-slot="footer">
+                  <slot
+                    name="footer"
+                    v-bind="{
+                      clearAll,
+                      selectAll,
+                      selectedOptions,
+                      query: typedQuery,
+                    }"
+                  />
+                </div>
+              </template>
+              <div
+                v-else
+                data-slot="footer"
+                class="flex items-center justify-between gap-2 border-t border-outline-gray-1 px-2 py-1.5"
               >
-                Clear All
-              </Button>
-              <Button
-                v-if="!allSelected"
-                variant="ghost"
-                size="sm"
-                class="ml-auto"
-                @click="selectAll"
-              >
-                Select All
-              </Button>
+                <Button
+                  v-if="safeModel.length > 0"
+                  variant="ghost"
+                  size="sm"
+                  @click="clearAll"
+                >
+                  Clear All
+                </Button>
+                <Button
+                  v-if="!allSelected"
+                  variant="ghost"
+                  size="sm"
+                  class="ml-auto"
+                  @click="selectAll"
+                >
+                  Select All
+                </Button>
+              </div>
             </div>
-          </div>
-        </FocusScope>
-      </ComboboxContent>
-    </ComboboxPortal>
-  </ComboboxRoot>
+          </FocusScope>
+        </ComboboxContent>
+      </ComboboxPortal>
+    </ComboboxRoot>
     <InputDescription
       v-if="showDescription || $slots.description"
       :id="descriptionId"

--- a/src/components/MultiSelect/stories/TagsTrigger.vue
+++ b/src/components/MultiSelect/stories/TagsTrigger.vue
@@ -29,12 +29,12 @@ function removeTag(value: string) {
 
 <template>
   <MultiSelect v-model="tags" :options="tagOptions">
-    <template #trigger="{ open, selectedOptions, toggleOpen }">
+    <template #trigger="{ open, selectedOptions, setOpen }">
       <button
         type="button"
         :data-state="open ? 'open' : 'closed'"
         class="flex w-96 min-h-8 cursor-pointer items-center gap-1.5 rounded border border-[--surface-gray-2] px-1.5 py-1 text-left transition-colors hover:border-outline-elevation-2 data-[state=open]:focus-ring"
-        @click="toggleOpen"
+        @click="setOpen(!open)"
       >
         <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1">
           <Badge

--- a/src/components/MultiSelect/types.ts
+++ b/src/components/MultiSelect/types.ts
@@ -106,7 +106,7 @@ export interface MultiSelectProps extends InputLabelingProps {
 /**
  * Shared shape for `#trigger`, `#prefix`, `#suffix`, and (with an added
  * `summary` field) `#summary`. The imperative helpers `clearAll` and
- * `toggleOpen` are exposed on every slot so consumers don't need to hoist
+ * `setOpen` are exposed on every slot so consumers don't need to hoist
  * into `#trigger` just to clear the selection.
  */
 export interface MultiSelectSlotProps {
@@ -128,8 +128,8 @@ export interface MultiSelectSlotProps {
   /** Clears all selected values. */
   clearAll: () => void
 
-  /** Toggles the popover open state. */
-  toggleOpen: () => void
+  /** Sets the popover open state. */
+  setOpen: (value: boolean) => void
 }
 
 export type MultiSelectTriggerSlotProps = MultiSelectSlotProps


### PR DESCRIPTION
## Summary
- replace slot-specific Combobox control prop types with a single ComboboxControlSlotProps type
- pass the same control slot props to trigger, prefix, suffix, and footer slots
- expose setOpen(value) for slot-driven popover control
- migrate MultiSelect trigger/prefix/suffix/summary slot props from toggleOpen to setOpen for naming consistency
- regenerate Combobox and MultiSelect API docs

## Verification
- yarn build
- yarn test:cypress --spec "src/components/Combobox/Combobox.cy.ts" (48 passing)
- yarn type-check (fails on existing unrelated repo-wide errors in Tabs/TextEditor/data-fetching/etc.)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-785/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 56.53% (+0.01% vs `main`)
<!-- coverage-report:end -->
