### PR TITLE
[codex] Polish frappe-ui component behavior and labels

### DIFF
--- a/src/components/Autocomplete/Autocomplete.vue
+++ b/src/components/Autocomplete/Autocomplete.vue
@@ -26,7 +26,7 @@
           }"
         >
           <div class="w-full space-y-1.5">
-            <label v-if="props.label" class="block text-xs text-ink-gray-5">
+            <label v-if="props.label" class="block text-base text-ink-gray-5">
               {{ props.label }}
             </label>
             <button

--- a/src/components/Checkbox/Checkbox.cy.ts
+++ b/src/components/Checkbox/Checkbox.cy.ts
@@ -19,7 +19,10 @@ describe('Checkbox', () => {
     })
 
     cy.get('input[type="checkbox"]').should('be.disabled')
-    cy.get('label').should('have.class', 'text-ink-gray-4')
+    cy.get('label')
+      .should('have.class', 'text-base')
+      .and('have.class', 'text-ink-gray-7')
+      .and('not.have.class', 'text-ink-gray-5')
   })
 
   it('test v-model', () => {
@@ -59,7 +62,12 @@ describe('Checkbox', () => {
 
     it('renders the canonical data-* hooks on the control', () => {
       cy.mount(Checkbox, {
-        props: { label: 'Accept', size: 'md', required: true, modelValue: true },
+        props: {
+          label: 'Accept',
+          size: 'md',
+          required: true,
+          modelValue: true,
+        },
       })
       cy.get('input').should('have.attr', 'data-slot', 'control')
       cy.get('input').should('have.attr', 'data-size', 'md')

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="inline-flex flex-col">
-    <div
-      class="inline-flex gap-2 rounded transition"
-      :class="rowClasses"
-    >
+    <div class="inline-flex gap-2 rounded transition" :class="rowClasses">
       <input
         class="rounded-sm mt-[1px] bg-surface-base"
         :class="inputClasses"
@@ -26,6 +23,7 @@
         :for-id="inputId"
         :label="props.label"
         :required="props.required"
+        color="gray-7"
         :class="labelClasses"
       >
         <template v-if="$slots.label" #default="slotProps">
@@ -41,11 +39,7 @@
       >
         <slot v-if="$slots.description" name="description" />
       </InputDescription>
-      <InputError
-        v-if="hasError"
-        :id="errorMessageId"
-        :lines="errorLines"
-      />
+      <InputError v-if="hasError" :id="errorMessageId" :lines="errorLines" />
     </div>
   </div>
 </template>
@@ -106,15 +100,7 @@ const {
 })
 
 const labelClasses = computed(() => {
-  return [
-    {
-      sm: 'text-base',
-      md: 'text-lg',
-    }[props.size],
-    'font-medium',
-    props.disabled ? 'text-ink-gray-4' : 'text-ink-gray-8',
-    'select-none',
-  ]
+  return 'select-none'
 })
 
 const rowClasses = computed(() => {

--- a/src/components/CodeEditor/CodeEditor.vue
+++ b/src/components/CodeEditor/CodeEditor.vue
@@ -9,7 +9,6 @@
       :id="labelId"
       :label="props.label"
       :required="props.required"
-      class="text-p-sm-medium text-ink-gray-7"
     >
       <template v-if="$slots.label" #default="slotProps">
         <slot name="label" v-bind="slotProps" />

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -434,7 +434,6 @@ defineSlots<ComboboxSlots>()
       :for-id="inputId"
       :label="label"
       :required="required"
-      class="text-p-sm-medium text-ink-gray-7"
     >
       <template v-if="$slots.label" #default="slotProps">
         <slot name="label" v-bind="slotProps" />

--- a/src/components/FormLabel.vue
+++ b/src/components/FormLabel.vue
@@ -1,11 +1,10 @@
 <template>
-  <label class="block" :class="labelClasses" :for="id">
+  <label class="block text-base text-ink-gray-5" :for="id">
     {{ label }}
     <RequiredIndicator :required="required" />
   </label>
 </template>
 <script setup lang="ts">
-import { computed } from 'vue'
 import RequiredIndicator from './InputLabeling/RequiredIndicator.vue'
 
 interface FormLabelProps {
@@ -15,17 +14,7 @@ interface FormLabelProps {
   required?: boolean
 }
 
-const props = withDefaults(defineProps<FormLabelProps>(), {
+withDefaults(defineProps<FormLabelProps>(), {
   size: 'sm',
-})
-
-const labelClasses = computed(() => {
-  return [
-    {
-      sm: 'text-xs',
-      md: 'text-base',
-    }[props.size],
-    'text-ink-gray-5',
-  ]
 })
 </script>

--- a/src/components/FormLabel.vue
+++ b/src/components/FormLabel.vue
@@ -1,10 +1,11 @@
 <template>
-  <label class="block text-base text-ink-gray-5" :for="id">
+  <label class="block text-ink-gray-5" :class="labelClasses" :for="id">
     {{ label }}
     <RequiredIndicator :required="required" />
   </label>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue'
 import RequiredIndicator from './InputLabeling/RequiredIndicator.vue'
 
 interface FormLabelProps {
@@ -14,7 +15,14 @@ interface FormLabelProps {
   required?: boolean
 }
 
-withDefaults(defineProps<FormLabelProps>(), {
+const props = withDefaults(defineProps<FormLabelProps>(), {
   size: 'sm',
+})
+
+const labelClasses = computed(() => {
+  return {
+    sm: 'text-xs',
+    md: 'text-base',
+  }[props.size]
 })
 </script>

--- a/src/components/InputLabeling/InputDescription.vue
+++ b/src/components/InputLabeling/InputDescription.vue
@@ -3,7 +3,7 @@
     v-if="$slots.default || description"
     :id="id"
     data-slot="description"
-    class="text-p-sm text-ink-gray-6"
+    class="text-p-sm text-ink-gray-5"
   >
     <slot>{{ description }}</slot>
   </p>

--- a/src/components/InputLabeling/InputLabel.vue
+++ b/src/components/InputLabeling/InputLabel.vue
@@ -4,7 +4,7 @@
     :id="id"
     :for="forId"
     data-slot="label"
-    class="block"
+    :class="labelClasses"
   >
     <slot v-if="$slots.default" :required="!!required" />
     <template v-else>
@@ -14,12 +14,26 @@
   </label>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue'
 import RequiredIndicator from './RequiredIndicator.vue'
 
-defineProps<{
-  id: string
-  forId?: string
-  label?: string
-  required?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    id: string
+    forId?: string
+    label?: string
+    required?: boolean
+    color?: 'gray-5' | 'gray-7'
+  }>(),
+  {
+    color: 'gray-5',
+  },
+)
+
+const labelClasses = computed(() => {
+  return [
+    'block text-base',
+    props.color === 'gray-7' ? 'text-ink-gray-7' : 'text-ink-gray-5',
+  ]
+})
 </script>

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -264,7 +264,6 @@ defineSlots<MultiSelectSlots>()
       :for-id="inputId"
       :label="label"
       :required="required"
-      class="text-p-sm-medium text-ink-gray-7"
     >
       <template v-if="$slots.label" #default="slotProps">
         <slot name="label" v-bind="slotProps" />

--- a/src/components/Popover/Popover.cy.ts
+++ b/src/components/Popover/Popover.cy.ts
@@ -40,6 +40,58 @@ describe('Popover', () => {
       cy.get('[data-cy="content"]').should('have.text', 'Popover content')
     })
 
+    it('toggles closed when the trigger is clicked while open', () => {
+      cy.mount(Popover, { slots: NewSlots })
+
+      // Open, then click the trigger again. The trigger click must END closed.
+      // Regression: a trigger pointerdown looks "outside" the content, so the
+      // dismissable layer would close it and reka's onOpenToggle would reopen
+      // it — leaving it stuck open (close-then-reopen flicker).
+      cy.get('[data-cy="trigger"]').click()
+      cy.get('[data-slot="content"]').should('exist')
+      cy.get('[data-cy="trigger"]').click()
+      cy.get('[data-slot="content"]').should('not.exist')
+    })
+
+    it('exposes reactive isOpen to the #trigger slot', () => {
+      // The #trigger click is auto-wired by reka, so the slot must NOT bind its
+      // own onClick (that would double-toggle). It can still read isOpen to
+      // reflect state — e.g. flip a label or a chevron.
+      cy.mount(Popover, {
+        slots: {
+          trigger: ({ isOpen }: { isOpen: boolean }) =>
+            h(Button, { 'data-cy': 'trigger' }, () =>
+              isOpen ? 'Close' : 'Open',
+            ),
+          default: () => h('div', { 'data-cy': 'content' }, 'content'),
+        },
+      })
+
+      cy.get('[data-cy="trigger"]').should('have.text', 'Open')
+      cy.get('[data-cy="trigger"]').click()
+      cy.get('[data-slot="content"]').should('exist')
+      cy.get('[data-cy="trigger"]').should('have.text', 'Close')
+    })
+
+    it('exposes close() to the #default slot content', () => {
+      cy.mount(Popover, {
+        slots: {
+          trigger: () => h(Button, { 'data-cy': 'trigger' }, () => 'T'),
+          default: ({ close }: { close: () => void }) =>
+            h(
+              Button,
+              { 'data-cy': 'dismiss', onClick: () => close() },
+              () => 'Done',
+            ),
+        },
+      })
+
+      cy.get('[data-cy="trigger"]').click()
+      cy.get('[data-slot="content"]').should('exist')
+      cy.get('[data-cy="dismiss"]').click()
+      cy.get('[data-slot="content"]').should('not.exist')
+    })
+
     it('renders #default inside the shared PopoverPanel shell', () => {
       cy.mount(Popover, { slots: NewSlots })
 

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -8,6 +8,7 @@
     -->
     <PopoverTrigger
       v-if="useNewTrigger"
+      ref="triggerRef"
       as-child
       data-slot="trigger"
       @pointerdown="markPointerDown"
@@ -228,6 +229,8 @@ if (slots.body || slots['body-main']) {
 // -----------------------------------------------------------------------------
 const _isOpen = ref(false)
 const anchorRef = ref<HTMLElement | null>(null)
+// reka's PopoverTrigger, exposes the trigger DOM node via `$el`.
+const triggerRef = ref<{ $el: Element } | null>(null)
 
 const isOpen = computed<boolean>({
   get: () =>
@@ -277,12 +280,18 @@ defineExpose({ open, close })
 // -----------------------------------------------------------------------------
 // Slot props.
 // -----------------------------------------------------------------------------
-const newSlotProps = computed<PopoverSlotProps>(() => ({ open, close }))
+const newSlotProps = computed<PopoverSlotProps>(() => ({
+  open,
+  close,
+  toggle: togglePopover,
+  isOpen: isOpen.value,
+}))
 const legacySlotProps = computed<PopoverLegacySlotProps>(() => ({
   togglePopover,
   updatePosition,
   open,
   close,
+  toggle: togglePopover,
   isOpen: isOpen.value,
 }))
 
@@ -342,12 +351,14 @@ function onInteractOutside(event: Event) {
     event.preventDefault()
     return
   }
-  // Prevent close-then-reopen flicker when clicking the legacy #target anchor.
+  // Prevent close-then-reopen flicker when clicking the trigger itself.
+  // The trigger's own click already toggles the popover (legacy #target via
+  // `togglePopover`, new #trigger via reka's `onOpenToggle`). Letting the
+  // dismissable layer also close it would race that toggle, so we suppress the
+  // outside-close and let the toggle decide the final state.
   const target = event.target as Element
-  if (
-    anchorRef.value &&
-    (anchorRef.value.contains(target) || anchorRef.value === target)
-  ) {
+  const triggerEl = triggerRef.value?.$el ?? anchorRef.value
+  if (triggerEl && (triggerEl.contains(target) || triggerEl === target)) {
     event.preventDefault()
   }
 }

--- a/src/components/Popover/types.ts
+++ b/src/components/Popover/types.ts
@@ -100,6 +100,8 @@ export interface PopoverEmits {
 export interface PopoverSlotProps {
   open: () => void
   close: () => void
+  toggle: (flag?: boolean | Event) => void
+  isOpen: boolean
 }
 
 /**
@@ -111,5 +113,6 @@ export interface PopoverLegacySlotProps {
   updatePosition: () => void
   open: () => void
   close: () => void
+  toggle: (flag?: boolean | Event) => void
   isOpen: boolean
 }

--- a/src/components/Rating/Rating.vue
+++ b/src/components/Rating/Rating.vue
@@ -2,14 +2,13 @@
   <LabelingWrapper
     :enabled="hasLabeling"
     :wrapper-class="['space-y-1', attrs.class]"
-    :wrapper-style="attrs.style"
+    :wrapper-style="attrs.style as any"
   >
     <InputLabel
       v-if="props.label || $slots.label"
       :id="labelId"
       :label="props.label"
       :required="props.required"
-      class="text-p-sm-medium text-ink-gray-7"
     >
       <template v-if="$slots.label" #default="slotProps">
         <slot name="label" v-bind="slotProps" />
@@ -44,10 +43,7 @@
         :key="index"
         type="button"
         class="rating-star relative inline-flex shrink-0 rounded-sm"
-        :class="[
-          sizeClass,
-          isDisabled ? 'cursor-default' : 'cursor-pointer',
-        ]"
+        :class="[sizeClass, isDisabled ? 'cursor-default' : 'cursor-pointer']"
         data-slot="star"
         :data-index="index"
         :data-state="starState(index)"

--- a/src/components/Rating/Rating.vue
+++ b/src/components/Rating/Rating.vue
@@ -2,7 +2,7 @@
   <LabelingWrapper
     :enabled="hasLabeling"
     :wrapper-class="['space-y-1', attrs.class]"
-    :wrapper-style="attrs.style as any"
+    :wrapper-style="attrs.style as StyleValue"
   >
     <InputLabel
       v-if="props.label || $slots.label"
@@ -130,6 +130,7 @@
 
 <script setup lang="ts">
 import { computed, ref, useAttrs, useSlots, watchEffect, nextTick } from 'vue'
+import type { StyleValue } from 'vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
 import { warnDeprecated } from '../../utils/warnDeprecated'
 import InputLabel from '../InputLabeling/InputLabel.vue'

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -235,7 +235,6 @@ defineSlots<SelectSlots>()
       :for-id="inputId"
       :label="label"
       :required="required"
-      class="text-p-sm-medium text-ink-gray-7"
     >
       <template v-if="$slots.label" #default="slotProps">
         <slot name="label" v-bind="slotProps" />

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -123,7 +123,6 @@ const hasLabeling = computed(() => {
       :for-id="inputId"
       :label="props.label"
       :required="props.required"
-      class="text-p-sm-medium text-ink-gray-7"
     >
       <template v-if="$slots.label" #default="slotProps">
         <slot name="label" v-bind="slotProps" />

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -42,10 +42,7 @@
         <SwitchThumb :class="switchCircleClasses" />
       </SwitchRoot>
     </div>
-    <div
-      v-if="showDescription || hasError || $slots.description"
-      class="mt-1"
-    >
+    <div v-if="showDescription || hasError || $slots.description" class="mt-1">
       <InputDescription
         v-if="showDescription || $slots.description"
         :id="descriptionId"
@@ -53,11 +50,7 @@
       >
         <slot v-if="$slots.description" name="description" />
       </InputDescription>
-      <InputError
-        v-if="hasError"
-        :id="errorMessageId"
-        :lines="errorLines"
-      />
+      <InputError v-if="hasError" :id="errorMessageId" :lines="errorLines" />
     </div>
   </div>
 </template>
@@ -153,14 +146,7 @@ const switchCircleClasses = computed(() => {
 const iconClasses = 'me-2 size-4 flex-shrink-0 text-ink-gray-6'
 
 const switchLabelClasses = computed(() => {
-  return [
-    'font-medium leading-normal',
-    props.disabled && !props.description
-      ? 'text-ink-gray-4'
-      : 'text-ink-gray-8',
-    props.size === 'md' ? 'text-lg' : 'text-base',
-    props.labelClasses,
-  ]
+  return 'leading-normal'
 })
 
 const switchGroupClasses = computed(() => {
@@ -169,9 +155,7 @@ const switchGroupClasses = computed(() => {
   if (!hasLabel && !hasDescription) return undefined
   const classes = ['flex justify-between']
   if (!hasDescription) {
-    classes.push(
-      'group items-center gap-x-3 py-1.5 cursor-pointer rounded',
-    )
+    classes.push('group items-center gap-x-3 py-1.5 cursor-pointer rounded')
 
     if (props.disabled) classes.push('cursor-not-allowed')
   } else {

--- a/src/components/TextEditor/extensions/iframe/InsertIframe.vue
+++ b/src/components/TextEditor/extensions/iframe/InsertIframe.vue
@@ -10,7 +10,7 @@
       <template #body-content>
         <div class="space-y-4">
           <div>
-            <label class="block text-sm-medium text-ink-gray-7 mb-2">
+            <label class="mb-2 block text-base text-ink-gray-5">
               URL or Embed Code
             </label>
             <Textarea

--- a/src/components/TextInput/TextInput.cy.ts
+++ b/src/components/TextInput/TextInput.cy.ts
@@ -104,11 +104,16 @@ describe('Textinput', () => {
         },
       })
       cy.contains('label', 'Email').should('exist')
+      cy.contains('label', 'Email')
+        .should('have.class', 'text-base')
+        .and('have.class', 'text-ink-gray-5')
       cy.get('input').then(($input) => {
         const id = $input.attr('id')!
         const describedBy = $input.attr('aria-describedby')!
         expect(describedBy).to.equal(`${id}-description`)
-        cy.get(`#${id}-description`).should('contain.text', 'We never share')
+        cy.get(`#${id}-description`)
+          .should('contain.text', 'We never share')
+          .and('have.class', 'text-ink-gray-5')
         cy.get(`label[for="${id}"]`).should('exist')
       })
     })

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -2,7 +2,7 @@
   <LabelingWrapper
     :enabled="hasLabeling"
     :wrapper-class="['space-y-1.5', attrs.class]"
-    :wrapper-style="attrs.style"
+    :wrapper-style="attrs.style as any"
   >
     <InputLabel
       v-if="props.label || $slots.label"
@@ -10,7 +10,6 @@
       :for-id="inputId"
       :label="props.label"
       :required="props.required"
-      class="text-p-sm-medium text-ink-gray-7"
     >
       <template v-if="$slots.label" #default="slotProps">
         <slot name="label" v-bind="slotProps" />
@@ -68,11 +67,7 @@
     >
       <slot v-if="$slots.description" name="description" />
     </InputDescription>
-    <InputError
-      v-if="hasError"
-      :id="errorMessageId"
-      :lines="errorLines"
-    />
+    <InputError v-if="hasError" :id="errorMessageId" :lines="errorLines" />
   </LabelingWrapper>
 </template>
 
@@ -140,10 +135,10 @@ const {
 const hasLabeling = computed(() => {
   return Boolean(
     props.label ||
-      props.description ||
-      hasError.value ||
-      slots.label ||
-      slots.description,
+    props.description ||
+    hasError.value ||
+    slots.label ||
+    slots.description,
   )
 })
 

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -2,7 +2,7 @@
   <LabelingWrapper
     :enabled="hasLabeling"
     :wrapper-class="['space-y-1.5', attrs.class]"
-    :wrapper-style="attrs.style as any"
+    :wrapper-style="attrs.style as StyleValue"
   >
     <InputLabel
       v-if="props.label || $slots.label"
@@ -73,6 +73,7 @@
 
 <script setup lang="ts">
 import { computed, ref, useAttrs, useSlots } from 'vue'
+import type { StyleValue } from 'vue'
 import debounce from '../../utils/debounce'
 import { useInputLabeling } from '../../composables/useInputLabeling'
 import InputLabel from '../InputLabeling/InputLabel.vue'

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -2,7 +2,7 @@
   <LabelingWrapper
     :enabled="hasLabeling"
     :wrapper-class="['space-y-1.5', attrs.class]"
-    :wrapper-style="attrs.style"
+    :wrapper-style="attrs.style as any"
   >
     <InputLabel
       v-if="props.label || $slots.label"
@@ -10,7 +10,6 @@
       :for-id="inputId"
       :label="props.label"
       :required="props.required"
-      class="text-p-sm-medium text-ink-gray-7"
     >
       <template v-if="$slots.label" #default="slotProps">
         <slot name="label" v-bind="slotProps" />
@@ -42,11 +41,7 @@
     >
       <slot v-if="$slots.description" name="description" />
     </InputDescription>
-    <InputError
-      v-if="hasError"
-      :id="errorMessageId"
-      :lines="errorLines"
-    />
+    <InputError v-if="hasError" :id="errorMessageId" :lines="errorLines" />
   </LabelingWrapper>
 </template>
 
@@ -102,10 +97,10 @@ const {
 const hasLabeling = computed(() => {
   return Boolean(
     props.label ||
-      slots.label ||
-      showDescription.value ||
-      slots.description ||
-      hasError.value,
+    slots.label ||
+    showDescription.value ||
+    slots.description ||
+    hasError.value,
   )
 })
 

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -2,7 +2,7 @@
   <LabelingWrapper
     :enabled="hasLabeling"
     :wrapper-class="['space-y-1.5', attrs.class]"
-    :wrapper-style="attrs.style as any"
+    :wrapper-style="attrs.style as StyleValue"
   >
     <InputLabel
       v-if="props.label || $slots.label"
@@ -47,6 +47,7 @@
 
 <script setup lang="ts">
 import { computed, ref, useAttrs, useSlots } from 'vue'
+import type { StyleValue } from 'vue'
 import debounce from '../../utils/debounce'
 import { useInputLabeling } from '../../composables/useInputLabeling'
 import InputLabel from '../InputLabeling/InputLabel.vue'

--- a/src/molecules/editor/extensions/iframe/IframeInsertDialog.vue
+++ b/src/molecules/editor/extensions/iframe/IframeInsertDialog.vue
@@ -6,7 +6,7 @@
   >
     <template #body-content>
       <div>
-        <label class="mb-2 block text-sm-medium text-ink-gray-7">
+        <label class="mb-2 block text-base text-ink-gray-5">
           URL or Embed Code
         </label>
         <Textarea

--- a/tailwind/plugin.js
+++ b/tailwind/plugin.js
@@ -31,6 +31,9 @@ function generateRadiusVariables() {
 
 // Map `DEFAULT` (Tailwind's `rounded` class) onto the numeric var that
 // shares its value, so we don't emit a `--radius-DEFAULT` (awkward name).
+// Each value carries a trailing `/* {px} */` comment so editor tooling
+// (Tailwind IntelliSense) surfaces the resolved px on hover, instead of
+// the opaque `var(--radius-*)` reference.
 function buildRadiusConfig() {
   const numericByValue = {}
   for (const [key, value] of Object.entries(radiusTokens)) {
@@ -40,9 +43,9 @@ function buildRadiusConfig() {
   for (const [key, value] of Object.entries(radiusTokens)) {
     if (key === 'DEFAULT') {
       const numeric = numericByValue[value]
-      out[key] = numeric ? `var(--radius-${numeric})` : value
+      out[key] = numeric ? `var(--radius-${numeric}) /* ${value} */` : value
     } else {
-      out[key] = `var(--radius-${key})`
+      out[key] = `var(--radius-${key}) /* ${value} */`
     }
   }
   return out


### PR DESCRIPTION
## Summary

- Annotate generated rounded utility output with pixel-value hints.
- Stabilize Popover trigger toggling so clicking an open trigger closes it instead of closing and reopening.
- Align input-family label and description typography, with Checkbox labels using the darker ink-gray-7 treatment.

## Validation

- `yarn test:cypress --spec "src/components/Popover/Popover.cy.ts,src/components/TextInput/TextInput.cy.ts,src/components/Checkbox/Checkbox.cy.ts"`
- `git diff --check`

## Notes

This PR intentionally keeps the changes in separate commits for review: Tailwind utility hints, Popover behavior, and input label styling.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-813/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 58.82% (+0.02% vs `main`)
<!-- coverage-report:end -->


