### PR TITLE
fix: tidy CodeEditor gutter chrome

### DIFF
--- a/src/components/CodeEditor/CodeEditor.vue
+++ b/src/components/CodeEditor/CodeEditor.vue
@@ -102,10 +102,10 @@ const {
 const hasLabeling = computed(() =>
   Boolean(
     props.label ||
-      slots.label ||
-      showDescription.value ||
-      slots.description ||
-      hasError.value,
+    slots.label ||
+    showDescription.value ||
+    slots.description ||
+    hasError.value,
   ),
 )
 
@@ -345,13 +345,16 @@ onMounted(async () => {
   const highlight = await buildSyntaxHighlight(cmState)
 
   const updateListener = EditorView.updateListener.of((update) => {
-    if (update.docChanged) {
-      if (!syncingFromProp)
-        emit('update:modelValue', update.state.doc.toString())
-      // Content height may have changed (capped scroller won't trigger the
-      // ResizeObserver, so re-check here on every doc edit).
+    if (update.docChanged && !syncingFromProp)
+      emit('update:modelValue', update.state.doc.toString())
+    // Content height may have changed — re-check the cap and the scroll-shadow
+    // overlay. A doc edit changes height, but so does folding/unfolding (a
+    // view-state effect, not a doc change) and any reflow. The capped/min-height
+    // scroller can keep its box size constant while content height shifts, so the
+    // ResizeObserver never fires for those — `geometryChanged` is what catches
+    // them (folding latching a stale Expand button was the bug this closes).
+    if (update.docChanged || update.geometryChanged) {
       measureOverflow()
-      // Text height changed too — keep the scroll-shadow overlay capped to it.
       syncGutterShadow()
     }
   })

--- a/src/components/CodeEditor/CodeEditor.vue
+++ b/src/components/CodeEditor/CodeEditor.vue
@@ -144,6 +144,21 @@ let lastOverflow = false
 // observer that nothing destroys. This flag lets the resume bail instead.
 let destroyed = false
 
+// Drive the gutter's horizontal-scroll shadow (see theme.ts). Two things: flag
+// `cm-scrolled-x` when the content is scrolled under the sticky gutter so the
+// shadow fades in, and publish `--cm-text-height` (the bottom of the last line)
+// so the shadow overlay is capped to the actual code and doesn't run down into
+// the empty min-height area below it. The scroller's `scroll` event doesn't
+// bubble, so the scroll half can't ride CodeMirror's `domEventHandlers`; it's a
+// plain listener on `scrollDOM`. The height half is refreshed wherever geometry
+// changes (mount, edits, reflow, size) alongside `measureOverflow`.
+function syncGutterShadow() {
+  if (!view) return
+  view.dom.classList.toggle('cm-scrolled-x', view.scrollDOM.scrollLeft > 0)
+  const textHeight = view.lineBlockAt(view.state.doc.length).bottom
+  view.dom.style.setProperty('--cm-text-height', `${textHeight}px`)
+}
+
 // Emit when the scroller becomes (un)scrollable — i.e. content crosses the cap.
 function measureOverflow() {
   if (!view) return
@@ -230,16 +245,23 @@ function buildVariant(v?: string, disabled?: boolean): Extension {
             ? '1px solid var(--outline-gray-2, #e2e8f0)'
             : '1px solid transparent',
       },
+      // Gutter shares the disabled surface so scrolled content can't bleed
+      // through behind it (the gutter is sticky over the scroller).
+      '.cm-gutters': { backgroundColor: 'var(--surface-gray-1, #f8fafc)' },
       '.cm-content': { opacity: '0.6' },
     })
   }
   const ring = '0 0 0 2px var(--outline-gray-3, #cbd5e1)'
+  // Each variant paints `.cm-gutters` to match its `&` surface in the same
+  // state — the gutter is sticky over the scroller, so a transparent one would
+  // let horizontally-scrolled code bleed through behind the line numbers.
   const fragments: Record<string, Record<string, Record<string, string>>> = {
     subtle: {
       '&': {
         backgroundColor: 'var(--surface-gray-2, #f1f5f9)',
         border: '1px solid var(--surface-gray-2, #e2e8f0)',
       },
+      '.cm-gutters': { backgroundColor: 'var(--surface-gray-2, #f1f5f9)' },
       // Hover mirrors frappe-ui's TextInput/Textarea `subtle` variant
       // (`hover:border-outline-elevation-2 hover:bg-surface-gray-3`) so a code
       // field reacts to hover the same way the inputs around it do. Declared
@@ -248,10 +270,16 @@ function buildVariant(v?: string, disabled?: boolean): Extension {
         backgroundColor: 'var(--surface-gray-3, #e2e8f0)',
         borderColor: 'var(--outline-elevation-2, #94a3b8)',
       },
+      '&:hover .cm-gutters': {
+        backgroundColor: 'var(--surface-gray-3, #e2e8f0)',
+      },
       '&.cm-focused': {
         backgroundColor: 'var(--surface-base, white)',
         borderColor: 'var(--outline-gray-4, #94a3b8)',
         boxShadow: ring,
+      },
+      '&.cm-focused .cm-gutters': {
+        backgroundColor: 'var(--surface-base, white)',
       },
     },
     outline: {
@@ -259,6 +287,7 @@ function buildVariant(v?: string, disabled?: boolean): Extension {
         backgroundColor: 'var(--surface-base, white)',
         border: '1px solid var(--outline-gray-2, #e2e8f0)',
       },
+      '.cm-gutters': { backgroundColor: 'var(--surface-base, white)' },
       '&.cm-focused': {
         borderColor: 'var(--outline-gray-4, #94a3b8)',
         boxShadow: ring,
@@ -322,6 +351,8 @@ onMounted(async () => {
       // Content height may have changed (capped scroller won't trigger the
       // ResizeObserver, so re-check here on every doc edit).
       measureOverflow()
+      // Text height changed too — keep the scroll-shadow overlay capped to it.
+      syncGutterShadow()
     }
   })
 
@@ -374,12 +405,19 @@ onMounted(async () => {
   })
 
   measureOverflow()
+  // Shadow the gutter while the content is scrolled horizontally. Listen on the
+  // scroller (the event doesn't bubble) and seed the initial state.
+  view.scrollDOM.addEventListener('scroll', syncGutterShadow, { passive: true })
+  syncGutterShadow()
   // Catches overflow changes the doc-edit path misses: wrapping reflow on width
   // change, and the cap being applied/removed (a consumer toggling
   // `--cm-max-height` resizes the scroller, which fires this). Fires once on
   // observe for the initial measurement.
   if (typeof ResizeObserver !== 'undefined') {
-    overflowObserver = new ResizeObserver(() => measureOverflow())
+    overflowObserver = new ResizeObserver(() => {
+      measureOverflow()
+      syncGutterShadow()
+    })
     overflowObserver.observe(view.scrollDOM)
   }
 })
@@ -479,6 +517,7 @@ watch(
     if (!view || !sizeCompartment) return
     view.dispatch({ effects: sizeCompartment.reconfigure(buildSize(s)) })
     measureOverflow()
+    syncGutterShadow()
   },
 )
 
@@ -507,6 +546,7 @@ onBeforeUnmount(() => {
   overflowObserver?.disconnect()
   overflowObserver = null
   if (view) {
+    view.scrollDOM.removeEventListener('scroll', syncGutterShadow)
     view.destroy()
     view = null
   }

--- a/src/components/CodeEditor/theme.ts
+++ b/src/components/CodeEditor/theme.ts
@@ -53,16 +53,42 @@ export function buildBaseTheme(
     '.cm-line': {
       padding: '0 6px',
     },
-    // Transparent so the gutter inherits whatever surface the active variant
-    // paints (gray-2 for `subtle`, white for `outline`) — otherwise a hardcoded
-    // gutter color seams against the filled `subtle`
-    // surface. The right border uses the `outline-gray-2` border token (a step
-    // darker than the gray-2 `subtle` fill) so the divider reads as a hairline on
-    // the filled `subtle` surface too, not only on hover/white `outline`.
+    // Gutter surface is owned by the variant compartment (`buildVariant`), the
+    // sole source of surface chrome — it paints `.cm-gutters` to match `&` in
+    // every state (hover/focus/disabled). It deliberately can't stay transparent:
+    // the gutter is sticky and the content scrolls *under* it, so a see-through
+    // gutter lets horizontally-scrolled code bleed through behind the line
+    // numbers. No divider border (overrides `basicSetup`'s default right border,
+    // hence an explicit `none`) so the gutter reads as part of the surface.
     '.cm-gutters': {
-      backgroundColor: 'transparent',
-      borderRight: '1px solid var(--outline-gray-2, #e2e2e2)',
+      borderRight: 'none',
       color: 'var(--ink-gray-5, #64748b)',
+    },
+    // Scroll shadow: while the content is scrolled horizontally it slides under
+    // the sticky gutter, so a right-edge shadow signals the hidden code. It's a
+    // pseudo-element rather than a `box-shadow` on `.cm-gutters` itself because
+    // CodeMirror stretches the gutter to the full editor height (`.cm-content`
+    // fills it, and the gutter's `min-height` tracks that) — a gutter shadow
+    // would run down past the last line into the empty area below, where, with
+    // the gutter camouflaged against the surface, it looks like a shadow
+    // floating in space. Instead this overlay is capped to the actual text
+    // height via `--cm-text-height` (the last line's bottom, set from the SFC),
+    // so it ends with the code. `cm-scrolled-x` (also set there) fades it in.
+    '.cm-gutters::after': {
+      content: '""',
+      position: 'absolute',
+      top: '0',
+      right: '0',
+      width: '6px',
+      height: 'var(--cm-text-height, 100%)',
+      transform: 'translateX(100%)',
+      pointerEvents: 'none',
+      opacity: '0',
+      transition: 'opacity 0.15s ease',
+      background: 'linear-gradient(to right, rgba(0, 0, 0, 0.16), transparent)',
+    },
+    '&.cm-scrolled-x .cm-gutters::after': {
+      opacity: '1',
     },
     // Fold marker. `basicSetup` renders a bare text caret pinned to the
     // cell's top-left; center it and swap the glyph for a masked chevron
@@ -96,6 +122,34 @@ export function buildBaseTheme(
     },
     ".cm-foldGutter .cm-gutterElement > span[title='Unfold line']": {
       transform: 'rotate(-90deg)',
+    },
+    // The fold gutter otherwise reserves a column even when nothing on screen is
+    // foldable (plain text, a flat markdown doc) — dead space next to the code.
+    // Collapse it to zero width until at least one line renders a real fold
+    // chevron. The catch: CodeMirror sizes the gutter with an always-present
+    // hidden "spacer" element (a FoldMarker span tagged with inline
+    // `visibility: hidden`), so a naive `:has(> span)` is always true. We exclude
+    // the spacer with `:not([style*='visibility'])`, leaving only the chevrons
+    // that actually appear on foldable lines. `overflow: hidden` then clips the
+    // spacer's span so it stops reserving width once collapsed. `:has`
+    // re-evaluates live, so the column appears/disappears as folds come and go.
+    ".cm-foldGutter:not(:has(.cm-gutterElement:not([style*='visibility']) > span))":
+      {
+        width: '0',
+        overflow: 'hidden',
+      },
+    ".cm-foldGutter:not(:has(.cm-gutterElement:not([style*='visibility']) > span)) .cm-gutterElement":
+      {
+        padding: '0',
+      },
+    // Same for the JSON lint gutter: it holds a fixed column for diagnostic
+    // markers, but valid JSON has none, so collapse it until a `.cm-lint-marker`
+    // appears. The column springs back the moment the parser reports an error.
+    '.cm-gutter-lint:not(:has(.cm-lint-marker))': {
+      width: '0',
+    },
+    '.cm-gutter-lint:not(:has(.cm-lint-marker)) .cm-gutterElement': {
+      padding: '0',
     },
     // `basicSetup` highlights the active line/gutter in a default light blue.
     // A fixed gray token can't stay visible across every surface the row sits on


### PR DESCRIPTION
- Collapse the fold gutter (until a line is foldable) and the JSON lint gutter (until a diagnostic appears) so empty gutters reserve no space.
- Remove the gutter divider border.
- Paint the gutter background to match the editor surface in every state so horizontally-scrolled code no longer bleeds through behind it.
- Add a horizontal-scroll shadow on the gutter, capped to the text height so it ends with the code instead of floating in the empty area below.

<!-- coverage-report:start -->
Coverage: 56.90% (+0.01% vs `main`)
<!-- coverage-report:end -->

