### PR TITLE
fix: forward attrs to actual root elements

### DIFF
--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -3,8 +3,8 @@
     <PopoverAnchor asChild>
       <div
         ref="anchorRef"
-        :class="['flex', $attrs.class]"
-        :style="($attrs.style as StyleValue)"
+        v-bind="$attrs"
+        class="flex"
         @mouseover="onMouseover"
         @mouseleave="onMouseleave"
       >
@@ -65,7 +65,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onUnmounted, type StyleValue } from 'vue'
+import { computed, ref, onUnmounted } from 'vue'
 import {
   PopoverAnchor,
   PopoverContent,

--- a/src/components/TimePicker/TimePicker.vue
+++ b/src/components/TimePicker/TimePicker.vue
@@ -1,7 +1,7 @@
 <template>
   <PopoverRoot v-model:open="isOpen">
     <PopoverAnchor :reference="anchorEl" as-child>
-      <div>
+      <div v-bind="$attrs">
         <TextInput
           ref="inputRef"
           v-model="displayValue"
@@ -156,6 +156,8 @@ defineSlots<{
    */
   suffix?: (props: { togglePopover: () => void; isOpen: boolean }) => any
 }>()
+
+defineOptions({ inheritAttrs: false })
 
 // ── Prop reconciliation (new wins; legacy aliases preserved with warnings) ──
 

--- a/src/components/shared/picker/PickerShell.vue
+++ b/src/components/shared/picker/PickerShell.vue
@@ -1,7 +1,7 @@
 <template>
   <PopoverRoot v-model:open="open">
     <PopoverAnchor :reference="anchorEl" as-child>
-      <div @keydown.down.prevent="onArrowDown">
+      <div v-bind="$attrs" @keydown.down.prevent="onArrowDown">
         <slot name="trigger" v-bind="triggerSlotProps">
           <slot name="target" v-bind="triggerSlotProps">
             <TextInput
@@ -144,6 +144,8 @@ const slots = defineSlots<{
   suffix?: (props: TriggerSlotProps) => any
   default?: (props: { close: () => void }) => any
 }>()
+
+defineOptions({ inheritAttrs: false })
 
 const open = defineModel<boolean>('open', { default: false })
 const inputValue = defineModel<string>('inputValue', { default: '' })


### PR DESCRIPTION
Forward attributes to the actual root elements for components that have a Popover as a root. Studio needs this for rendering the selector

<!-- coverage-report:start -->
Coverage: 57.10% (±0.00% vs `main`)
<!-- coverage-report:end -->
