### PR TITLE
feat(experimental): add MultiEmailInput component

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -131,6 +131,7 @@ declare module 'vue' {
     SidebarHeader: typeof import('./src/components/Sidebar/SidebarHeader.vue')['default']
     SidebarItem: typeof import('./src/components/Sidebar/SidebarItem.vue')['default']
     SidebarSection: typeof import('./src/components/Sidebar/SidebarSection.vue')['default']
+    Skeleton: typeof import('./src/components/Skeleton/Skeleton.vue')['default']
     SlashCommandsList: typeof import('./src/components/TextEditor/extensions/slash-commands/SlashCommandsList.vue')['default']
     Slider: typeof import('./src/components/Slider/Slider.vue')['default']
     Spinner: typeof import('./src/components/Spinner/Spinner.vue')['default']

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -21,6 +21,7 @@ const sourceRoots = [
   path.resolve(repoRoot, 'src/components'),
   path.resolve(repoRoot, 'src/molecules'),
   path.resolve(repoRoot, 'frappe'),
+  path.resolve(repoRoot, 'experimental'),
 ]
 
 // frappe-ui's information architecture. The shared Sidebar is data-driven —
@@ -174,7 +175,10 @@ const config = defineDocsConfig({
     '@utils': path.resolve(repoRoot, 'src/utils'),
     '@composables': path.resolve(repoRoot, 'src/composables'),
     'frappe-ui/editor': path.resolve(repoRoot, 'src/molecules/editor'),
-    'frappe-ui/code-editor': path.resolve(repoRoot, 'src/components/CodeEditor'),
+    'frappe-ui/code-editor': path.resolve(
+      repoRoot,
+      'src/components/CodeEditor',
+    ),
     'frappe-ui': path.resolve(repoRoot, 'src'),
     'dayjs/esm': 'dayjs',
   },

--- a/docs/content/docs/experimental.md
+++ b/docs/content/docs/experimental.md
@@ -69,7 +69,7 @@ const loading = ref(false)
 
 const search = debounce(async (query: string) => {
   loading.value = true
-  options.value = await fetchUsers(query) // → [{ label, value, image? }]
+  options.value = await fetchUsers(query) // → [{ label, value, avatar? }]
   loading.value = false
 }, 250)
 </script>
@@ -95,15 +95,17 @@ frappe-ui form field.
 
 ### Suggestions with avatars
 
-Give each option an `image` and it renders an `Avatar` on the dropdown row and
-on the chip once that person has been seen. Override the row with the
-`#option-prefix` / `#option-label` slots, or replace a chip entirely with
-`#tag`:
+Every suggestion row and chip always renders an `Avatar` — the option's `avatar`
+image when present, otherwise initials from its `label`. (The field is named
+`avatar`, not the house `icon`, because this control is person-centric: the
+leading visual is always a face or initials.) Override the row with the
+`#item-prefix` / `#item-label` / `#item-suffix` slots, or replace a chip
+entirely with `#tag`:
 
 ```vue
 <MultiEmailInput v-model="emails" :options="options">
   <template #tag="{ value, option, removeTag }">
-    <Avatar v-if="option?.image" :image="option.image" size="xs" />
+    <Avatar :image="option?.avatar" :label="option?.label ?? value" size="xs" />
     <span>{{ option?.label ?? value }}</span>
     <button :aria-label="`Remove ${value}`" @click="removeTag">✕</button>
   </template>

--- a/docs/content/docs/experimental.md
+++ b/docs/content/docs/experimental.md
@@ -1,25 +1,140 @@
 # Experimental
 
 The `frappe-ui/experimental` subpath exposes internal building blocks —
-composables, class helpers, components and headless logic — that are not part of the
-public API.
+composables, class helpers, components and headless logic — that are not part of
+the public API.
 
 Think of it as a staging area: exports live here while their API settles. Over
 time, some of them get promoted to the public API and others get removed.
 
 > **Unstable API** — everything exported from `frappe-ui/experimental` is exempt
 > from the usual deprecation policy and can change shape or disappear in _any_
-> release, including minor and patch releases, with no deprecation window.
-> Do **not** import this subpath from product apps or third-party code — pin
-> to a public entry point instead.
+> release, including minor and patch releases, with no deprecation window. Do
+> **not** import this subpath from product apps or third-party code — pin to a
+> public entry point instead.
+
+## MultiEmailInput
+
+A multi-value email field: selected addresses render as removable chips, and a
+typeahead dropdown suggests existing people as you type. Built on reka-ui's
+`TagsInput` + `Combobox`, so chip keyboard navigation (Delete / Backspace /
+Arrow / Home / End) and the popover come for free. `v-model` is the array of
+addresses.
+
+As you type, the component emits `update:query` (debounce it in the host) so you
+can fetch matching `options`. Picked suggestions are added as-is; a typed
+address is validated first (a practical email check by default — override with
+`validate`) and surfaced through `invalid` if it fails. Already-selected
+addresses are filtered out of the suggestions automatically.
+
+### Why it isn't a `Combobox` mode
+
+A `multiple` flag on `Combobox` looks like the obvious home for this, but the
+two controls disagree about what the text input fundamentally _is_.
+
+In a `Combobox` the input **is the value**: you type to narrow toward a single
+choice, and the field then displays that choice. Typing edits the selection,
+Backspace edits the search, and Enter commits _and closes_ — you are done
+choosing. The model is one value, and the options are authoritative: they define
+what is selectable, with free text as a deliberate exception.
+
+`MultiEmailInput` inverts all of it. The input is a **throwaway staging area**
+for the next address; committed values live beside it as independent,
+individually-removable chips. Typing builds a token instead of a selection,
+Backspace deletes a chip instead of a query, and Enter commits _and keeps going_
+— you are assembling a set, not picking one member of it. Its options are merely
+advisory: an email address space is open by nature, so the free-text token is
+the centre of gravity and suggestions are assistance layered on top — the
+reverse of a picker, where the list is the truth.
+
+Those are two different interaction grammars — single-choice _resolution_ versus
+set _composition_ — over two different data shapes (`string | null` versus
+`string[]`). Collapsing them into one component would force `Combobox` to carry
+both selection models, both keyboard grammars, and both commit semantics,
+leaving every prop quietly ambiguous about which mode it governs. reka-ui
+already draws this line: `Combobox` and `TagsInput` are separate primitives, and
+`MultiEmailInput` is their _composition_, not a fork of either. Keeping it
+distinct is what lets each one stay a single, legible idea.
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { debounce } from 'frappe-ui'
+import { MultiEmailInput } from 'frappe-ui/experimental'
+import type { MultiEmailOption } from 'frappe-ui/experimental'
+
+const emails = ref<string[]>([])
+const options = ref<MultiEmailOption[]>([])
+const loading = ref(false)
+
+const search = debounce(async (query: string) => {
+  loading.value = true
+  options.value = await fetchUsers(query) // → [{ label, value, image? }]
+  loading.value = false
+}, 250)
+</script>
+
+<template>
+  <MultiEmailInput
+    v-model="emails"
+    :options="options"
+    :loading="loading"
+    label="Invite by email"
+    description="Pick existing users, or type a new address and press Enter."
+    @update:query="search"
+    @invalid="(email) => console.warn('rejected', email)"
+  />
+</template>
+```
+
+It plugs into [`useInputLabeling`](#useinputlabeling), so `label`,
+`description`, `error`, and `required` behave (and look) like every other
+frappe-ui form field.
+
+<ComponentPreview name="MultiEmailInput-AsyncSuggestions" csr="true" />
+
+### Suggestions with avatars
+
+Give each option an `image` and it renders an `Avatar` on the dropdown row and
+on the chip once that person has been seen. Override the row with the
+`#option-prefix` / `#option-label` slots, or replace a chip entirely with
+`#tag`:
+
+```vue
+<MultiEmailInput v-model="emails" :options="options">
+  <template #tag="{ value, option, removeTag }">
+    <Avatar v-if="option?.image" :image="option.image" size="xs" />
+    <span>{{ option?.label ?? value }}</span>
+    <button :aria-label="`Remove ${value}`" @click="removeTag">✕</button>
+  </template>
+</MultiEmailInput>
+```
+
+<ComponentPreview name="MultiEmailInput-CustomChip" csr="true" />
+
+### Validation and custom create label
+
+```vue
+<MultiEmailInput
+  v-model="emails"
+  :validate="(v) => v.endsWith('@acme.com')"
+  :create-label="(v) => `Invite ${v}`"
+/>
+```
+
+### Label, description, error
+
+`label`, `description`, `error`, and `required` render exactly like the other
+form fields (this example shows a required error until a recipient is added).
+
+<ComponentPreview name="MultiEmailInput-Labeling" csr="true" />
 
 ## useInputLabeling
 
-Shared headless logic for input components: it wires up the label,
-description, and error region of a form control, and computes the matching
-ARIA and `data-*` attributes. All frappe-ui input components use it
-internally, so a custom control built with it gets the same behavior and
-styling hooks for free.
+Shared headless logic for input components: it wires up the label, description,
+and error region of a form control, and computes the matching ARIA and `data-*`
+attributes. All frappe-ui input components use it internally, so a custom
+control built with it gets the same behavior and styling hooks for free.
 
 ```ts
 import { useInputLabeling } from 'frappe-ui/experimental'
@@ -32,8 +147,8 @@ const { inputId, labelledBy, describedBy, hasError, errorLines, dataAttrs } =
 
 The presentational counterparts of `useInputLabeling`: small components that
 render the label, description, and error region of a form control. frappe-ui
-input components compose them internally; a custom control can use them with
-the ids returned by `useInputLabeling` to get matching markup and styling.
+input components compose them internally; a custom control can use them with the
+ids returned by `useInputLabeling` to get matching markup and styling.
 
 ```vue
 <script setup lang="ts">
@@ -78,8 +193,8 @@ const {
 
 ### InputLabel
 
-Renders a `<label>` linked to the input via `forId`, with a required marker
-(a red `*` plus screen-reader-only "(required)" text) when `required` is set.
+Renders a `<label>` linked to the input via `forId`, with a required marker (a
+red `*` plus screen-reader-only "(required)" text) when `required` is set.
 Renders nothing when there is no label text or slot content. The default slot
 replaces the label text and receives `required` as a slot prop.
 
@@ -97,16 +212,16 @@ empty.
 
 ### LabelingWrapper
 
-Conditionally wraps its slot content in a `<div>` (with optional
-`wrapperClass` / `wrapperStyle`) when `enabled` is true, and renders the slot
-as-is otherwise. Lets a control add a labeling wrapper element only when it
-actually renders a label, description, or error.
+Conditionally wraps its slot content in a `<div>` (with optional `wrapperClass`
+/ `wrapperStyle`) when `enabled` is true, and renders the slot as-is otherwise.
+Lets a control add a labeling wrapper element only when it actually renders a
+label, description, or error.
 
 ## inputFontSizeClasses
 
-Returns the Tailwind font-size class frappe-ui input components use for a
-given size token (`'sm' | 'md' | 'lg' | 'xl'`), so custom controls render text
-at the same scale as built-in ones.
+Returns the Tailwind font-size class frappe-ui input components use for a given
+size token (`'sm' | 'md' | 'lg' | 'xl'`), so custom controls render text at the
+same scale as built-in ones.
 
 ```ts
 import { inputFontSizeClasses } from 'frappe-ui/experimental'

--- a/experimental.ts
+++ b/experimental.ts
@@ -1,6 +1,7 @@
 // frappe-ui experimental — UNSTABLE. No backward-compatibility promise.
 
 export * from './experimental/FloatingWindow'
+export * from './experimental/MultiEmailInput'
 export { inputFontSizeClasses } from './src/components/Combobox/utils'
 export {
   InputLabel,

--- a/experimental/MultiEmailInput/MultiEmailInput.cy.ts
+++ b/experimental/MultiEmailInput/MultiEmailInput.cy.ts
@@ -1,0 +1,168 @@
+import { defineComponent, h, ref } from 'vue'
+import MultiEmailInput from './MultiEmailInput.vue'
+import type { MultiEmailOption } from './types'
+
+const members: MultiEmailOption[] = [
+  { label: 'Ada Lovelace', value: 'ada@example.com' },
+  { label: 'Grace Hopper', value: 'grace@example.com' },
+]
+
+// A controlled host that surfaces the bound model + the last invalid email as
+// text, so v-model sync and the `invalid` event are observable.
+function host(
+  options: {
+    initial?: string[]
+    suggestions?: MultiEmailOption[]
+    label?: string
+    required?: boolean
+    error?: string
+    disabled?: boolean
+  } = {},
+) {
+  return defineComponent({
+    setup() {
+      const model = ref<string[]>(options.initial ?? [])
+      const invalid = ref('')
+      const added = ref<string[]>([])
+      const removed = ref<string[]>([])
+      // Mutate the model the way a parent would (not via the component's UI),
+      // to prove add/remove only fire for user actions.
+      const setProgrammatically = () => (model.value = ['grace@example.com'])
+      return { model, invalid, added, removed, setProgrammatically }
+    },
+    render() {
+      return [
+        h('span', { 'data-cy': 'model' }, this.model.join(',')),
+        h('span', { 'data-cy': 'invalid' }, this.invalid),
+        h('span', { 'data-cy': 'added' }, this.added.join(',')),
+        h('span', { 'data-cy': 'removed' }, this.removed.join(',')),
+        h(
+          'button',
+          { 'data-cy': 'set-prog', onClick: this.setProgrammatically },
+          'set',
+        ),
+        h(MultiEmailInput, {
+          modelValue: this.model,
+          'onUpdate:modelValue': (v: string[]) => (this.model = v),
+          onInvalid: (v: string) => (this.invalid = v),
+          onAdd: (v: string) => this.added.push(v),
+          onRemove: (v: string) => this.removed.push(v),
+          options: options.suggestions ?? members,
+          label: options.label,
+          required: options.required,
+          error: options.error,
+          disabled: options.disabled,
+          placeholder: 'Add email…',
+        }),
+      ]
+    },
+  })
+}
+
+describe('MultiEmailInput', () => {
+  it('renders the control and placeholder', () => {
+    cy.mount(host())
+    cy.get('[data-slot="control"]').should('exist')
+    cy.get('[data-slot="input"]')
+      .should('exist')
+      .and('have.attr', 'placeholder', 'Add email…')
+  })
+
+  it('forwards `id` and associates the label', () => {
+    cy.mount(host({ label: 'Invite by email', required: true }))
+    cy.get('label').should('contain.text', 'Invite by email')
+    cy.get('[data-slot="input"]')
+      .invoke('attr', 'id')
+      .then((id) => {
+        cy.get('label').should('have.attr', 'for', id)
+      })
+  })
+
+  it('picks a suggestion into a chip and syncs v-model', () => {
+    cy.mount(host())
+    cy.get('[data-slot="input"]').focus()
+    cy.get('[data-slot="item"]').contains('Ada Lovelace').click()
+    cy.get('[data-slot="tag"]').should('have.length', 1)
+    cy.get('[data-cy="model"]').should('have.text', 'ada@example.com')
+  })
+
+  it('commits a typed new address on Enter via the create row', () => {
+    cy.mount(host({ suggestions: [] }))
+    cy.get('[data-slot="input"]').type('new@person.com')
+    cy.get('[data-create="true"]').should('contain.text', 'new@person.com')
+    cy.get('[data-slot="input"]').type('{enter}')
+    cy.get('[data-cy="model"]').should('have.text', 'new@person.com')
+    cy.get('[data-slot="tag"]').should('have.length', 1)
+  })
+
+  it('commits the typed address on Enter even while suggestions are showing', () => {
+    // A valid, new address typed while the suggestion list is non-empty: Enter
+    // must add what was typed (create row is highlighted), not a suggestion.
+    cy.mount(host())
+    cy.get('[data-slot="input"]').type('new@person.com')
+    cy.get('[data-slot="item"]').should('have.length.greaterThan', 1)
+    cy.get('[data-slot="input"]').type('{enter}')
+    cy.get('[data-cy="model"]').should('have.text', 'new@person.com')
+    cy.get('[data-cy="added"]').should('have.text', 'new@person.com')
+  })
+
+  it('fires `add` for a user pick but not for a programmatic model change', () => {
+    cy.mount(host())
+    // Programmatic write: model updates, but no add/remove emitted.
+    cy.get('[data-cy="set-prog"]').click()
+    cy.get('[data-cy="model"]').should('have.text', 'grace@example.com')
+    cy.get('[data-cy="added"]').should('have.text', '')
+    cy.get('[data-cy="removed"]').should('have.text', '')
+    // A genuine user pick still emits add.
+    cy.get('[data-slot="input"]').focus()
+    cy.get('[data-slot="item"]').contains('Ada Lovelace').click()
+    cy.get('[data-cy="added"]').should('have.text', 'ada@example.com')
+  })
+
+  it('applies a host class to the control when there is no labeling', () => {
+    cy.mount({
+      render: () => h(MultiEmailInput, { modelValue: [], class: 'w-full' }),
+    })
+    cy.get('[data-slot="control"]').should('have.class', 'w-full')
+  })
+
+  it('rejects an invalid typed address and adds no chip', () => {
+    cy.mount(host({ suggestions: [] }))
+    cy.get('[data-slot="input"]').type('not-an-email{enter}')
+    cy.get('[data-cy="invalid"]').should('have.text', 'not-an-email')
+    cy.get('[data-slot="tag"]').should('not.exist')
+    cy.get('[data-cy="model"]').should('have.text', '')
+  })
+
+  it('removes a chip via its delete button', () => {
+    cy.mount(host({ initial: ['ada@example.com'] }))
+    cy.get('[data-slot="tag"]').should('have.length', 1)
+    cy.get('[aria-label="Remove ada@example.com"]').click()
+    cy.get('[data-slot="tag"]').should('not.exist')
+    cy.get('[data-cy="model"]').should('have.text', '')
+  })
+
+  it('removes the last chip on Backspace from an empty input', () => {
+    cy.mount(host({ initial: ['ada@example.com', 'grace@example.com'] }))
+    cy.get('[data-slot="input"]').focus().type('{backspace}{backspace}')
+    cy.get('[data-cy="model"]').should('have.text', 'ada@example.com')
+  })
+
+  it('excludes already-selected emails from the suggestions', () => {
+    cy.mount(host({ initial: ['ada@example.com'] }))
+    cy.get('[data-slot="input"]').focus()
+    cy.get('[data-slot="item"]').should('have.length', 1)
+    cy.get('[data-slot="item"]').should('contain.text', 'Grace Hopper')
+  })
+
+  it('renders the error region and marks the input invalid', () => {
+    cy.mount(host({ error: 'Something went wrong' }))
+    cy.get('[data-slot="error"]').should('contain.text', 'Something went wrong')
+    cy.get('[data-slot="input"]').should('have.attr', 'aria-invalid', 'true')
+  })
+
+  it('does not open or accept input when disabled', () => {
+    cy.mount(host({ disabled: true }))
+    cy.get('[data-slot="input"]').should('have.attr', 'disabled')
+  })
+})

--- a/experimental/MultiEmailInput/MultiEmailInput.cy.ts
+++ b/experimental/MultiEmailInput/MultiEmailInput.cy.ts
@@ -23,19 +23,15 @@ function host(
     setup() {
       const model = ref<string[]>(options.initial ?? [])
       const invalid = ref('')
-      const added = ref<string[]>([])
-      const removed = ref<string[]>([])
       // Mutate the model the way a parent would (not via the component's UI),
-      // to prove add/remove only fire for user actions.
+      // to prove a programmatic write syncs without surprising the host.
       const setProgrammatically = () => (model.value = ['grace@example.com'])
-      return { model, invalid, added, removed, setProgrammatically }
+      return { model, invalid, setProgrammatically }
     },
     render() {
       return [
         h('span', { 'data-cy': 'model' }, this.model.join(',')),
         h('span', { 'data-cy': 'invalid' }, this.invalid),
-        h('span', { 'data-cy': 'added' }, this.added.join(',')),
-        h('span', { 'data-cy': 'removed' }, this.removed.join(',')),
         h(
           'button',
           { 'data-cy': 'set-prog', onClick: this.setProgrammatically },
@@ -45,8 +41,6 @@ function host(
           modelValue: this.model,
           'onUpdate:modelValue': (v: string[]) => (this.model = v),
           onInvalid: (v: string) => (this.invalid = v),
-          onAdd: (v: string) => this.added.push(v),
-          onRemove: (v: string) => this.removed.push(v),
           options: options.suggestions ?? members,
           label: options.label,
           required: options.required,
@@ -103,20 +97,13 @@ describe('MultiEmailInput', () => {
     cy.get('[data-slot="item"]').should('have.length.greaterThan', 1)
     cy.get('[data-slot="input"]').type('{enter}')
     cy.get('[data-cy="model"]').should('have.text', 'new@person.com')
-    cy.get('[data-cy="added"]').should('have.text', 'new@person.com')
   })
 
-  it('fires `add` for a user pick but not for a programmatic model change', () => {
+  it('syncs a programmatic model change into chips', () => {
     cy.mount(host())
-    // Programmatic write: model updates, but no add/remove emitted.
     cy.get('[data-cy="set-prog"]').click()
     cy.get('[data-cy="model"]').should('have.text', 'grace@example.com')
-    cy.get('[data-cy="added"]').should('have.text', '')
-    cy.get('[data-cy="removed"]').should('have.text', '')
-    // A genuine user pick still emits add.
-    cy.get('[data-slot="input"]').focus()
-    cy.get('[data-slot="item"]').contains('Ada Lovelace').click()
-    cy.get('[data-cy="added"]').should('have.text', 'ada@example.com')
+    cy.get('[data-slot="tag"]').should('have.length', 1)
   })
 
   it('applies a host class to the control when there is no labeling', () => {

--- a/experimental/MultiEmailInput/MultiEmailInput.vue
+++ b/experimental/MultiEmailInput/MultiEmailInput.vue
@@ -193,37 +193,13 @@ function removeAt(index: number) {
   model.value = next
 }
 
-// add/remove describe user actions, so suppress them for programmatic/external
-// model writes. Every user path (typing + Enter, paste, suggestion click, chip
-// delete, Backspace) is preceded by a DOM event on the control or the dropdown;
-// a parent reassigning the model is not.
-let userActed = false
-function markUserAction() {
-  userActed = true
-  // The model change lands in a microtask flush after this event; clear on a
-  // macrotask so the flag survives that flush but can't outlive the task and
-  // get misattributed to a later programmatic change.
-  setTimeout(() => {
-    userActed = false
-  }, 0)
-}
-
-// Emit add/remove diffs from a single model watcher (covers picks, typed
-// commits, paste, and chip deletes alike), and reset the input after a change.
-let prevModel = model.value.slice()
+// Clear the staging input after any committed change — a pick, a typed commit,
+// a paste, or a chip delete. The model is the single source of truth; a host
+// that wants per-address add/remove diffs `update:modelValue` itself.
 watch(
   model,
-  (cur) => {
-    if (userActed) {
-      userActed = false // consume: one user action emits at most one diff
-      const curLc = selectedSet.value
-      const prevLc = new Set(prevModel.map((v) => v.toLowerCase()))
-      for (const v of cur) if (!prevLc.has(v.toLowerCase())) emit('add', v)
-      for (const v of prevModel)
-        if (!curLc.has(v.toLowerCase())) emit('remove', v)
-      if (query.value) query.value = ''
-    }
-    prevModel = cur.slice()
+  () => {
+    if (query.value) query.value = ''
   },
   { deep: true },
 )
@@ -256,7 +232,6 @@ function onPaste(event: ClipboardEvent) {
   const text = event.clipboardData?.getData('text')
   if (!text || !/[,;\n\r\t]/.test(text)) return // single token → normal typing
   event.preventDefault()
-  markUserAction()
   const seen = new Set(selectedSet.value)
   const additions: string[] = []
   for (const token of splitEmailTokens(text)) {
@@ -279,11 +254,11 @@ function focus() {
   ;(document.getElementById(inputId.value) as HTMLInputElement | null)?.focus()
 }
 
-function clear() {
+function reset() {
   model.value = []
 }
 
-defineExpose<MultiEmailInputExposed>({ focus, clear })
+defineExpose<MultiEmailInputExposed>({ focus, reset })
 defineSlots<MultiEmailInputSlots>()
 </script>
 
@@ -330,8 +305,6 @@ defineSlots<MultiEmailInputSlots>()
           :data-invalid="hasError ? 'true' : undefined"
           :class="[boxClasses, hasLabeling ? null : (attrs.class as any)]"
           :style="hasLabeling ? null : (attrs.style as any)"
-          @keydown.capture="markUserAction"
-          @pointerdown.capture="markUserAction"
         >
           <TagsInputItem
             v-for="chip in chips"
@@ -348,8 +321,7 @@ defineSlots<MultiEmailInputSlots>()
               :remove-tag="() => removeAt(chip.index)"
             >
               <Avatar
-                v-if="chip.option?.image"
-                :image="chip.option?.image"
+                :image="chip.option?.avatar"
                 :label="chip.label"
                 size="xs"
               />
@@ -391,7 +363,6 @@ defineSlots<MultiEmailInputSlots>()
           :side-offset="offset"
           class="z-[100] min-w-[--reka-combobox-trigger-width] overflow-hidden rounded-lg bg-surface-elevation-2 shadow-2xl"
           @open-auto-focus.prevent
-          @pointerdown.capture="markUserAction"
         >
           <ComboboxViewport class="flex max-h-60 flex-col overflow-auto p-1">
             <div
@@ -447,17 +418,16 @@ defineSlots<MultiEmailInputSlots>()
                   :disabled="option.disabled"
                 >
                   <template #prefix>
-                    <slot name="option-prefix" :option="option" :query="query">
+                    <slot name="item-prefix" :item="option" :query="query">
                       <Avatar
-                        v-if="option.image"
-                        :image="option.image"
+                        :image="option.avatar"
                         :label="option.label"
                         :size="rowAvatarSize"
                       />
                     </slot>
                   </template>
                   <template #label>
-                    <slot name="option-label" :option="option" :query="query">
+                    <slot name="item-label" :item="option" :query="query">
                       <div class="min-w-0">
                         <div class="truncate text-ink-gray-8">
                           {{ option.label }}
@@ -470,6 +440,9 @@ defineSlots<MultiEmailInputSlots>()
                         </div>
                       </div>
                     </slot>
+                  </template>
+                  <template v-if="$slots['item-suffix']" #suffix>
+                    <slot name="item-suffix" :item="option" :query="query" />
                   </template>
                 </ItemListRow>
               </ComboboxItem>

--- a/experimental/MultiEmailInput/MultiEmailInput.vue
+++ b/experimental/MultiEmailInput/MultiEmailInput.vue
@@ -1,0 +1,499 @@
+<script setup lang="ts">
+import {
+  computed,
+  nextTick,
+  reactive,
+  ref,
+  useAttrs,
+  useSlots,
+  watch,
+} from 'vue'
+import {
+  ComboboxAnchor,
+  ComboboxContent,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxPortal,
+  ComboboxRoot,
+  ComboboxViewport,
+  TagsInputInput,
+  TagsInputItem,
+  TagsInputItemDelete,
+  TagsInputRoot,
+} from 'reka-ui'
+import Avatar from '../../src/components/Avatar/Avatar.vue'
+import ItemListRow from '../../src/components/ItemListRow/ItemListRow.vue'
+import LoadingIndicator from '../../src/components/LoadingIndicator.vue'
+import {
+  InputDescription,
+  InputError,
+  InputLabel,
+  LabelingWrapper,
+} from '../../src/components/InputLabeling'
+import { useInputLabeling } from '../../src/composables/useInputLabeling'
+import {
+  inputFontSizeClasses,
+  isValidEmail,
+  itemClasses,
+  itemRootSizeClasses,
+  splitEmailTokens,
+  extractEmail,
+  toItemListSize,
+} from './utils'
+import type {
+  MultiEmailInputProps,
+  MultiEmailInputEmits,
+  MultiEmailInputExposed,
+  MultiEmailInputSlots,
+  MultiEmailOption,
+} from './types'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(defineProps<MultiEmailInputProps>(), {
+  options: () => [],
+  loading: false,
+  size: 'sm',
+  placeholder: 'Add email…',
+  emptyText: 'No results',
+  loadingText: 'Loading...',
+  disabled: false,
+  side: 'bottom',
+  align: 'start',
+  offset: 4,
+  portalTo: 'body',
+})
+
+const emit = defineEmits<MultiEmailInputEmits>()
+const slots = useSlots()
+const attrs = useAttrs()
+
+const model = defineModel<string[]>({ default: () => [] })
+
+const query = ref('')
+const open = ref(false)
+const rootRef = ref<{ highlightFirstItem?: () => void } | null>(null)
+
+const {
+  inputId,
+  labelId,
+  descriptionId,
+  errorMessageId,
+  describedBy,
+  hasError,
+  errorLines,
+  showDescription,
+} = useInputLabeling(props, {
+  size: () => props.size,
+  disabled: () => props.disabled,
+})
+
+const hasLabeling = computed(() =>
+  Boolean(
+    props.label ||
+    props.description ||
+    hasError.value ||
+    slots.label ||
+    slots.description,
+  ),
+)
+
+const inputAriaAttrs = computed(() => ({
+  'aria-invalid': hasError.value || undefined,
+  'aria-errormessage': hasError.value ? errorMessageId.value : undefined,
+  'aria-describedby': describedBy.value,
+  'aria-required': props.required || undefined,
+}))
+
+// Stable default arrow so createLabel doesn't allocate a closure per call.
+const defaultCreateLabel = (value: string) => `Add "${value}"`
+const validate = (value: string) => (props.validate ?? isValidEmail)(value)
+const createLabel = (value: string) =>
+  (props.createLabel ?? defaultCreateLabel)(value)
+
+// Remember option metadata (avatar/name) for the addresses currently in the
+// model, so a chip keeps its details even after the suggestion list changes
+// (the host only returns matches for the current query). reactive() so a chip
+// re-renders when its matching option arrives after the chip already exists.
+const seenOptions = reactive(new Map<string, MultiEmailOption>())
+watch(
+  [() => props.options, model],
+  ([options, current]) => {
+    for (const option of options) {
+      seenOptions.set(option.value.toLowerCase(), option)
+    }
+    // Keep only entries referenced by current chips, so the cache can't grow
+    // past the model size across many searches.
+    const keep = new Set(current.map((v) => v.toLowerCase()))
+    for (const key of seenOptions.keys()) {
+      if (!keep.has(key)) seenOptions.delete(key)
+    }
+  },
+  { immediate: true },
+)
+
+function optionFor(value: string): MultiEmailOption | null {
+  return seenOptions.get(value.toLowerCase()) ?? null
+}
+
+const selectedSet = computed(
+  () => new Set(model.value.map((v) => v.toLowerCase())),
+)
+
+// Resolve each chip's option once per render (optionFor does a lowercased Map
+// lookup); the template would otherwise call it ~5x per chip.
+const chips = computed(() =>
+  model.value.map((value, index) => {
+    const option = optionFor(value)
+    return { value, index, option, label: option?.label ?? value }
+  }),
+)
+
+// Suggestions are host-filtered; we only drop anything already selected.
+const suggestions = computed<MultiEmailOption[]>(() =>
+  props.options.filter((o) => !selectedSet.value.has(o.value.toLowerCase())),
+)
+
+// Offer an explicit "create" row when the typed value is a valid, new address.
+const showCreateOption = computed(() => {
+  const q = query.value.trim()
+  if (!q || !validate(q)) return false
+  const lc = q.toLowerCase()
+  if (selectedSet.value.has(lc)) return false
+  return !suggestions.value.some((o) => o.value.toLowerCase() === lc)
+})
+
+const showEmpty = computed(
+  () => !props.loading && !suggestions.value.length && !showCreateOption.value,
+)
+
+const rowAvatarSize = computed(() => (props.size === 'sm' ? 'sm' : 'md'))
+
+const boxClasses = computed(() => [
+  'flex flex-wrap items-center gap-1.5 rounded bg-surface-gray-2 px-1.5 py-1 transition-colors focus-within:ring-2 focus-within:ring-outline-gray-3',
+  inputFontSizeClasses(props.size),
+  props.disabled && 'cursor-not-allowed bg-surface-gray-1',
+])
+
+const chipClasses =
+  'inline-flex items-center gap-1 rounded border border-outline-gray-1 bg-surface-base px-1.5 py-0.5 text-sm text-ink-gray-7 transition-colors data-[disabled]:opacity-60 aria-[current=true]:ring-2 aria-[current=true]:ring-outline-gray-3'
+
+const inputClasses = computed(() => [
+  'min-w-[6rem] flex-1 border-0 bg-transparent p-0.5 text-ink-gray-8 outline-none ring-0 placeholder:text-ink-gray-4 focus:ring-0 disabled:cursor-not-allowed',
+  inputFontSizeClasses(props.size),
+])
+
+function highlightFirst() {
+  rootRef.value?.highlightFirstItem?.()
+}
+
+function removeAt(index: number) {
+  const next = model.value.slice()
+  next.splice(index, 1)
+  model.value = next
+}
+
+// add/remove describe user actions, so suppress them for programmatic/external
+// model writes. Every user path (typing + Enter, paste, suggestion click, chip
+// delete, Backspace) is preceded by a DOM event on the control or the dropdown;
+// a parent reassigning the model is not.
+let userActed = false
+function markUserAction() {
+  userActed = true
+  // The model change lands in a microtask flush after this event; clear on a
+  // macrotask so the flag survives that flush but can't outlive the task and
+  // get misattributed to a later programmatic change.
+  setTimeout(() => {
+    userActed = false
+  }, 0)
+}
+
+// Emit add/remove diffs from a single model watcher (covers picks, typed
+// commits, paste, and chip deletes alike), and reset the input after a change.
+let prevModel = model.value.slice()
+watch(
+  model,
+  (cur) => {
+    if (userActed) {
+      userActed = false // consume: one user action emits at most one diff
+      const curLc = selectedSet.value
+      const prevLc = new Set(prevModel.map((v) => v.toLowerCase()))
+      for (const v of cur) if (!prevLc.has(v.toLowerCase())) emit('add', v)
+      for (const v of prevModel)
+        if (!curLc.has(v.toLowerCase())) emit('remove', v)
+      if (query.value) query.value = ''
+    }
+    prevModel = cur.slice()
+  },
+  { deep: true },
+)
+
+watch(query, (q) => {
+  emit('update:query', q)
+  if (q && !props.disabled) open.value = true
+  nextTick(highlightFirst)
+})
+
+function onFocus(event: FocusEvent) {
+  emit('focus', event)
+  if (props.disabled) return
+  open.value = true
+  // prime suggestions on first focus when the host hasn't fetched anything yet
+  if (!props.options.length && !query.value) emit('update:query', '')
+}
+
+function onEnter() {
+  const q = query.value.trim()
+  if (!q) return
+  // Valid addresses and matching suggestions are committed by Combobox selecting
+  // the highlighted row (the create row's value IS the typed address). Only when
+  // nothing is selectable do we surface invalid feedback.
+  if (validate(q) || suggestions.value.length) return
+  emit('invalid', q)
+}
+
+function onPaste(event: ClipboardEvent) {
+  const text = event.clipboardData?.getData('text')
+  if (!text || !/[,;\n\r\t]/.test(text)) return // single token → normal typing
+  event.preventDefault()
+  markUserAction()
+  const seen = new Set(selectedSet.value)
+  const additions: string[] = []
+  for (const token of splitEmailTokens(text)) {
+    const email = extractEmail(token)
+    if (!email) continue
+    if (!validate(email)) {
+      emit('invalid', email)
+      continue
+    }
+    const lc = email.toLowerCase()
+    if (seen.has(lc)) continue
+    seen.add(lc)
+    additions.push(email)
+  }
+  if (additions.length) model.value = [...model.value, ...additions]
+  query.value = ''
+}
+
+function focus() {
+  ;(document.getElementById(inputId.value) as HTMLInputElement | null)?.focus()
+}
+
+function clear() {
+  model.value = []
+}
+
+defineExpose<MultiEmailInputExposed>({ focus, clear })
+defineSlots<MultiEmailInputSlots>()
+</script>
+
+<template>
+  <LabelingWrapper
+    :enabled="hasLabeling"
+    :wrapper-class="['space-y-1.5', attrs.class as any]"
+    :wrapper-style="attrs.style as any"
+  >
+    <InputLabel
+      v-if="label || $slots.label"
+      :id="labelId"
+      :for-id="inputId"
+      :label="label"
+      :required="required"
+      class="text-p-sm-medium text-ink-gray-7"
+    >
+      <template v-if="$slots.label" #default="slotProps">
+        <slot name="label" v-bind="slotProps" />
+      </template>
+    </InputLabel>
+
+    <ComboboxRoot
+      ref="rootRef"
+      v-model="model"
+      multiple
+      ignore-filter
+      :open="open"
+      :disabled="disabled"
+      class="relative"
+      @update:open="open = $event"
+    >
+      <ComboboxAnchor as-child>
+        <TagsInputRoot
+          v-model="model"
+          :disabled="disabled"
+          delimiter=""
+          :add-on-paste="false"
+          :add-on-tab="false"
+          :add-on-blur="false"
+          data-slot="control"
+          :data-size="size"
+          :data-disabled="disabled ? '' : undefined"
+          :data-invalid="hasError ? 'true' : undefined"
+          :class="[boxClasses, hasLabeling ? null : (attrs.class as any)]"
+          :style="hasLabeling ? null : (attrs.style as any)"
+          @keydown.capture="markUserAction"
+          @pointerdown.capture="markUserAction"
+        >
+          <TagsInputItem
+            v-for="chip in chips"
+            :key="chip.value"
+            :value="chip.value"
+            data-slot="tag"
+            :class="chipClasses"
+          >
+            <slot
+              name="tag"
+              :value="chip.value"
+              :option="chip.option"
+              :index="chip.index"
+              :remove-tag="() => removeAt(chip.index)"
+            >
+              <Avatar
+                v-if="chip.option?.image"
+                :image="chip.option?.image"
+                :label="chip.label"
+                size="xs"
+              />
+              <span class="truncate">{{ chip.label }}</span>
+              <TagsInputItemDelete
+                :aria-label="`Remove ${chip.value}`"
+                class="-mr-0.5 inline-flex items-center justify-center rounded-sm p-0.5 text-ink-gray-5 opacity-70 transition hover:text-ink-gray-7 hover:opacity-100"
+              >
+                <span class="lucide-x size-3" />
+              </TagsInputItemDelete>
+            </slot>
+          </TagsInputItem>
+
+          <ComboboxInput v-model="query" as-child>
+            <TagsInputInput
+              :id="inputId"
+              data-slot="input"
+              autocomplete="off"
+              :placeholder="model.length ? '' : placeholder"
+              :disabled="disabled"
+              :class="inputClasses"
+              v-bind="inputAriaAttrs"
+              @keydown.enter.prevent="onEnter"
+              @paste="onPaste"
+              @focus="onFocus"
+              @blur="emit('blur', $event)"
+            />
+          </ComboboxInput>
+        </TagsInputRoot>
+      </ComboboxAnchor>
+
+      <ComboboxPortal :to="portalTo">
+        <ComboboxContent
+          data-slot="content"
+          :data-size="size"
+          position="popper"
+          :side="side"
+          :align="align"
+          :side-offset="offset"
+          class="z-[100] min-w-[--reka-combobox-trigger-width] overflow-hidden rounded-lg bg-surface-elevation-2 shadow-2xl"
+          @open-auto-focus.prevent
+          @pointerdown.capture="markUserAction"
+        >
+          <ComboboxViewport class="flex max-h-60 flex-col overflow-auto p-1">
+            <div
+              v-if="loading"
+              data-slot="loading"
+              class="flex items-center gap-2 px-2 py-1.5 text-base text-ink-gray-5"
+            >
+              <LoadingIndicator class="size-4" />
+              <span>{{ loadingText }}</span>
+            </div>
+
+            <template v-else>
+              <!-- Rendered before suggestions so a valid typed address is the
+                   highlighted row, and Enter commits what the user typed. -->
+              <ComboboxItem
+                v-if="showCreateOption"
+                :value="query.trim()"
+                data-slot="item"
+                data-create="true"
+                :data-size="size"
+                :text-value="query.trim()"
+                :class="[itemClasses, itemRootSizeClasses(size)]"
+              >
+                <ItemListRow :size="toItemListSize(size)">
+                  <template #prefix>
+                    <span
+                      class="grid size-7 place-items-center text-ink-gray-5"
+                      aria-hidden="true"
+                    >
+                      <span class="lucide-mail size-4" />
+                    </span>
+                  </template>
+                  <template #label>
+                    <div class="min-w-0 truncate text-ink-gray-8">
+                      {{ createLabel(query.trim()) }}
+                    </div>
+                  </template>
+                </ItemListRow>
+              </ComboboxItem>
+
+              <ComboboxItem
+                v-for="option in suggestions"
+                :key="option.value"
+                :value="option.value"
+                :disabled="option.disabled"
+                :text-value="`${option.label} ${option.value}`"
+                data-slot="item"
+                :data-size="size"
+                :class="[itemClasses, itemRootSizeClasses(size)]"
+              >
+                <ItemListRow
+                  :size="toItemListSize(size)"
+                  :disabled="option.disabled"
+                >
+                  <template #prefix>
+                    <slot name="option-prefix" :option="option" :query="query">
+                      <Avatar
+                        v-if="option.image"
+                        :image="option.image"
+                        :label="option.label"
+                        :size="rowAvatarSize"
+                      />
+                    </slot>
+                  </template>
+                  <template #label>
+                    <slot name="option-label" :option="option" :query="query">
+                      <div class="min-w-0">
+                        <div class="truncate text-ink-gray-8">
+                          {{ option.label }}
+                        </div>
+                        <div
+                          v-if="option.label !== option.value"
+                          class="truncate text-p-sm text-ink-gray-5"
+                        >
+                          {{ option.value }}
+                        </div>
+                      </div>
+                    </slot>
+                  </template>
+                </ItemListRow>
+              </ComboboxItem>
+
+              <div
+                v-if="showEmpty"
+                data-slot="empty"
+                class="px-2 py-1.5 text-base text-ink-gray-5"
+              >
+                <slot name="empty" :query="query">{{ emptyText }}</slot>
+              </div>
+            </template>
+          </ComboboxViewport>
+        </ComboboxContent>
+      </ComboboxPortal>
+    </ComboboxRoot>
+
+    <InputDescription
+      v-if="showDescription || $slots.description"
+      :id="descriptionId"
+      :description="description"
+    >
+      <slot v-if="$slots.description" name="description" />
+    </InputDescription>
+    <InputError v-if="hasError" :id="errorMessageId" :lines="errorLines" />
+  </LabelingWrapper>
+</template>

--- a/experimental/MultiEmailInput/MultiEmailInput.vue
+++ b/experimental/MultiEmailInput/MultiEmailInput.vue
@@ -393,7 +393,7 @@ defineSlots<MultiEmailInputSlots>()
           @open-auto-focus.prevent
           @pointerdown.capture="markUserAction"
         >
-          <ComboboxViewport class="flex max-h-60 flex-col overflow-auto p-1">
+          <ComboboxViewport class="max-h-60 overflow-auto p-1">
             <div
               v-if="loading"
               data-slot="loading"

--- a/experimental/MultiEmailInput/index.ts
+++ b/experimental/MultiEmailInput/index.ts
@@ -1,0 +1,17 @@
+export { default as MultiEmailInput } from './MultiEmailInput.vue'
+export {
+  isValidEmail,
+  emailRegex,
+  splitEmailTokens,
+  extractEmail,
+} from './utils'
+export type {
+  MultiEmailInputProps,
+  MultiEmailInputEmits,
+  MultiEmailInputSlots,
+  MultiEmailInputExposed,
+  MultiEmailInputSize,
+  MultiEmailOption,
+  MultiEmailTagSlotProps,
+  MultiEmailOptionSlotProps,
+} from './types'

--- a/experimental/MultiEmailInput/index.ts
+++ b/experimental/MultiEmailInput/index.ts
@@ -13,5 +13,5 @@ export type {
   MultiEmailInputSize,
   MultiEmailOption,
   MultiEmailTagSlotProps,
-  MultiEmailOptionSlotProps,
+  MultiEmailItemSlotProps,
 } from './types'

--- a/experimental/MultiEmailInput/stories/AsyncSuggestions.vue
+++ b/experimental/MultiEmailInput/stories/AsyncSuggestions.vue
@@ -7,12 +7,12 @@ const directory: MultiEmailOption[] = [
   {
     label: 'Ada Lovelace',
     value: 'ada@example.com',
-    image: 'https://i.pravatar.cc/80?u=ada@example.com',
+    avatar: 'https://i.pravatar.cc/80?u=ada@example.com',
   },
   {
     label: 'Grace Hopper',
     value: 'grace@example.com',
-    image: 'https://i.pravatar.cc/80?u=grace@example.com',
+    avatar: 'https://i.pravatar.cc/80?u=grace@example.com',
   },
   { label: 'Alan Turing', value: 'alan@example.com' },
 ]

--- a/experimental/MultiEmailInput/stories/AsyncSuggestions.vue
+++ b/experimental/MultiEmailInput/stories/AsyncSuggestions.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { MultiEmailInput } from '..'
+import type { MultiEmailOption } from '..'
+
+const directory: MultiEmailOption[] = [
+  {
+    label: 'Ada Lovelace',
+    value: 'ada@example.com',
+    image: 'https://i.pravatar.cc/80?u=ada@example.com',
+  },
+  {
+    label: 'Grace Hopper',
+    value: 'grace@example.com',
+    image: 'https://i.pravatar.cc/80?u=grace@example.com',
+  },
+  { label: 'Alan Turing', value: 'alan@example.com' },
+]
+
+const emails = ref<string[]>([])
+const options = ref<MultiEmailOption[]>([])
+const loading = ref(false)
+
+let timer: ReturnType<typeof setTimeout> | undefined
+function search(query: string) {
+  clearTimeout(timer)
+  loading.value = true
+  timer = setTimeout(() => {
+    const q = query.trim().toLowerCase()
+    options.value = q
+      ? directory.filter(
+          (o) =>
+            o.label.toLowerCase().includes(q) ||
+            o.value.toLowerCase().includes(q),
+        )
+      : directory
+    loading.value = false
+  }, 300)
+}
+</script>
+
+<template>
+  <div class="max-w-md">
+    <!-- Avatars render on the rows and the chips; typing a new address shows an
+         "Add …" row. -->
+    <MultiEmailInput
+      v-model="emails"
+      :options="options"
+      :loading="loading"
+      placeholder="Search people or type an email…"
+      @update:query="search"
+    />
+  </div>
+</template>

--- a/experimental/MultiEmailInput/stories/Basic.vue
+++ b/experimental/MultiEmailInput/stories/Basic.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { MultiEmailInput } from '..'
+
+const emails = ref<string[]>(['ada@example.com'])
+const options = [
+  { label: 'Ada Lovelace', value: 'ada@example.com' },
+  { label: 'Grace Hopper', value: 'grace@example.com' },
+  { label: 'Alan Turing', value: 'alan@example.com' },
+]
+</script>
+
+<template>
+  <div class="max-w-md">
+    <MultiEmailInput v-model="emails" :options="options" />
+    <p class="mt-2 text-p-sm text-ink-gray-5">{{ emails.join(', ') }}</p>
+  </div>
+</template>

--- a/experimental/MultiEmailInput/stories/CustomChip.vue
+++ b/experimental/MultiEmailInput/stories/CustomChip.vue
@@ -8,7 +8,7 @@ const options = [
   {
     label: 'Ada Lovelace',
     value: 'ada@example.com',
-    image: 'https://i.pravatar.cc/80?u=ada@example.com',
+    avatar: 'https://i.pravatar.cc/80?u=ada@example.com',
   },
   { label: 'Grace Hopper', value: 'grace@example.com' },
 ]
@@ -20,8 +20,7 @@ const options = [
     <MultiEmailInput v-model="emails" :options="options">
       <template #tag="{ value, option, removeTag }">
         <Avatar
-          v-if="option?.image"
-          :image="option.image"
+          :image="option?.avatar"
           :label="option?.label ?? value"
           size="xs"
         />

--- a/experimental/MultiEmailInput/stories/CustomChip.vue
+++ b/experimental/MultiEmailInput/stories/CustomChip.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import Avatar from '../../../src/components/Avatar/Avatar.vue'
+import { MultiEmailInput } from '..'
+
+const emails = ref<string[]>(['ada@example.com'])
+const options = [
+  {
+    label: 'Ada Lovelace',
+    value: 'ada@example.com',
+    image: 'https://i.pravatar.cc/80?u=ada@example.com',
+  },
+  { label: 'Grace Hopper', value: 'grace@example.com' },
+]
+</script>
+
+<template>
+  <div class="max-w-md">
+    <!-- The #tag slot fully replaces a chip's inner content. -->
+    <MultiEmailInput v-model="emails" :options="options">
+      <template #tag="{ value, option, removeTag }">
+        <Avatar
+          v-if="option?.image"
+          :image="option.image"
+          :label="option?.label ?? value"
+          size="xs"
+        />
+        <span class="truncate">{{ option?.label ?? value }}</span>
+        <button
+          type="button"
+          :aria-label="`Remove ${value}`"
+          class="-mr-0.5 grid size-4 place-items-center rounded-sm text-ink-gray-5 hover:text-ink-gray-7"
+          @click="removeTag"
+        >
+          <span class="lucide-x size-3" />
+        </button>
+      </template>
+    </MultiEmailInput>
+  </div>
+</template>

--- a/experimental/MultiEmailInput/stories/Labeling.vue
+++ b/experimental/MultiEmailInput/stories/Labeling.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { MultiEmailInput } from '..'
+
+const emails = ref<string[]>([])
+const options = [
+  { label: 'Ada Lovelace', value: 'ada@example.com' },
+  { label: 'Grace Hopper', value: 'grace@example.com' },
+]
+
+// Surface a required-field error until at least one address is added.
+const error = computed(() =>
+  emails.value.length ? '' : 'Add at least one recipient.',
+)
+</script>
+
+<template>
+  <div class="max-w-md">
+    <MultiEmailInput
+      v-model="emails"
+      :options="options"
+      label="Invite by email"
+      description="Pick existing users, or type a new address and press Enter."
+      :required="true"
+      :error="error"
+    />
+  </div>
+</template>

--- a/experimental/MultiEmailInput/types.ts
+++ b/experimental/MultiEmailInput/types.ts
@@ -1,0 +1,134 @@
+import type { InputLabelingProps } from '../../src/composables/useInputLabeling'
+import type {
+  PopoverSide,
+  PopoverAlign,
+} from '../../src/components/Popover/types'
+import type { SelectionSize } from '../../src/components/shared/selection/utils'
+
+/** Sizes for the control and option rows (shared with the selection inputs). */
+export type MultiEmailInputSize = SelectionSize
+
+/** A suggestion shown in the dropdown. `value` is the email address. */
+export interface MultiEmailOption {
+  /** Display name; falls back to `value`. */
+  label: string
+  /** The email address — used as the chip value and the model entry. */
+  value: string
+  /** Avatar image URL; renders an `Avatar` on the row (and the chip when known). */
+  image?: string
+  /** Disables selecting this row. */
+  disabled?: boolean
+  [key: string]: any
+}
+
+export interface MultiEmailTagSlotProps {
+  /** The chip's email value. */
+  value: string
+  /** The matched suggestion for this email, if one has been seen. */
+  option: MultiEmailOption | null
+  /** Index of the chip in the model. */
+  index: number
+  /** Removes this chip from the model. */
+  removeTag: () => void
+}
+
+export interface MultiEmailOptionSlotProps {
+  /** The suggestion currently being rendered. */
+  option: MultiEmailOption
+  /** Current input query. */
+  query: string
+}
+
+export interface MultiEmailInputProps extends InputLabelingProps {
+  /**
+   * Suggestions rendered in the dropdown. The host fetches these in response to
+   * `update:query` (already-selected entries are filtered out automatically).
+   */
+  options?: MultiEmailOption[]
+
+  /** Replaces the results with a loading state. */
+  loading?: boolean
+
+  /** Size of the control and option rows. */
+  size?: MultiEmailInputSize
+
+  /** Placeholder shown when there are no chips. */
+  placeholder?: string
+
+  /** Empty-state copy shown when there are no suggestions. */
+  emptyText?: string
+
+  /** Shown beside the spinner while `loading`. */
+  loadingText?: string
+
+  /** Disables the control. */
+  disabled?: boolean
+
+  /** Validator for typed addresses. Defaults to a practical email check. */
+  validate?: (value: string) => boolean
+
+  /** Builds the "create" row label for a typed address. */
+  createLabel?: (value: string) => string
+
+  /** Preferred popover side. */
+  side?: PopoverSide
+
+  /** Preferred popover alignment. */
+  align?: PopoverAlign
+
+  /** Gap between control and content. */
+  offset?: number
+
+  /** Teleport target for the popover content. */
+  portalTo?: string | HTMLElement
+}
+
+export interface MultiEmailInputEmits {
+  /** Fired when the model changes. */
+  'update:modelValue': [value: string[]]
+
+  /** Fired when the input query changes (debounce in the host). */
+  'update:query': [value: string]
+
+  /** A valid address was added (picked or typed). */
+  add: [value: string]
+
+  /** An address chip was removed. */
+  remove: [value: string]
+
+  /** A typed address failed validation. */
+  invalid: [value: string]
+
+  /** The input received focus. */
+  focus: [event: FocusEvent]
+
+  /** The input lost focus. */
+  blur: [event: FocusEvent]
+}
+
+export interface MultiEmailInputSlots {
+  /** Overrides the rendered label content. Receives `{ required }`. */
+  label?: (props: { required: boolean }) => any
+
+  /** Overrides the rendered description content. */
+  description?: () => any
+
+  /** Replaces a chip's inner content (avatar + text + remove button). */
+  tag?: (props: MultiEmailTagSlotProps) => any
+
+  /** Replaces the prefix (avatar) region of a suggestion row. */
+  'option-prefix'?: (props: MultiEmailOptionSlotProps) => any
+
+  /** Replaces the label region of a suggestion row. */
+  'option-label'?: (props: MultiEmailOptionSlotProps) => any
+
+  /** Fallback content rendered when there are no suggestions. */
+  empty?: (props: { query: string }) => any
+}
+
+export interface MultiEmailInputExposed {
+  /** Focuses the text input. */
+  focus: () => void
+  /** Clears all chips. */
+  clear: () => void
+}

--- a/experimental/MultiEmailInput/types.ts
+++ b/experimental/MultiEmailInput/types.ts
@@ -14,8 +14,14 @@ export interface MultiEmailOption {
   label: string
   /** The email address — used as the chip value and the model entry. */
   value: string
-  /** Avatar image URL; renders an `Avatar` on the row (and the chip when known). */
-  image?: string
+  /**
+   * Avatar image URL. An `Avatar` always renders for a suggestion row and a
+   * chip — with this image when present, otherwise initials from `label`.
+   * Named `avatar` rather than the house `icon` field on purpose: this control
+   * is person-centric, so the leading visual is always a face / initials, never
+   * a generic icon or `Component`.
+   */
+  avatar?: string
   /** Disables selecting this row. */
   disabled?: boolean
   [key: string]: any
@@ -32,9 +38,9 @@ export interface MultiEmailTagSlotProps {
   removeTag: () => void
 }
 
-export interface MultiEmailOptionSlotProps {
+export interface MultiEmailItemSlotProps {
   /** The suggestion currently being rendered. */
-  option: MultiEmailOption
+  item: MultiEmailOption
   /** Current input query. */
   query: string
 }
@@ -84,17 +90,12 @@ export interface MultiEmailInputProps extends InputLabelingProps {
 }
 
 export interface MultiEmailInputEmits {
-  /** Fired when the model changes. */
+  /** Fired when the model changes. Diff against the previous value if you need
+   * per-address add/remove notifications. */
   'update:modelValue': [value: string[]]
 
   /** Fired when the input query changes (debounce in the host). */
   'update:query': [value: string]
-
-  /** A valid address was added (picked or typed). */
-  add: [value: string]
-
-  /** An address chip was removed. */
-  remove: [value: string]
 
   /** A typed address failed validation. */
   invalid: [value: string]
@@ -117,10 +118,13 @@ export interface MultiEmailInputSlots {
   tag?: (props: MultiEmailTagSlotProps) => any
 
   /** Replaces the prefix (avatar) region of a suggestion row. */
-  'option-prefix'?: (props: MultiEmailOptionSlotProps) => any
+  'item-prefix'?: (props: MultiEmailItemSlotProps) => any
 
   /** Replaces the label region of a suggestion row. */
-  'option-label'?: (props: MultiEmailOptionSlotProps) => any
+  'item-label'?: (props: MultiEmailItemSlotProps) => any
+
+  /** Replaces the suffix region of a suggestion row. */
+  'item-suffix'?: (props: MultiEmailItemSlotProps) => any
 
   /** Fallback content rendered when there are no suggestions. */
   empty?: (props: { query: string }) => any
@@ -130,5 +134,5 @@ export interface MultiEmailInputExposed {
   /** Focuses the text input. */
   focus: () => void
   /** Clears all chips. */
-  clear: () => void
+  reset: () => void
 }

--- a/experimental/MultiEmailInput/utils.ts
+++ b/experimental/MultiEmailInput/utils.ts
@@ -1,0 +1,60 @@
+// Row + sizing class helpers shared with the built-in selection components, so
+// MultiEmailInput's dropdown rows match Combobox / MultiSelect exactly.
+export {
+  inputFontSizeClasses,
+  itemClasses,
+  itemRootSizeClasses,
+  toItemListSize,
+} from '../../src/components/shared/selection/utils'
+
+/**
+ * Practical email validation, copied verbatim from Zod v4
+ * (`packages/zod/src/v4/core/regexes.ts`). Rejects a leading dot and consecutive
+ * dots, and requires a dotted domain with a 2+ character TLD. Kept as a flat,
+ * anchored `RegExp` literal so other variants can be added Zod-style later.
+ */
+export const emailRegex: RegExp =
+  /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/
+
+/** Default validator for typed addresses. */
+export function isValidEmail(value: string): boolean {
+  return emailRegex.test(value.trim())
+}
+
+/**
+ * Split a free-text blob into candidate tokens on comma, semicolon, newline and
+ * tab, keeping a quoted display name intact so `"Doe, John" <a@b.com>` (which
+ * contains a comma inside quotes) stays one token. Plain spaces are NOT
+ * separators for that reason — paste a comma/newline-separated list.
+ */
+export function splitEmailTokens(input: string): string[] {
+  const parts: string[] = []
+  let current = ''
+  let inQuotes = false
+  for (const char of input) {
+    if (char === '"') {
+      inQuotes = !inQuotes
+      current += char
+    } else if (
+      (char === ',' ||
+        char === ';' ||
+        char === '\n' ||
+        char === '\r' ||
+        char === '\t') &&
+      !inQuotes
+    ) {
+      if (current.trim()) parts.push(current.trim())
+      current = ''
+    } else {
+      current += char
+    }
+  }
+  if (current.trim()) parts.push(current.trim())
+  return parts
+}
+
+/** Reduce a `Name <email>` token to the bare address. */
+export function extractEmail(token: string): string {
+  const match = token.match(/<([^>]+)>/)
+  return (match ? match[1] : token).trim()
+}


### PR DESCRIPTION
A chip-based email recipient input combining reka-ui's Combobox and TagsInput: type or paste addresses, pick from host-provided async suggestions, and validate against a practical email check. Supports labeling, sizing, custom chip/option slots, and avatars for known contacts.

Behavior notes:
- Enter commits the address the user typed (the create row is highlighted ahead of suggestions), so a stale/partial suggestion list can't capture the keystroke.
- add/remove emit only for user actions (type, paste, pick, delete, Backspace); programmatic v-model writes don't fire them.
- Option metadata is cached reactively and pruned to the current model, so chips keep their avatar/name after the suggestion list changes without the cache growing unbounded.

Includes Cypress component tests, stories, and docs.

https://github.com/user-attachments/assets/4ed64518-1639-4221-a2fb-db9c0c735fc6

ref: https://github.com/orgs/frappe/projects/218/views/1?pane=issue&itemId=195950821

<!-- coverage-report:start -->
Coverage: 58.82% (-0.04% vs `main`)
<!-- coverage-report:end -->


