### PR TITLE
fix: make shell docs SSR-safe

### DIFF
--- a/src/components/ScrollArea/ScrollBar.vue
+++ b/src/components/ScrollArea/ScrollBar.vue
@@ -11,7 +11,9 @@
           : 'opacity-0 pointer-events-none',
         // Grow the 44px touch target only along the scroll axis; a cross-axis
         // minimum would bleed the (invisible) hit area over adjacent content.
-        orientation === 'horizontal' ? 'before:min-w-[44px]' : 'before:min-h-[44px]',
+        orientation === 'horizontal'
+          ? 'before:min-w-[44px]'
+          : 'before:min-h-[44px]',
       ]"
     />
   </ScrollAreaScrollbar>
@@ -45,17 +47,17 @@ const rootContext = injectScrollAreaRootContext()
 const isThumbVisible = ref(false)
 const isPointerDown = ref(false)
 
-let idleTimeout: ReturnType<typeof window.setTimeout> | undefined
+let idleTimeout: ReturnType<typeof setTimeout> | undefined
 
 function clearIdleTimeout() {
   if (!idleTimeout) return
-  window.clearTimeout(idleTimeout)
+  clearTimeout(idleTimeout)
   idleTimeout = undefined
 }
 
 function scheduleHide() {
   clearIdleTimeout()
-  idleTimeout = window.setTimeout(() => {
+  idleTimeout = setTimeout(() => {
     isThumbVisible.value = false
     idleTimeout = undefined
   }, rootContext.scrollHideDelay.value)
@@ -89,7 +91,11 @@ useEventListener(rootContext.scrollArea, 'pointermove', showThumb)
 useEventListener(rootContext.scrollArea, 'pointerdown', handlePointerDown)
 useEventListener(rootContext.scrollArea, 'pointerleave', hideThumb)
 useEventListener(rootContext.viewport, 'scroll', showThumb)
-useEventListener(window, 'pointerup', handlePointerUp)
+useEventListener(
+  () => (typeof window === 'undefined' ? null : window),
+  'pointerup',
+  handlePointerUp,
+)
 
 onUnmounted(clearIdleTimeout)
 </script>

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -62,11 +62,15 @@ defineSlots<{
 
 // Cmd/Ctrl+Shift+, toggles the dialog. Use e.code (physical key) since Shift
 // rewrites e.key for "," to "<" on most layouts.
-useEventListener(window, 'keydown', (e: KeyboardEvent) => {
-  if (!props.shortcut) return
-  if (e.code === 'Comma' && e.shiftKey && (e.metaKey || e.ctrlKey)) {
-    e.preventDefault()
-    modelValue.value = !modelValue.value
-  }
-})
+useEventListener(
+  () => (typeof window === 'undefined' ? null : window),
+  'keydown',
+  (e: KeyboardEvent) => {
+    if (!props.shortcut) return
+    if (e.code === 'Comma' && e.shiftKey && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      modelValue.value = !modelValue.value
+    }
+  },
+)
 </script>


### PR DESCRIPTION
## What changed
- avoid reading `window` during SSR in `ScrollBar` and `SettingsDialog`
- keeps the new shell/list docs pages renderable during VitePress static generation

## Verification
- `yarn docs:build`
- confirmed built routes include `desktopshell`, `mobileshell`, `mobilenav`, `pageheader`, `rail`, `settingsdialog`, `sidebar`, and molecule `list`

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-821/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 69.10% (-0.03% vs `main`)
<!-- coverage-report:end -->
