### PR TITLE
fix(Sidebar): center item icons when collapsed

### DIFF
--- a/src/components/Sidebar/SidebarItem.vue
+++ b/src/components/Sidebar/SidebarItem.vue
@@ -44,12 +44,15 @@
           </slot>
         </span>
       </Tooltip>
+      <!-- flex-none when collapsed: with flex-1, the grow factor would override
+           w-0 (flex-basis 0% wins over width) and the invisible label would
+           still fill the row, pushing the icon off-center. -->
       <span
-        class="min-w-0 flex-1 transition-all ease-in-out"
+        class="min-w-0 transition-all ease-in-out"
         :class="
           isCollapsed
-            ? 'ml-0 w-0 overflow-hidden opacity-0'
-            : 'ml-2 w-auto opacity-100'
+            ? 'ml-0 w-0 flex-none overflow-hidden opacity-0'
+            : 'ml-2 w-auto flex-1 opacity-100'
         "
       >
         <span ref="labelEl" class="flex min-w-0 items-center">
@@ -85,12 +88,15 @@
           </slot>
         </span>
       </Tooltip>
+      <!-- flex-none when collapsed: with flex-1, the grow factor would override
+           w-0 (flex-basis 0% wins over width) and the invisible label would
+           still fill the row, pushing the icon off-center. -->
       <span
-        class="min-w-0 flex-1 transition-all ease-in-out"
+        class="min-w-0 transition-all ease-in-out"
         :class="
           isCollapsed
-            ? 'ml-0 w-0 overflow-hidden opacity-0'
-            : 'ml-2 w-auto opacity-100'
+            ? 'ml-0 w-0 flex-none overflow-hidden opacity-0'
+            : 'ml-2 w-auto flex-1 opacity-100'
         "
       >
         <span ref="labelEl" class="flex min-w-0 items-center">


### PR DESCRIPTION
## Problem

When the sidebar is collapsed, item icons sit hard left in the rail instead of centered, and the active item's pill shows a large empty area to the right of the icon.

The label span keeps `flex-1` in the collapsed state. Its `flex-basis: 0%` takes precedence over `w-0`, so the grow factor expands the invisible label to fill the row — `justify-center` on the link has no free space left to center in.

## Solution

Apply `flex-none` to the label span when collapsed (and `flex-1` only when expanded), so the hidden label truly collapses to zero width and the icon centers in the rail.

| Before | After |
|--------|-------|
| Icon left-hugged, empty pill space right | Icon centered, compact pill |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PXJnZXUyt5vyE7DiuLnD3

<!-- coverage-report:start -->
Coverage: 68.82% (±0.00% vs `main`)
<!-- coverage-report:end -->
