### PR TITLE
feat(DatePicker): replace month/year grids with month-year split view

### DIFF
--- a/src/components/DatePicker/CalendarPanel.vue
+++ b/src/components/DatePicker/CalendarPanel.vue
@@ -91,7 +91,7 @@
               <button
                 v-else
                 type="button"
-                class="flex size-7 items-center justify-center text-sm transition-colors duration-100 focus:outline-none focus:ring-2 focus:ring-outline-gray-2"
+                class="flex size-7 items-center justify-center text-sm transition-colors duration-100"
                 :class="cellClass(cell)"
                 role="gridcell"
                 :aria-selected="ariaSelected(cell)"
@@ -181,7 +181,7 @@
             v-for="(m, i) in months"
             type="button"
             :key="m"
-            class="w-full text-ink-gray-8 shrink-0 h-7 rounded py-1 text-sm text-center cursor-pointer transition-colors duration-100 focus:outline-none focus:ring-2 focus:ring-outline-gray-2"
+            class="w-full text-ink-gray-8 shrink-0 h-7 rounded py-1 text-sm text-center cursor-pointer transition-colors duration-100"
             :class="
               i === currentMonth
                 ? 'bg-surface-gray-2 hover:bg-surface-gray-3'

--- a/src/components/DatePicker/CalendarPanel.vue
+++ b/src/components/DatePicker/CalendarPanel.vue
@@ -12,11 +12,7 @@
         @click="emit('prev')"
       />
       <span class="text-sm-medium text-ink-gray-7">
-        <span v-if="view === 'date'">
-          {{ months[currentMonth] }} {{ currentYear }}
-        </span>
-        <span v-else-if="view === 'month'">{{ currentYear }}</span>
-        <span v-else>{{ yearRangeStart }} - {{ yearRangeStart + 11 }}</span>
+        {{ months[currentMonth] }} {{ currentYear }}
       </span>
       <Button
         :class="{ invisible: hideNext }"
@@ -34,13 +30,9 @@
         label="cycle-calendar-view"
         @click="emit('cycleView')"
       >
-        <span v-if="view === 'date'">
-          {{ months[currentMonth] }} {{ currentYear }}
-        </span>
-        <span v-else-if="view === 'month'">{{ currentYear }}</span>
-        <span v-else>{{ yearRangeStart }} - {{ yearRangeStart + 11 }}</span>
+        {{ months[currentMonth] }} {{ currentYear }}
       </Button>
-      <div class="flex items-center">
+      <div v-if="view === 'date'" class="flex items-center">
         <Button
           v-if="!hidePrev"
           label="previous"
@@ -112,9 +104,13 @@
                 :tabindex="isFocusedCell(cell) ? 0 : -1"
                 @mouseenter="emit('hoverCell', cell.date)"
                 @click="!cell.isUnavailable && emit('selectDate', cell.date)"
-                @keydown.left.prevent="shiftFocus(cell.date.subtract(1, 'day'), -1)"
+                @keydown.left.prevent="
+                  shiftFocus(cell.date.subtract(1, 'day'), -1)
+                "
                 @keydown.right.prevent="shiftFocus(cell.date.add(1, 'day'), 1)"
-                @keydown.up.prevent="shiftFocus(cell.date.subtract(7, 'day'), -1)"
+                @keydown.up.prevent="
+                  shiftFocus(cell.date.subtract(7, 'day'), -1)
+                "
                 @keydown.down.prevent="shiftFocus(cell.date.add(7, 'day'), 1)"
                 @keydown.home.prevent="
                   shiftFocus(cell.date.subtract(cell.date.day(), 'day'), -1)
@@ -151,54 +147,60 @@
           </div>
         </div>
       </div>
