### PR TITLE
fix(data-fetching): bind useDoc reactively and guard whitespace names

### DIFF
--- a/src/data-fetching/docStore.ts
+++ b/src/data-fetching/docStore.ts
@@ -54,7 +54,7 @@ class DocStore {
     name: MaybeRefOrGetter<string>,
     transform: (doc: Doc) => Doc,
   ): Ref<Doc | null> {
-    const nameStr = toValue(name)
+    const nameStr = toValue(name)?.trim()
     if (!doctype || !nameStr) {
       throw new Error('doctype and name are required')
     }

--- a/src/data-fetching/useDoc/useDoc.test.ts
+++ b/src/data-fetching/useDoc/useDoc.test.ts
@@ -4,6 +4,7 @@
 import { ref } from 'vue'
 import { baseUrl, waitUntilValueChanges } from '../../mocks/utils'
 import { useCall, useDoc } from '../index'
+import { docStore } from '../docStore'
 
 describe('useDoc', () => {
   it('it returns expected object', async () => {
@@ -115,5 +116,63 @@ describe('useDoc', () => {
 
     // Verify that the doc was updated
     expect(user.doc.email).toBe(newEmail)
+  })
+
+  it('does not bind or fetch while the name is empty', async () => {
+    interface User {
+      name: string
+      email: string
+    }
+
+    const user = useDoc<User>({
+      baseUrl,
+      doctype: 'User',
+      name: '',
+    })
+
+    // No name → nothing to bind and no request should fire.
+    expect(user.doc).toBe(null)
+    expect(user.loading).toBe(false)
+  })
+
+  it('binds to the doc once a late-resolving name is set', async () => {
+    interface User {
+      name: string
+      email: string
+      first_name: string
+      last_name: string
+    }
+
+    // Name is empty at setup (e.g. bound to a doc that is still loading).
+    const name = ref('')
+    const user = useDoc<User>({
+      baseUrl,
+      doctype: 'User',
+      name,
+    })
+
+    // Nothing fetched or bound yet.
+    expect(user.doc).toBe(null)
+    expect(user.loading).toBe(false)
+
+    // Name resolves after setup — the doc ref should re-point to the real slot.
+    name.value = 'user1'
+
+    await waitUntilValueChanges(() => user.loading, true)
+    await waitUntilValueChanges(() => user.loading, false)
+
+    expect(user.doc).toStrictEqual({
+      doctype: 'User',
+      name: 'user1',
+      email: 'user1@example.com',
+      first_name: 'User',
+      last_name: '1',
+    })
+  })
+
+  it('throws when getDoc is called with a whitespace-only name', () => {
+    expect(() => docStore.getDoc('User', '   ', (d) => d)).toThrow(
+      'doctype and name are required',
+    )
   })
 })

--- a/src/data-fetching/useDoc/useDoc.ts
+++ b/src/data-fetching/useDoc/useDoc.ts
@@ -72,7 +72,10 @@ export function useDoc<TDoc extends { name: string }, TMethods = {}>(
   }
 
   const fetchOptions: UseFetchOptions = {
-    immediate,
+    // Don't fire the initial GET while the name is still unresolved (it would
+    // hit the malformed `/api/v2/document/<doctype>/` URL). refetch:true makes
+    // the request fire automatically once the name resolves and the URL changes.
+    immediate: immediate && Boolean(toValue(name)?.trim()),
     refetch: true,
     afterFetch(ctx: AfterFetchContext<{ data: TDoc }>) {
       if (ctx.data) {
@@ -152,14 +155,28 @@ export function useDoc<TDoc extends { name: string }, TMethods = {}>(
     },
   })
 
-  let doc = docStore.getDoc(doctype, name, transform) as Ref<TDoc | null>
-  if (doc.value && transform) {
-    try {
-      doc.value = transform(doc.value)
-    } catch (e) {
-      docStore.removeDoc(doctype, toValue(name))
+  // Bind reactively to the document keyed by the *current* name. Resolving the
+  // name once at setup would statically bind to whatever it was then — if the
+  // name resolves after setup (e.g. while the GET is still in flight) the ref
+  // would never re-point to the real cache slot. A computed re-evaluates when
+  // the name resolves and when the store ref is populated.
+  const doc = computed<TDoc | null>(() => {
+    const nameStr = toValue(name)?.trim()
+    if (!nameStr) return null
+    const storeRef = docStore.getDoc(doctype, nameStr, transform) as Ref<
+      TDoc | null
+    >
+    let value = storeRef.value
+    if (value && transform) {
+      try {
+        value = transform(value)
+      } catch (e) {
+        docStore.removeDoc(doctype, nameStr)
+        return null
+      }
     }
-  }
+    return value
+  })
   let out = reactive({
     doc,
     error,

--- a/src/data-fetching/useDoc/useDoc.ts
+++ b/src/data-fetching/useDoc/useDoc.ts
@@ -133,11 +133,10 @@ export function useDoc<TDoc extends { name: string }, TMethods = {}>(
     immediate: false,
     refetch: false,
     onSuccess(data) {
-      let docWithType = { ...data, doctype }
-      if (transform) {
-        docWithType = transform(docWithType)
-      }
-      docStore.setDoc(docWithType)
+      // Store the untransformed doc; the `doc` computed applies `transform` on
+      // read. Transforming here too would run it twice (a bug for any
+      // non-idempotent transform). Mirrors afterFetch.
+      docStore.setDoc({ ...data, doctype })
       listStore.updateRow(doctype, data)
     },
   })


### PR DESCRIPTION
useDoc resolved `name` once at setup and bound the returned doc ref statically. If the name resolved after setup (e.g. bound to a doc still loading), the ref never re-pointed to the real cache slot — edits and saves targeted different objects, so the first save serialized the pristine doc (silent data loss). Surfaced downstream in frappe/crm#2282.

- docStore.getDoc: trim before the falsy-check so a whitespace-only name throws instead of minting the shared `doctype/` slot.
- useDoc: gate the immediate fetch on a resolved name, and bind the doc via a computed keyed by the current name so a late-resolving name self-heals.

Refs frappe/frappe-ui#792

<!-- coverage-report:start -->
Coverage: 57.18% (+0.08% vs `main`)
<!-- coverage-report:end -->

