### PR TITLE
Minor Dialog and dropdown style tweaks

### DIFF
--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -75,7 +75,7 @@
                             <slot name="body-title">
                               <h3
                                 v-if="resolved.title"
-                                class="text-3xl-semibold leading-6 text-ink-gray-9"
+                                class="text-2xl-semibold leading-6 text-ink-gray-8"
                               >
                                 {{ resolved.title }}
                               </h3>

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -159,7 +159,7 @@ export function getMenuBackgroundColor(item: { theme?: MenuTheme }) {
   }
 
   return [
-    'focus:bg-surface-gray-2 data-[highlighted]:bg-surface-gray-2 data-[state=open]:bg-surface-gray-2',
+    'focus:bg-surface-gray-2 data-[highlighted]:bg-surface-alpha-gray-2 data-[state=open]:bg-surface-gray-2',
     'data-[state=checked]:bg-surface-gray-3',
     'data-[highlighted]:data-[state=checked]:bg-surface-gray-4',
   ].join(' ')


### PR DESCRIPTION
Two small styling tweaks:

- **Dialog**: title is now `text-2xl-semibold` / `text-ink-gray-8` (was `text-3xl-semibold` / `text-ink-gray-9`) — smaller and softer.
- **Menu (dropdown)**: highlighted item background uses `surface-alpha-gray-2` instead of `surface-gray-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-797/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 57.15% (±0.00% vs `main`)
<!-- coverage-report:end -->
