### PR TITLE
feat(SettingsDialog): add close button

### DIFF
--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -12,8 +12,21 @@
       orientation="vertical"
       activation-mode="manual"
       :unmount-on-hide="unmountOnHide"
-      class="flex h-[100dvh] min-h-0 w-screen flex-col overflow-hidden sm:h-[min(860px,calc(100vh-8rem))] sm:min-h-[560px] sm:w-auto sm:flex-row"
+      class="relative flex h-[100dvh] min-h-0 w-screen flex-col overflow-hidden sm:h-[min(860px,calc(100vh-8rem))] sm:min-h-[560px] sm:w-auto sm:flex-row"
     >
+      <!-- Bare mode suppresses the base Dialog's close button, so provide one
+           here. Setting the v-model closes the dialog and lets route-driven
+           consumers react (e.g. navigate back) via their own watcher. -->
+      <Button
+        class="absolute right-3 top-3 z-10"
+        variant="ghost"
+        label="Close"
+        @click="modelValue = false"
+      >
+        <template #icon>
+          <span class="lucide-x size-4 text-ink-gray-9" />
+        </template>
+      </Button>
       <Dialog.Title as-child>
         <h1 class="sr-only"><slot name="title">Settings</slot></h1>
       </Dialog.Title>
@@ -33,6 +46,7 @@
 import { useEventListener } from '@vueuse/core'
 import { TabsRoot } from 'reka-ui'
 import { Dialog } from '../Dialog'
+import { Button } from '../Button'
 import type { SettingsDialogProps } from './types'
 
 const props = withDefaults(defineProps<SettingsDialogProps>(), {


### PR DESCRIPTION
## Problem

`SettingsDialog` renders the base `Dialog` in `bare` mode, and in bare mode the base Dialog deliberately skips its own close button. That left the settings dialog with **no visible close affordance** — users could only dismiss it via Esc or a backdrop click, which isn't discoverable.

## Change

Add a floating ghost X button in the dialog's top-right corner. It closes the dialog by setting the `v-model`, so route-driven consumers (e.g. Gameplan, whose open state is derived from the URL) still react through their own open-state watcher — no consumer changes needed.

- Made the `TabsRoot` container `relative` to anchor the button.
- Button styling mirrors the standalone close button already used by the base `Dialog` (ghost variant, `lucide-x`, `text-ink-gray-9`).

## Verification

Verified in Gameplan against the local demo site: opening Settings shows the X in the top-right (no overlap with panel header content), and clicking it closes the dialog and navigates back to the underlying page.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-829/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 68.81% (+0.01% vs `main`)
<!-- coverage-report:end -->
