### PR TITLE
feat(avatar): introduce themes for avatar

### DIFF
--- a/docs/components/builders/AvatarBuilder.vue
+++ b/docs/components/builders/AvatarBuilder.vue
@@ -28,6 +28,21 @@ const knobs: Knob[] = [
       { label: 'square', value: 'square' },
     ],
   },
+  {
+    name: 'theme',
+    type: 'tabs',
+    default: 'gray',
+    options: [
+      { label: 'gray', value: 'gray' },
+      { label: 'blue', value: 'blue' },
+      { label: 'green', value: 'green' },
+      { label: 'amber', value: 'amber' },
+      { label: 'red', value: 'red' },
+      { label: 'violet', value: 'violet' },
+      { label: 'orange', value: 'orange' },
+      { label: 'auto', value: 'auto' },
+    ],
+  },
 ]
 
 function buildCode(v: Record<string, any>) {
@@ -35,18 +50,24 @@ function buildCode(v: Record<string, any>) {
   if (v.image) attrs.push(`image="${v.image}"`)
   if (v.size !== 'md') attrs.push(`size="${v.size}"`)
   if (v.shape !== 'circle') attrs.push(`shape="${v.shape}"`)
+  if (v.theme !== 'gray') attrs.push(`theme="${v.theme}"`)
   return ['<Avatar', ...attrs.map((a) => '  ' + a), '/>'].join('\n')
 }
 </script>
 
 <template>
-  <ComponentPlayground :knobs="knobs" :code="buildCode" preview-min-height="120px">
+  <ComponentPlayground
+    :knobs="knobs"
+    :code="buildCode"
+    preview-min-height="120px"
+  >
     <template #preview="{ values }">
       <Avatar
         :label="values.label"
         :image="values.image || undefined"
         :size="values.size"
         :shape="values.shape"
+        :theme="values.theme"
       />
     </template>
   </ComponentPlayground>

--- a/docs/components/builders/AvatarBuilder.vue
+++ b/docs/components/builders/AvatarBuilder.vue
@@ -39,8 +39,6 @@ const knobs: Knob[] = [
       { label: 'amber', value: 'amber' },
       { label: 'red', value: 'red' },
       { label: 'violet', value: 'violet' },
-      { label: 'orange', value: 'orange' },
-      { label: 'auto', value: 'auto' },
     ],
   },
 ]

--- a/src/components/Avatar/Avatar.api.md
+++ b/src/components/Avatar/Avatar.api.md
@@ -35,7 +35,7 @@
     name: 'theme',
     description: 'Visual color theme used for the fallback avatar',
     required: false,
-    type: '"gray" | "blue" | "green" | "amber" | "red" | "violet" | "orange" | "auto"',
+    type: '"gray" | "blue" | "green" | "amber" | "red" | "violet"',
     default: '"gray"'
   }
 ]

--- a/src/components/Avatar/Avatar.api.md
+++ b/src/components/Avatar/Avatar.api.md
@@ -30,6 +30,13 @@
     required: false,
     type: '"circle" | "square"',
     default: '"circle"'
+  },
+  {
+    name: 'theme',
+    description: 'Visual color theme used for the fallback avatar',
+    required: false,
+    type: '"gray" | "blue" | "green" | "amber" | "red" | "violet" | "orange" | "auto"',
+    default: '"gray"'
   }
 ]
 
@@ -51,4 +58,3 @@
 <PropsTable name="Avatar" :data="propsData"/> 
 
 <SlotsTable :data="slotsData"/> 
-

--- a/src/components/Avatar/Avatar.cy.ts
+++ b/src/components/Avatar/Avatar.cy.ts
@@ -65,11 +65,4 @@ describe('Avatar', () => {
       .and('have.class', 'text-ink-blue-8')
   })
 
-  it('Supports automatic fallback themes', () => {
-    cy.mount(Avatar, {
-      props: { 'data-cy': 'avatar', label: 'Abc', theme: 'auto' },
-    })
-
-    cy.get('[data-cy="avatar"] > div').should('not.have.class', 'bg-surface-gray-2')
-  })
 })

--- a/src/components/Avatar/Avatar.cy.ts
+++ b/src/components/Avatar/Avatar.cy.ts
@@ -44,4 +44,32 @@ describe('Avatar', () => {
 
     cy.get('[data-cy="avatar"]').should('have.text', 'A')
   })
