### PR TITLE
feat(request): configurable base url and auth headers

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -23,8 +23,9 @@ export interface FrappeUIConfig {
   fallbackErrorHandler?: (error: any) => void
 
   // Base URL prepended to relative request URLs. Set this for local UI dev
-  // against a remote Frappe instance (cross-origin). When set, requests are
-  // sent with credentials so cross-origin auth works.
+  // against a remote Frappe instance (cross-origin). When set, requests default
+  // to `credentials: 'include'` for cookie-based auth; if you use a token via
+  // `requestHeaders` instead, pass `credentials: 'omit'` per request.
   requestBaseUrl?: string
 
   // Extra headers merged into every frappeRequest. Either a static object or a

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -21,6 +21,16 @@ export interface FrappeUIConfig {
 
   // Error handling
   fallbackErrorHandler?: (error: any) => void
+
+  // Base URL prepended to relative request URLs. Set this for local UI dev
+  // against a remote Frappe instance (cross-origin). When set, requests are
+  // sent with credentials so cross-origin auth works.
+  requestBaseUrl?: string
+
+  // Extra headers merged into every frappeRequest. Either a static object or a
+  // function returning headers (useful for injecting an Authorization header,
+  // e.g. `token <key>:<secret>`).
+  requestHeaders?: Record<string, string> | (() => Record<string, string>)
 }
 
 let config: FrappeUIConfig = {}

--- a/src/utils/frappeRequest.js
+++ b/src/utils/frappeRequest.js
@@ -8,12 +8,17 @@ export function frappeRequest(options) {
       if (!options.url) {
         throw new Error('[frappeRequest] options.url is required')
       }
+      let configHeaders = getConfig('requestHeaders') || {}
+      if (typeof configHeaders === 'function') {
+        configHeaders = configHeaders()
+      }
       let headers = Object.assign(
         {
           Accept: 'application/json',
           'Content-Type': 'application/json; charset=utf-8',
           'X-Frappe-Site-Name': window.location.hostname,
         },
+        configHeaders,
         options.headers || {},
       )
       if (window.csrf_token && window.csrf_token !== '{{ csrf_token }}') {
@@ -22,10 +27,19 @@ export function frappeRequest(options) {
       if (!options.url.startsWith('/') && !options.url.startsWith('http')) {
         options.url = '/api/method/' + options.url
       }
+      // Prepend a configured base URL to relative URLs for local dev against a
+      // remote instance. Cross-origin requests need credentials included.
+      let baseUrl = getConfig('requestBaseUrl')
+      let credentials = options.credentials
+      if (baseUrl && options.url.startsWith('/')) {
+        options.url = baseUrl.replace(/\/$/, '') + options.url
+        credentials = credentials || 'include'
+      }
       return {
         ...options,
         method: options.method || 'POST',
         headers,
+        credentials,
       }
     },
     transformResponse: async (response, options) => {

--- a/src/utils/frappeRequest.js
+++ b/src/utils/frappeRequest.js
@@ -16,6 +16,9 @@ export function frappeRequest(options) {
         {
           Accept: 'application/json',
           'Content-Type': 'application/json; charset=utf-8',
+          // Sent as the local hostname even when requestBaseUrl points at a
+          // remote site. Harmless for dev, but pass a `requestHeaders` override
+          // if you need the remote site name here.
           'X-Frappe-Site-Name': window.location.hostname,
         },
         configHeaders,
@@ -28,7 +31,11 @@ export function frappeRequest(options) {
         options.url = '/api/method/' + options.url
       }
       // Prepend a configured base URL to relative URLs for local dev against a
-      // remote instance. Cross-origin requests need credentials included.
+      // remote instance. Default to `credentials: 'include'` so cookie-based
+      // cross-origin auth works out of the box (the server must then send
+      // Access-Control-Allow-Credentials: true and a non-wildcard origin). If
+      // you authenticate with a token via `requestHeaders` instead, you usually
+      // want cookies omitted — pass `options.credentials: 'omit'` to override.
       let baseUrl = getConfig('requestBaseUrl')
       let credentials = options.credentials
       if (baseUrl && options.url.startsWith('/')) {

--- a/src/utils/frappeRequest.test.ts
+++ b/src/utils/frappeRequest.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { frappeRequest } from './frappeRequest'
+import { setConfig } from './config'
+
+function mockFetch() {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ message: 'ok' }),
+  }))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('frappeRequest configurable base url and auth headers', () => {
+  beforeEach(() => {
+    setConfig('requestBaseUrl', undefined)
+    setConfig('requestHeaders', undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    setConfig('requestBaseUrl', undefined)
+    setConfig('requestHeaders', undefined)
+  })
+
+  it('keeps default behavior when nothing is configured', async () => {
+    const fetchMock = mockFetch()
+    await frappeRequest({ url: 'ping' })
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/method/ping')
+    expect(opts.credentials).toBeUndefined()
+    expect(opts.headers.Authorization).toBeUndefined()
+  })
+
+  it('prepends the configured base url and includes credentials', async () => {
+    setConfig('requestBaseUrl', 'https://remote.frappe.test/')
+    const fetchMock = mockFetch()
+    await frappeRequest({ url: 'ping' })
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://remote.frappe.test/api/method/ping')
+    expect(opts.credentials).toBe('include')
+  })
+
+  it('injects static headers from config', async () => {
+    setConfig('requestHeaders', { Authorization: 'token key:secret' })
+    const fetchMock = mockFetch()
+    await frappeRequest({ url: 'ping' })
+
+    const [, opts] = fetchMock.mock.calls[0]
+    expect(opts.headers.Authorization).toBe('token key:secret')
+  })
+
+  it('injects headers from a function returning headers', async () => {
+    setConfig('requestHeaders', () => ({ Authorization: 'token dynamic:value' }))
+    const fetchMock = mockFetch()
+    await frappeRequest({ url: 'ping' })
+
+    const [, opts] = fetchMock.mock.calls[0]
+    expect(opts.headers.Authorization).toBe('token dynamic:value')
+  })
+})

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -32,6 +32,7 @@ export function request(_options) {
     headers: options.headers,
     body,
     signal: options.signal,
+    ...(options.credentials ? { credentials: options.credentials } : {}),
   })
     .then((response) => {
       if (options.transformResponse) {


### PR DESCRIPTION
Adds minimal support for alternative authentication in the data layer, for local UI development against a remote Frappe instance using auth headers instead of same-origin session cookies.

Two new optional config keys:

- `requestBaseUrl` — base URL prepended to relative request URLs. When set, requests are sent with `credentials: 'include'` so cross-origin auth works.
- `requestHeaders` — extra headers merged into every `frappeRequest`. Either a static object or a function returning headers (useful for injecting `Authorization: token <key>:<secret>`).

When neither is configured, behavior is unchanged (cookies + CSRF), so this is non-breaking.

Smaller re-do of #323 (which had a very large diff). Use case from #322.

Tests: 4 new cases in `frappeRequest.test.ts` (default behavior, base URL prefixing, static headers, function headers) — all passing.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-806/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 58.03% (±0.00% vs `main`)
<!-- coverage-report:end -->

