### PR TITLE
fix(tokens): rename 15px text size to md

### DIFF
--- a/docs/components/Docs/MobileNavSheet.vue
+++ b/docs/components/Docs/MobileNavSheet.vue
@@ -118,7 +118,7 @@ onUnmounted(() => {
       <nav class="flex-1 overflow-y-auto px-3 pb-6 pt-2 flex flex-col gap-6">
         <div
           v-if="filteredList.length === 0"
-          class="px-2 py-6 text-lg text-ink-gray-5 text-center"
+          class="px-2 py-6 text-md text-ink-gray-5 text-center"
         >
           No results for "{{ query }}"
         </div>
@@ -131,7 +131,7 @@ onUnmounted(() => {
               v-for="item in section.items"
               :key="item.text"
               :href="withBase(item.link)"
-              class="pl-2 flex h-11 items-center rounded-md text-lg transition-colors"
+              class="pl-2 flex h-11 items-center rounded-md text-md transition-colors"
               :class="
                 isActive(item.link)
                   ? 'bg-surface-gray-2 text-ink-gray-8'

--- a/docs/components/Home/ComponentGroups.vue
+++ b/docs/components/Home/ComponentGroups.vue
@@ -79,7 +79,7 @@ const componentGroups = {
       />
 
       <div class="grid gap-2 p-4 bg-surface-elevation-1 rounded-b">
-        <h3 class="text-lg font-semibold text-ink-gray-9">
+        <h3 class="text-md font-semibold text-ink-gray-9">
           {{ group }}
         </h3>
 

--- a/docs/components/Home/Hero.vue
+++ b/docs/components/Home/Hero.vue
@@ -15,7 +15,7 @@ import { withBase } from 'vitepress'
       </h1>
 
       <p
-        class="text-p-base sm:text-p-xl text-ink-gray-5 sm:w-3/4 mx-auto"
+        class="text-p-base sm:text-p-lg text-ink-gray-5 sm:w-3/4 mx-auto"
       >
         Beautifully crafted components built for real world applications. Better
         defaults helping you ship faster.

--- a/docs/components/Home/Showcase/col1.vue
+++ b/docs/components/Home/Showcase/col1.vue
@@ -121,7 +121,7 @@ const selOpts = ["Admin", "Editor", "Viewer", "Guest"]
     </div>
 
     <div class="p-5 grid gap-5">
-      <h1 class="font-semibold text-lg">Create Project</h1>
+      <h1 class="font-semibold text-md">Create Project</h1>
       <FormControl
         label="Title"
         variant="outline"

--- a/docs/components/Home/Showcase/col3.vue
+++ b/docs/components/Home/Showcase/col3.vue
@@ -175,7 +175,7 @@ const toggledDiv = ref(false)
       class="p-4 grid"
       :class="{ 'animate-bounce bg-surface-base shadow-lg': toggledDiv }"
     >
-      <h3 class="text-xl mb-2 font-semibold flex gap-3 justify-between">
+      <h3 class="text-lg mb-2 font-semibold flex gap-3 justify-between">
         Schedule an event
         <LucideX class="size-5" @click="toggledDiv = !toggledDiv" />
       </h3>

--- a/docs/components/foundations/PalettePage.vue
+++ b/docs/components/foundations/PalettePage.vue
@@ -75,7 +75,7 @@ const overlayBlack = computed(
       :id="family.key"
       class="grid gap-3"
     >
-      <h2 class="text-xl font-semibold text-ink-gray-8 m-0">
+      <h2 class="text-lg font-semibold text-ink-gray-8 m-0">
         {{ family.label }}
       </h2>
       <div
@@ -111,7 +111,7 @@ const overlayBlack = computed(
       :id="family.key"
       class="grid gap-3"
     >
-      <h2 class="text-xl font-semibold text-ink-gray-8 m-0">
+      <h2 class="text-lg font-semibold text-ink-gray-8 m-0">
         {{ family.label }}
       </h2>
       <div
@@ -148,7 +148,7 @@ const overlayBlack = computed(
     </section>
 
     <section id="overlays" class="grid gap-3">
-      <h2 class="text-xl font-semibold text-ink-gray-8 m-0">Overlays</h2>
+      <h2 class="text-lg font-semibold text-ink-gray-8 m-0">Overlays</h2>
 
       <div class="grid gap-4">
         <div class="grid gap-1.5">
@@ -203,7 +203,7 @@ const overlayBlack = computed(
     </section>
 
     <section id="neutrals" class="grid gap-3">
-      <h2 class="text-xl font-semibold text-ink-gray-8 m-0">Neutrals</h2>
+      <h2 class="text-lg font-semibold text-ink-gray-8 m-0">Neutrals</h2>
       <div
         class="grid gap-1.5"
         :style="{ gridTemplateColumns: `repeat(11, minmax(0, 1fr))` }"

--- a/docs/components/foundations/SemanticPage.vue
+++ b/docs/components/foundations/SemanticPage.vue
@@ -106,7 +106,7 @@ const sections = computed(() =>
       class="grid gap-4"
     >
       <div class="grid gap-1">
-        <h2 class="text-xl font-semibold text-ink-gray-8 m-0 capitalize">
+        <h2 class="text-lg font-semibold text-ink-gray-8 m-0 capitalize">
           {{ section.category }}
         </h2>
         <p class="text-p-sm text-ink-gray-5 m-0">

--- a/docs/components/foundations/TypographyPage.vue
+++ b/docs/components/foundations/TypographyPage.vue
@@ -130,11 +130,11 @@ const paragraphSample =
         class="rounded-xl border border-outline-gray-2 bg-surface-gray-1 px-6 py-5 grid gap-3"
       >
         <div class="flex items-baseline justify-between gap-4">
-          <span class="text-2xl font-semibold text-ink-gray-8">{{
+          <span class="text-xl font-semibold text-ink-gray-8">{{
             family
           }}</span>
         </div>
-        <div class="text-4xl text-ink-gray-8 leading-tight">
+        <div class="text-3xl text-ink-gray-8 leading-tight">
           AaBbCcDdEe 0123456789
         </div>
       </div>
@@ -146,7 +146,7 @@ const paragraphSample =
 
     <section class="grid gap-5">
       <div class="grid gap-1">
-        <h2 class="text-xl font-semibold text-ink-gray-8 m-0">Text sizes</h2>
+        <h2 class="text-lg font-semibold text-ink-gray-8 m-0">Text sizes</h2>
         <p class="text-p-sm text-ink-gray-5 m-0">
           Sizes for UI text like labels, controls, table cells, and body copy.
         </p>
@@ -180,7 +180,7 @@ const paragraphSample =
 
     <section class="grid gap-5">
       <div class="grid gap-1">
-        <h2 class="text-xl font-semibold text-ink-gray-8 m-0">Display sizes</h2>
+        <h2 class="text-lg font-semibold text-ink-gray-8 m-0">Display sizes</h2>
         <p class="text-p-sm text-ink-gray-5 m-0">
           Larger sizes for marketing, landing pages, and headings.
         </p>
@@ -214,7 +214,7 @@ const paragraphSample =
 
     <section class="grid gap-5">
       <div class="grid gap-1">
-        <h2 class="text-xl font-semibold text-ink-gray-8 m-0">Paragraph</h2>
+        <h2 class="text-lg font-semibold text-ink-gray-8 m-0">Paragraph</h2>
         <p class="text-p-sm text-ink-gray-5 m-0">
           The <code class="text-ink-gray-8">text-p-*</code> variants use looser
           line-height and tracking for multi-line text.

--- a/docs/components/tokens/Text.vue
+++ b/docs/components/tokens/Text.vue
@@ -36,7 +36,7 @@ const para =
         <template v-for="color in data.txtColors" :key="color.name">
           <span
             v-if="!color.value"
-            class="capitalize col-span-full font-semibold text-xl"
+            class="capitalize col-span-full font-semibold text-lg"
           >
             {{ color.name }}
           </span>

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -160,6 +160,11 @@ and merges static text size + weight class pairs, for example `text-base font-me
 to `text-base-medium`. Run it once per codebase; the token migration is not idempotent
 because some v2 names overlap with v0 names.
 
+After upgrading to `frappe-ui@1.0.0-beta.11`, run the codemod again. Apps that
+already ran it will only get the typography correction (`text-lg` → `text-md`,
+`text-xl` → `text-lg`, ...). Apps that still have pre-v2 color tokens can pass
+`--force`, but review the output carefully because color tokens may double-shift.
+
 ## Editor
 
 The v0 monolith `<TextEditor>` (imported from `frappe-ui`) is replaced by the

--- a/espresso-v2-design-tokens/text.styles.tokens.json
+++ b/espresso-v2-design-tokens/text.styles.tokens.json
@@ -298,7 +298,7 @@
         }
       }
     },
-    "lg": {
+    "md": {
       "regular": {
         "$type": "typography",
         "$value": {
@@ -352,6 +352,68 @@
         "$value": {
           "fontFamily": "Inter Variable",
           "fontSize": "15px",
+          "fontWeight": 800,
+          "letterSpacing": "1.5%",
+          "lineHeight": "115%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      }
+    },
+    "lg": {
+      "regular": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "16px",
+          "fontWeight": 420,
+          "letterSpacing": "2%",
+          "lineHeight": "115%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "medium": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "16px",
+          "fontWeight": 500,
+          "letterSpacing": "1.5%",
+          "lineHeight": "115%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "semibold": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "16px",
+          "fontWeight": 600,
+          "letterSpacing": "1.5%",
+          "lineHeight": "115%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "bold": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "16px",
+          "fontWeight": 700,
+          "letterSpacing": "1.5%",
+          "lineHeight": "115%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "black": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "16px",
           "fontWeight": 800,
           "letterSpacing": "1.5%",
           "lineHeight": "115%",
@@ -365,7 +427,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "16px",
+          "fontSize": "17px",
           "fontWeight": 420,
           "letterSpacing": "2%",
           "lineHeight": "115%",
@@ -377,7 +439,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "16px",
+          "fontSize": "17px",
           "fontWeight": 500,
           "letterSpacing": "1.5%",
           "lineHeight": "115%",
@@ -389,7 +451,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "16px",
+          "fontSize": "17px",
           "fontWeight": 600,
           "letterSpacing": "1.5%",
           "lineHeight": "115%",
@@ -401,7 +463,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "16px",
+          "fontSize": "17px",
           "fontWeight": 700,
           "letterSpacing": "1.5%",
           "lineHeight": "115%",
@@ -413,7 +475,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "16px",
+          "fontSize": "17px",
           "fontWeight": 800,
           "letterSpacing": "1.5%",
           "lineHeight": "115%",
@@ -427,9 +489,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "17px",
+          "fontSize": "18px",
           "fontWeight": 420,
-          "letterSpacing": "2%",
+          "letterSpacing": "1%",
           "lineHeight": "115%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -439,9 +501,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "17px",
+          "fontSize": "18px",
           "fontWeight": 500,
-          "letterSpacing": "1.5%",
+          "letterSpacing": "1%",
           "lineHeight": "115%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -451,9 +513,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "17px",
+          "fontSize": "18px",
           "fontWeight": 600,
-          "letterSpacing": "1.5%",
+          "letterSpacing": "1%",
           "lineHeight": "115%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -463,9 +525,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "17px",
+          "fontSize": "18px",
           "fontWeight": 700,
-          "letterSpacing": "1.5%",
+          "letterSpacing": "1%",
           "lineHeight": "115%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -475,9 +537,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "17px",
+          "fontSize": "18px",
           "fontWeight": 800,
-          "letterSpacing": "1.5%",
+          "letterSpacing": "1%",
           "lineHeight": "115%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -489,9 +551,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "18px",
+          "fontSize": "20px",
           "fontWeight": 420,
-          "letterSpacing": "1%",
+          "letterSpacing": "0.5%",
           "lineHeight": "115%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -501,7 +563,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "18px",
+          "fontSize": "20px",
           "fontWeight": 500,
           "letterSpacing": "1%",
           "lineHeight": "115%",
@@ -513,7 +575,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "18px",
+          "fontSize": "20px",
           "fontWeight": 600,
           "letterSpacing": "1%",
           "lineHeight": "115%",
@@ -525,7 +587,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "18px",
+          "fontSize": "20px",
           "fontWeight": 700,
           "letterSpacing": "1%",
           "lineHeight": "115%",
@@ -537,7 +599,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "18px",
+          "fontSize": "20px",
           "fontWeight": 800,
           "letterSpacing": "1%",
           "lineHeight": "115%",
@@ -551,7 +613,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "20px",
+          "fontSize": "24px",
           "fontWeight": 420,
           "letterSpacing": "0.5%",
           "lineHeight": "115%",
@@ -563,9 +625,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "20px",
+          "fontSize": "24px",
           "fontWeight": 500,
-          "letterSpacing": "1%",
+          "letterSpacing": "0.5%",
           "lineHeight": "115%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -575,9 +637,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "20px",
+          "fontSize": "24px",
           "fontWeight": 600,
-          "letterSpacing": "1%",
+          "letterSpacing": "0.5%",
           "lineHeight": "115%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -587,9 +649,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "20px",
+          "fontSize": "24px",
           "fontWeight": 700,
-          "letterSpacing": "1%",
+          "letterSpacing": "0.5%",
           "lineHeight": "115%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -599,9 +661,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "20px",
+          "fontSize": "24px",
           "fontWeight": 800,
-          "letterSpacing": "1%",
+          "letterSpacing": "0.5%",
           "lineHeight": "115%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -613,10 +675,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "24px",
+          "fontSize": "26px",
           "fontWeight": 420,
-          "letterSpacing": "0.5%",
-          "lineHeight": "115%",
+          "letterSpacing": "1%",
+          "lineHeight": "160%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -625,10 +687,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "24px",
+          "fontSize": "26px",
           "fontWeight": 500,
           "letterSpacing": "0.5%",
-          "lineHeight": "115%",
+          "lineHeight": "160%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -637,10 +699,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "24px",
+          "fontSize": "26px",
           "fontWeight": 600,
           "letterSpacing": "0.5%",
-          "lineHeight": "115%",
+          "lineHeight": "160%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -649,10 +711,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "24px",
+          "fontSize": "26px",
           "fontWeight": 700,
           "letterSpacing": "0.5%",
-          "lineHeight": "115%",
+          "lineHeight": "160%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -661,78 +723,16 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "24px",
+          "fontSize": "26px",
           "fontWeight": 800,
-          "letterSpacing": "0.5%",
-          "lineHeight": "115%",
+          "letterSpacing": "1%",
+          "lineHeight": "160%",
           "textTransform": "none",
           "textDecoration": "none"
         }
       }
     },
     "6xl": {
-      "regular": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "26px",
-          "fontWeight": 420,
-          "letterSpacing": "1%",
-          "lineHeight": "160%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "medium": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "26px",
-          "fontWeight": 500,
-          "letterSpacing": "0.5%",
-          "lineHeight": "160%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "semibold": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "26px",
-          "fontWeight": 600,
-          "letterSpacing": "0.5%",
-          "lineHeight": "160%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "bold": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "26px",
-          "fontWeight": 700,
-          "letterSpacing": "0.5%",
-          "lineHeight": "160%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "black": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "26px",
-          "fontWeight": 800,
-          "letterSpacing": "1%",
-          "lineHeight": "160%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      }
-    },
-    "7xl": {
       "regular": {
         "$type": "typography",
         "$value": {
@@ -794,7 +794,7 @@
         }
       }
     },
-    "8xl": {
+    "7xl": {
       "regular": {
         "$type": "typography",
         "$value": {
@@ -856,7 +856,7 @@
         }
       }
     },
-    "9xl": {
+    "8xl": {
       "regular": {
         "$type": "typography",
         "$value": {
@@ -910,6 +910,68 @@
         "$value": {
           "fontFamily": "Inter Variable",
           "fontSize": "40px",
+          "fontWeight": 800,
+          "letterSpacing": "0%",
+          "lineHeight": "140%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      }
+    },
+    "9xl": {
+      "regular": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "44px",
+          "fontWeight": 420,
+          "letterSpacing": "0%",
+          "lineHeight": "140%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "medium": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "44px",
+          "fontWeight": 500,
+          "letterSpacing": "0%",
+          "lineHeight": "140%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "semibold": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "44px",
+          "fontWeight": 600,
+          "letterSpacing": "0%",
+          "lineHeight": "140%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "bold": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "44px",
+          "fontWeight": 700,
+          "letterSpacing": "0%",
+          "lineHeight": "140%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "black": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "44px",
           "fontWeight": 800,
           "letterSpacing": "0%",
           "lineHeight": "140%",
@@ -923,68 +985,6 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "44px",
-          "fontWeight": 420,
-          "letterSpacing": "0%",
-          "lineHeight": "140%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "medium": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "44px",
-          "fontWeight": 500,
-          "letterSpacing": "0%",
-          "lineHeight": "140%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "semibold": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "44px",
-          "fontWeight": 600,
-          "letterSpacing": "0%",
-          "lineHeight": "140%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "bold": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "44px",
-          "fontWeight": 700,
-          "letterSpacing": "0%",
-          "lineHeight": "140%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "black": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "44px",
-          "fontWeight": 800,
-          "letterSpacing": "0%",
-          "lineHeight": "140%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      }
-    },
-    "11xl": {
-      "regular": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
           "fontSize": "48px",
           "fontWeight": 420,
           "letterSpacing": "0%",
@@ -1034,6 +1034,68 @@
         "$value": {
           "fontFamily": "Inter Variable",
           "fontSize": "48px",
+          "fontWeight": 800,
+          "letterSpacing": "0.5%",
+          "lineHeight": "140%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      }
+    },
+    "11xl": {
+      "regular": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "52px",
+          "fontWeight": 420,
+          "letterSpacing": "0%",
+          "lineHeight": "140%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "medium": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "52px",
+          "fontWeight": 500,
+          "letterSpacing": "0%",
+          "lineHeight": "140%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "semibold": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "52px",
+          "fontWeight": 600,
+          "letterSpacing": "0%",
+          "lineHeight": "140%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "bold": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "52px",
+          "fontWeight": 700,
+          "letterSpacing": "0%",
+          "lineHeight": "140%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "black": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "52px",
           "fontWeight": 800,
           "letterSpacing": "0.5%",
           "lineHeight": "140%",
@@ -1047,9 +1109,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "52px",
+          "fontSize": "56px",
           "fontWeight": 420,
-          "letterSpacing": "0%",
+          "letterSpacing": "0.5%",
           "lineHeight": "140%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -1059,7 +1121,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "52px",
+          "fontSize": "56px",
           "fontWeight": 500,
           "letterSpacing": "0%",
           "lineHeight": "140%",
@@ -1071,7 +1133,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "52px",
+          "fontSize": "56px",
           "fontWeight": 600,
           "letterSpacing": "0%",
           "lineHeight": "140%",
@@ -1083,7 +1145,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "52px",
+          "fontSize": "56px",
           "fontWeight": 700,
           "letterSpacing": "0%",
           "lineHeight": "140%",
@@ -1095,9 +1157,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "52px",
+          "fontSize": "56px",
           "fontWeight": 800,
-          "letterSpacing": "0.5%",
+          "letterSpacing": "0%",
           "lineHeight": "140%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -1109,10 +1171,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "56px",
+          "fontSize": "64px",
           "fontWeight": 420,
-          "letterSpacing": "0.5%",
-          "lineHeight": "140%",
+          "letterSpacing": "0%",
+          "lineHeight": "130%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -1121,10 +1183,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "56px",
+          "fontSize": "64px",
           "fontWeight": 500,
           "letterSpacing": "0%",
-          "lineHeight": "140%",
+          "lineHeight": "130%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -1133,10 +1195,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "56px",
+          "fontSize": "64px",
           "fontWeight": 600,
           "letterSpacing": "0%",
-          "lineHeight": "140%",
+          "lineHeight": "130%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -1145,10 +1207,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "56px",
+          "fontSize": "64px",
           "fontWeight": 700,
           "letterSpacing": "0%",
-          "lineHeight": "140%",
+          "lineHeight": "130%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -1157,10 +1219,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "56px",
+          "fontSize": "64px",
           "fontWeight": 800,
           "letterSpacing": "0%",
-          "lineHeight": "140%",
+          "lineHeight": "130%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -1171,7 +1233,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "64px",
+          "fontSize": "72px",
           "fontWeight": 420,
           "letterSpacing": "0%",
           "lineHeight": "130%",
@@ -1183,7 +1245,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "64px",
+          "fontSize": "72px",
           "fontWeight": 500,
           "letterSpacing": "0%",
           "lineHeight": "130%",
@@ -1195,7 +1257,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "64px",
+          "fontSize": "72px",
           "fontWeight": 600,
           "letterSpacing": "0%",
           "lineHeight": "130%",
@@ -1207,7 +1269,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "64px",
+          "fontSize": "72px",
           "fontWeight": 700,
           "letterSpacing": "0%",
           "lineHeight": "130%",
@@ -1219,7 +1281,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "64px",
+          "fontSize": "72px",
           "fontWeight": 800,
           "letterSpacing": "0%",
           "lineHeight": "130%",
@@ -1233,68 +1295,6 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "72px",
-          "fontWeight": 420,
-          "letterSpacing": "0%",
-          "lineHeight": "130%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "medium": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "72px",
-          "fontWeight": 500,
-          "letterSpacing": "0%",
-          "lineHeight": "130%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "semibold": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "72px",
-          "fontWeight": 600,
-          "letterSpacing": "0%",
-          "lineHeight": "130%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "bold": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "72px",
-          "fontWeight": 700,
-          "letterSpacing": "0%",
-          "lineHeight": "130%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "black": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "72px",
-          "fontWeight": 800,
-          "letterSpacing": "0%",
-          "lineHeight": "130%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      }
-    },
-    "16xl": {
-      "regular": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
           "fontSize": "80px",
           "fontWeight": 420,
           "letterSpacing": "0%",
@@ -1352,7 +1352,7 @@
         }
       }
     },
-    "17xl": {
+    "16xl": {
       "regular": {
         "$type": "typography",
         "$value": {
@@ -1664,7 +1664,7 @@
         }
       }
     },
-    "lg": {
+    "md": {
       "regular": {
         "$type": "typography",
         "$value": {
@@ -1718,6 +1718,68 @@
         "$value": {
           "fontFamily": "Inter Variable",
           "fontSize": "15px",
+          "fontWeight": 800,
+          "letterSpacing": "1.5%",
+          "lineHeight": "150%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      }
+    },
+    "lg": {
+      "regular": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "16px",
+          "fontWeight": 420,
+          "letterSpacing": "2%",
+          "lineHeight": "150%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "medium": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "16px",
+          "fontWeight": 500,
+          "letterSpacing": "1.5%",
+          "lineHeight": "150%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "semibold": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "16px",
+          "fontWeight": 600,
+          "letterSpacing": "1.5%",
+          "lineHeight": "150%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "bold": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "16px",
+          "fontWeight": 700,
+          "letterSpacing": "1.5%",
+          "lineHeight": "150%",
+          "textTransform": "none",
+          "textDecoration": "none"
+        }
+      },
+      "black": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter Variable",
+          "fontSize": "16px",
           "fontWeight": 800,
           "letterSpacing": "1.5%",
           "lineHeight": "150%",
@@ -1731,7 +1793,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "16px",
+          "fontSize": "17px",
           "fontWeight": 420,
           "letterSpacing": "2%",
           "lineHeight": "150%",
@@ -1743,7 +1805,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "16px",
+          "fontSize": "17px",
           "fontWeight": 500,
           "letterSpacing": "1.5%",
           "lineHeight": "150%",
@@ -1755,7 +1817,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "16px",
+          "fontSize": "17px",
           "fontWeight": 600,
           "letterSpacing": "1.5%",
           "lineHeight": "150%",
@@ -1767,7 +1829,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "16px",
+          "fontSize": "17px",
           "fontWeight": 700,
           "letterSpacing": "1.5%",
           "lineHeight": "150%",
@@ -1779,7 +1841,7 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "16px",
+          "fontSize": "17px",
           "fontWeight": 800,
           "letterSpacing": "1.5%",
           "lineHeight": "150%",
@@ -1793,9 +1855,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "17px",
+          "fontSize": "18px",
           "fontWeight": 420,
-          "letterSpacing": "2%",
+          "letterSpacing": "1%",
           "lineHeight": "150%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -1805,9 +1867,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "17px",
+          "fontSize": "18px",
           "fontWeight": 500,
-          "letterSpacing": "1.5%",
+          "letterSpacing": "1%",
           "lineHeight": "150%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -1817,9 +1879,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "17px",
+          "fontSize": "18px",
           "fontWeight": 600,
-          "letterSpacing": "1.5%",
+          "letterSpacing": "1%",
           "lineHeight": "150%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -1829,9 +1891,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "17px",
+          "fontSize": "18px",
           "fontWeight": 700,
-          "letterSpacing": "1.5%",
+          "letterSpacing": "1%",
           "lineHeight": "150%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -1841,9 +1903,9 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "17px",
+          "fontSize": "18px",
           "fontWeight": 800,
-          "letterSpacing": "1.5%",
+          "letterSpacing": "1%",
           "lineHeight": "150%",
           "textTransform": "none",
           "textDecoration": "none"
@@ -1855,10 +1917,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "18px",
+          "fontSize": "20px",
           "fontWeight": 420,
           "letterSpacing": "1%",
-          "lineHeight": "150%",
+          "lineHeight": "148%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -1867,10 +1929,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "18px",
+          "fontSize": "20px",
           "fontWeight": 500,
           "letterSpacing": "1%",
-          "lineHeight": "150%",
+          "lineHeight": "148%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -1879,10 +1941,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "18px",
+          "fontSize": "20px",
           "fontWeight": 600,
           "letterSpacing": "1%",
-          "lineHeight": "150%",
+          "lineHeight": "148%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -1891,10 +1953,10 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "18px",
+          "fontSize": "20px",
           "fontWeight": 700,
           "letterSpacing": "1%",
-          "lineHeight": "150%",
+          "lineHeight": "148%",
           "textTransform": "none",
           "textDecoration": "none"
         }
@@ -1903,78 +1965,16 @@
         "$type": "typography",
         "$value": {
           "fontFamily": "Inter Variable",
-          "fontSize": "18px",
+          "fontSize": "20px",
           "fontWeight": 800,
           "letterSpacing": "1%",
-          "lineHeight": "150%",
+          "lineHeight": "148%",
           "textTransform": "none",
           "textDecoration": "none"
         }
       }
     },
     "4xl": {
-      "regular": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "20px",
-          "fontWeight": 420,
-          "letterSpacing": "1%",
-          "lineHeight": "148%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "medium": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "20px",
-          "fontWeight": 500,
-          "letterSpacing": "1%",
-          "lineHeight": "148%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "semibold": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "20px",
-          "fontWeight": 600,
-          "letterSpacing": "1%",
-          "lineHeight": "148%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "bold": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "20px",
-          "fontWeight": 700,
-          "letterSpacing": "1%",
-          "lineHeight": "148%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      },
-      "black": {
-        "$type": "typography",
-        "$value": {
-          "fontFamily": "Inter Variable",
-          "fontSize": "20px",
-          "fontWeight": 800,
-          "letterSpacing": "1%",
-          "lineHeight": "148%",
-          "textTransform": "none",
-          "textDecoration": "none"
-        }
-      }
-    },
-    "5xl": {
       "regular": {
         "$type": "typography",
         "$value": {

--- a/frappe/DataImport/DataImportList.vue
+++ b/frappe/DataImport/DataImportList.vue
@@ -2,7 +2,7 @@
     <div class="flex min-h-0 flex-col text-base py-5 w-[90%] lg:w-[700px] mx-auto">
 		<div class="flex items-center justify-between">
 			<div>
-				<div class="text-xl font-semibold mb-1 text-ink-gray-9">
+				<div class="text-lg font-semibold mb-1 text-ink-gray-9">
 					Data Import
 				</div>
 				<div class="text-ink-gray-6 leading-5">

--- a/frappe/DataImport/MappingStep.vue
+++ b/frappe/DataImport/MappingStep.vue
@@ -2,7 +2,7 @@
     <div class="w-[85%] lg:w-[700px] mx-auto py-12 space-y-8 text-base">
        <div class="flex justify-between">
             <div class="space-y-2">
-                <div class="text-lg font-semibold text-ink-gray-9">
+                <div class="text-md font-semibold text-ink-gray-9">
                     <span>
                         Map Data
                     </span>

--- a/frappe/DataImport/PreviewStep.vue
+++ b/frappe/DataImport/PreviewStep.vue
@@ -2,7 +2,7 @@
     <div class="text-base h-full flex flex-col w-[90%] lg:w-[700px] mx-auto py-12 space-y-10">
         <div class="flex flex-col space-y-1">
             <div class="flex items-center justify-between text-ink-gray-7">
-                <div class="flex items-center space-x-2 text-lg font-semibold text-ink-gray-9">
+                <div class="flex items-center space-x-2 text-md font-semibold text-ink-gray-9">
                     <span>
                         Review and Import
                     </span>

--- a/frappe/DataImport/UploadStep.vue
+++ b/frappe/DataImport/UploadStep.vue
@@ -2,7 +2,7 @@
     <div class="text-base h-full flex flex-col w-[85%] lg:w-[700px] mx-auto pt-12 space-y-8">
         <div class="flex flex-col space-y-1 text-ink-gray-7">
             <div class="flex items-center justify-between">
-                <div class="flex items-center space-x-2 text-xl font-semibold text-ink-gray-9">
+                <div class="flex items-center space-x-2 text-lg font-semibold text-ink-gray-9">
                     <span>
                         Choose Import
                     </span>

--- a/frappe/drive/components/InfoDialog.vue
+++ b/frappe/drive/components/InfoDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <Dialog v-model="open" @close="dialogType = ''">
     <template #body-title>
-      <h3 class="text-2xl font-semibold leading-6 text-ink-gray-9 cursor-pointer pr-2" @click="emitter.emit('rename')">
+      <h3 class="text-xl font-semibold leading-6 text-ink-gray-9 cursor-pointer pr-2" @click="emitter.emit('rename')">
         {{ entity.title }}
       </h3>
     </template>

--- a/frappe/drive/components/MoveDialog.vue
+++ b/frappe/drive/components/MoveDialog.vue
@@ -3,7 +3,7 @@
     <template #body-main>
       <div class="p-4 sm:px-6">
         <div class="flex w-full justify-between gap-x-15 mb-4">
-          <div class="font-semibold text-2xl flex text-nowrap overflow-hidden">
+          <div class="font-semibold text-xl flex text-nowrap overflow-hidden">
             <template v-if="props.entities.length > 1">
               Moving {{ props.entities.length }} items
             </template>

--- a/frappe/drive/components/ShareDialog.vue
+++ b/frappe/drive/components/ShareDialog.vue
@@ -4,7 +4,7 @@
       <div class="p-4">
         <!-- Header -->
         <div class="flex w-full justify-between gap-x-2 mb-4">
-          <div class="font-semibold text-2xl flex text-nowrap overflow-hidden">
+          <div class="font-semibold text-xl flex text-nowrap overflow-hidden">
             Sharing "
             <div class="truncate max-w-[80%]">
               {{ entity?.title }}

--- a/skills/frappe-ui/TOKENS.md
+++ b/skills/frappe-ui/TOKENS.md
@@ -67,10 +67,12 @@ Pick the wrong one and copy looks cramped (multi-line text in `text-*`) or flopp
 | `text-xs` / `text-p-xs`     | 12px  | Captions, meta / multi-line meta        |
 | `text-sm` / `text-p-sm`     | 13px  | Secondary labels / secondary paragraphs |
 | `text-base` / `text-p-base` | 14px  | Body labels / body paragraphs (default) |
+| `text-md` / `text-p-md`     | 15px  | Dense section labels / compact intro    |
 | `text-lg` / `text-p-lg`     | 16px  | Section subheads / long-form intro      |
-| `text-xl` / `text-p-xl`     | 18px  | Card / panel titles / lead paragraphs   |
-| `text-2xl`                  | 20px  | Page titles                             |
-| `text-3xl`+                 | 24px+ | Marketing / hero only                   |
+| `text-xl` / `text-p-xl`     | 17px  | Card / panel titles / lead paragraphs   |
+| `text-2xl`                  | 18px  | Page titles                             |
+| `text-3xl`                  | 20px  | Prominent page titles                   |
+| `text-4xl`+                 | 24px+ | Marketing / hero only                   |
 
 **Heuristic:** if the element is `<p>`, a description below a label, a feed entry that wraps, or helper text — use `text-p-*`. If it's `<h*>`, a `<Button>`/`<Badge>` label, a one-line meta row like "Updated 2h ago", or a stat value — use `text-*`.
 

--- a/spec/adr/0007-typography-style-utilities.md
+++ b/spec/adr/0007-typography-style-utilities.md
@@ -10,6 +10,7 @@ Figma models typography in espresso v2 as **named styles**, not as independent s
 |---|---|---|---|
 | `text/base/regular` | 14px | 420 | 2% (0.28px) |
 | `text/base/medium`  | 14px | 500 | **1.5%** (0.21px) |
+| `text/md/medium`    | 15px | 500 | **1.5%** (0.225px) |
 | `text/lg/medium`    | 16px | 500 | **1.5%** (0.24px) |
 
 Medium-weight text is **tracked tighter** than regular-weight text of the same size. This is a deliberate optical correction baked into the design system.
@@ -24,6 +25,7 @@ Expose Figma's named typography styles as Tailwind **component utilities** gener
 
 ```css
 .text-base-medium { font-size: 14px; line-height: 16px; font-weight: 500; letter-spacing: 0.015em; }
+.text-md-medium   { font-size: 15px; line-height: 17px; font-weight: 500; letter-spacing: 0.015em; }
 .text-lg-medium  { font-size: 16px; line-height: 18px; font-weight: 500; letter-spacing: 0.015em; }
 ```
 
@@ -56,5 +58,5 @@ Naming follows Figma's slash convention flattened to hyphens: `text/base/medium`
 - `tailwind/plugin.js` is the single source of truth for which medium variants exist. Adding a new one is a one-line addition to `FONT_SIZE_MEDIUM_TRACKING`.
 - The Figma token pipeline (`espresso-v2-design-tokens/`) does **not** model these — the values are hand-encoded in `plugin.js` from Figma observation. If the token export gains composite styles later, `buildTextStyleUtilities()` should be rewritten to read from the export instead.
 - Migration is incremental. Components that haven't moved off `text-base font-medium` still render; they just have 0.07–0.08px of tracking drift from Figma.
-- Currently emitted: `text-base-medium`, `text-lg-medium` (confirmed against Figma). Other sizes pending Figma verification.
+- Currently emitted: `text-base-medium`, `text-md-medium`, `text-lg-medium` (confirmed against Figma). Other sizes pending Figma verification.
 - Button md (`text-base-medium`) and Button lg (`text-lg-medium`) are the first consumers; verified pixel-exact against Figma node `25393-27651`.

--- a/spec/foundations.md
+++ b/spec/foundations.md
@@ -37,7 +37,7 @@ Anything in this repo that diverges from Figma is either (a) drift to be fixed, 
 Atomic tokens are exported from Figma to [`tailwind/generated/typography.json`](../tailwind/generated/typography.json):
 
 - `fontFamily` — `text: 'Inter Variable'`
-- `fontSize` — keyed by size name (`tiny`, `2xs`, `xs`, `sm`, `base`, `lg`, `xl`, `2xl`, `3xl`, …), each paired with a `lineHeight`
+- `fontSize` — keyed by size name (`tiny`, `2xs`, `xs`, `sm`, `base`, `md`, `lg`, `xl`, `2xl`, `3xl`, …), each paired with a `lineHeight`
 - `fontWeight` — named weights: `regular: 400`, `medium: 500`, `semibold: 600`, `bold: 700`, `black: 800`
 
 Letter-spacing is **not** exported from Figma — it is encoded by hand in [`tailwind/plugin.js`](../tailwind/plugin.js) via `FONT_SIZE_AUGMENT` (for the regular-weight variant of each size) and `FONT_SIZE_MEDIUM_TRACKING` (for the medium-weight variant).
@@ -49,6 +49,7 @@ Figma models typography as named styles (`text/base/regular`, `text/base/medium`
 | Utility | font-size | line-height | weight | letter-spacing | Figma |
 |---|---|---|---|---|---|
 | `text-base-medium` | 14px | 16px | 500 | 0.015em (1.5%) | `text/base/medium` |
+| `text-md-medium`   | 15px | 17px | 500 | 0.015em (1.5%) | `text/md/medium` |
 | `text-lg-medium`   | 16px | 18px | 500 | 0.015em (1.5%) | `text/lg/medium` |
 
 Regular-weight tracking is carried by the base `text-{size}` utility — there is no `text-{size}-regular` because it would be a redundant alias.
@@ -65,6 +66,8 @@ Confirmed against Figma typography variables on `2026-05-24`:
 |---|---|---|---|
 | `text-base`         | 14px | 16px | `text/base/regular` (with weight 420, ls 2%) |
 | `text-base-medium`  | 14px | 16px | `text/base/medium` (weight 500, ls 1.5%) |
+| `text-md`           | 15px | 17px | `text/md/regular` (with weight 420, ls 2%) |
+| `text-md-medium`    | 15px | 17px | `text/md/medium` (weight 500, ls 1.5%) |
 | `text-lg`           | 16px | 18px | (no Figma usage in component scope yet) |
 | `text-lg-medium`    | 16px | 18px | `text/lg/medium` (weight 500, ls 1.5%) |
 

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -80,9 +80,9 @@ const labelClasses = computed(() => {
     sm: 'text-sm',
     md: 'text-base',
     lg: 'text-base',
-    xl: 'text-xl',
-    '2xl': 'text-3xl',
-    '3xl': 'text-4xl',
+    xl: 'text-lg',
+    '2xl': 'text-2xl',
+    '3xl': 'text-3xl',
   }[props.size]
   return ['font-medium', sizeClass]
 })

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -19,7 +19,7 @@
           v-if="item.route"
           :to="item.route"
           @click="item.onClick ? item.onClick() : null"
-          class="flex items-center rounded px-0.5 py-1 text-xl-medium"
+          class="flex items-center rounded px-0.5 py-1 text-lg-medium"
           :class="[
             i == crumbs.length - 1
               ? 'min-w-0 text-ink-gray-9'
@@ -39,7 +39,7 @@
           v-else-if="item.href"
           :href="item.href"
           @click="item.onClick ? item.onClick() : null"
-          class="flex items-center rounded px-0.5 py-1 text-xl-medium"
+          class="flex items-center rounded px-0.5 py-1 text-lg-medium"
           :class="[
             i == crumbs.length - 1
               ? 'min-w-0 text-ink-gray-9'
@@ -58,7 +58,7 @@
         <button
           v-else
           @click="item.onClick ? item.onClick() : null"
-          class="flex items-center rounded px-0.5 py-1 text-xl-medium"
+          class="flex items-center rounded px-0.5 py-1 text-lg-medium"
           :class="[
             i == crumbs.length - 1
               ? 'min-w-0 text-ink-gray-9'

--- a/src/components/Button/Button.cy.ts
+++ b/src/components/Button/Button.cy.ts
@@ -45,7 +45,7 @@ describe('<Button />', () => {
     })
 
     cy.get('button').should('have.class', 'h-10')
-    cy.get('button').should('have.class', 'text-xl-medium')
+    cy.get('button').should('have.class', 'text-lg-medium')
   })
 
   it('renders xs size', () => {

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -166,7 +166,7 @@ export default defineComponent({
             xs: 'h-6 text-xs px-1.5 rounded-3',
             sm: 'h-7 text-base px-2 rounded-4',
             md: 'h-8 text-base-medium px-2.5 rounded-4',
-            lg: 'h-10 text-xl-medium px-3 rounded-5',
+            lg: 'h-10 text-lg-medium px-3 rounded-5',
           }[props.size]
 
       return [

--- a/src/components/Button/stories/LiveClassCard.vue
+++ b/src/components/Button/stories/LiveClassCard.vue
@@ -8,7 +8,7 @@ import { Button } from 'frappe-ui'
   >
     <div class="flex flex-col gap-5">
       <div class="flex flex-col gap-3">
-        <p class="text-lg-semibold text-ink-gray-7">Frappe january - 2023</p>
+        <p class="text-md-semibold text-ink-gray-7">Frappe january - 2023</p>
         <div class="flex flex-col gap-3">
           <div class="flex items-center gap-2 text-base text-ink-gray-7">
             <span class="lucide-calendar size-4" aria-hidden="true" />

--- a/src/components/Calendar/Calendar.vue
+++ b/src/components/Calendar/Calendar.vue
@@ -28,7 +28,7 @@
             <template #target="{ togglePopover }">
               <Button
                 variant="ghost"
-                class="text-xl-medium text-ink-gray-7"
+                class="text-lg-medium text-ink-gray-7"
                 :label="currentMonthYear"
                 iconRight="lucide-chevron-down"
                 @click="togglePopover"

--- a/src/components/Calendar/EventModalContent.vue
+++ b/src/components/Calendar/EventModalContent.vue
@@ -12,7 +12,7 @@
       </span>
     </div>
     <div class="flex flex-col gap-5">
-      <div class="flex justify-between text-3xl-semibold">
+      <div class="flex justify-between text-2xl-semibold">
         <span>{{ calendarEvent.title || 'New Event' }}</span>
       </div>
       <div class="flex flex-col gap-4">

--- a/src/components/Calendar/stories/CustomHeader.vue
+++ b/src/components/Calendar/stories/CustomHeader.vue
@@ -111,7 +111,7 @@ const events = ref([
               <template #target="{ togglePopover }">
                 <Button
                   variant="ghost"
-                  class="text-xl-medium text-ink-gray-7"
+                  class="text-lg-medium text-ink-gray-7"
                   :label="headerProps.currentMonthYear"
                   iconRight="lucide-chevron-down"
                   @click="togglePopover"

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -5,7 +5,7 @@
         <div class="flex items-center space-x-2" v-if="$slots['actions-left']">
           <slot name="actions-left"></slot>
         </div>
-        <h2 class="text-3xl-semibold">{{ title }}</h2>
+        <h2 class="text-2xl-semibold">{{ title }}</h2>
       </div>
       <div class="flex items-center space-x-2" v-if="$slots['actions']">
         <slot name="actions"></slot>

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -109,7 +109,7 @@ const labelClasses = computed(() => {
   return [
     {
       sm: 'text-base',
-      md: 'text-xl',
+      md: 'text-lg',
     }[props.size],
     'font-medium',
     props.disabled ? 'text-ink-gray-4' : 'text-ink-gray-8',

--- a/src/components/Checkbox/stories/HorizontalGroup.vue
+++ b/src/components/Checkbox/stories/HorizontalGroup.vue
@@ -11,7 +11,7 @@ const settings = reactive({
 
 <template>
   <div class="flex flex-col gap-4 items-start w-[32rem]">
-    <p class="text-xl-medium text-ink-gray-9">Print settings</p>
+    <p class="text-lg-medium text-ink-gray-9">Print settings</p>
     <div class="flex flex-wrap gap-x-8 gap-y-2">
       <Checkbox v-model="settings.inclusiveText" label="Show inclusive text in print" />
       <Checkbox

--- a/src/components/Combobox/stories/InDialog.vue
+++ b/src/components/Combobox/stories/InDialog.vue
@@ -43,7 +43,7 @@ const emojis = [
 
   <Dialog v-model="open">
     <template #body-title>
-      <h3 class="text-4xl-semibold text-ink-gray-9">
+      <h3 class="text-3xl-semibold text-ink-gray-9">
         Combobox inside Dialog
       </h3>
     </template>

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -75,7 +75,7 @@
                             <slot name="body-title">
                               <h3
                                 v-if="resolved.title"
-                                class="text-4xl-semibold leading-6 text-ink-gray-9"
+                                class="text-3xl-semibold leading-6 text-ink-gray-9"
                               >
                                 {{ resolved.title }}
                               </h3>

--- a/src/components/FormControl/stories/RealForm.vue
+++ b/src/components/FormControl/stories/RealForm.vue
@@ -88,7 +88,7 @@ function reset() {
     @submit.prevent="submit"
   >
     <div class="space-y-1">
-      <h2 class="text-xl-semibold text-ink-gray-9">Create account</h2>
+      <h2 class="text-lg-semibold text-ink-gray-9">Create account</h2>
       <p class="text-p-sm text-ink-gray-6">
         Every <code>FormControl</code> type rendered together. Submit to see
         validation light up.

--- a/src/components/ItemListRow/ItemListRow.vue
+++ b/src/components/ItemListRow/ItemListRow.vue
@@ -19,8 +19,8 @@ const sizeClasses = computed(() => {
   return {
     sm: 'min-h-7 px-2 py-1.5 text-base',
     md: 'min-h-8 px-2.5 py-1.5 text-base',
-    lg: 'min-h-10 px-3 py-2 text-xl',
-    xl: 'min-h-10 px-3 py-2 text-3xl',
+    lg: 'min-h-10 px-3 py-2 text-lg',
+    xl: 'min-h-10 px-3 py-2 text-2xl',
   }[props.size]
 })
 

--- a/src/components/KeyboardShortcutsModal/KeyboardShortcutsModal.vue
+++ b/src/components/KeyboardShortcutsModal/KeyboardShortcutsModal.vue
@@ -8,7 +8,7 @@
     <template #title>
       <div class="flex items-center pr-2">
         <h3
-          class="shrink-0 text-4xl-semibold leading-6 text-ink-gray-9 flex-1"
+          class="shrink-0 text-3xl-semibold leading-6 text-ink-gray-9 flex-1"
         >
           {{ title }}
         </h3>

--- a/src/components/ListView/ListEmptyState.vue
+++ b/src/components/ListView/ListEmptyState.vue
@@ -3,7 +3,7 @@
     class="flex h-full w-full flex-col items-center justify-center text-base"
   >
     <slot>
-      <div class="text-3xl-medium text-ink-gray-8 mt-6">{{ list.options.emptyState.title }}</div>
+      <div class="text-2xl-medium text-ink-gray-8 mt-6">{{ list.options.emptyState.title }}</div>
       <div class="mt-1 text-base text-ink-gray-5">
         {{ list.options.emptyState.description }}
       </div>

--- a/src/components/Rating/stories/CustomSlot.vue
+++ b/src/components/Rating/stories/CustomSlot.vue
@@ -14,7 +14,7 @@ const scores = ['💩', '👎', '👌', '👍', '🔥']
     <Rating v-model="mood" label="How was your day?" size="lg">
       <template #icon="{ index, value, previewValue }">
         <span
-          class="text-4xl leading-none transition-transform"
+          class="text-3xl leading-none transition-transform"
           :class="
             index === (previewValue ?? value) ? 'scale-110' : 'opacity-40'
           "
@@ -26,7 +26,7 @@ const scores = ['💩', '👎', '👌', '👍', '🔥']
     <Rating v-model="score" label="Rate this meal" size="lg">
       <template #icon="{ index, value, previewValue }">
         <span
-          class="text-4xl leading-none"
+          class="text-3xl leading-none"
           :class="
             index === (previewValue ?? value) ? '' : 'grayscale opacity-50'
           "

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -158,7 +158,7 @@ const switchLabelClasses = computed(() => {
     props.disabled && !props.description
       ? 'text-ink-gray-4'
       : 'text-ink-gray-8',
-    props.size === 'md' ? 'text-xl' : 'text-base',
+    props.size === 'md' ? 'text-lg' : 'text-base',
     props.labelClasses,
   ]
 })

--- a/src/components/TextEditor/extensions/iframe/IframeNodeView.vue
+++ b/src/components/TextEditor/extensions/iframe/IframeNodeView.vue
@@ -282,7 +282,7 @@ function setCursorBeforeIframe() {
           class="flex items-center justify-center bg-surface-gray-1 rounded-lg w-[640px] h-[360px]"
         >
           <div class="text-ink-gray-5 text-center">
-            <div class="text-xl mb-1">🔗</div>
+            <div class="text-lg mb-1">🔗</div>
             <div class="text-sm">Loading embed...</div>
           </div>
         </div>

--- a/src/components/TextInput/TextInput.cy.ts
+++ b/src/components/TextInput/TextInput.cy.ts
@@ -17,8 +17,8 @@ const inputTypes = [
 const sizeCLass = {
   sm: 'text-base rounded h-7',
   md: 'text-base rounded h-8',
-  lg: 'text-xl rounded-md h-10',
-  xl: 'text-3xl rounded-md h-10',
+  lg: 'text-lg rounded-md h-10',
+  xl: 'text-2xl rounded-md h-10',
 }
 
 const variantClasses = {

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -159,8 +159,8 @@ const inputClasses = computed(() => {
   let sizeClasses = {
     sm: 'text-base rounded h-7',
     md: 'text-base rounded h-8',
-    lg: 'text-xl rounded-md h-10',
-    xl: 'text-3xl rounded-md h-10',
+    lg: 'text-lg rounded-md h-10',
+    xl: 'text-2xl rounded-md h-10',
   }[props.size]
 
   let paddingClasses = {

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -119,8 +119,8 @@ const inputClasses = computed(() => {
   let sizeClasses = {
     sm: 'text-base rounded',
     md: 'text-base rounded',
-    lg: 'text-xl rounded-md',
-    xl: 'text-3xl rounded-md',
+    lg: 'text-lg rounded-md',
+    xl: 'text-2xl rounded-md',
   }[props.size]
 
   let paddingClasses = {

--- a/src/components/shared/selection/utils.ts
+++ b/src/components/shared/selection/utils.ts
@@ -24,8 +24,8 @@ export function inputFontSizeClasses(size: SelectionSize) {
   return {
     sm: 'text-base',
     md: 'text-base',
-    lg: 'text-xl',
-    xl: 'text-3xl',
+    lg: 'text-lg',
+    xl: 'text-2xl',
   }[size]
 }
 

--- a/src/molecules/editor/extensions/iframe/IframeNodeView.vue
+++ b/src/molecules/editor/extensions/iframe/IframeNodeView.vue
@@ -203,7 +203,7 @@ function commitCaption(event: Event): void {
           class="flex h-[360px] w-[640px] items-center justify-center rounded bg-surface-gray-1"
         >
           <div class="text-center text-ink-gray-5">
-            <div class="mb-1 text-xl">🔗</div>
+            <div class="mb-1 text-lg">🔗</div>
             <div class="text-sm">Loading embed…</div>
           </div>
         </div>

--- a/src/molecules/editor/stories/Inline.vue
+++ b/src/molecules/editor/stories/Inline.vue
@@ -18,7 +18,7 @@ const title = ref('<p>Q3 launch plan</p>')
     <Editor v-model="title" :extensions="extensions" placeholder="Untitled">
       <EditorBubbleMenu :items="minimalToolbar" />
       <EditorContent
-        class="rounded-md border border-outline-gray-2 bg-surface-base px-3 py-2 text-4xl-semibold text-ink-gray-9 focus-within:border-outline-gray-3 focus-within:ring-2 focus-within:ring-outline-gray-2"
+        class="rounded-md border border-outline-gray-2 bg-surface-base px-3 py-2 text-3xl-semibold text-ink-gray-9 focus-within:border-outline-gray-3 focus-within:ring-2 focus-within:ring-outline-gray-2"
       />
     </Editor>
     <p class="mt-2 text-sm text-ink-gray-5">

--- a/tailwind/generated/typography.json
+++ b/tailwind/generated/typography.json
@@ -50,7 +50,7 @@
         "fontWeight": "420"
       }
     ],
-    "lg": [
+    "md": [
       "15px",
       {
         "lineHeight": "1.15",
@@ -58,7 +58,7 @@
         "fontWeight": "420"
       }
     ],
-    "xl": [
+    "lg": [
       "16px",
       {
         "lineHeight": "1.15",
@@ -66,7 +66,7 @@
         "fontWeight": "420"
       }
     ],
-    "2xl": [
+    "xl": [
       "17px",
       {
         "lineHeight": "1.15",
@@ -74,7 +74,7 @@
         "fontWeight": "420"
       }
     ],
-    "3xl": [
+    "2xl": [
       "18px",
       {
         "lineHeight": "1.15",
@@ -82,7 +82,7 @@
         "fontWeight": "420"
       }
     ],
-    "4xl": [
+    "3xl": [
       "20px",
       {
         "lineHeight": "1.15",
@@ -90,7 +90,7 @@
         "fontWeight": "420"
       }
     ],
-    "5xl": [
+    "4xl": [
       "24px",
       {
         "lineHeight": "1.15",
@@ -98,7 +98,7 @@
         "fontWeight": "420"
       }
     ],
-    "6xl": [
+    "5xl": [
       "26px",
       {
         "lineHeight": "1.6",
@@ -106,7 +106,7 @@
         "fontWeight": "420"
       }
     ],
-    "7xl": [
+    "6xl": [
       "28px",
       {
         "lineHeight": "1.6",
@@ -114,7 +114,7 @@
         "fontWeight": "420"
       }
     ],
-    "8xl": [
+    "7xl": [
       "32px",
       {
         "lineHeight": "1.6",
@@ -122,7 +122,7 @@
         "fontWeight": "420"
       }
     ],
-    "9xl": [
+    "8xl": [
       "40px",
       {
         "lineHeight": "1.4",
@@ -130,7 +130,7 @@
         "fontWeight": "420"
       }
     ],
-    "10xl": [
+    "9xl": [
       "44px",
       {
         "lineHeight": "1.4",
@@ -138,7 +138,7 @@
         "fontWeight": "420"
       }
     ],
-    "11xl": [
+    "10xl": [
       "48px",
       {
         "lineHeight": "1.4",
@@ -146,7 +146,7 @@
         "fontWeight": "420"
       }
     ],
-    "12xl": [
+    "11xl": [
       "52px",
       {
         "lineHeight": "1.4",
@@ -154,7 +154,7 @@
         "fontWeight": "420"
       }
     ],
-    "13xl": [
+    "12xl": [
       "56px",
       {
         "lineHeight": "1.4",
@@ -162,7 +162,7 @@
         "fontWeight": "420"
       }
     ],
-    "14xl": [
+    "13xl": [
       "64px",
       {
         "lineHeight": "1.3",
@@ -170,7 +170,7 @@
         "fontWeight": "420"
       }
     ],
-    "15xl": [
+    "14xl": [
       "72px",
       {
         "lineHeight": "1.3",
@@ -178,7 +178,7 @@
         "fontWeight": "420"
       }
     ],
-    "16xl": [
+    "15xl": [
       "80px",
       {
         "lineHeight": "1.2",
@@ -186,7 +186,7 @@
         "fontWeight": "420"
       }
     ],
-    "17xl": [
+    "16xl": [
       "88px",
       {
         "lineHeight": "1.2",
@@ -215,6 +215,10 @@
       "lineHeight": "1.5",
       "letterSpacing": "0.02em"
     },
+    "md": {
+      "lineHeight": "1.5",
+      "letterSpacing": "0.02em"
+    },
     "lg": {
       "lineHeight": "1.5",
       "letterSpacing": "0.02em"
@@ -225,17 +229,13 @@
     },
     "2xl": {
       "lineHeight": "1.5",
-      "letterSpacing": "0.02em"
-    },
-    "3xl": {
-      "lineHeight": "1.5",
       "letterSpacing": "0.01em"
     },
-    "4xl": {
+    "3xl": {
       "lineHeight": "1.48",
       "letterSpacing": "0.01em"
     },
-    "5xl": {
+    "4xl": {
       "lineHeight": "1.4",
       "letterSpacing": "0.005em"
     }
@@ -276,6 +276,13 @@
         "semibold": "0.015em",
         "bold": "0.015em"
       },
+      "md": {
+        "regular": "0.02em",
+        "medium": "0.015em",
+        "semibold": "0.015em",
+        "bold": "0.015em",
+        "black": "0.015em"
+      },
       "lg": {
         "regular": "0.02em",
         "medium": "0.015em",
@@ -291,14 +298,14 @@
         "black": "0.015em"
       },
       "2xl": {
-        "regular": "0.02em",
-        "medium": "0.015em",
-        "semibold": "0.015em",
-        "bold": "0.015em",
-        "black": "0.015em"
+        "regular": "0.01em",
+        "medium": "0.01em",
+        "semibold": "0.01em",
+        "bold": "0.01em",
+        "black": "0.01em"
       },
       "3xl": {
-        "regular": "0.01em",
+        "regular": "0.005em",
         "medium": "0.01em",
         "semibold": "0.01em",
         "bold": "0.01em",
@@ -306,38 +313,38 @@
       },
       "4xl": {
         "regular": "0.005em",
-        "medium": "0.01em",
-        "semibold": "0.01em",
-        "bold": "0.01em",
-        "black": "0.01em"
-      },
-      "5xl": {
-        "regular": "0.005em",
         "medium": "0.005em",
         "semibold": "0.005em",
         "bold": "0.005em",
         "black": "0.005em"
       },
-      "6xl": {
+      "5xl": {
         "regular": "0.01em",
         "medium": "0.005em",
         "semibold": "0.005em",
         "bold": "0.005em",
         "black": "0.01em"
       },
-      "7xl": {
+      "6xl": {
         "regular": "0.01em",
         "medium": "0.005em",
         "semibold": "0.01em",
         "bold": "0.015em",
         "black": "0.01em"
       },
-      "8xl": {
+      "7xl": {
         "regular": "0.02em",
         "medium": "0.015em",
         "semibold": "0.015em",
         "bold": "0.015em",
         "black": "0.005em"
+      },
+      "8xl": {
+        "regular": "0em",
+        "medium": "0em",
+        "semibold": "0em",
+        "bold": "0em",
+        "black": "0em"
       },
       "9xl": {
         "regular": "0em",
@@ -350,25 +357,25 @@
         "regular": "0em",
         "medium": "0em",
         "semibold": "0em",
-        "bold": "0em",
-        "black": "0em"
+        "bold": "0.005em",
+        "black": "0.005em"
       },
       "11xl": {
         "regular": "0em",
         "medium": "0em",
         "semibold": "0em",
-        "bold": "0.005em",
-        "black": "0.005em"
-      },
-      "12xl": {
-        "regular": "0em",
-        "medium": "0em",
-        "semibold": "0em",
         "bold": "0em",
         "black": "0.005em"
       },
-      "13xl": {
+      "12xl": {
         "regular": "0.005em",
+        "medium": "0em",
+        "semibold": "0em",
+        "bold": "0em",
+        "black": "0em"
+      },
+      "13xl": {
+        "regular": "0em",
         "medium": "0em",
         "semibold": "0em",
         "bold": "0em",
@@ -383,19 +390,12 @@
       },
       "15xl": {
         "regular": "0em",
-        "medium": "0em",
-        "semibold": "0em",
-        "bold": "0em",
-        "black": "0em"
-      },
-      "16xl": {
-        "regular": "0em",
         "medium": "0.005em",
         "semibold": "0em",
         "bold": "0em",
         "black": "0em"
       },
-      "17xl": {
+      "16xl": {
         "regular": "0em",
         "medium": "0em",
         "semibold": "0em",
@@ -432,6 +432,13 @@
         "bold": "0.015em",
         "black": "0.015em"
       },
+      "md": {
+        "regular": "0.02em",
+        "medium": "0.015em",
+        "semibold": "0.015em",
+        "bold": "0.015em",
+        "black": "0.015em"
+      },
       "lg": {
         "regular": "0.02em",
         "medium": "0.015em",
@@ -447,11 +454,11 @@
         "black": "0.015em"
       },
       "2xl": {
-        "regular": "0.02em",
-        "medium": "0.015em",
-        "semibold": "0.015em",
-        "bold": "0.015em",
-        "black": "0.015em"
+        "regular": "0.01em",
+        "medium": "0.01em",
+        "semibold": "0.01em",
+        "bold": "0.01em",
+        "black": "0.01em"
       },
       "3xl": {
         "regular": "0.01em",
@@ -461,13 +468,6 @@
         "black": "0.01em"
       },
       "4xl": {
-        "regular": "0.01em",
-        "medium": "0.01em",
-        "semibold": "0.01em",
-        "bold": "0.01em",
-        "black": "0.01em"
-      },
-      "5xl": {
         "regular": "0.005em",
         "medium": "0.005em",
         "semibold": "0.005em",

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -18,11 +18,12 @@
  *
  * IMPORTANT: the token replacement is single-pass/simultaneous. Several renames
  * chain (outline red-2→3, red-3→4, red-4→5); applying them sequentially would
- * cascade (red-2 ending up as red-5). Run this script exactly once per
+ * cascade (red-2 ending up as red-5). Color renames must run exactly once per
  * codebase — the v2 scheme reuses names (e.g. surface-gray-5 exists in both
- * scales with different values), so a second run would double-shift tokens. As
- * a guard, the script refuses to run on a codebase that looks already migrated
- * (v2-only tokens present, no pre-v2 tokens); pass --force to override.
+ * scales with different values), so a second full run would double-shift tokens.
+ * As a guard, the script detects already-migrated codebases and runs only the
+ * typography correction (`text-lg` → `text-md`, `text-xl` → `text-lg`, ...).
+ * Pass --force to run the full migration anyway.
  */
 
 import fs from 'fs'
@@ -89,57 +90,91 @@ const OUTLINE_ALPHA_RENAMES = {
 
 // ---------- TYPOGRAPHY SIZE RENAMES ----------
 
-// The espresso text scale gained 15px (`lg`) and 17px (`2xl`) stops, pushing
-// every size from the old `lg` (16px) upward by two names. Each physical size
-// keeps its meaning under a new name, so existing utility classes must be
-// renamed to render identically (old `text-lg`/16px → `text-xl`, etc.). These
-// chain (lg→xl, xl→3xl, …) and so MUST run in the same single simultaneous pass
-// as the color renames below — a sequential pass would cascade.
+// The espresso text scale gained 15px (`md`) and 17px (`xl`) stops. Each
+// physical size keeps its meaning under a new name, so existing utility classes
+// must be renamed to render identically. These chain and so MUST run in a single
+// simultaneous pass — a sequential pass would cascade.
 //
 // Caveat: these names (`text-lg` … `text-9xl`) coincide with stock Tailwind
 // font-size utilities, so only point this at code using the espresso scale, and
 // run exactly once (see header).
-const TEXT_SIZE_SHIFT = [
-  ['lg', 'xl'],
-  ['xl', '3xl'],
-  ['2xl', '4xl'],
-  ['3xl', '5xl'],
-  ['4xl', '6xl'],
-  ['5xl', '7xl'],
-  ['6xl', '8xl'],
-  ['7xl', '9xl'],
-  ['8xl', '10xl'],
-  ['9xl', '11xl'],
-  ['10xl', '12xl'],
-  ['11xl', '13xl'],
-  ['12xl', '14xl'],
-  ['13xl', '15xl'],
-  ['14xl', '16xl'],
-  ['15xl', '17xl'],
+const UNMIGRATED_TEXT_SIZE_SHIFT = [
+  ['xl', '2xl'],
+  ['2xl', '3xl'],
+  ['3xl', '4xl'],
+  ['4xl', '5xl'],
+  ['5xl', '6xl'],
+  ['6xl', '7xl'],
+  ['7xl', '8xl'],
+  ['8xl', '9xl'],
+  ['9xl', '10xl'],
+  ['10xl', '11xl'],
+  ['11xl', '12xl'],
+  ['12xl', '13xl'],
+  ['13xl', '14xl'],
+  ['14xl', '15xl'],
+  ['15xl', '16xl'],
 ]
 
-// Each size surfaces as three utility forms: the size utility (`text-lg`), the
-// paragraph variant (`text-p-lg`), and the medium-weight component class
-// (`text-lg-medium`). All three shift together.
-const TEXT_SIZE_RENAMES = Object.fromEntries(
-  TEXT_SIZE_SHIFT.flatMap(([from, to]) => [
+// Apps that already ran the original v2 codemod use the temporary typography
+// names where `text-lg` was 15px and `text-xl` was 16px. Shift those one step
+// down into the corrected names without touching color tokens.
+const MIGRATED_TEXT_SIZE_SHIFT = [
+  ['lg', 'md'],
+  ['xl', 'lg'],
+  ['2xl', 'xl'],
+  ['3xl', '2xl'],
+  ['4xl', '3xl'],
+  ['5xl', '4xl'],
+  ['6xl', '5xl'],
+  ['7xl', '6xl'],
+  ['8xl', '7xl'],
+  ['9xl', '8xl'],
+  ['10xl', '9xl'],
+  ['11xl', '10xl'],
+  ['12xl', '11xl'],
+  ['13xl', '12xl'],
+  ['14xl', '13xl'],
+  ['15xl', '14xl'],
+  ['16xl', '15xl'],
+  ['17xl', '16xl'],
+]
+
+// Each size surfaces as a bare size utility, a paragraph variant, and weighted
+// component classes. All forms shift together.
+const textSizeRenames = (shift) => Object.fromEntries(
+  shift.flatMap(([from, to]) => [
     [`text-${from}`, `text-${to}`],
     [`text-p-${from}`, `text-p-${to}`],
     [`text-${from}-medium`, `text-${to}-medium`],
+    [`text-p-${from}-medium`, `text-p-${to}-medium`],
+    [`text-${from}-semibold`, `text-${to}-semibold`],
+    [`text-p-${from}-semibold`, `text-p-${to}-semibold`],
+    [`text-${from}-bold`, `text-${to}-bold`],
+    [`text-p-${from}-bold`, `text-p-${to}-bold`],
+    [`text-${from}-black`, `text-${to}-black`],
+    [`text-p-${from}-black`, `text-p-${to}-black`],
   ]),
 )
+
+const UNMIGRATED_TEXT_SIZE_RENAMES = textSizeRenames(UNMIGRATED_TEXT_SIZE_SHIFT)
+const MIGRATED_TEXT_SIZE_RENAMES = textSizeRenames(MIGRATED_TEXT_SIZE_SHIFT)
 
 // Full old token name → full new token name. NOTE: alpha categories must come
 // before their base category when building the alternation so that e.g.
 // `surface-alpha-gray-5` is never half-matched by a `surface-…` rule (the
 // longest-first sort below also guarantees this).
-export const TOKEN_RENAMES = {
+export const COLOR_TOKEN_RENAMES = {
   ...prefix('surface-alpha', SURFACE_ALPHA_RENAMES),
   ...prefix('outline-alpha', OUTLINE_ALPHA_RENAMES),
   ...prefix('surface', SURFACE_RENAMES),
   ...prefix('ink', INK_RENAMES),
   ...prefix('outline', OUTLINE_RENAMES),
-  ...TEXT_SIZE_RENAMES,
+}
+
+export const TOKEN_RENAMES = {
+  ...COLOR_TOKEN_RENAMES,
+  ...UNMIGRATED_TEXT_SIZE_RENAMES,
 }
 
 // Tokens dropped in v2 with no replacement — usage is reported, never rewritten.
@@ -169,8 +204,8 @@ function prefix(category, renames) {
 // `surface-gray-2` not in `surface-gray-2-contrast`).
 const byLengthDesc = (a, b) => b.length - a.length
 
-const RENAME_REGEX = new RegExp(
-  `(?<![a-zA-Z0-9])(${Object.keys(TOKEN_RENAMES).sort(byLengthDesc).join('|')})(?![a-zA-Z0-9-])`,
+const renameRegexFor = (renames) => new RegExp(
+  `(?<![a-zA-Z0-9])(${Object.keys(renames).sort(byLengthDesc).join('|')})(?![a-zA-Z0-9-])`,
   'g',
 )
 const FLAG_REGEX = new RegExp(
@@ -202,9 +237,9 @@ const WEIGHT_SUFFIX = {
 }
 
 const TEXT_SIZES = [
-  'tiny', '2xs', 'xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl',
-  '6xl', '7xl', '8xl', '9xl', '10xl', '11xl', '12xl', '13xl', '14xl', '15xl',
-  '16xl', '17xl',
+  'tiny', '2xs', 'xs', 'sm', 'base', 'md', 'lg', 'xl', '2xl', '3xl', '4xl',
+  '5xl', '6xl', '7xl', '8xl', '9xl', '10xl', '11xl', '12xl', '13xl', '14xl',
+  '15xl', '16xl', '17xl',
 ]
 const SIZE_CLASS = new RegExp(`^text-(?:p-)?(?:${TEXT_SIZES.join('|')})$`)
 
@@ -242,9 +277,9 @@ export function mergeWeightClasses(content) {
 // ---------- ALREADY-MIGRATED DETECTION ----------
 
 // Tokens that exist ONLY pre-migration (renamed away) vs ONLY post-migration. A
-// codebase with the post-migration names and none of the pre-migration ones has
-// almost certainly been migrated already — and re-running is destructive (the
-// color renames reuse names, so a second pass double-shifts them).
+// codebase with post-migration names has almost certainly been migrated already
+// or partially. Re-running color renames is destructive because the color
+// renames reuse names, so default to typography-only when v2 sentinels exist.
 const PRE_MIGRATION_TOKENS = [
   'surface-white', 'ink-white', 'outline-white', 'surface-menu-bar',
   'surface-card', 'surface-cards', 'surface-modal', 'surface-selected',
@@ -268,21 +303,29 @@ function detectAlreadyMigrated(files) {
     pre += (content.match(PRE_REGEX) || []).length
     post += (content.match(POST_REGEX) || []).length
   }
-  return { pre, post, likelyMigrated: post > 0 && pre === 0 }
+  return { pre, post, likelyMigrated: post > 0 }
 }
 
-export function migrateTokens(content) {
+export function migrateTokens(content, { mode = 'full' } = {}) {
+  const tokenRenames = mode === 'migrated-typography'
+    ? MIGRATED_TEXT_SIZE_RENAMES
+    : TOKEN_RENAMES
+  const renameRegex = renameRegexFor(tokenRenames)
   const replacements = []
-  let migrated = content.replace(RENAME_REGEX, (match, _token, offset) => {
-    const to = TOKEN_RENAMES[match]
+  let migrated = content.replace(renameRegex, (match, _token, offset) => {
+    const to = tokenRenames[match]
     replacements.push({ from: match, to, line: lineAt(content, offset) })
     return to
   })
 
-  // Merge weight classes on the post-rename text so `text-lg font-medium`
-  // becomes `text-xl-medium` (size shift first, then merge).
-  const { migrated: weightMerged, merges } = mergeWeightClasses(migrated)
-  migrated = weightMerged
+  let merges = []
+  if (mode === 'full') {
+    // Merge weight classes on the post-rename text so `text-xl font-medium`
+    // becomes `text-2xl-medium` (size shift first, then merge).
+    const result = mergeWeightClasses(migrated)
+    migrated = result.migrated
+    merges = result.merges
+  }
 
   const flagged = []
   for (const m of content.matchAll(FLAG_REGEX)) {
@@ -343,18 +386,17 @@ function main() {
   const files = []
   for (const target of targets) for (const file of walk(target)) files.push(file)
 
-  // Guard against a destructive second pass (the color renames reuse names).
+  // Guard against a destructive second full pass (the color renames reuse names).
   const { pre, post, likelyMigrated } = detectAlreadyMigrated(files)
+  const mode = likelyMigrated && !force ? 'migrated-typography' : 'full'
   if (likelyMigrated) {
-    console.warn('\n⚠  This codebase looks ALREADY MIGRATED to espresso v2.')
-    console.warn(`   Found ${post} v2-only token(s) and 0 pre-v2 token(s).`)
-    console.warn('   This migration is NOT idempotent — the color renames reuse names,')
-    console.warn('   so a second pass would double-shift tokens (e.g. surface-gray-5 → -8 → -11).')
-    if (!force && !dryRun) {
-      console.warn('   Refusing to run. Pass --force to override, or --dry-run to preview.\n')
-      process.exit(2)
+    console.warn('\n⚠  This codebase looks already or partially migrated to espresso v2.')
+    console.warn(`   Found ${post} v2-only token(s) and ${pre} pre-v2 token(s).`)
+    if (force) {
+      console.warn('   --force set: running the full migration anyway. Color tokens may double-shift.\n')
+    } else {
+      console.warn('   Running only the typography correction (`text-lg` → `text-md`, ...).\n')
     }
-    console.warn(dryRun ? '   (--dry-run: previewing only.)\n' : '   (--force: proceeding anyway.)\n')
   }
 
   let filesChanged = 0
@@ -364,7 +406,7 @@ function main() {
 
   for (const file of files) {
     const content = fs.readFileSync(file, 'utf8')
-    const { migrated, replacements, merges, flagged } = migrateTokens(content)
+    const { migrated, replacements, merges, flagged } = migrateTokens(content, { mode })
 
     for (const f of flagged) allFlagged.push({ file, ...f })
     const changeCount = replacements.length + merges.length
@@ -385,7 +427,8 @@ function main() {
 
   console.log(
     `\n${dryRun ? '[dry-run] would update' : 'Updated'} ${filesChanged} files, ` +
-      `${totalReplacements} token renames, ${totalMerges} weight-class merges`,
+      `${totalReplacements} token renames, ${totalMerges} weight-class merges` +
+      (mode === 'migrated-typography' ? ' (typography correction only)' : ''),
   )
 
   if (allFlagged.length > 0) {

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -295,7 +295,7 @@ const sentinelRegex = (tokens) =>
 const PRE_REGEX = sentinelRegex(PRE_MIGRATION_TOKENS)
 const POST_REGEX = sentinelRegex(POST_MIGRATION_TOKENS)
 
-function detectAlreadyMigrated(files) {
+export function detectMigrationState(files) {
   let pre = 0
   let post = 0
   for (const file of files) {
@@ -304,6 +304,10 @@ function detectAlreadyMigrated(files) {
     post += (content.match(POST_REGEX) || []).length
   }
   return { pre, post, likelyMigrated: post > 0 }
+}
+
+export function getMigrationMode({ likelyMigrated }, { force = false } = {}) {
+  return likelyMigrated && !force ? 'migrated-typography' : 'full'
 }
 
 export function migrateTokens(content, { mode = 'full' } = {}) {
@@ -387,14 +391,18 @@ function main() {
   for (const target of targets) for (const file of walk(target)) files.push(file)
 
   // Guard against a destructive second full pass (the color renames reuse names).
-  const { pre, post, likelyMigrated } = detectAlreadyMigrated(files)
-  const mode = likelyMigrated && !force ? 'migrated-typography' : 'full'
+  const { pre, post, likelyMigrated } = detectMigrationState(files)
+  const mode = getMigrationMode({ likelyMigrated }, { force })
   if (likelyMigrated) {
     console.warn('\n⚠  This codebase looks already or partially migrated to espresso v2.')
     console.warn(`   Found ${post} v2-only token(s) and ${pre} pre-v2 token(s).`)
     if (force) {
       console.warn('   --force set: running the full migration anyway. Color tokens may double-shift.\n')
     } else {
+      if (pre > 0) {
+        console.warn(`   ${pre} pre-v2 color token(s) will be left untouched.`)
+        console.warn('   Pass --force to run the color migration too. Review carefully: color tokens may double-shift.')
+      }
       console.warn('   Running only the typography correction (`text-lg` → `text-md`, ...).\n')
     }
   }

--- a/tailwind/migrate-tokens-v2.test.js
+++ b/tailwind/migrate-tokens-v2.test.js
@@ -1,0 +1,55 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  detectMigrationState,
+  getMigrationMode,
+  migrateTokens,
+} from './migrate-tokens-v2.js'
+
+const tempDirs = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('tokens v2 migration', () => {
+  it('runs the full migration for unmigrated content', () => {
+    const result = migrateTokens('<div class="bg-surface-white text-xl font-medium"></div>')
+
+    expect(result.migrated).toBe('<div class="bg-surface-base text-2xl-medium"></div>')
+  })
+
+  it('runs typography-only correction for already migrated content', () => {
+    const result = migrateTokens(
+      '<div class="bg-surface-base text-lg text-xl text-2xl-medium"></div>',
+      { mode: 'migrated-typography' },
+    )
+
+    expect(result.migrated).toBe(
+      '<div class="bg-surface-base text-md text-lg text-xl-medium"></div>',
+    )
+  })
+
+  it('selects typography-only mode when v2 sentinels are present', () => {
+    const file = writeTempFile(
+      '<div class="bg-surface-base bg-surface-white text-xl"></div>',
+    )
+    const state = detectMigrationState([file])
+
+    expect(state).toEqual({ pre: 1, post: 1, likelyMigrated: true })
+    expect(getMigrationMode(state)).toBe('migrated-typography')
+    expect(getMigrationMode(state, { force: true })).toBe('full')
+  })
+})
+
+function writeTempFile(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tokens-v2-'))
+  tempDirs.push(dir)
+  const file = path.join(dir, 'fixture.vue')
+  fs.writeFileSync(file, content)
+  return file
+}


### PR DESCRIPTION
## Summary

This updates the espresso v2 typography scale so the 15px utility is `text-md` and `text-lg` is 16px again.

It also updates the token migration codemod so it can safely handle both app states:

- apps that have not run the v2 codemod get the full token migration with the corrected typography mapping
- apps that already ran the v2 codemod are detected and get only the typography correction (`text-lg` -> `text-md`, `text-xl` -> `text-lg`, etc.)

Existing frappe-ui usage and docs were updated to preserve current rendered sizes.

## Verification

- Ran `yarn sync-tokens`
- Ran `node --check tailwind/migrate-tokens-v2.js`
- Ran `yarn vitest run tailwind/migrate-tokens-v2.test.js`
- Smoke-tested full migration mode and already-migrated typography-only mode

`yarn type-check:tsc` was attempted but currently fails on existing project-wide type/module declaration issues unrelated to this change.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-790/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 57.15% (+0.05% vs `main`)
<!-- coverage-report:end -->