+
+  it('Uses gray fallback theme by default', () => {
+    cy.mount(Avatar, {
+      props: { 'data-cy': 'avatar', label: 'Abc' },
+    })
+
+    cy.get('[data-cy="avatar"] > div')
+      .should('have.class', 'bg-surface-gray-2')
+      .and('have.class', 'text-ink-gray-5')
+  })
+
+  it('Supports colorful fallback themes', () => {
+    cy.mount(Avatar, {
+      props: { 'data-cy': 'avatar', label: 'Abc', theme: 'blue' },
+    })
+
+    cy.get('[data-cy="avatar"] > div')
+      .should('have.class', 'bg-surface-blue-2')
+      .and('have.class', 'text-ink-blue-8')
+  })
+
+  it('Supports automatic fallback themes', () => {
+    cy.mount(Avatar, {
+      props: { 'data-cy': 'avatar', label: 'Abc', theme: 'auto' },
+    })
+
+    cy.get('[data-cy="avatar"] > div').should('not.have.class', 'bg-surface-gray-2')
+  })
 })

--- a/src/components/Avatar/Avatar.md
+++ b/src/components/Avatar/Avatar.md
@@ -6,10 +6,13 @@ A visual representation of a user, typically shown as an image, initials, or an 
 
 <ClientOnly><AvatarBuilder /></ClientOnly>
 
-## Themes
+## Shapes
 <ComponentPreview name="Avatar-Shapes" />
 
-## Controlled state
+## Sizes
 <ComponentPreview name="Avatar-Sizes" />
+
+## Themes
+<ComponentPreview name="Avatar-Themes" />
 
 <!-- @include: ./Avatar.api.md -->

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -12,8 +12,8 @@
     />
     <div
       v-else
-      class="flex h-full w-full items-center justify-center bg-surface-gray-2 uppercase text-ink-gray-5 select-none"
-      :class="[labelClasses, shapeClasses]"
+      class="flex h-full w-full items-center justify-center uppercase select-none"
+      :class="[labelClasses, fallbackThemeClasses, shapeClasses]"
     >
       <div :class="iconClasses" v-if="$slots.default">
         <slot></slot>
@@ -38,13 +38,30 @@
 
 <script setup lang="ts">
 import { ref, computed, useAttrs } from 'vue'
-import type { AvatarProps } from './types'
+import type { AvatarProps, AvatarTheme } from './types'
+
+type ResolvedAvatarTheme = Exclude<AvatarTheme, 'auto'>
 
 const imgFetchError = ref(false)
 
 const props = withDefaults(defineProps<AvatarProps>(), {
   size: 'md',
   shape: 'circle',
+  theme: 'gray',
+})
+
+const fallbackThemeClasses = computed(() => {
+  const theme = props.theme === 'auto' ? getAutoTheme(props.label) : props.theme
+  const classes: Record<ResolvedAvatarTheme, string> = {
+    gray: 'bg-surface-gray-2 text-ink-gray-5',
+    blue: 'bg-surface-blue-2 text-ink-blue-8',
+    green: 'bg-surface-green-2 text-ink-green-8',
+    amber: 'bg-surface-amber-2 text-ink-amber-8',
+    red: 'bg-surface-red-2 text-ink-red-8',
+    violet: 'bg-surface-violet-2 text-ink-violet-8',
+    orange: 'bg-surface-amber-2 text-ink-amber-8',
+  }
+  return classes[theme]
 })
 
 // Let a consumer size the avatar with a Tailwind utility (`class="size-16"`)
@@ -60,7 +77,9 @@ const hasSizeOverride = computed(() => {
       ? attrs.class
       : ''
   return cls.split(/\s+/).some((token) => {
-    const base = token.includes(':') ? token.slice(token.lastIndexOf(':') + 1) : token
+    const base = token.includes(':')
+      ? token.slice(token.lastIndexOf(':') + 1)
+      : token
     return /^-?(size|w|h|min-w|max-w|min-h|max-h)-/.test(base)
   })
 })
@@ -142,10 +161,28 @@ const iconClasses = computed(() => {
   }[props.size]
 })
 
