### PR TITLE
fix(useDoc): don't self-evict the doc ref on first uncached load

### DIFF
--- a/src/data-fetching/docStore.test.ts
+++ b/src/data-fetching/docStore.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment node
+ */
+import { computed, watchSyncEffect } from 'vue'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { docStore } from './docStore'
+import { idbStore } from './idbStore'
+
+const DOCTYPE = 'User'
+const identity = <T>(d: T): T => d
+
+function idbKey(name: string) {
+  return `doc:${DOCTYPE}/${name}`
+}
+
+/**
+ * Mirror useDoc's `doc` computed: it calls getDoc and dereferences the returned
+ * ref *without* optional chaining, so a getDoc that returns undefined throws.
+ * A synchronous watcher reproduces the in-browser render effect that re-runs
+ * this computed the instant setDoc assigns the ref — the trigger for the crash.
+ */
+function subscribeLikeUseDoc(name: string) {
+  const doc = computed(() => docStore.getDoc(DOCTYPE, name, identity).value)
+  const seen: unknown[] = []
+  const stop = watchSyncEffect(() => {
+    seen.push(doc.value)
+  })
+  return { doc, seen, stop }
+}
+
+describe('docStore', () => {
+  beforeEach(async () => {
+    await docStore.clearAll()
+  })
+  afterEach(async () => {
+    await docStore.clearAll()
+  })
+
+  it('first uncached load: setDoc does not crash a synchronously-tracked reader and keeps the IDB copy', async () => {
+    const name = 'user1'
+    const { doc, stop } = subscribeLikeUseDoc(name)
+    // Nothing cached yet.
+    expect(doc.value).toBe(null)
+
+    const record = { doctype: DOCTYPE, name, email: 'user1@example.com' }
+    // Regression: before the fix this rejects. Assigning docRef.value synchronously
+    // re-enters getDoc, which (lastFetched unset) saw the entry as stale, evicted
+    // the ref it had just created, and the reader dereferenced undefined.
+    await expect(docStore.setDoc({ ...record })).resolves.toBeUndefined()
+
+    expect(doc.value).toMatchObject(record)
+    // The IDB copy setDoc wrote must survive — no spurious stale-reload eviction.
+    expect(await idbStore.get(idbKey(name))).toMatchObject(record)
+    stop()
+  })
+
+  it('stale access: getDoc never returns undefined (no self-eviction under its caller)', async () => {
+    const name = 'user2'
+    const record = { doctype: DOCTYPE, name }
+    await docStore.setDoc({ ...record })
+
+    // Force the entry past the cache timeout, as a long-lived useDoc would be.
+    const key = `${DOCTYPE}/${name}`
+    ;(
+      docStore as unknown as { lastFetched: Map<string, number> }
+    ).lastFetched.set(key, Date.now() - 10 * 60 * 1000)
+
+    const ref = docStore.getDoc(DOCTYPE, name, identity)
+    expect(ref).toBeDefined()
+    expect(() => ref.value).not.toThrow()
+    expect(ref.value).toMatchObject(record)
+  })
+})

--- a/src/data-fetching/docStore.ts
+++ b/src/data-fetching/docStore.ts
@@ -38,11 +38,15 @@ class DocStore {
       if (!this.docs.has(key)) {
         this.docs.set(key, ref(null))
       }
+      // Mark fresh BEFORE assigning the ref. Assigning docRef.value synchronously
+      // re-runs any computed reading this doc (e.g. useDoc's `doc`), which calls
+      // getDoc again — if the entry still looked stale at that point it would kick
+      // off a needless reload that evicts the IDB copy we just wrote.
+      this.lastFetched.set(key, Date.now())
       const docRef = this.docs.get(key)
       if (docRef) {
         docRef.value = doc
       }
-      this.lastFetched.set(key, Date.now())
     } catch (error) {
       console.error('Failed to set doc in IDB:', error)
       throw error
@@ -77,7 +81,16 @@ class DocStore {
   ) {
     try {
       if (!isFirstLoad && this.isStale(key)) {
-        await this.cleanup(key)
+        // Evict the stale IDB copy and clear the timestamp so the next read
+        // reloads — but DON'T delete the in-memory ref (as cleanup() does).
+        // getDoc() returns this ref synchronously and its caller (useDoc's `doc`
+        // computed) dereferences it immediately; cleanup() deletes the map entry
+        // on its first synchronous line, so a stale-but-present key would make
+        // getDoc's `return this.docs.get(key)` yield undefined and crash the
+        // computed on `.value`. This is reachable for any doc accessed after it
+        // goes stale (a long-lived useDoc re-evaluated past the cache timeout).
+        this.lastFetched.delete(key)
+        await idbStore.delete(this.storePrefix + key)
       }
 
       const idbDoc = (await idbStore.get(this.storePrefix + key)) as Doc | null


### PR DESCRIPTION
## Problem

The first uncached load of any document via `useDoc` crashes and renders blank:

```
Failed to set doc in IDB: TypeError: Cannot read properties of undefined (reading 'value')
  at useDoc.ts   → let value = storeRef.value
  at docStore.ts → docRef.value = doc   (setDoc)
```

## Root cause — two defects, both from `getDoc` returning the in-memory ref synchronously

`getDoc` returns the ref synchronously and its caller (useDoc's `doc` computed) dereferences it immediately. Two separate paths violate that contract:

**1. `setDoc` ordering → first-uncached-load crash + IDB churn**

`setDoc` set `lastFetched` *after* `docRef.value = doc`. Assigning the ref synchronously re-runs the `doc` computed, which re-enters `getDoc`; the entry still looked stale (`lastFetched` unset), so `getDoc` kicked off a reload that — via `cleanup()` — deleted the very ref it was about to return. `getDoc` then returned `undefined` and the computed crashed on `.value`. `loadDoc(firstLoad=true)` never sets `lastFetched` when IDB is empty, so this fired on **every first uncached load**.

**2. `loadDoc` stale path → stale-access crash (independent of #1)**

The stale-reload branch called `cleanup()`, whose first synchronous line is `this.docs.delete(key)`. So any doc accessed after it goes stale (a long-lived `useDoc` re-evaluated past the cache timeout) makes `getDoc`'s `return this.docs.get(key)!` yield `undefined` and crash — the first-uncached-load was just the most common trigger.

## Fix

1. `setDoc` marks `lastFetched` **before** assigning the ref, so the synchronous re-run sees a fresh entry and never reloads — no crash, and the just-written IDB copy isn't evicted by a needless reload.
2. The `loadDoc` stale path evicts the IDB copy and clears the timestamp but **keeps the in-memory ref**. `cleanup()` is untouched and still used by `invalidateDoc`/`removeDoc`, which intend full removal.

## Tests

Adds `src/data-fetching/docStore.test.ts` (none existed):
- **first uncached load** — a synchronously-tracked reader (mirroring useDoc's computed via `watchSyncEffect`) through `setDoc`; asserts no crash and that the IDB copy survives.
- **stale access** — forces the entry past the cache timeout; asserts `getDoc` never returns `undefined`.

Both fail on the prior code and pass with this change. Full `src/data-fetching/` suite (29 tests) passes.

Reproduced and verified in a downstream app (Gameplan): every first discussion open rendered blank with the error above; with this change the doc loads on first visit, the console is clean, and no unhandled rejection fires.

https://claude.ai/code/session_01CG9r6WdYSLUhcTKbNXcoki

<!-- coverage-report:start -->
Coverage: 57.93% (±0.00% vs `main`)
<!-- coverage-report:end -->
