### PR TITLE
feat: add defaultCollapsed prop to SidebarSection.

### DIFF
--- a/src/components/Sidebar/Sidebar.api.md
+++ b/src/components/Sidebar/Sidebar.api.md
@@ -180,6 +180,12 @@
     description: '',
     required: false,
     type: 'boolean'
+  },
+  {
+    name: 'defaultCollapsed',
+    description: '',
+    required: false,
+    type: 'boolean'
   }
 ]
 

--- a/src/components/Sidebar/SidebarSection.vue
+++ b/src/components/Sidebar/SidebarSection.vue
@@ -66,7 +66,7 @@ import { SidebarSectionProps, sidebarCollapsedKey } from './types'
 const props = defineProps<SidebarSectionProps>()
 
 const isSidebarCollapsed = inject(sidebarCollapsedKey, computed(() => false))
-const isCollapsed = ref(false)
+const isCollapsed = ref(props.defaultCollapsed ?? false)
 const visibleItems = computed(() =>
   props.items.filter((item) => toValue(item.condition) !== false),
 )

--- a/src/components/Sidebar/types.ts
+++ b/src/components/Sidebar/types.ts
@@ -30,6 +30,7 @@ export type SidebarSectionProps = {
   label?: string
   items: SidebarItemProps[]
   collapsible?: boolean
+  defaultCollapsed?: boolean
 }
 
 export type SidebarProps = {


### PR DESCRIPTION
Adds `defaultCollapsed` prop to `SidebarSection`, allowing sections to be rendered in a collapsed state on mount.

Defaults to `false` — no breaking changes.

### Changes
- `types.ts` — added `defaultCollapsed?: boolean` to `SidebarSectionProps`
- `SidebarSection.vue` — initialize `isCollapsed` from prop
- `Sidebar.api.md` — regenerated via `propsgen.ts`

Closes #795
