### PR TITLE
feat(editor): inline file attachments

### DIFF
--- a/src/molecules/editor/commands.ts
+++ b/src/molecules/editor/commands.ts
@@ -145,6 +145,13 @@ export const commandMeta = {
     isAvailable: (editor) =>
       hasNode('video')(editor) && hasCommand('selectAndUploadVideo')(editor),
   },
+  attachment: {
+    label: 'Attachment',
+    icon: 'lucide-paperclip',
+    isAvailable: (editor) =>
+      hasNode('attachment')(editor) &&
+      hasCommand('selectAndUploadFile')(editor),
+  },
   link: {
     label: 'Link',
     icon: 'lucide-link',

--- a/src/molecules/editor/components/AttachmentNodeView.vue
+++ b/src/molecules/editor/components/AttachmentNodeView.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { computed, toRaw } from 'vue'
+import { NodeViewWrapper, nodeViewProps } from '@tiptap/vue-3'
+import { formatBytes } from '#utils/fileSize'
+import {
+  abortUpload,
+  getUploadProgress,
+} from '#molecules/editor/extensions/shared/media-upload-state'
+import { useNodeViewEditable } from '#molecules/editor/composables/useNodeViewEditable'
+
+const props = defineProps(nodeViewProps)
+
+// Operate on the raw editor for commands (see MediaNodeView for the rationale:
+// the proxied editor throws "Applying a mismatched transaction").
+const editor = toRaw(props.editor)
+const isEditable = useNodeViewEditable(editor)
+
+const fileName = computed(() => props.node.attrs.fileName || 'Attachment')
+const fileSize = computed(() => {
+  const size = Number(props.node.attrs.fileSize)
+  return Number.isFinite(size) && size > 0 ? formatBytes(size) : ''
+})
+const href = computed(() => props.node.attrs.src || undefined)
+const isLoading = computed(() => Boolean(props.node.attrs.loading))
+const error = computed(() => props.node.attrs.error as string | null)
+const isUploaded = computed(() => Boolean(props.node.attrs.src))
+
+const uploadId = computed(() => props.node.attrs.uploadId as string | undefined)
+const progress = computed(() =>
+  uploadId.value ? getUploadProgress(uploadId.value) : undefined,
+)
+const percent = computed(() => progress.value?.percent ?? 0)
+
+function cancel() {
+  if (uploadId.value) abortUpload(uploadId.value)
+}
+
+function retry() {
+  if (uploadId.value) editor.commands.reuploadAttachment(uploadId.value)
+}
+
+// Plain link is non-interactive while a chip is loading/errored.
+const isLink = computed(() => isUploaded.value && !isLoading.value)
+</script>
+
+<template>
+  <NodeViewWrapper
+    as="span"
+    class="gp-attachment"
+    :class="{ 'gp-attachment--error': error }"
+    data-drag-handle
+    draggable="true"
+  >
+    <component
+      :is="isLink ? 'a' : 'span'"
+      class="gp-attachment__chip"
+      :href="isLink ? href : undefined"
+      :target="isLink ? '_blank' : undefined"
+      :rel="isLink ? 'noopener noreferrer' : undefined"
+      :download="isLink ? fileName : undefined"
+      contenteditable="false"
+    >
+      <span
+        v-if="isLoading"
+        class="lucide-loader-circle gp-attachment__icon gp-attachment__icon--spin"
+        aria-hidden="true"
+      />
+      <span
+        v-else-if="error"
+        class="lucide-triangle-alert gp-attachment__icon"
+        aria-hidden="true"
+      />
+      <span
+        v-else
+        class="lucide-paperclip gp-attachment__icon"
+        aria-hidden="true"
+      />
+
+      <span class="gp-attachment__name">{{ fileName }}</span>
+      <span v-if="fileSize && !error" class="gp-attachment__size">
+        {{ fileSize }}
+      </span>
+      <span v-if="isLoading && percent > 0" class="gp-attachment__size">
+        {{ percent }}%
+      </span>
+    </component>
+
+    <button
+      v-if="isLoading && isEditable"
+      type="button"
+      class="gp-attachment__action"
+      title="Cancel upload"
+      contenteditable="false"
+      @click="cancel"
+    >
+      <span class="lucide-x gp-attachment__icon" aria-hidden="true" />
+    </button>
+    <button
+      v-else-if="error && isEditable"
+      type="button"
+      class="gp-attachment__action"
+      title="Try again"
+      contenteditable="false"
+      @click="retry"
+    >
+      <span class="lucide-rotate-cw gp-attachment__icon" aria-hidden="true" />
+    </button>
+  </NodeViewWrapper>
+</template>
+
+<style scoped>
+/* Gray-only chip (frappe-ui / Gameplan rule: never color shades). */
+.gp-attachment {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  vertical-align: baseline;
+  max-width: 100%;
+}
+
+.gp-attachment__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  max-width: 100%;
+  padding: 0.125rem 0.5rem;
+  border: 1px solid var(--outline-gray-2, #e2e2e2);
+  border-radius: 0.5rem;
+  background-color: var(--surface-gray-2, #f4f4f4);
+  color: var(--ink-gray-8, #1f272e);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  text-decoration: none;
+  cursor: default;
+}
+
+a.gp-attachment__chip {
+  cursor: pointer;
+}
+
+a.gp-attachment__chip:hover {
+  background-color: var(--surface-gray-3, #ebebeb);
+}
+
+.gp-attachment--error .gp-attachment__chip {
+  border-style: dashed;
+  color: var(--ink-gray-6, #4f5a64);
+}
+
+.gp-attachment__icon {
+  flex: none;
+  width: 0.875rem;
+  height: 0.875rem;
+  color: var(--ink-gray-6, #4f5a64);
+}
+
+.gp-attachment__icon--spin {
+  animation: gp-attachment-spin 0.8s linear infinite;
+}
+
+.gp-attachment__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 16rem;
+}
+
+.gp-attachment__size {
+  flex: none;
+  color: var(--ink-gray-5, #7c7c7c);
+}
+
+.gp-attachment__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.125rem;
+  border-radius: 0.25rem;
+  color: var(--ink-gray-6, #4f5a64);
+  background: transparent;
+}
+
+.gp-attachment__action:hover {
+  background-color: var(--surface-gray-3, #ebebeb);
+}
+
+@keyframes gp-attachment-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/molecules/editor/components/AttachmentNodeView.vue
+++ b/src/molecules/editor/components/AttachmentNodeView.vue
@@ -44,16 +44,22 @@ const isLink = computed(() => isUploaded.value && !isLoading.value)
 </script>
 
 <template>
+  <!-- Gray-only chip (frappe-ui / Gameplan rule: never color shades). -->
   <NodeViewWrapper
     as="span"
-    class="gp-attachment"
-    :class="{ 'gp-attachment--error': error }"
+    class="inline-flex max-w-full items-center gap-1 align-baseline"
     data-drag-handle
     draggable="true"
   >
     <component
       :is="isLink ? 'a' : 'span'"
-      class="gp-attachment__chip"
+      class="inline-flex h-6 max-w-full items-center gap-1.5 rounded-lg border bg-surface-gray-2 px-2 text-sm no-underline"
+      :class="[
+        error
+          ? 'border-dashed border-outline-gray-2 text-ink-gray-6'
+          : 'border-outline-gray-2 text-ink-gray-8',
+        isLink ? 'cursor-pointer hover:bg-surface-gray-3' : 'cursor-default',
+      ]"
       :href="isLink ? href : undefined"
       :target="isLink ? '_blank' : undefined"
       :rel="isLink ? 'noopener noreferrer' : undefined"
@@ -62,25 +68,25 @@ const isLink = computed(() => isUploaded.value && !isLoading.value)
     >
       <span
         v-if="isLoading"
-        class="lucide-loader-circle gp-attachment__icon gp-attachment__icon--spin"
+        class="lucide-loader-circle size-3.5 shrink-0 animate-spin text-ink-gray-6"
         aria-hidden="true"
       />
       <span
         v-else-if="error"
-        class="lucide-triangle-alert gp-attachment__icon"
+        class="lucide-triangle-alert size-3.5 shrink-0 text-ink-gray-6"
         aria-hidden="true"
       />
       <span
         v-else
-        class="lucide-paperclip gp-attachment__icon"
+        class="lucide-paperclip size-3.5 shrink-0 text-ink-gray-6"
         aria-hidden="true"
       />
 
-      <span class="gp-attachment__name">{{ fileName }}</span>
-      <span v-if="fileSize && !error" class="gp-attachment__size">
+      <span class="max-w-64 truncate">{{ fileName }}</span>
+      <span v-if="fileSize && !error" class="shrink-0 text-ink-gray-5">
         {{ fileSize }}
       </span>
-      <span v-if="isLoading && percent > 0" class="gp-attachment__size">
+      <span v-if="isLoading && percent > 0" class="shrink-0 text-ink-gray-5">
         {{ percent }}%
       </span>
     </component>
@@ -88,105 +94,22 @@ const isLink = computed(() => isUploaded.value && !isLoading.value)
     <button
       v-if="isLoading && isEditable"
       type="button"
-      class="gp-attachment__action"
+      class="inline-flex items-center justify-center rounded p-0.5 text-ink-gray-6 hover:bg-surface-gray-3"
       title="Cancel upload"
       contenteditable="false"
       @click="cancel"
     >
-      <span class="lucide-x gp-attachment__icon" aria-hidden="true" />
+      <span class="lucide-x size-3.5 shrink-0" aria-hidden="true" />
     </button>
     <button
       v-else-if="error && isEditable"
       type="button"
-      class="gp-attachment__action"
+      class="inline-flex items-center justify-center rounded p-0.5 text-ink-gray-6 hover:bg-surface-gray-3"
       title="Try again"
       contenteditable="false"
       @click="retry"
     >
-      <span class="lucide-rotate-cw gp-attachment__icon" aria-hidden="true" />
+      <span class="lucide-rotate-cw size-3.5 shrink-0" aria-hidden="true" />
     </button>
   </NodeViewWrapper>
 </template>
-
-<style scoped>
-/* Gray-only chip (frappe-ui / Gameplan rule: never color shades). */
-.gp-attachment {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  vertical-align: baseline;
-  max-width: 100%;
-}
-
-.gp-attachment__chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  max-width: 100%;
-  padding: 0.125rem 0.5rem;
-  border: 1px solid var(--outline-gray-2, #e2e2e2);
-  border-radius: 0.5rem;
-  background-color: var(--surface-gray-2, #f4f4f4);
-  color: var(--ink-gray-8, #1f272e);
-  font-size: 0.8125rem;
-  line-height: 1.25rem;
-  text-decoration: none;
-  cursor: default;
-}
-
-a.gp-attachment__chip {
-  cursor: pointer;
-}
-
-a.gp-attachment__chip:hover {
-  background-color: var(--surface-gray-3, #ebebeb);
-}
-
-.gp-attachment--error .gp-attachment__chip {
-  border-style: dashed;
-  color: var(--ink-gray-6, #4f5a64);
-}
-
-.gp-attachment__icon {
-  flex: none;
-  width: 0.875rem;
-  height: 0.875rem;
-  color: var(--ink-gray-6, #4f5a64);
-}
-
-.gp-attachment__icon--spin {
-  animation: gp-attachment-spin 0.8s linear infinite;
-}
-
-.gp-attachment__name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 16rem;
-}
-
-.gp-attachment__size {
-  flex: none;
-  color: var(--ink-gray-5, #7c7c7c);
-}
-
-.gp-attachment__action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.125rem;
-  border-radius: 0.25rem;
-  color: var(--ink-gray-6, #4f5a64);
-  background: transparent;
-}
-
-.gp-attachment__action:hover {
-  background-color: var(--surface-gray-3, #ebebeb);
-}
-
-@keyframes gp-attachment-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-</style>

--- a/src/molecules/editor/extensions.ts
+++ b/src/molecules/editor/extensions.ts
@@ -68,6 +68,7 @@ import { ImageExtension } from './extensions/image'
 import { ImageGroup as ImageGroupExtension } from './extensions/image-group'
 import ImageViewerExtension from './extensions/image-viewer'
 import { VideoExtension } from './extensions/video'
+import { AttachmentExtension } from './extensions/attachment'
 import { MediaDrop as MediaDropExtension } from './extensions/media-drop/media-drop-extension'
 import { IframeExtension } from './extensions/iframe'
 import {
@@ -288,6 +289,9 @@ export const Image = ImageExtension
 export const ImageGroup = ImageGroupExtension
 export const ImageViewer = ImageViewerExtension
 export const Video = VideoExtension
+// Inline file attachments (pdf, docx, zip, csv, …). Same shared upload function
+// as image/video; renders a gray chip/link via AttachmentNodeView.
+export const Attachment = AttachmentExtension
 export const MediaDrop = MediaDropExtension
 export const Iframe = IframeExtension
 export const Mention = MentionExtension

--- a/src/molecules/editor/extensions/attachment/attachment-engine.ts
+++ b/src/molecules/editor/extensions/attachment/attachment-engine.ts
@@ -1,0 +1,242 @@
+/**
+ * The attachment upload pipeline.
+ *
+ * Attachments are non-image, non-video files (pdf, docx, zip, csv, …) rendered
+ * as an inline chip/link. The lifecycle mirrors the image/video engine — stage
+ * the file, insert a loading placeholder, upload via the shared upload function,
+ * write the resulting `file_url` back onto the node — but it is deliberately
+ * leaner: no base64 preview and no intrinsic-dimension probe (a file chip has no
+ * dimensions). It reuses the shared placeholder / success / error doc ops and
+ * the shared upload/progress state so behaviour stays identical to media.
+ *
+ * Async safety (conventions §0.6): `editor.view` is resolved fresh at every
+ * dispatch site (the shared doc ops read it from the passed view), and every
+ * post-`await` write is guarded by an `editor.isDestroyed` check. The staged
+ * file is dropped only on the success path so `reupload` ("Try again") can
+ * re-read it after a terminal error.
+ */
+import type { Editor } from '@tiptap/core'
+import { fileSizeLimitMessage } from '#utils/fileSize'
+import { isSafeUrl } from '#molecules/editor/extensions/shared/url-safety'
+import { findNodeByUploadId } from '#molecules/editor/extensions/shared/node-view'
+import {
+  applyUploadError,
+  applyUploadSuccess,
+  insertPlaceholder,
+  removeNodeByUploadId,
+} from '#molecules/editor/extensions/shared/media-node-ops'
+import { createUploadId } from '#molecules/editor/extensions/shared/upload-id'
+import {
+  deleteLocalFile,
+  deleteUploadProgress,
+  getLocalFile,
+  setLocalFile,
+  setUploadProgress,
+  updateUploadProgress,
+} from '#molecules/editor/extensions/shared/media-upload-state'
+import type { MediaUploadOptions } from '#molecules/editor/extensions/shared/media-upload-engine'
+import type { InsertMode } from '#molecules/editor/extensions/shared/media-upload-types'
+
+/** Schema node name this engine inserts/updates. */
+export const ATTACHMENT_NODE_NAME = 'attachment'
+
+/** Attachments have no intrinsic dimensions; the shared ops want a value. */
+const NO_DIMENSIONS = { width: null, height: null }
+
+/** The node attrs derived from a `File` before upload (filename/size/type). */
+function attachmentAttrsFromFile(file: File): Record<string, unknown> {
+  return {
+    fileName: file.name,
+    fileSize: file.size,
+    mimeType: file.type || 'application/octet-stream',
+  }
+}
+
+/**
+ * Core upload run: stage file -> placeholder -> upload -> write-back. Returns
+ * the uploadId so multi-upload sequencing can anchor the next insert.
+ */
+async function run(
+  file: File,
+  editor: Editor,
+  pos: number | null | undefined,
+  mode: InsertMode,
+  options: MediaUploadOptions,
+  placeholderAttrs: Record<string, unknown> = attachmentAttrsFromFile(file),
+): Promise<string | null> {
+  if (!options.uploadFunction) {
+    console.error('uploadFunction option is not provided')
+    return null
+  }
+  const uploadId = createUploadId()
+  const abortController = new AbortController()
+  setUploadProgress(uploadId, {
+    loaded: 0,
+    total: file.size,
+    percent: 0,
+    abort: () => abortController.abort(),
+  })
+  try {
+    // Reject over-limit files before staging: insert an error placeholder with
+    // the file kept so "Try again" / "Choose another" still work.
+    const validationError = fileSizeLimitMessage(file)
+    if (validationError) {
+      setLocalFile(uploadId, { file })
+      if (editor.isDestroyed) {
+        deleteLocalFile(uploadId)
+        deleteUploadProgress(uploadId)
+        return uploadId
+      }
+      insertPlaceholder(
+        editor.view,
+        ATTACHMENT_NODE_NAME,
+        pos,
+        mode,
+        uploadId,
+        NO_DIMENSIONS,
+        placeholderAttrs,
+      )
+      applyUploadError(
+        editor.view,
+        ATTACHMENT_NODE_NAME,
+        uploadId,
+        validationError,
+      )
+      return uploadId
+    }
+
+    setLocalFile(uploadId, { file })
+    if (editor.isDestroyed) {
+      deleteLocalFile(uploadId)
+      deleteUploadProgress(uploadId)
+      return uploadId
+    }
+    insertPlaceholder(
+      editor.view,
+      ATTACHMENT_NODE_NAME,
+      pos,
+      mode,
+      uploadId,
+      NO_DIMENSIONS,
+      placeholderAttrs,
+    )
+
+    const uploaded = await options.uploadFunction(file, {
+      signal: abortController.signal,
+      onProgress: (progress) => {
+        updateUploadProgress(uploadId, {
+          ...progress,
+          abort: () => abortController.abort(),
+        })
+      },
+    })
+    if (editor.isDestroyed) {
+      deleteLocalFile(uploadId)
+      deleteUploadProgress(uploadId)
+      return uploadId
+    }
+    if (
+      !uploaded?.file_url ||
+      !isSafeUrl(uploaded.file_url, { base: window.location.origin })
+    ) {
+      applyUploadError(
+        editor.view,
+        ATTACHMENT_NODE_NAME,
+        uploadId,
+        'Upload returned no file URL',
+      )
+      return uploadId
+    }
+    // applyUploadSuccess preserves the existing attrs (fileName/fileSize/…) and
+    // only sets `src`, clears `loading`/`error`.
+    applyUploadSuccess(editor.view, ATTACHMENT_NODE_NAME, uploadId, uploaded)
+    deleteLocalFile(uploadId)
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      if (!editor.isDestroyed) {
+        removeNodeByUploadId(editor.view, ATTACHMENT_NODE_NAME, uploadId)
+      }
+      deleteLocalFile(uploadId)
+      deleteUploadProgress(uploadId)
+      return uploadId
+    }
+    const message = (error as Error)?.message || 'Failed to upload attachment'
+    if (!editor.isDestroyed) {
+      applyUploadError(editor.view, ATTACHMENT_NODE_NAME, uploadId, message)
+    }
+  } finally {
+    if (!abortController.signal.aborted) {
+      deleteUploadProgress(uploadId)
+    }
+  }
+  return uploadId
+}
+
+/** Upload a single file, replacing the current selection with the chip. */
+export async function uploadAttachment(
+  file: File,
+  editor: Editor,
+  options: MediaUploadOptions,
+): Promise<void> {
+  await run(file, editor, null, 'replace', options)
+}
+
+/**
+ * Doc-mutating multi-upload for drop/paste. Uploads sequentially, anchoring each
+ * insert immediately after the previous placeholder via its uploadId. Reads
+ * `editor.view` fresh each iteration (the host may swap it mid-flight).
+ */
+export async function uploadAttachmentFiles(
+  files: File[],
+  editor: Editor,
+  pos: number | null,
+  options: MediaUploadOptions,
+): Promise<void> {
+  if (files.length === 0) return
+  if (files.length === 1) {
+    await run(files[0], editor, pos, 'replace', options)
+    return
+  }
+  let lastUploadId: string | null = null
+  for (const file of files) {
+    let insertPos = pos
+    if (lastUploadId) {
+      const prevPos = findNodeByUploadId(
+        editor.view,
+        ATTACHMENT_NODE_NAME,
+        lastUploadId,
+      )
+      if (prevPos !== null) {
+        const prevNode = editor.view.state.doc.nodeAt(prevPos)
+        insertPos = prevPos + (prevNode?.nodeSize ?? 1)
+      }
+    }
+    lastUploadId = await run(file, editor, insertPos, 'insert', options)
+  }
+}
+
+/** Re-run a failed upload for the node at `pos` using its staged file. */
+export async function reuploadAttachment(
+  editor: Editor,
+  pos: number,
+  options: MediaUploadOptions,
+): Promise<void> {
+  const node = editor.view.state.doc.nodeAt(pos)
+  const uploadId = node?.attrs.uploadId as string | undefined
+  const entry = uploadId ? getLocalFile(uploadId) : undefined
+  if (!uploadId || !entry) {
+    console.error(`reuploadAttachment: no staged file for node at ${pos}`)
+    return
+  }
+  const replacementUploadId = await run(
+    entry.file,
+    editor,
+    pos,
+    'replace',
+    options,
+    node?.attrs ?? attachmentAttrsFromFile(entry.file),
+  )
+  if (replacementUploadId) {
+    deleteLocalFile(uploadId)
+  }
+}

--- a/src/molecules/editor/extensions/attachment/attachment-engine.ts
+++ b/src/molecules/editor/extensions/attachment/attachment-engine.ts
@@ -68,6 +68,14 @@ async function run(
     console.error('uploadFunction option is not provided')
     return null
   }
+  // Yield one microtask before mutating the doc. These engine entry points run
+  // from a command callback that returns `true`, after which ProseMirror's
+  // CommandManager dispatches its own transaction for that tick. Inserting the
+  // placeholder synchronously here would dispatch a second transaction built on
+  // the pre-command state, which ProseMirror rejects with "Applying a mismatched
+  // transaction". The image/video engines get this yield implicitly from their
+  // `await probeOrNull(...)`; an attachment has no dimensions to probe.
+  await Promise.resolve()
   const uploadId = createUploadId()
   const abortController = new AbortController()
   setUploadProgress(uploadId, {

--- a/src/molecules/editor/extensions/attachment/attachment-extension.ts
+++ b/src/molecules/editor/extensions/attachment/attachment-extension.ts
@@ -145,6 +145,11 @@ export const AttachmentExtension =
       return [
         {
           tag: 'a[data-attachment]',
+          // A saved chip serializes to `<a data-attachment href=…>`, which also
+          // matches the Link mark's `a[href]` rule (priority 1000). Without a
+          // higher priority the mark wins and the chip re-parses as a plain
+          // link, so outrank it.
+          priority: 1100,
           getAttrs: (node) => {
             if (typeof node === 'string') return {}
             const element = node as HTMLElement

--- a/src/molecules/editor/extensions/attachment/attachment-extension.ts
+++ b/src/molecules/editor/extensions/attachment/attachment-extension.ts
@@ -1,0 +1,243 @@
+/**
+ * The attachment node: an inline chip/link for non-image, non-video files
+ * (pdf, docx, zip, csv, …).
+ *
+ * Mirrors the image node's thin-shell shape: schema, attributes, parse/render
+ * and a small command map that delegates all upload/queue/find work to the
+ * dedicated `attachment-engine`. The chip renders via `AttachmentNodeView`, and
+ * uploads run through the same shared upload function as image/video — resolved
+ * at use-time via `resolveUploadOptions` (a per-extension `uploadFunction`
+ * config wins, else `editor.storage.upload.uploadFunction`).
+ *
+ * Drop/paste routing is owned by the shared `media-drop` extension: it sends
+ * non-image, non-video files here via `uploadAttachmentFiles`.
+ */
+import {
+  Node as NodeExtension,
+  mergeAttributes,
+  type Editor,
+} from '@tiptap/core'
+import { VueNodeViewRenderer } from '@tiptap/vue-3'
+import AttachmentNodeView from '#molecules/editor/components/AttachmentNodeView.vue'
+import { pickFiles } from '#molecules/editor/extensions/shared/file-picker'
+import {
+  resolveUploadOptions,
+  type MediaUploadOptions,
+  type UploadFunction,
+} from '#molecules/editor/extensions/shared/media-upload-engine'
+import { findNodeByUploadId } from '#molecules/editor/extensions/shared/node-view'
+import {
+  uploadAttachment,
+  uploadAttachmentFiles,
+  reuploadAttachment,
+  ATTACHMENT_NODE_NAME,
+} from './attachment-engine'
+
+export interface AttachmentExtensionOptions {
+  /**
+   * Function to handle file uploads. Receives optional request options
+   * (abort signal + progress callback) as the second argument.
+   * @default null
+   */
+  uploadFunction: UploadFunction | null
+
+  /**
+   * HTML attributes to add to the attachment anchor element.
+   * @default {}
+   */
+  HTMLAttributes: Record<string, unknown>
+}
+
+export interface SetAttachmentOptions {
+  src: string
+  fileName?: string
+  fileSize?: number | null
+  mimeType?: string | null
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    attachment: {
+      /** Insert an already-uploaded attachment chip. */
+      setAttachment: (options: SetAttachmentOptions) => ReturnType
+      /** Upload and insert a single file as an attachment. */
+      uploadAttachment: (file: File) => ReturnType
+      /** Upload and insert already-provided files (e.g. from a drop/paste). */
+      uploadAttachmentFiles: (files: File[], pos?: number | null) => ReturnType
+      /** Select file(s) using the file picker and upload them as attachments. */
+      selectAndUploadFile: () => ReturnType
+      /** Re-upload a failed attachment using the file stored in localFileMap. */
+      reuploadAttachment: (uploadId: string) => ReturnType
+    }
+  }
+}
+
+export const AttachmentExtension =
+  NodeExtension.create<AttachmentExtensionOptions>({
+    name: ATTACHMENT_NODE_NAME,
+
+    group: 'inline',
+    inline: true,
+    draggable: true,
+    selectable: true,
+    atom: true,
+
+    addOptions() {
+      return {
+        uploadFunction: null,
+        HTMLAttributes: {},
+      }
+    },
+
+    addAttributes() {
+      return {
+        src: { default: null },
+        fileName: {
+          default: null,
+          parseHTML: (element) =>
+            element.getAttribute('data-file-name') ||
+            element.getAttribute('download') ||
+            null,
+          renderHTML: (attributes) =>
+            attributes.fileName
+              ? { 'data-file-name': attributes.fileName }
+              : {},
+        },
+        fileSize: {
+          default: null,
+          parseHTML: (element) => {
+            const raw = element.getAttribute('data-file-size')
+            const size = raw == null ? NaN : Number(raw)
+            return Number.isFinite(size) ? size : null
+          },
+          renderHTML: (attributes) =>
+            attributes.fileSize != null
+              ? { 'data-file-size': String(attributes.fileSize) }
+              : {},
+        },
+        mimeType: {
+          default: null,
+          parseHTML: (element) =>
+            element.getAttribute('data-mime-type') ||
+            element.getAttribute('type') ||
+            null,
+          renderHTML: (attributes) =>
+            attributes.mimeType
+              ? { 'data-mime-type': attributes.mimeType }
+              : {},
+        },
+        uploadId: {
+          default: null,
+          parseHTML: () => null,
+        },
+        loading: {
+          default: false,
+          parseHTML: () => false,
+        },
+        error: {
+          default: null,
+          parseHTML: () => null,
+        },
+      }
+    },
+
+    parseHTML() {
+      return [
+        {
+          tag: 'a[data-attachment]',
+          getAttrs: (node) => {
+            if (typeof node === 'string') return {}
+            const element = node as HTMLElement
+            return { src: element.getAttribute('href') }
+          },
+        },
+      ]
+    },
+
+    renderHTML({ node, HTMLAttributes }) {
+      return [
+        'a',
+        mergeAttributes(this.options.HTMLAttributes || {}, HTMLAttributes, {
+          'data-attachment': '',
+          href: node.attrs.src,
+          download: node.attrs.fileName || null,
+          target: '_blank',
+          rel: 'noopener noreferrer',
+        }),
+        node.attrs.fileName || 'Attachment',
+      ]
+    },
+
+    addNodeView() {
+      return VueNodeViewRenderer(AttachmentNodeView)
+    },
+
+    addCommands() {
+      const resolve = (editor: Editor): MediaUploadOptions =>
+        resolveUploadOptions({ ...this.options, editor })
+
+      return {
+        setAttachment:
+          (attributes: SetAttachmentOptions) =>
+          ({ commands }) => {
+            if (
+              typeof attributes.src !== 'string' ||
+              attributes.src.trim() === ''
+            ) {
+              return false
+            }
+            return commands.insertContent({
+              type: this.name,
+              attrs: attributes,
+            })
+          },
+
+        uploadAttachment:
+          (file: File) =>
+          ({ editor }) => {
+            void uploadAttachment(file, editor, resolve(editor))
+            return true
+          },
+
+        uploadAttachmentFiles:
+          (files: File[], pos?: number | null) =>
+          ({ editor }) => {
+            if (files.length === 0) return false
+            void uploadAttachmentFiles(
+              files,
+              editor,
+              pos ?? null,
+              resolve(editor),
+            )
+            return true
+          },
+
+        selectAndUploadFile:
+          () =>
+          ({ editor }) => {
+            void pickFiles({ multiple: true }).then((files) => {
+              if (editor.isDestroyed || files.length === 0) return
+              editor.commands.uploadAttachmentFiles(files)
+            })
+            return true
+          },
+
+        reuploadAttachment:
+          (uploadId: string) =>
+          ({ editor }) => {
+            const pos = findNodeByUploadId(editor.view, this.name, uploadId)
+            if (pos === null) {
+              console.error(
+                'reuploadAttachment: could not find node with uploadId',
+                uploadId,
+              )
+              return false
+            }
+            void reuploadAttachment(editor, pos, resolve(editor))
+            return true
+          },
+      }
+    },
+  })
+
+export default AttachmentExtension

--- a/src/molecules/editor/extensions/attachment/attachment.flow.test.ts
+++ b/src/molecules/editor/extensions/attachment/attachment.flow.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Exercises the REAL drop path Gameplan uses: CommentKit editor + a shared
+ * upload function, then `uploadAttachmentFiles` (what media-drop / EditorDropZone
+ * call). Asserts a chip node is actually inserted and the NodeView mounts.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createApp, h, nextTick, reactive } from 'vue'
+
+let Editor: any
+let EditorContent: any
+let CommentKit: any
+
+beforeEach(async () => {
+  ;({ default: Editor } = await import('../../Editor.vue'))
+  ;({ default: EditorContent } = await import('../../EditorContent.vue'))
+  ;({ CommentKit } = await import('../../kits'))
+})
+
+function mount(staticProps: Record<string, any>) {
+  const state = reactive<Record<string, any>>({ modelValue: '' })
+  let editor: any = null
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  const app = createApp({
+    render() {
+      return h(Editor, { ...staticProps, ...state }, {
+        default: ({ editor: e }: any) => {
+          editor = e
+          return h(EditorContent, { editor: e })
+        },
+      })
+    },
+  })
+  app.mount(root)
+  return { getEditor: () => editor, app, root }
+}
+
+const flush = async () => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('attachment drop flow (CommentKit)', () => {
+  it('inserts a chip node when a non-media file is uploaded', async () => {
+    const upload = vi.fn(async (file: File) => ({ file_url: `/files/${file.name}` }))
+    const ctx = mount({ extensions: [CommentKit], uploadFunction: upload })
+    const editor = ctx.getEditor()
+
+    // diagnostics: does the editor expose the command + upload storage?
+    expect(typeof editor.commands.uploadAttachmentFiles).toBe('function')
+    expect(editor.storage?.upload?.uploadFunction).toBeTypeOf('function')
+
+    const pdf = new File([new Uint8Array([1, 2, 3])], 'report.pdf', {
+      type: 'application/pdf',
+    })
+
+    editor.commands.uploadAttachmentFiles([pdf])
+    await flush()
+
+    expect(upload).toHaveBeenCalledOnce()
+
+    const json = editor.getJSON()
+    const flat: any[] = []
+    const walk = (n: any) => {
+      flat.push(n)
+      ;(n.content ?? []).forEach(walk)
+    }
+    walk(json)
+    const node = flat.find((n) => n.type === 'attachment')
+    expect(node, 'attachment node should be inserted').toBeTruthy()
+    expect(node.attrs.src).toBe('/files/report.pdf')
+    expect(node.attrs.fileName).toBe('report.pdf')
+
+    ctx.app.unmount()
+  })
+})

--- a/src/molecules/editor/extensions/attachment/attachment.roundtrip.test.ts
+++ b/src/molecules/editor/extensions/attachment/attachment.roundtrip.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Round-trips the SERIALIZED attachment HTML (what the server stores) back
+ * through a CommentKit editor and asserts it re-parses as an `attachment` node,
+ * not a plain link. Reproduces "after submit the chip becomes a simple <a>".
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Editor } from '@tiptap/core'
+
+let CommentKit: any
+
+beforeEach(async () => {
+  ;({ CommentKit } = await import('../../kits'))
+})
+
+function nodesOf(editor: Editor): string[] {
+  const out: string[] = []
+  editor.state.doc.descendants((n) => {
+    out.push(n.type.name)
+    return true
+  })
+  return out
+}
+
+describe('attachment HTML round-trip (CommentKit)', () => {
+  it('re-parses a serialized attachment chip as an attachment node', () => {
+    const editor = new Editor({ extensions: [CommentKit] })
+    // The shape the attachment node serializes to (and the server keeps).
+    editor.commands.setContent(
+      `<p><a data-attachment href="/files/report.pdf" data-file-name="report.pdf" data-file-size="1234" data-mime-type="application/pdf" download="report.pdf">report.pdf</a></p>`,
+    )
+
+    const names = nodesOf(editor)
+    expect(names, 'should contain an attachment node').toContain('attachment')
+
+    const json = editor.getJSON()
+    const flat: any[] = []
+    const walk = (n: any) => {
+      flat.push(n)
+      ;(n.content ?? []).forEach(walk)
+    }
+    walk(json)
+    const node = flat.find((n) => n.type === 'attachment')
+    expect(node?.attrs.src).toBe('/files/report.pdf')
+    expect(node?.attrs.fileName).toBe('report.pdf')
+
+    editor.destroy()
+  })
+})

--- a/src/molecules/editor/extensions/attachment/index.ts
+++ b/src/molecules/editor/extensions/attachment/index.ts
@@ -1,0 +1,5 @@
+export {
+  AttachmentExtension,
+  type AttachmentExtensionOptions,
+  type SetAttachmentOptions,
+} from './attachment-extension'

--- a/src/molecules/editor/extensions/media-drop/media-drop-extension.ts
+++ b/src/molecules/editor/extensions/media-drop/media-drop-extension.ts
@@ -16,10 +16,14 @@ import { openImageGroupUploadDialog } from '#molecules/editor/extensions/image-g
  *   - several images     -> open the image group dialog (matches the toolbar's
  *                           multi-image pick, instead of stacking them inline)
  *   - any video(s)       -> upload inline (`uploadVideoFiles`)
- *   - anything else      -> reserved for attachments (not yet supported)
+ *   - anything else      -> upload inline as attachments (`uploadAttachmentFiles`)
  *
  * Type routing is feature-detected via the editor's commands, so a kit without
- * the image or video extension simply skips that branch.
+ * the image, video, or attachment extension simply skips that branch.
+ *
+ * Drop is handled under `handleDOMEvents.drop`; a file paste of non-image,
+ * non-video files is handled under `props.handlePaste` (image/video pastes keep
+ * flowing to their own extensions' paste handlers).
  */
 
 const IMAGE_RE = /^image\//i
@@ -64,8 +68,10 @@ export const MediaDrop = Extension.create({
 
           const images = files.filter((f) => IMAGE_RE.test(f.type))
           const videos = files.filter((f) => VIDEO_RE.test(f.type))
-          // Files that are neither image nor video are left for attachment
-          // support (not yet implemented).
+          // Everything that is neither image nor video becomes an attachment.
+          const others = files.filter(
+            (f) => !IMAGE_RE.test(f.type) && !VIDEO_RE.test(f.type),
+          )
 
           const can = (name: string): boolean =>
             typeof (editor.commands as Record<string, unknown>)[name] ===
@@ -86,12 +92,23 @@ export const MediaDrop = Extension.create({
             handled = true
           }
 
+          if (others.length > 0 && can('uploadAttachmentFiles')) {
+            editor.commands.uploadAttachmentFiles(others)
+            handled = true
+          }
+
           return handled
         },
     }
   },
 
   addProseMirrorPlugins() {
+    const editor = this.editor
+
+    /** Whether a kit exposes a given routing command. */
+    const can = (name: string): boolean =>
+      typeof (editor.commands as Record<string, unknown>)[name] === 'function'
+
     return [
       new Plugin({
         props: {
@@ -100,11 +117,16 @@ export const MediaDrop = Extension.create({
               const files = collectFiles(event.dataTransfer)
               if (files.length === 0) return false
               // Only claim drops we can actually route; let ProseMirror handle
-              // the rest (and, later, attachments).
-              const isMedia = files.some(
+              // the rest. Non-media files route to attachments when available.
+              const hasMedia = files.some(
                 (f) => IMAGE_RE.test(f.type) || VIDEO_RE.test(f.type),
               )
-              if (!isMedia) return false
+              const hasOther = files.some(
+                (f) => !IMAGE_RE.test(f.type) && !VIDEO_RE.test(f.type),
+              )
+              const routable =
+                hasMedia || (hasOther && can('uploadAttachmentFiles'))
+              if (!routable) return false
 
               event.preventDefault()
               event.stopPropagation()
@@ -123,9 +145,28 @@ export const MediaDrop = Extension.create({
                 )
               }
 
-              this.editor.commands.dropFiles(files)
+              editor.commands.dropFiles(files)
               return true
             },
+          },
+
+          // Paste of non-image, non-video files (image/video pastes keep
+          // flowing to their own extensions' paste handlers, so we never claim
+          // them here). Pure-attachment pastes are uploaded at the cursor.
+          handlePaste: (_view, event): boolean => {
+            if (!can('uploadAttachmentFiles')) return false
+            const files = collectFiles(event.clipboardData)
+            if (files.length === 0) return false
+            const others = files.filter(
+              (f) => !IMAGE_RE.test(f.type) && !VIDEO_RE.test(f.type),
+            )
+            // Only claim when the paste is exclusively attachments; otherwise
+            // defer to the image/video paste handlers.
+            if (others.length !== files.length) return false
+
+            event.preventDefault()
+            editor.commands.uploadAttachmentFiles(others)
+            return true
           },
         },
       }),

--- a/src/molecules/editor/extensions/slash-commands/slash-commands-extension.ts
+++ b/src/molecules/editor/extensions/slash-commands/slash-commands-extension.ts
@@ -91,6 +91,9 @@ const getCommands = (): CommandItem[] => [
     slashCommand(commandMeta.video, ({ editor, range }) => {
       editor.chain().focus().deleteRange(range).selectAndUploadVideo().run()
     }),
+    slashCommand(commandMeta.attachment, ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).selectAndUploadFile().run()
+    }),
   ]),
   ...inGroup('Embeds', [
     slashCommand(commandMeta.embed, ({ editor, range }) => {

--- a/src/molecules/editor/kits.test.ts
+++ b/src/molecules/editor/kits.test.ts
@@ -46,6 +46,7 @@ describe('editor kits', () => {
     expect(nodes.has('paragraph')).toBe(true)
     expect(nodes.has('heading')).toBe(true)
     expect(nodes.has('image')).toBe(true)
+    expect(nodes.has('attachment')).toBe(true)
     expect(nodes.has('mention')).toBe(true)
     expect(nodes.has('tagItem')).toBe(true)
     expect(marks.has('link')).toBe(true)
@@ -54,9 +55,17 @@ describe('editor kits', () => {
 
     const names = extensionNames(CommentKit)
     expect(names.has('imageViewer')).toBe(true)
+    expect(names.has('mediaDrop')).toBe(true)
     expect(names.has('table')).toBe(false)
     expect(names.has('tableOfContents')).toBe(false)
     expect(names.has('slashCommands')).toBe(false)
+  })
+
+  it('drops the attachment node when removed with `false`', () => {
+    expect(schemaOf(CommentKit).nodes.has('attachment')).toBe(true)
+    const { nodes } = schemaOf(CommentKit.configure({ attachment: false }))
+    expect(nodes.has('attachment')).toBe(false)
+    expect(nodes.has('image')).toBe(true) // others remain
   })
 
   it('RichTextKit adds tables, task lists, color, and slash commands', () => {

--- a/src/molecules/editor/kits.ts
+++ b/src/molecules/editor/kits.ts
@@ -19,6 +19,7 @@ import {
   ImageGroup,
   ImageViewer,
   Video,
+  Attachment,
   MediaDrop,
   ContentPaste,
   Emoji,
@@ -108,6 +109,7 @@ export interface CommentKitOptions {
   imageGroup: CustomMember
   imageViewer: CustomMember
   video: CustomMember
+  attachment: CustomMember
   // Tables. Off by default for CommentKit (the lighter stack); RichTextKit turns
   // it on. Opt in with `CommentKit.configure({ table: {} })`.
   table: CustomMember
@@ -126,6 +128,7 @@ const commentKitDefaults = (): CommentKitOptions => ({
   imageGroup: {},
   imageViewer: {},
   video: {},
+  attachment: {},
   table: false,
   contentPaste: {},
   emoji: {},
@@ -146,8 +149,15 @@ function commentMembers(options: CommentKitOptions): Extensions {
   if (options.image !== false)
     pushMember(list, ImageViewer, options.imageViewer)
   pushMember(list, Video, options.video)
-  // The single drop pipeline; only useful when there's a media node to route to.
-  if (options.image !== false || options.video !== false) list.push(MediaDrop)
+  pushMember(list, Attachment, options.attachment)
+  // The single drop pipeline; only useful when there's a media or attachment
+  // node to route to.
+  if (
+    options.image !== false ||
+    options.video !== false ||
+    options.attachment !== false
+  )
+    list.push(MediaDrop)
   // Table needs its row/cell/header companions; TableNavigation adds the
   // spreadsheet-style cell navigation. Shared so both kits get it (off by
   // default for CommentKit, on for RichTextKit).

--- a/src/molecules/editor/menu.ts
+++ b/src/molecules/editor/menu.ts
@@ -181,6 +181,14 @@ export const InsertVideo = command(
   undefined,
   false,
 )
+// Like InsertVideo, exposed as a command but not added to any default toolbar;
+// the primary entry points for attachments are drag/drop and paste.
+export const InsertAttachment = command(
+  commandMeta.attachment,
+  (editor) => editor.chain().focus().selectAndUploadFile().run(),
+  undefined,
+  false,
+)
 export const InsertLink = command(
   commandMeta.link,
   (editor) => editor.commands.openLinkEditor(),


### PR DESCRIPTION

<img width="832" height="180" alt="image" src="https://github.com/user-attachments/assets/a033e108-e585-4b08-b879-e49c14d92bf6" />


Adds inline file attachment support to the Editor molecule (CommentKit). Non-image/non-video files (pdf, docx, zip, csv, …) render as a compact gray chip with a paperclip icon, filename, and size.

## What's included
- `attachment` inline node + NodeView chip (upload progress, cancel, retry)
- Drop and paste routing for non-media files via the media-drop extension
- `/attachment` slash command
- Commands: `selectAndUploadFile`, `uploadAttachmentFiles`, `reuploadAttachment`

## Notes
- Chip is gray-only and styled with Tailwind/frappe-ui tokens, fixed 24px height.
- The node's parse rule outranks the Link mark so a saved chip reloads as a chip, not a plain link.

Replaces #530.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-805/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 58.55% (+0.52% vs `main`)
<!-- coverage-report:end -->
