### PR TITLE
fix: add DomPurify to sanitize html

### DIFF
--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,12 +1,14 @@
 import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 
 export function markdownToHTML(text: string): string {
   // Use synchronous marked.parse
-  return marked.parse(text, {
+  const html = marked.parse(text, {
     gfm: true,
     breaks: true,
     async: false,
   }) as string
+  return DOMPurify.sanitize(html)
 }
 
 export function detectMarkdown(text: string): boolean {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -8,7 +8,8 @@ export function markdownToHTML(text: string): string {
     breaks: true,
     async: false,
   }) as string
-  return DOMPurify.sanitize(html)
+  // DOMPurify needs a DOM; without one (SSR/Node) it returns '' and drops all output.
+  return typeof window === 'undefined' ? html : DOMPurify.sanitize(html)
 }
 
 export function detectMarkdown(text: string): boolean {


### PR DESCRIPTION
marked output was rendered without sanitization, letting javascript and event handlers execute in other users' browsers. 

fix: Pass it through DOMPurify to successfully render md to HTML with any issues

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-819/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 69.10% (-0.03% vs `main`)
<!-- coverage-report:end -->