-function handleImageError(err) {
+function handleImageError(err: Event) {
   if (err.type) {
     imgFetchError.value = true
   }
+}
+
+function getAutoTheme(label?: string): ResolvedAvatarTheme {
+  const themes: ResolvedAvatarTheme[] = [
+    'blue',
+    'green',
+    'amber',
+    'red',
+    'violet',
+  ]
+  const value = label || ''
+  let hash = 0
+
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0
+  }
+
+  return themes[hash % themes.length]
 }
 
 defineSlots<{
@@ -155,5 +192,4 @@ defineSlots<{
   /** Small indicator shown at the bottom-right of the avatar */
   indicator?: () => any
 }>()
-
 </script>

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -40,8 +40,6 @@
 import { ref, computed, useAttrs } from 'vue'
 import type { AvatarProps, AvatarTheme } from './types'
 
-type ResolvedAvatarTheme = Exclude<AvatarTheme, 'auto'>
-
 const imgFetchError = ref(false)
 
 const props = withDefaults(defineProps<AvatarProps>(), {
@@ -51,17 +49,15 @@ const props = withDefaults(defineProps<AvatarProps>(), {
 })
 
 const fallbackThemeClasses = computed(() => {
-  const theme = props.theme === 'auto' ? getAutoTheme(props.label) : props.theme
-  const classes: Record<ResolvedAvatarTheme, string> = {
+  const classes: Record<AvatarTheme, string> = {
     gray: 'bg-surface-gray-2 text-ink-gray-5',
     blue: 'bg-surface-blue-2 text-ink-blue-8',
     green: 'bg-surface-green-2 text-ink-green-8',
     amber: 'bg-surface-amber-2 text-ink-amber-8',
     red: 'bg-surface-red-2 text-ink-red-8',
     violet: 'bg-surface-violet-2 text-ink-violet-8',
-    orange: 'bg-surface-amber-2 text-ink-amber-8',
   }
-  return classes[theme]
+  return classes[props.theme]
 })
 
 // Let a consumer size the avatar with a Tailwind utility (`class="size-16"`)
@@ -165,24 +161,6 @@ function handleImageError(err: Event) {
   if (err.type) {
     imgFetchError.value = true
   }
-}
-
-function getAutoTheme(label?: string): ResolvedAvatarTheme {
-  const themes: ResolvedAvatarTheme[] = [
-    'blue',
-    'green',
-    'amber',
-    'red',
-    'violet',
-  ]
-  const value = label || ''
-  let hash = 0
-
-  for (let i = 0; i < value.length; i++) {
-    hash = (hash * 31 + value.charCodeAt(i)) >>> 0
-  }
-
-  return themes[hash % themes.length]
 }
 
 defineSlots<{

--- a/src/components/Avatar/index.ts
+++ b/src/components/Avatar/index.ts
@@ -1,2 +1,2 @@
 export { default as Avatar } from './Avatar.vue'
-export type { AvatarProps } from './types'
+export type { AvatarProps, AvatarTheme } from './types'

--- a/src/components/Avatar/stories/Themes.vue
+++ b/src/components/Avatar/stories/Themes.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Avatar } from 'frappe-ui'
+import type { AvatarTheme } from 'frappe-ui'
+
+const themes: AvatarTheme[] = [
+  'gray',
+  'blue',
+  'green',
+  'amber',
+  'red',
+  'violet',
+  'orange',
+  'auto',
+]
+</script>
+
+<template>
+  <Avatar
+    v-for="theme in themes"
+    :key="theme"
+    :label="theme === 'auto' ? 'Jane Doe' : theme"
+    :theme="theme"
+    size="lg"
+  />
+</template>

--- a/src/components/Avatar/stories/Themes.vue
+++ b/src/components/Avatar/stories/Themes.vue
@@ -9,8 +9,6 @@ const themes: AvatarTheme[] = [
   'amber',
   'red',
   'violet',
-  'orange',
-  'auto',
 ]
 </script>
 
@@ -18,7 +16,7 @@ const themes: AvatarTheme[] = [
   <Avatar
     v-for="theme in themes"
     :key="theme"
-    :label="theme === 'auto' ? 'Jane Doe' : theme"
+    :label="theme"
     :theme="theme"
     size="lg"
   />

--- a/src/components/Avatar/types.ts
+++ b/src/components/Avatar/types.ts
@@ -1,3 +1,13 @@
+export type AvatarTheme =
+  | 'gray'
+  | 'blue'
+  | 'green'
+  | 'amber'
+  | 'red'
+  | 'violet'
+  | 'orange'
+  | 'auto'
+
 export interface AvatarProps {
   /** Image URL used for the avatar */
   image?: string
@@ -10,4 +20,7 @@ export interface AvatarProps {
 
   /** Defines the avatar shape */
   shape?: 'circle' | 'square'
+
+  /** Visual color theme used for the fallback avatar */
+  theme?: AvatarTheme
 }

--- a/src/components/Avatar/types.ts
+++ b/src/components/Avatar/types.ts
@@ -5,8 +5,6 @@ export type AvatarTheme =
   | 'amber'
   | 'red'
   | 'violet'
-  | 'orange'
-  | 'auto'
 
 export interface AvatarProps {
   /** Image URL used for the avatar */


### PR DESCRIPTION
defaults to gray, so no breaking change, but let's you override with few themes similar to Badge and has auto option that picks a deterministic value based on the label.

<!-- coverage-report:start -->
Coverage: 68.83% (+0.01% vs `main`)
<!-- coverage-report:end -->

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-828/
<!-- docs-preview:end -->


