### PR TITLE
fix(select): use translucent gray for picker item hover highlight

### DIFF
--- a/src/components/Autocomplete/Autocomplete.vue
+++ b/src/components/Autocomplete/Autocomplete.vue
@@ -118,9 +118,9 @@
                 >
                   <li
                     :class="[
-                      'flex cursor-pointer items-center justify-between rounded px-2.5 py-1.5 text-base',
+                      'flex cursor-pointer items-center justify-between rounded px-2.5 py-1.5 text-base transition-colors duration-100 ease-out',
                       {
-                        'bg-surface-gray-3': active,
+                        'bg-surface-alpha-gray-2': active,
                         'opacity-50': option.disabled,
                       },
                     ]"

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -33,6 +33,7 @@ import PopoverPanel from '../shared/popover/PopoverPanel.vue'
 import {
   EMPTY_VALUE_PREFIX,
   inputFontSizeClasses,
+  itemClasses,
   itemRootSizeClasses,
   toItemListSize,
   triggerBaseClasses,
@@ -366,8 +367,7 @@ defineSlots<SelectSlots>()
                   :disabled="internalOption.option.disabled"
                   :value="internalOption.internalValue"
                   data-slot="item"
-                  :class="itemRootClasses"
-                  class="select-none rounded border-0 text-base text-ink-gray-9 data-[disabled]:text-ink-gray-4 data-[highlighted]:bg-surface-gray-2 data-[state=checked]:bg-surface-gray-3 data-[highlighted]:data-[state=checked]:bg-surface-gray-4"
+                  :class="[itemClasses, itemRootClasses]"
                 >
                   <ItemListRow
                     :size="itemSize"

--- a/src/components/Select/utils.ts
+++ b/src/components/Select/utils.ts
@@ -2,6 +2,7 @@ import type { SelectionSize, SelectionVariant } from '../shared/selection/utils'
 
 export {
   inputFontSizeClasses,
+  itemClasses,
   itemRootSizeClasses,
   toItemListSize,
   triggerSizeClasses,

--- a/src/components/shared/selection/utils.ts
+++ b/src/components/shared/selection/utils.ts
@@ -76,7 +76,7 @@ export const triggerBaseClassesFocusWithin =
   'relative inline-flex items-center gap-2 text-left text-ink-gray-7 outline-none transition-[background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-within:focus-ring data-[state=open]:focus-ring'
 
 export const itemClasses =
-  'select-none rounded border-0 text-base text-ink-gray-9 transition-colors duration-100 ease-out data-[disabled]:text-ink-gray-4 data-[highlighted]:bg-surface-gray-2 data-[state=checked]:bg-surface-gray-3 data-[highlighted]:data-[state=checked]:bg-surface-gray-4'
+  'select-none rounded border-0 text-base text-ink-gray-9 transition-colors duration-100 ease-out data-[disabled]:text-ink-gray-4 data-[highlighted]:bg-surface-alpha-gray-2 data-[state=checked]:bg-surface-gray-3 data-[highlighted]:data-[state=checked]:bg-surface-gray-4'
 
 /**
  * Case-insensitive substring match against an option's label and value.


### PR DESCRIPTION
## Summary
- Select, MultiSelect, Combobox, and Autocomplete highlighted the active/hovered item with a solid `bg-surface-gray-2`/`gray-3`, while Dropdown and ContextMenu (via `Menu/utils.ts`) already used the translucent `bg-surface-alpha-gray-2`. This aligns all pickers on the translucent treatment so it reads correctly regardless of the surface behind it (works in both light/dark automatically).
- `Select.vue` had inlined a copy of the shared `itemClasses` string instead of importing it, so it had drifted (and was missing the `transition-colors` the shared version has). Switched it to import the shared constant from `Select/utils.ts` → `shared/selection/utils.ts`.

## Test plan
- [x] Verified via `git diff` that only the item highlight class changed for Select/MultiSelect/Combobox (single shared `itemClasses` constant) and Autocomplete (separate legacy implementation)
- [ ] Visual check of Select, MultiSelect, Combobox, Autocomplete dropdowns in light and dark mode

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-817/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 58.85% (-0.03% vs `main`)
<!-- coverage-report:end -->