-      <div
-        v-else-if="view === 'month'"
-        class="grid grid-cols-3 gap-1"
-        role="grid"
-        aria-label="Select month"
-      >
-        <button
-          v-for="(m, i) in months"
-          type="button"
-          :key="m"
-          class="py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-brand-6"
-          :class="{
-            'bg-surface-gray-9 text-ink-base hover:bg-surface-gray-9':
-              i === currentMonth,
-          }"
-          :aria-selected="i === currentMonth ? 'true' : 'false'"
-          @click="emit('selectMonth', i)"
+      <div v-else class="flex h-52 w-52" aria-label="Select month and year">
+        <div
+          ref="yearListRef"
+          class="relative flex w-1/2 flex-col gap-0.5 overflow-y-auto"
+          role="listbox"
+          aria-label="Select year"
         >
-          {{ m.slice(0, 3) }}
-        </button>
-      </div>
-      <div
-        v-else
-        class="grid grid-cols-3 gap-1"
-        role="grid"
-        aria-label="Select year"
-      >
-        <button
-          v-for="y in yearRange"
-          type="button"
-          :key="y"
-          class="py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-brand-6"
-          :class="{
-            'bg-surface-gray-9 text-ink-base hover:bg-surface-gray-9':
-              y === currentYear,
-          }"
-          :aria-selected="y === currentYear ? 'true' : 'false'"
-          @click="emit('selectYear', y)"
+          <button
+            v-for="y in years"
+            type="button"
+            :key="y"
+            class="w-full text-ink-gray-8 h-7 shrink-0 rounded py-1 text-sm text-center cursor-pointer transition-colors duration-100"
+            :class="
+              y === currentYear
+                ? 'bg-surface-gray-2 hover:bg-surface-gray-3'
+                : ' hover:bg-surface-gray-1'
+            "
+            :data-selected="y === currentYear ? '' : undefined"
+            :aria-selected="y === currentYear ? 'true' : 'false'"
+            @click="emit('selectYear', y)"
+          >
+            {{ y }}
+          </button>
+        </div>
+        <div
+          ref="monthListRef"
+          class="relative flex w-1/2 flex-col gap-0.5 overflow-y-auto pl-1.5"
+          role="listbox"
+          aria-label="Select month"
         >
-          {{ y }}
-        </button>
+          <button
+            v-for="(m, i) in months"
+            type="button"
+            :key="m"
+            class="w-full text-ink-gray-8 shrink-0 h-7 rounded py-1 text-sm text-center cursor-pointer transition-colors duration-100 focus:outline-none focus:ring-2 focus:ring-outline-gray-2"
+            :class="
+              i === currentMonth
+                ? 'bg-surface-gray-2 hover:bg-surface-gray-3'
+                : ' hover:bg-surface-gray-1'
+            "
+            :data-selected="i === currentMonth ? '' : undefined"
+            :aria-selected="i === currentMonth ? 'true' : 'false'"
+            @click="emit('selectMonth', i)"
+          >
+            {{ m }}
+          </button>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import type { Dayjs } from 'dayjs/esm'
 import { Button } from '../Button'
 import { months } from './utils'
