### PR TITLE
ci(beta-release): add workflow_dispatch trigger (fixes fork-PR release gap)

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,10 +1,18 @@
 name: Bump Beta Version
 
-# When a PR labeled `beta-release` is merged into main, bump the beta
-# prerelease in package.json (e.g. 1.0.0-beta.0 -> 1.0.0-beta.1) and push it.
-# The push triggers Tests -> "Publish on NPM" (publish.yml), which detects the
-# version change and publishes to the matching dist-tag (beta).
+# Bump the beta prerelease in package.json (e.g. 1.0.0-beta.0 -> 1.0.0-beta.1)
+# and push it. The push triggers Tests -> "Publish on NPM" (publish.yml), which
+# detects the version change and publishes to the matching dist-tag (beta).
+#
+# Triggers on a manual `workflow_dispatch`, or when a `beta-release`-labeled PR
+# is merged into main. Prefer the manual dispatch for fork contributions: a PR
+# merged from a fork does not get repository secrets (RELEASE_TOKEN), so the
+# pull_request path can't publish for it.
 on:
+  # Manual trigger: run the bump from main directly. Needed because a labeled PR
+  # merged from a FORK does not receive repository secrets (RELEASE_TOKEN), so the
+  # pull_request path below silently can't publish for fork contributions.
+  workflow_dispatch:
   pull_request:
     types: [closed]
     branches: [main]
@@ -16,9 +24,12 @@ concurrency:
 
 jobs:
   bump-beta:
+    # Run on a manual dispatch, or when a `beta-release`-labeled PR is merged.
+    # (A dispatch event has no `pull_request`, so gate the label check on it.)
     if: >-
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'beta-release')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'beta-release'))
     runs-on: ubuntu-latest
     permissions:
       contents: write # push the version-bump commit back to main


### PR DESCRIPTION
## Why

beta.17 never published after #746 merged. Root cause: #746 was merged **from a fork** (`nextchamp-saqib:feat-2356`), and GitHub does **not** pass repository secrets to `pull_request` workflows triggered by fork PRs. So `RELEASE_TOKEN` was empty in the `Bump Beta Version` run and it failed its own guard step. (`RELEASE_TOKEN` is set correctly — it just isn't injected for fork-triggered runs.)

## What this does

- Adds a manual `workflow_dispatch` trigger so the bump can run from `main` (same-repo context → secrets available), independent of how a PR was merged.
- Updates the job `if:` so a dispatch event runs it (a dispatch has no `pull_request`, so the label check is gated behind the merge path).
- Documents the fork-secret caveat inline.

## Note

This PR carries the `beta-release` label and is from a **same-repo** branch, so merging it will trigger the bump correctly and cut the pending beta (SettingsDialog, #746 + #815) from main.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-816/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 58.84% (±0.00% vs `main`)
<!-- coverage-report:end -->
