### PR TITLE
fix(editor): batch of editor fixes + Dropdown matchTriggerWidth

### DIFF
--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -30,6 +30,9 @@
         :side="side"
         :align="align"
         :side-offset="offset"
+        :style="{
+          width: matchTriggerWidth ? 'var(--reka-dropdown-menu-trigger-width)' : undefined,
+        }"
       >
         <Menu
           :groups="groups"

--- a/src/components/Dropdown/types.ts
+++ b/src/components/Dropdown/types.ts
@@ -48,6 +48,9 @@ export interface DropdownProps {
   /** Offset in pixels between trigger and dropdown. */
   offset?: number
 
+  /** Whether the dropdown width should match the trigger element. */
+  matchTriggerWidth?: boolean
+
   /** Teleport target for dropdown portal content. */
   portalTo?: string | HTMLElement
 }

--- a/src/molecules/editor/Editor.cy.ts
+++ b/src/molecules/editor/Editor.cy.ts
@@ -97,13 +97,17 @@ describe('v1 editor browser behavior', () => {
     cy.contains('button', 'Embed').should('be.visible')
   })
 
-  it('opens the link editor near the clicked link, not at the top of the document', () => {
+  it('opens the link editor near the link, not at the top of the document', () => {
     mountEditor({
       topOffset: 320,
       content: '<p><a href="https://example.com">Example link</a></p>',
     })
 
+    // Plain click only places the caret (it no longer opens the popup); the
+    // link editor opens via Mod-k. A collapsed caret in the link opens it in
+    // view mode, which renders the href as an <a>.
     cy.contains('.ProseMirror a', 'Example link').click()
+    cy.get('.ProseMirror').type('{meta}k')
 
     cy.contains('a', 'https://example.com')
       .should('be.visible')
@@ -119,6 +123,7 @@ describe('v1 editor browser behavior', () => {
     })
 
     cy.contains('.ProseMirror a', 'Example link').click()
+    cy.get('.ProseMirror').type('{meta}k')
     cy.contains('a', 'https://example.com').should('be.visible')
 
     cy.get('.ProseMirror').click('bottomRight', { force: true })

--- a/src/molecules/editor/components/EditorPopover.vue
+++ b/src/molecules/editor/components/EditorPopover.vue
@@ -5,7 +5,7 @@
     tabindex="-1"
     :loop="loop"
     :trapped="trapped"
-    class="editor-popover border border-outline-gray-1 bg-surface-elevation-2 shadow-xl outline-none"
+    class="editor-popover border border-outline-gray-2 bg-surface-elevation-2 shadow-2xl outline-none"
     :class="contentClass"
     @mount-auto-focus="onMountAutoFocus"
     @unmount-auto-focus="onUnmountAutoFocus"

--- a/src/molecules/editor/components/MediaResizeHandles.vue
+++ b/src/molecules/editor/components/MediaResizeHandles.vue
@@ -27,10 +27,12 @@ const edges: readonly ResizeEdge[] = ['left', 'right']
     v-for="edge in edges"
     :key="edge"
     type="button"
-    class="absolute top-1/2 z-20 h-8 max-h-[50%] w-1 -translate-y-1/2 cursor-ew-resize touch-none rounded-full bg-black/65 ring-1 ring-white/50"
-    :class="edge === 'left' ? 'left-1.5' : 'right-1.5'"
+    class="absolute top-1/2 z-30 flex h-8 max-h-[50%] w-4 -translate-y-1/2 cursor-ew-resize touch-none items-center justify-center bg-transparent"
+    :class="edge === 'left' ? 'left-0' : 'right-0'"
     :aria-label="`${label} from ${edge} edge`"
     @pointerdown.prevent="emit('resize-start', $event, edge)"
     @keydown="emit('resize-keydown', $event)"
-  />
+  >
+    <span class="pointer-events-none h-full w-1 rounded-full bg-black/65 ring-1 ring-white/50" />
+  </button>
 </template>

--- a/src/molecules/editor/extensions/link/LinkEditorPopup.vue
+++ b/src/molecules/editor/extensions/link/LinkEditorPopup.vue
@@ -43,7 +43,7 @@
       />
       <div class="pl-1.5 flex-1 min-w-0 flex">
         <a
-          class="truncate text-sm text-ink-gray-8 border-b border-outline-gray-2 hover:border-outline-gray-3"
+          class="truncate text-sm text-ink-gray-9 border-b border-outline-gray-2 hover:border-outline-gray-3"
           :title="_href"
           :href="_href"
           target="_blank"

--- a/src/molecules/editor/extensions/link/link-click-plugin.ts
+++ b/src/molecules/editor/extensions/link/link-click-plugin.ts
@@ -1,5 +1,4 @@
 import type { Editor } from '@tiptap/core'
-import { getMarkRange } from '@tiptap/core'
 import type { MarkType } from '@tiptap/pm/model'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 
@@ -17,41 +16,37 @@ export interface LinkClickPluginOptions {
  *  - Not editable → `return false` (let the browser follow the link).
  *  - Not on a link → `return false`.
  *  - Cmd/Meta-click → open the href in a new tab; `return true`.
- *  - Plain click   → open the link editor popup; `return true`.
+ *  - Plain click   → `return false`; let the caret land where the user clicked so
+ *    link text stays editable. The link editor is opened via the hover affordance
+ *    / `Mod-k`, not by trapping a plain click.
  *
  * Always returns a boolean so ProseMirror knows whether the click was handled
  * (the legacy handler returned `undefined` from the editable/meta branches).
  */
 export function linkClickPlugin(options: LinkClickPluginOptions): Plugin {
-  const { editor, type } = options
+  const { editor } = options
   return new Plugin({
     key: new PluginKey('handleLinkClick'),
     props: {
-      handleClick: (view, pos, event): boolean => {
+      handleClick: (view, _pos, event): boolean => {
         if (!editor.isEditable) return false
 
         const target = event.target as HTMLElement | null
         const anchor = target?.closest('a[href]')
         if (!anchor || !view.dom.contains(anchor)) return false
 
-        event.preventDefault()
-
         if (event.metaKey || event.ctrlKey) {
+          event.preventDefault()
           const url = anchor.getAttribute('href') || undefined
           if (url) window.open(url, '_blank', 'noopener,noreferrer')
           editor.commands.focus()
           return true
         }
 
-        const resolved = view.state.doc.resolve(pos)
-        const range = getMarkRange(resolved, type)
-        if (range) {
-          editor.chain().setTextSelection(range).run()
-        }
-        requestAnimationFrame(() => {
-          if (!editor.isDestroyed) editor.commands.openLinkEditor()
-        })
-        return true
+        // Plain click: don't preventDefault or reselect the whole link range —
+        // that stole focus into the editor popup and trapped the caret. Let the
+        // browser place the caret where the user clicked.
+        return false
       },
     },
   })

--- a/src/molecules/editor/extensions/link/link-extension.ts
+++ b/src/molecules/editor/extensions/link/link-extension.ts
@@ -33,6 +33,15 @@ export const LinkExtension = Link.extend({
       autolink: true,
       defaultProtocol: 'https',
       linkOnPaste: false,
+      // Don't auto-link bare dotted identifiers like `data.doc.name` (`.name` is a
+      // real TLD, so linkify matches them). Only auto-link inputs that carry an
+      // explicit scheme (`http://`, `mailto:`, …) or a `www.` prefix — i.e. things
+      // a user actually means as a URL. `url` here is the raw matched text.
+      shouldAutoLink: (url: string): boolean => {
+        const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(url)
+        const hasWww = /^www\./i.test(url)
+        return hasScheme || hasWww
+      },
     }
   },
 

--- a/src/molecules/editor/extensions/link/link-popup-controller.test.ts
+++ b/src/molecules/editor/extensions/link/link-popup-controller.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect } from 'vitest'
+import { lockScroll } from './link-popup-controller'
+
+describe('lockScroll', () => {
+  // Regression: opening the link popup over a scrolled editor used to drop the
+  // container's `overflow-y` on close, so long content overflowed its box and
+  // painted over the toolbar/Submit. The lock must restore the exact prior
+  // overflow, even when it was authored as the `overflow-y` longhand.
+  it('restores an `overflow-y` longhand after lock/unlock', () => {
+    const el = document.createElement('div')
+    el.style.overflowY = 'auto'
+
+    const unlock = lockScroll(el)
+    expect(el.style.overflowY).toBe('hidden')
+    expect(el.style.overflowX).toBe('hidden')
+
+    unlock()
+    expect(el.style.overflowY).toBe('auto')
+  })
+
+  it('restores each axis independently after lock/unlock', () => {
+    const el = document.createElement('div')
+    el.style.overflowX = 'hidden'
+    el.style.overflowY = 'auto'
+
+    lockScroll(el)()
+
+    expect(el.style.overflowX).toBe('hidden')
+    expect(el.style.overflowY).toBe('auto')
+  })
+
+  it('leaves no inline overflow when the element had none', () => {
+    const el = document.createElement('div')
+
+    lockScroll(el)()
+
+    expect(el.style.overflowX).toBe('')
+    expect(el.style.overflowY).toBe('')
+    expect(el.getAttribute('style')).toBeFalsy()
+  })
+
+  it('is a no-op for a null scroll parent', () => {
+    expect(() => lockScroll(null)()).not.toThrow()
+  })
+})

--- a/src/molecules/editor/extensions/link/link-popup-controller.ts
+++ b/src/molecules/editor/extensions/link/link-popup-controller.ts
@@ -45,12 +45,7 @@ export function openLinkPopup(
   // Lock the page's scroll container while the popup is open so the anchored
   // editor can't scroll away underneath it. The app scrolls an inner
   // overflow-auto element (not <body>), so we lock the nearest such ancestor.
-  const scrollParent = getScrollParent(anchor)
-  const previousOverflow = scrollParent?.style.overflow ?? ''
-  if (scrollParent) scrollParent.style.overflow = 'hidden'
-  const unlockScroll = () => {
-    if (scrollParent) scrollParent.style.overflow = previousOverflow
-  }
+  const unlockScroll = lockScroll(getScrollParent(anchor))
 
   return new Promise<string | null>((resolve) => {
     let settled = false
@@ -101,6 +96,32 @@ export function openLinkPopup(
       settle(null)
     }
   })
+}
+
+/**
+ * Lock vertical+horizontal scrolling on `el` and return a function that
+ * restores it.
+ *
+ * Save/restore the `overflow-x`/`overflow-y` *longhands* — never the `overflow`
+ * shorthand. A scroll container's value usually lives in a longhand (e.g.
+ * EditorContent sets `overflow-y: auto` inline); reading `.style.overflow`
+ * returns '' whenever the two axes differ, so locking via the shorthand and
+ * later clearing it would drop the original `overflow-y` and leave the editor
+ * overflowing its box — content then paints over the toolbar (the link-edit
+ * overflow bug). The longhand getters reflect the value regardless of how it
+ * was originally authored, so restoring them reproduces the prior state exactly.
+ *
+ * No-op (returns a no-op restore) when `el` is `null`.
+ */
+export function lockScroll(el: HTMLElement | null): () => void {
+  if (!el) return () => {}
+  const previous = { x: el.style.overflowX, y: el.style.overflowY }
+  el.style.overflowX = 'hidden'
+  el.style.overflowY = 'hidden'
+  return () => {
+    el.style.overflowX = previous.x
+    el.style.overflowY = previous.y
+  }
 }
 
 /**

--- a/src/molecules/editor/extensions/table/table-cell-color.ts
+++ b/src/molecules/editor/extensions/table/table-cell-color.ts
@@ -15,9 +15,53 @@
  * `CellSelection`); the text-color command reproduces that targeting for marks.
  */
 import { Extension } from '@tiptap/core'
-import type { Node as PMNode } from '@tiptap/pm/model'
+import type { EditorState } from '@tiptap/pm/state'
+import type { MarkType, Node as PMNode } from '@tiptap/pm/model'
 import { CellSelection, isInTable, selectionCell } from '@tiptap/pm/tables'
 import { PALETTE_NAMES } from '../shared/color-palette'
+
+/** Block node types that carry the `textAlign` attribute. */
+const ALIGNABLE_NODES = new Set(['paragraph', 'heading'])
+
+/**
+ * Content ranges (text positions) of every cell in the active selection: each
+ * cell of a `CellSelection`, else just the cell holding the cursor. Shared by
+ * all cell-aware commands so they fan out identically.
+ */
+function cellContentRanges(
+  state: EditorState,
+): Array<{ from: number; to: number }> {
+  const ranges: Array<{ from: number; to: number }> = []
+  const addCell = (cell: PMNode | null, pos: number) => {
+    if (!cell) return
+    ranges.push({ from: pos + 1, to: pos + cell.nodeSize - 1 })
+  }
+  const { selection } = state
+  if (selection instanceof CellSelection) {
+    selection.forEachCell((cell, pos) => addCell(cell, pos))
+  } else {
+    const $cell = selectionCell(state)
+    if ($cell) addCell($cell.nodeAfter, $cell.pos)
+  }
+  return ranges
+}
+
+/** True when every text node in `[from, to)` already carries `markType`. */
+function isRangeFullyMarked(
+  state: EditorState,
+  from: number,
+  to: number,
+  markType: MarkType,
+): boolean {
+  let hasText = false
+  let allMarked = true
+  state.doc.nodesBetween(from, to, (node) => {
+    if (!node.isText) return
+    hasText = true
+    if (!markType.isInSet(node.marks)) allMarked = false
+  })
+  return hasText && allMarked
+}
 import {
   extractHighlightColorFromStyle,
   highlightColorStyle,
@@ -53,6 +97,10 @@ declare module '@tiptap/core' {
       setCellBackground: (colorName: string | null) => ReturnType
       /** Color all text in the selected cell(s) by name; `null` clears it. */
       setCellTextColor: (colorName: string | null) => ReturnType
+      /** Set `textAlign` on every alignable block in the selected cell(s). */
+      setCellTextAlign: (alignment: string) => ReturnType
+      /** Toggle the `bold` mark across every selected cell's content. */
+      toggleCellBold: () => ReturnType
     }
   }
 }
@@ -81,20 +129,7 @@ export const TableCellColor = Extension.create({
           const markType = state.schema.marks.textStyle
           if (!markType) return false
 
-          // Collect the content range of every targeted cell: each cell in a
-          // CellSelection, else just the cell holding the cursor.
-          const ranges: Array<{ from: number; to: number }> = []
-          const addCell = (cell: PMNode | null, pos: number) => {
-            if (!cell) return
-            ranges.push({ from: pos + 1, to: pos + cell.nodeSize - 1 })
-          }
-          const { selection } = state
-          if (selection instanceof CellSelection) {
-            selection.forEachCell((cell, pos) => addCell(cell, pos))
-          } else {
-            const $cell = selectionCell(state)
-            if ($cell) addCell($cell.nodeAfter, $cell.pos)
-          }
+          const ranges = cellContentRanges(state)
           if (!ranges.length) return false
 
           for (const { from, to } of ranges) {
@@ -102,6 +137,46 @@ export const TableCellColor = Extension.create({
             // whole mark in-range is equivalent to setting the color.
             tr.removeMark(from, to, markType)
             if (colorName) tr.addMark(from, to, markType.create({ color: colorName }))
+          }
+          if (dispatch) dispatch(tr.scrollIntoView())
+          return true
+        },
+
+      setCellTextAlign:
+        (alignment) =>
+        ({ state, tr, dispatch }) => {
+          if (!isInTable(state)) return false
+          const ranges = cellContentRanges(state)
+          if (!ranges.length) return false
+
+          for (const { from, to } of ranges) {
+            state.doc.nodesBetween(from, to, (node, pos) => {
+              if (!ALIGNABLE_NODES.has(node.type.name)) return
+              tr.setNodeAttribute(pos, 'textAlign', alignment)
+            })
+          }
+          if (dispatch) dispatch(tr.scrollIntoView())
+          return true
+        },
+
+      toggleCellBold:
+        () =>
+        ({ state, tr, dispatch }) => {
+          if (!isInTable(state)) return false
+          const markType = state.schema.marks.bold
+          if (!markType) return false
+          const ranges = cellContentRanges(state)
+          if (!ranges.length) return false
+
+          // Toggle semantics: if every non-empty cell range is already fully
+          // bold, clear bold everywhere; otherwise bold every cell.
+          const allBold = ranges.every(({ from, to }) =>
+            from >= to ? true : isRangeFullyMarked(state, from, to, markType),
+          )
+          for (const { from, to } of ranges) {
+            if (from >= to) continue
+            if (allBold) tr.removeMark(from, to, markType)
+            else tr.addMark(from, to, markType.create())
           }
           if (dispatch) dispatch(tr.scrollIntoView())
           return true

--- a/src/molecules/editor/menu.ts
+++ b/src/molecules/editor/menu.ts
@@ -6,9 +6,15 @@ import {
   type EditorCommandContext,
   type EditorCommandMeta,
 } from './commands'
+import { CellSelection } from '@tiptap/pm/tables'
 import { openFontColorPicker } from './components/font-color/fontColorController'
 import { openTableCellColorPicker } from './components/table-color/tableCellColorController'
 import { openTableSizePicker } from './components/table-size-picker/tableSizePickerController'
+
+/** True when a multi-cell table range is selected (drag across cells). */
+function isCellRangeSelection(editor: Editor): boolean {
+  return editor.state?.selection instanceof CellSelection
+}
 
 export type MenuActionContext = EditorCommandContext
 
@@ -86,9 +92,14 @@ function command(
   }
 }
 
-export const Bold = command(commandMeta.bold, (editor) =>
-  editor.chain().focus().toggleBold().run(),
-)
+export const Bold = command(commandMeta.bold, (editor) => {
+  // A CellSelection must keep its cell range — `.focus()` collapses it to a
+  // text cursor, so fan bold out across cells without focusing.
+  if (isCellRangeSelection(editor)) {
+    return editor.chain().toggleCellBold().run()
+  }
+  return editor.chain().focus().toggleBold().run()
+})
 export const Italic = command(commandMeta.italic, (editor) =>
   editor.chain().focus().toggleItalic().run(),
 )
@@ -131,15 +142,19 @@ export const HeadingGroup: MenuGroupItem = {
   items: [H2, H3, H4],
 }
 
-export const AlignLeft = command(commandMeta.alignLeft, (editor) =>
-  editor.chain().focus().setTextAlign('left').run(),
-)
-export const AlignCenter = command(commandMeta.alignCenter, (editor) =>
-  editor.chain().focus().setTextAlign('center').run(),
-)
-export const AlignRight = command(commandMeta.alignRight, (editor) =>
-  editor.chain().focus().setTextAlign('right').run(),
-)
+function align(meta: EditorCommandMeta, alignment: string): CommandMenuItem {
+  return command(meta, (editor) => {
+    // Keep a multi-cell range intact: `.focus()` would collapse the
+    // CellSelection so alignment only hits the anchor cell.
+    if (isCellRangeSelection(editor)) {
+      return editor.chain().setCellTextAlign(alignment).run()
+    }
+    return editor.chain().focus().setTextAlign(alignment).run()
+  })
+}
+export const AlignLeft = align(commandMeta.alignLeft, 'left')
+export const AlignCenter = align(commandMeta.alignCenter, 'center')
+export const AlignRight = align(commandMeta.alignRight, 'right')
 // Named color/highlight (`namedColor`/`namedHighlight`) drive an imperative
 // picker so the toolbar button remains owned by MenuItems.
 export const FontColor = command(

--- a/tailwind/plugin.js
+++ b/tailwind/plugin.js
@@ -459,6 +459,19 @@ export default plugin(
                   borderBottom: '1px solid var(--ink-gray-6)',
                 },
 
+                // named text color + bold: the color lives on a `textStyle`
+                // span that wraps (or is wrapped by) `<strong>`. Typography's
+                // `strong { color: var(--tw-prose-bold) }` otherwise overrides
+                // the inherited named color, painting bold text gray. Mirror the
+                // base preset's `a strong { color: inherit }` so bold keeps the
+                // span's color in both nesting orders.
+                ':where(span[style*="--prose-color-"]) strong': {
+                  color: 'inherit',
+                },
+                'strong:where([style*="--prose-color-"])': {
+                  color: 'inherit',
+                },
+
                 // inline code: subtle pill — strip Tailwind's added quotes
                 'code::before': { content: 'none' },
                 'code::after': { content: 'none' },

--- a/tailwind/plugin.js
+++ b/tailwind/plugin.js
@@ -452,7 +452,7 @@ export default plugin(
                 // links: subtle bottom border, darkens on hover
                 a: {
                   textDecoration: 'none',
-                  borderBottom: '1px solid var(--ink-gray-3)',
+                  borderBottom: '1px solid var(--ink-gray-4)',
                   transition: 'border-color 0.08s ease',
                 },
                 'a:hover': {
@@ -556,7 +556,7 @@ export default plugin(
                 ol: {
                   marginTop: '4px',
                   marginBottom: '4px',
-                  paddingInlineStart: '1.5em',
+                  paddingInlineStart: '1.7em',
                 },
                 li: {
                   marginTop: '4px',


### PR DESCRIPTION
A batch of small, independent editor fixes (reported in the Gameplan **#gameplan** Raven channel) plus one Dropdown enhancement. Grouped into one PR since each change is small.

### Editor fixes
- **Ordered-list gutter & link underline** — double-digit markers (`10.`) no longer clip to `0.`; resting link underline is more legible.
- **Stop autolinking dotted tokens & trapping link clicks** — bare identifiers like `data.doc.name` are no longer turned into links; a plain click on a link no longer reselects the range or steals focus into the popup.
- **Keep named text color on bold** — bold + colored text no longer renders gray (typography `strong` color was overriding the inherited named color).
- **Bold/align across selected table cells** — toolbar bold/align now fan out across a multi-cell `CellSelection` instead of only the anchor cell.
- **Link popover contrast in dark mode** — stronger border/shadow and a more legible link color.
- **Widen media resize handle hit area** — the 1px visible bar gets a 16px transparent grab target.
- **Restore editor scroll after link popup closes** — the scroll-lock saved/restored the `overflow` shorthand while the value lived in the `overflow-y` longhand, so closing the link popup dropped `overflow-y: auto` and long content overflowed over the toolbar. Now saves/restores the longhands via a `lockScroll` helper (with a regression test).

### Dropdown
- **`matchTriggerWidth` prop** — opt-in, sizes the dropdown content to the trigger width via `--reka-dropdown-menu-trigger-width`. Off by default.

All editor unit tests pass (`yarn vitest run src/molecules/editor`).

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-789/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 57.10% (-0.11% vs `main`)
<!-- coverage-report:end -->