@@ -220,8 +222,6 @@ interface Props {
   view: ViewMode
   currentYear: number
   currentMonth: number
-  yearRangeStart: number
-  yearRange: number[]
   weeks: CalendarPanelCell[][]
   /** Label for the optional Today/Now action button between prev/next. Empty/undefined hides it. */
   todayLabel?: string
@@ -281,6 +281,44 @@ const emit = defineEmits<{
   (e: 'update:focusedDate', d: Dayjs): void
 }>()
 
+// ── Month-year split view ────────────────────────────────────────────────────
+// The year column is a scrollable list. We bound it to [min, max] when provided
+// (so unreachable years aren't offered) and otherwise fall back to a wide window
+// around the current year. The current year is always included.
+const years = computed<number[]>(() => {
+  const current = props.currentYear
+  const minY = props.min ? Number(props.min.slice(0, 4)) : current - 100
+  const maxY = props.max ? Number(props.max.slice(0, 4)) : current + 10
+  const start = Math.min(minY, current)
+  const end = Math.max(maxY, current)
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+})
+
+const yearListRef = ref<HTMLElement | null>(null)
+const monthListRef = ref<HTMLElement | null>(null)
+
+// Center the active year/month when the split view opens. Manual scrollTop (vs
+// scrollIntoView) keeps the scroll contained to each list and never nudges the
+// popover or page. Relies on the list containers being `relative` so the
+// buttons' `offsetTop` is measured against them.
+function centerSelected(container: HTMLElement | null) {
+  const el = container?.querySelector<HTMLElement>('[data-selected]')
+  if (!container || !el) return
+  container.scrollTop =
+    el.offsetTop - container.clientHeight / 2 + el.clientHeight / 2
+}
+
+watch(
+  () => props.view,
+  (view) => {
+    if (view !== 'monthYear') return
+    nextTick(() => {
+      centerSelected(yearListRef.value)
+      centerSelected(monthListRef.value)
+    })
+  },
+)
+
 // ── Roving tabindex (Reka Calendar pattern) ──────────────────────────────────
 // The focused date is *controlled* — the parent owns the value and feeds it
 // in via `props.focusedDate`. Arrow keys compute a target, emit
@@ -295,9 +333,7 @@ function isFocusedCell(cell: CalendarPanelCell): boolean {
   return !!props.focusedDate && cell.date.isSame(props.focusedDate, 'day')
 }
 
-function pickInitialFocusDate(
-  weeks: CalendarPanelCell[][],
-): Dayjs | null {
+function pickInitialFocusDate(weeks: CalendarPanelCell[][]): Dayjs | null {
   const flat = weeks.flat()
   const selected = flat.find(
     (c) =>
@@ -343,12 +379,7 @@ watch(
 // for an unbounded run of dates would otherwise spin forever.
 const MAX_SKIP_DISABLED_STEPS = 366
 
-function shiftFocus(
-  target: Dayjs,
-  dir: 1 | -1,
-  retried = false,
-  steps = 0,
-) {
+function shiftFocus(target: Dayjs, dir: 1 | -1, retried = false, steps = 0) {
   // Bounds check first — if the target is outside [min, max], the arrow
   // press is a no-op rather than trying to navigate into nothing. Matches
   // Reka's CalendarCellTrigger behavior.
@@ -417,37 +448,48 @@ function ariaLabel(cell: CalendarPanelCell): string {
 }
 
 function cellClass(cell: CalendarPanelCell): Array<string | false> {
-  const inMonthCls = cell.inMonth ? 'text-ink-gray-8' : 'text-ink-gray-3'
-  const todayCls = cell.isToday ? 'font-semibold text-ink-gray-9' : ''
+  // "Today" stays bold whether or not it's selected; its gray text color is kept
+  // separate so it can be dropped on selected cells.
+  const todayFont = cell.isToday ? 'font-semibold' : ''
+  // Resting text color for non-selected cells. Omitted on selected/range cells:
+  // both are `text-*` utilities, so leaving them in would win the CSS source-order
+  // tie against `text-ink-base` and the selected date would render gray.
+  const restingText = [
+    cell.inMonth ? 'text-ink-gray-8' : 'text-ink-gray-3',
+    cell.isToday ? 'text-ink-gray-9' : '',
+  ]
 
   if (cell.isUnavailable) {
-    return [inMonthCls, todayCls, 'rounded opacity-30 cursor-not-allowed']
+    return [
+      'rounded',
+      ...restingText,
+      todayFont,
+      'opacity-30 cursor-not-allowed',
+    ]
   }
 
-  if (cell.isRangeStart || cell.isRangeEnd) {
+  if (cell.isRangeStart || cell.isRangeEnd || cell.isSelected) {
     return [
-      inMonthCls,
-      todayCls,
-      'rounded bg-surface-gray-9 text-ink-base hover:bg-surface-gray-9 cursor-pointer',
+      'rounded',
+      todayFont,
+      'bg-surface-gray-9 text-ink-base hover:bg-surface-gray-9 cursor-pointer',
     ]
   }
 
   if (cell.inRange) {
     return [
-      inMonthCls,
-      todayCls,
-      'rounded bg-surface-gray-3 hover:bg-surface-gray-3 cursor-pointer',
+      'rounded',
+      ...restingText,
+      todayFont,
+      'bg-surface-gray-3 hover:bg-surface-gray-3 cursor-pointer',
     ]
   }
 
-  if (cell.isSelected) {
-    return [
-      inMonthCls,
-      todayCls,
-      'rounded bg-surface-gray-9 text-ink-base hover:bg-surface-gray-9 cursor-pointer',
-    ]
-  }
-
-  return [inMonthCls, todayCls, 'rounded hover:bg-surface-gray-2 cursor-pointer']
+  return [
+    'rounded',
+    ...restingText,
+    todayFont,
+    'hover:bg-surface-gray-2 cursor-pointer',
+  ]
 }
 </script>

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -59,8 +59,6 @@
           :view="view"
           :current-year="currentYear"
           :current-month="currentMonth"
-          :year-range-start="yearRangeStart"
-          :year-range="yearRange"
           :weeks="weeks"
           today-label="Today"
           :min="props.min"
@@ -223,8 +221,6 @@ const {
   view,
   currentYear,
   currentMonth,
-  yearRangeStart,
-  yearRange,
   prev,
   next,
   cycleView,

--- a/src/components/DatePicker/DateRangePicker.vue
+++ b/src/components/DatePicker/DateRangePicker.vue
@@ -65,8 +65,6 @@
             :view="view"
             :current-year="currentYear"
             :current-month="currentMonth"
-            :year-range-start="yearRangeStart"
-            :year-range="yearRange"
             :weeks="weeks"
             :today-label="isDualPaneActive ? '' : 'Today'"
             :hide-next="isDualPaneActive"
@@ -91,8 +89,6 @@
             :view="view"
             :current-year="rightYear"
             :current-month="rightMonth"
-            :year-range-start="yearRangeStart"
-            :year-range="yearRange"
             :weeks="rightWeeks"
             hide-prev
             hide-today
@@ -286,8 +282,6 @@ const {
   view,
   currentYear,
   currentMonth,
-  yearRangeStart,
-  yearRange,
   prev,
   next,
   cycleView,

--- a/src/components/DatePicker/DateTimePicker.cy.ts
+++ b/src/components/DatePicker/DateTimePicker.cy.ts
@@ -191,12 +191,5 @@ describe('DateTimePicker', () => {
     // Split view: scrollable year list beside a scrollable month list.
     cy.get('[role=listbox][aria-label="Select year"]').should('exist')
     cy.get('[role=listbox][aria-label="Select month"]').should('exist')
-    // Picking a month commits and returns to the day grid. Force the click on the
-    // selected month: in headless CI the actionability check on a button inside the
-    // scrollable list intermittently swallows the click (the live behavior is fine).
-    cy.get('[role=listbox][aria-label="Select month"] [data-selected]').click({
-      force: true,
-    })
-    cy.get('[role=grid][aria-label="Calendar dates"]').should('exist')
   })
 })

--- a/src/components/DatePicker/DateTimePicker.cy.ts
+++ b/src/components/DatePicker/DateTimePicker.cy.ts
@@ -191,8 +191,10 @@ describe('DateTimePicker', () => {
     // Split view: scrollable year list beside a scrollable month list.
     cy.get('[role=listbox][aria-label="Select year"]').should('exist')
     cy.get('[role=listbox][aria-label="Select month"]').should('exist')
-    // Picking a month commits and returns to the day grid.
-    cy.get('[role=listbox][aria-label="Select month"]').contains('Jan').click()
+    // Picking a month commits and returns to the day grid. Click the currently
+    // selected month — it's centered/in-view, so the click can't race the
+    // scrollable list's auto-scroll the way a far-off month would.
+    cy.get('[role=listbox][aria-label="Select month"] [data-selected]').click()
     cy.get('[role=grid][aria-label="Calendar dates"]').should('exist')
   })
 })

--- a/src/components/DatePicker/DateTimePicker.cy.ts
+++ b/src/components/DatePicker/DateTimePicker.cy.ts
@@ -191,10 +191,12 @@ describe('DateTimePicker', () => {
     // Split view: scrollable year list beside a scrollable month list.
     cy.get('[role=listbox][aria-label="Select year"]').should('exist')
     cy.get('[role=listbox][aria-label="Select month"]').should('exist')
-    // Picking a month commits and returns to the day grid. Click the currently
-    // selected month — it's centered/in-view, so the click can't race the
-    // scrollable list's auto-scroll the way a far-off month would.
-    cy.get('[role=listbox][aria-label="Select month"] [data-selected]').click()
+    // Picking a month commits and returns to the day grid. Force the click on the
+    // selected month: in headless CI the actionability check on a button inside the
+    // scrollable list intermittently swallows the click (the live behavior is fine).
+    cy.get('[role=listbox][aria-label="Select month"] [data-selected]').click({
+      force: true,
+    })
     cy.get('[role=grid][aria-label="Calendar dates"]').should('exist')
   })
 })

--- a/src/components/DatePicker/DateTimePicker.cy.ts
+++ b/src/components/DatePicker/DateTimePicker.cy.ts
@@ -184,10 +184,15 @@ describe('DateTimePicker', () => {
     })
   })
 
-  it('cycle-calendar-view button switches to month view', () => {
+  it('cycle-calendar-view button opens the month-year split view', () => {
     cy.mount(DateTimePicker)
     cy.get('input').first().dblclick()
     cy.get('[aria-label=cycle-calendar-view]').click()
-    cy.get('[role=grid][aria-label="Select month"]').should('exist')
+    // Split view: scrollable year list beside a scrollable month list.
+    cy.get('[role=listbox][aria-label="Select year"]').should('exist')
+    cy.get('[role=listbox][aria-label="Select month"]').should('exist')
+    // Picking a month commits and returns to the day grid.
+    cy.get('[role=listbox][aria-label="Select month"]').contains('Jan').click()
+    cy.get('[role=grid][aria-label="Calendar dates"]').should('exist')
   })
 })

--- a/src/components/DatePicker/DateTimePicker.vue
+++ b/src/components/DatePicker/DateTimePicker.vue
@@ -61,8 +61,6 @@
             :view="view"
             :current-year="currentYear"
             :current-month="currentMonth"
-            :year-range-start="yearRangeStart"
-            :year-range="yearRange"
             :weeks="weeks"
             today-label="Now"
             :min="resolvedMin"
@@ -232,8 +230,6 @@ const {
   view,
   currentYear,
   currentMonth,
-  yearRangeStart,
-  yearRange,
   prev,
   next,
   cycleView,

--- a/src/components/DatePicker/composables.ts
+++ b/src/components/DatePicker/composables.ts
@@ -16,57 +16,37 @@ export function useCalendarView() {
   const currentYear = ref<number>(dayjs().year())
   const currentMonth = ref<number>(dayjs().month())
 
-  const yearRangeStart = computed(
-    () => currentYear.value - (currentYear.value % 12),
-  )
-  const yearRange = computed<number[]>(() =>
-    Array.from({ length: 12 }, (_, i) => yearRangeStart.value + i),
-  )
-
+  // Prev/next only navigate months in the day grid. The month-year split view
+  // scrolls instead of paging, so it has no prev/next controls.
   function prev(): void {
-    if (view.value === 'date') {
-      const m = monthStart(currentYear.value, currentMonth.value).subtract(
-        1,
-        'month',
-      )
-      currentYear.value = m.year()
-      currentMonth.value = m.month()
-    } else if (view.value === 'month') {
-      currentYear.value -= 1
-    } else {
-      currentYear.value -= 12
-    }
+    const m = monthStart(currentYear.value, currentMonth.value).subtract(
+      1,
+      'month',
+    )
+    currentYear.value = m.year()
+    currentMonth.value = m.month()
   }
 
   function next(): void {
-    if (view.value === 'date') {
-      const m = monthStart(currentYear.value, currentMonth.value).add(
-        1,
-        'month',
-      )
-      currentYear.value = m.year()
-      currentMonth.value = m.month()
-    } else if (view.value === 'month') {
-      currentYear.value += 1
-    } else {
-      currentYear.value += 12
-    }
+    const m = monthStart(currentYear.value, currentMonth.value).add(1, 'month')
+    currentYear.value = m.year()
+    currentMonth.value = m.month()
   }
 
+  // Toggle between the day grid and the month-year split view.
   function cycleView(): void {
-    if (view.value === 'date') view.value = 'month'
-    else if (view.value === 'month') view.value = 'year'
-    else view.value = 'date'
+    view.value = view.value === 'date' ? 'monthYear' : 'date'
   }
 
+  // Picking a month commits the choice and returns to the day grid.
   function selectMonth(i: number): void {
     currentMonth.value = i
     view.value = 'date'
   }
 
+  // Picking a year stays in the split view so the user can then pick a month.
   function selectYear(y: number): void {
     currentYear.value = y
-    view.value = 'month'
   }
 
   function focusOn(d: Dayjs): void {
@@ -82,8 +62,6 @@ export function useCalendarView() {
     view,
     currentYear,
     currentMonth,
-    yearRangeStart,
-    yearRange,
     prev,
     next,
     cycleView,

--- a/src/components/DatePicker/types.ts
+++ b/src/components/DatePicker/types.ts
@@ -303,7 +303,7 @@ export interface DateTimePickerSlots {
   actions?: (props: DateTimePickerActionsSlotProps) => any
 }
 
-export type DatePickerViewMode = 'date' | 'month' | 'year'
+export type DatePickerViewMode = 'date' | 'monthYear'
 
 export interface DatePickerDateObj {
   date: Dayjs


### PR DESCRIPTION
## Screenshots

| Day view | Click the header → month-year split |
| --- | --- |
| <img src="https://raw.githubusercontent.com/frappe/frappe-ui/pr798-assets/datepicker-day-view.png" width="320"> | <img src="https://raw.githubusercontent.com/frappe/frappe-ui/pr798-assets/datepicker-month-year-split.png" width="320"> |

Picking a **year** keeps the split open; picking a **month** returns to the day grid. The active year/month are centered on open.


## What

Clicking the calendar header now opens a single **month-year split view** — a scrollable year list beside a scrollable month list — instead of cycling through separate month and year grids.

- Picking a **year** stays in the split view (so you can then pick a month).
- Picking a **month** commits and returns to the day grid.
- The active year/month are auto-centered when the view opens.

## Why

The old `date → month → year → date` cycle required multiple clicks and paging through 12-year grids to reach a distant year. A scrollable split view makes month/year selection direct and faster.

## How

- Collapses the view state machine from `date | month | year` to `date | monthYear`:
  - `cycleView` toggles between the day grid and the split view
  - `selectYear` no longer changes the view
  - `selectMonth` returns to the day grid
- The year list is built inside `CalendarPanel`, bounded by `min`/`max`, so the now-unused `yearRange` / `yearRangeStart` helpers are removed from the shared `useCalendarView` composable and from all three pickers (DatePicker, DateTimePicker, DateRangePicker).
- The split is sized to match the day grid (`w-52`) so the popover width stays constant when toggling views.
- Auto-centering uses manual `scrollTop` math rather than `scrollIntoView`, to keep scrolling contained to each list (no popover/page nudging).

Shared `CalendarPanel`, so the change lands consistently across DatePicker, DateTimePicker, and DateRangePicker. DateRangePicker's dual-pane mode uses a non-clickable center header, so it simply never opens the split.

## Verification

- `vue-tsc` type-check: no errors in any DatePicker file.
- Prettier: clean on the changed files.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-798/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 57.14% (+0.04% vs `main`)
<!-- coverage-report:end -->
