### PR TITLE
fix (Textarea): correct font sizes for size variants

### DIFF
--- a/src/components/Textarea/Textarea.cy.ts
+++ b/src/components/Textarea/Textarea.cy.ts
@@ -70,6 +70,42 @@ describe('Textarea', () => {
       .and('have.been.calledWith', 'Delayed update')
   })
 
+  describe('sizes', () => {
+    const sizes = [
+      { size: 'sm', fontClass: 'text-base', px: 14 },
+      { size: 'md', fontClass: 'text-lg', px: 16 },
+      { size: 'lg', fontClass: 'text-2xl', px: 18 },
+      { size: 'xl', fontClass: 'text-3xl', px: 20 },
+    ] as const
+
+    sizes.forEach(({ size, fontClass, px }) => {
+      it(`size="${size}" applies ${fontClass} and renders at ${px}px`, () => {
+        cy.mount(Textarea, { props: { size } })
+
+        cy.get('textarea')
+          .should('have.class', fontClass)
+          .and('have.css', 'font-size', `${px}px`)
+      })
+    })
+
+    it('increases font size monotonically across sizes', () => {
+      const rendered: number[] = []
+
+      sizes.forEach(({ size }) => {
+        cy.mount(Textarea, { props: { size } })
+        cy.get('textarea').then(($el) => {
+          rendered.push(parseFloat(getComputedStyle($el[0]).fontSize))
+        })
+      })
+
+      cy.then(() => {
+        rendered.slice(1).forEach((px, i) => {
+          expect(px).to.be.greaterThan(rendered[i])
+        })
+      })
+    })
+  })
+
   describe('shared labeling contract', () => {
     it('wires aria-describedby to the description region', () => {
       cy.mount(Textarea, {

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -114,9 +114,9 @@ const attrsWithoutClassStyle = computed(() => {
 const inputClasses = computed(() => {
   let sizeClasses = {
     sm: 'text-base rounded',
-    md: 'text-base rounded',
-    lg: 'text-lg rounded-md',
-    xl: 'text-2xl rounded-md',
+    md: 'text-lg rounded',
+    lg: 'text-2xl rounded-md',
+    xl: 'text-3xl rounded-md',
   }[props.size]
 
   let paddingClasses = {


### PR DESCRIPTION
Corrects the font sizes for `Textarea` size variants per the specifications in #738.

### Font Size Mapping:
- **`sm`** -> `text-base` (`14px`)
- **`md`** -> `text-lg` (`16px`)
- **`lg`** -> `text-2xl` (`18px`)
- **`xl`** -> `text-3xl` (`20px`)

*Note: `xl` was bumped to `text-3xl` (20px) to preserve monotonic size progression, as `lg` was updated to `text-2xl` (18px).*

### Changes:
- `src/components/Textarea/Textarea.vue` — updated size-to-font-class mappings.

Closes #738

<!-- coverage-report:start -->
Coverage: 66.40% (+0.03% vs `main`)
<!-- coverage-report:end -->

