### PR TITLE
feat(Select): hug the selected value + drop open/close animation

### DIFF
--- a/src/components/Select/Select.cy.ts
+++ b/src/components/Select/Select.cy.ts
@@ -123,20 +123,24 @@ describe('Select', () => {
     cy.get('[role=combobox]').should('contain.text', 'Sentinel-like')
   })
 
-  it('sizes the trigger to the widest option by default', () => {
+  it('sizes the trigger to the selected value, not the widest option', () => {
+    // Both selects share the same options, so a widest-option strategy would
+    // make them equal width. Instead the trigger hugs the *selected value*:
+    // the one showing the longer value is wider, and the dropdown expands
+    // outward to fit the rest.
     const WidthHarness = defineComponent({
       setup() {
         return () =>
           h('div', { class: 'flex items-start gap-6' }, [
             h(Select, {
-              options: ['Short'],
+              options: ['Short', 'A much longer option label'],
               modelValue: 'Short',
-              'data-cy': 'short-select',
+              'data-cy': 'short-value-select',
             }),
             h(Select, {
               options: ['Short', 'A much longer option label'],
-              modelValue: 'Short',
-              'data-cy': 'long-select',
+              modelValue: 'A much longer option label',
+              'data-cy': 'long-value-select',
             }),
           ])
       },
@@ -144,10 +148,10 @@ describe('Select', () => {
 
     cy.mount(WidthHarness)
 
-    cy.get('[data-cy="short-select"]').then(($short) => {
+    cy.get('[data-cy="short-value-select"]').then(($short) => {
       const shortWidth = $short[0].getBoundingClientRect().width
 
-      cy.get('[data-cy="long-select"]').should(($long) => {
+      cy.get('[data-cy="long-value-select"]').should(($long) => {
         const longWidth = $long[0].getBoundingClientRect().width
         expect(longWidth).to.be.greaterThan(shortWidth)
       })
@@ -219,23 +223,21 @@ describe('Select', () => {
 
     cy.get('[data-cy="trigger-content"]').should('have.text', 'def')
     cy.get('[role=combobox]').click()
-    cy.get('[data-slot="content-body"]').should(
-      'have.attr',
-      'data-motion',
-      'animated',
-    )
     cy.get('[data-slot="content"]')
       .parent()
       .should('have.attr', 'style')
       .and('include', 'min-width')
   })
 
-  it('skips content animation for keyboard-opened interactions', () => {
+  it('opens without an enter/exit animation (instant motion)', () => {
+    // The menu is anchored item-aligned over the trigger, so a
+    // scale-from-trigger entrance would read as a glitch. Both pointer and
+    // keyboard opens use the `instant` rhythm (opacity-only, no scale).
     cy.mount(Select, {
       props: { options },
     })
 
-    cy.get('[role=combobox]').focus().trigger('keydown', { key: 'Enter' })
+    cy.get('[role=combobox]').click()
     cy.get('[data-slot="content-body"]').should(
       'have.attr',
       'data-motion',

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, useAttrs, useSlots } from 'vue'
-import { usePopoverMotion } from '../../composables/usePopoverMotion'
 import { useInputLabeling } from '../../composables/useInputLabeling'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import type {
@@ -86,9 +85,6 @@ const hasLabeling = computed(() => {
 })
 
 const formAttrKeys = ['name', 'autocomplete'] as const
-
-const { motion: contentMotion, onPointerDown: markPointerDown } =
-  usePopoverMotion(open)
 
 const rootAttrs = computed(() => {
   const out: Record<string, unknown> = Object.fromEntries(
@@ -210,12 +206,11 @@ const displayValue = computed(() => {
   return selectedOption.value?.label || ''
 })
 
-const selectSizingText = computed(() => {
-  return [
-    props.placeholder,
-    ...selectOptions.value.map((option) => option.label),
-  ].join('\n')
-})
+// Text the hidden sizer reserves trigger width for: the current value (or
+// placeholder when unselected). The trigger hugs the selection, so the
+// item-aligned dropdown — anchored over the trigger — expands outward to fit
+// longer options (Linear-style). Trigger width shifts as the value changes.
+const selectSizingText = computed(() => displayValue.value || props.placeholder)
 
 function getOptionSlotName(option: SelectNormalizedOption) {
   return option.slot ? `item-${option.slot}` : undefined
@@ -264,7 +259,6 @@ defineSlots<SelectSlots>()
         :aria-required="required || undefined"
         :data-invalid="hasError ? 'true' : undefined"
         :data-required="required ? 'true' : undefined"
-        @pointerdown="markPointerDown"
       >
         <template v-if="$slots.trigger">
           <slot name="trigger" v-bind="triggerSlotProps" />
@@ -347,8 +341,14 @@ defineSlots<SelectSlots>()
           data-slot="content"
           class="z-[100] origin-[var(--reka-select-content-transform-origin)]"
         >
+          <!--
+          `instant` (no scale-from-trigger enter, no exit) rather than the
+          animated rhythm: the menu is anchored item-aligned *over* the
+          trigger, so a scale/translate entrance reads as a glitch. The ~80ms
+          opacity fade `instant` keeps masks reka's 1-frame position-settle.
+        -->
           <PopoverPanel
-            :motion="contentMotion"
+            motion="instant"
             class="flex flex-col origin-[var(--reka-select-content-transform-origin)]"
           >
             <SelectViewport class="flex min-h-0 flex-col p-1">

--- a/src/components/Select/stories/Example.vue
+++ b/src/components/Select/stories/Example.vue
@@ -46,7 +46,8 @@ const options = [
       <div class="pb-8 md:pr-8">
         <div class="text-sm-medium text-ink-gray-7">Auto width</div>
         <div class="mt-1 text-p-sm text-ink-gray-5">
-          Matches the widest option by default, closer to a native select.
+          Hugs the selected value; the dropdown expands outward to fit longer
+          options.
         </div>
 
         <div class="mt-4">

--- a/src/components/Select/utils.ts
+++ b/src/components/Select/utils.ts
@@ -62,4 +62,4 @@ export function triggerVariantClasses(
  * which is why Select doesn't reuse the shared base string.
  */
 export const triggerBaseClasses =
-  'relative inline-flex items-center gap-2 text-left transition-[background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] data-[state=open]:focus-ring text-ink-gray-7 data-[placeholder]:text-ink-gray-4 data-[disabled]:text-ink-gray-4'
+  'relative inline-flex items-center gap-2 text-left transition-[background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] data-[state=open]:outline-none text-ink-gray-7 data-[placeholder]:text-ink-gray-4 data-[disabled]:text-ink-gray-4'


### PR DESCRIPTION
## What

Make `Select` behave like Linear's select control, where the open menu anchors so the selected option sits exactly over the trigger.

The item-aligned overlay already worked (reka-ui defaults `position="item-aligned"`). This PR aligns the two remaining behaviors with it, **by default** — no opt-in:

### 1. Trigger hugs the selected value
Previously the trigger reserved width for the **widest** option. Now it fits the **currently selected value**, so the item-aligned dropdown expands *outward* to fit longer options — the Linear feel. (Trigger width shifts as the value changes; that's intended.)

Implemented by changing what the hidden width-sizer reserves space for (current value vs. widest option).

### 2. No open/close animation
The menu is anchored *over* the trigger, so the scale-from-trigger enter/exit motion reads as a glitch. Switched the panel to the `instant` rhythm: no scale/translate enter, no exit. The ~80ms opacity fade is kept to mask reka's 1-frame position settle (removing it entirely causes a position flash). Open state also clears the trigger focus ring (`outline-none`) to match.

## Tests
`Select.cy.ts` updated for the new defaults:
- "sizes the trigger to the selected value, not the widest option" — two selects with identical options but different selected values; the one showing the longer value is wider.
- "opens without an enter/exit animation (instant motion)" — pointer open yields `data-motion="instant"`.

All 25 Select component tests pass locally.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-811/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 58.80% (-0.06% vs `main`)
<!-- coverage-report:end -->
