### PR TITLE
fix: bump reka-ui to 2.9.9 so dialog inputs focus on mouse click

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "ora": "5.4.1",
     "prettier": "^3.3.2",
     "prosemirror-tables": "^1.8.1",
-    "reka-ui": "^2.5.0",
+    "reka-ui": "^2.9.9",
     "slugify": "^1.6.6",
     "socket.io-client": "^4.5.1",
     "tippy.js": "^6.3.7",

--- a/src/components/Dialog/Dialog.cy.ts
+++ b/src/components/Dialog/Dialog.cy.ts
@@ -86,19 +86,90 @@ describe('Dialog', () => {
 
   // ---- New behavior props ----------------------------------------------------
 
-  it('dismissible=false blocks outside click and Escape from closing', () => {
-    cy.mount(Dialog, {
-      props: {
-        open: true,
-        title: 'Locked',
-        message: 'Cannot dismiss',
-        dismissible: false,
+  it('closes on outside click when dismissible', () => {
+    const Wrapper = defineComponent({
+      setup() {
+        const open = ref(true)
+        return { open }
+      },
+      render() {
+        return h(Dialog, {
+          open: this.open,
+          'onUpdate:open': (v: boolean) => (this.open = v),
+          title: 'Dismissible',
+        })
       },
     })
 
+    cy.mount(Wrapper)
+    cy.get('[role=dialog]').should('exist')
+    cy.get('.dialog-overlay').click(0, 0, { force: true })
+    cy.get('[role=dialog]').should('not.exist')
+  })
+
+  it('dismissible=false blocks outside click and Escape from closing', () => {
+    const Wrapper = defineComponent({
+      setup() {
+        const open = ref(true)
+        return { open }
+      },
+      render() {
+        return h(Dialog, {
+          open: this.open,
+          'onUpdate:open': (v: boolean) => (this.open = v),
+          title: 'Locked',
+          message: 'Cannot dismiss',
+          dismissible: false,
+        })
+      },
+    })
+
+    cy.mount(Wrapper)
+    cy.get('[role=dialog]').should('exist')
+    cy.get('.dialog-overlay').click(0, 0, { force: true })
     cy.get('[role=dialog]').should('exist')
     cy.get('body').type('{esc}')
     cy.get('[role=dialog]').should('exist')
+  })
+
+  it('focuses and types into an input clicked inside a scrollable dialog', () => {
+    cy.mount(Dialog, {
+      props: { open: true, title: 'Long form' },
+      slots: {
+        default: () =>
+          h(
+            'div',
+            {
+              'data-cy': 'tall-dialog-body',
+              style: {
+                height: '1200px',
+                display: 'flex',
+                alignItems: 'flex-end',
+              },
+            },
+            [
+              h('input', {
+                'data-cy': 'mouse-focus-input',
+                type: 'text',
+              }),
+            ],
+          ),
+      },
+    })
+
+    cy.get('.dialog-overlay').should(($overlay) => {
+      expect($overlay[0].scrollHeight).to.be.greaterThan(
+        $overlay[0].clientHeight,
+      )
+    })
+
+    // Cypress cannot synthesize fully trusted OS-level events, so this guards
+    // the click-to-focus behavior contract rather than the exact event chain.
+    cy.get('[data-cy=mouse-focus-input]')
+      .click()
+      .should('be.focused')
+      .type('Focused by mouse')
+      .should('have.value', 'Focused by mouse')
   })
 
   it('showCloseButton renders an accessible close affordance that closes the dialog', () => {
@@ -218,11 +289,7 @@ describe('Dialog', () => {
     cy.mount(Dialog, {
       props: { modelValue: true },
       slots: {
-        'body-header': h(
-          'div',
-          { 'data-cy': 'body-header' },
-          'legacy header',
-        ),
+        'body-header': h('div', { 'data-cy': 'body-header' }, 'legacy header'),
         'body-content': h(
           'div',
           { 'data-cy': 'body-content' },
@@ -261,11 +328,7 @@ describe('Dialog', () => {
     cy.mount(Dialog, {
       props: { modelValue: true },
       slots: {
-        'body-header': h(
-          'div',
-          { 'data-cy': 'body-header' },
-          'legacy header',
-        ),
+        'body-header': h('div', { 'data-cy': 'body-header' }, 'legacy header'),
       },
     })
 
@@ -320,11 +383,7 @@ describe('Dialog', () => {
         default: () =>
           h('div', { autofocus: '' }, [
             h('span', 'label'),
-            h(
-              'button',
-              { 'data-cy': 'toggle', type: 'button' },
-              'Toggle',
-            ),
+            h('button', { 'data-cy': 'toggle', type: 'button' }, 'Toggle'),
             h('button', { 'data-cy': 'second', type: 'button' }, 'Other'),
           ]),
       },

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -16,7 +16,6 @@
             ref="contentRef"
             class="my-8 inline-block w-full transform overflow-hidden rounded-xl bg-surface-elevation-1 text-start align-middle shadow-xl dialog-content focus-visible:outline-none"
             :class="sizeClass"
-            @pointerdown.stop
             @open-auto-focus="handleOpenAutoFocus"
             @escape-key-down="
               (e: Event) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,7 +2024,7 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.30.tgz#5d7a0d3ca151647484303fd9f057e2e13ecb80ef"
   integrity sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==
 
-"@vueuse/core@14.1.0", "@vueuse/core@^14.0.0":
+"@vueuse/core@14.1.0", "@vueuse/core@^14.0.0", "@vueuse/core@^14.1.0":
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-14.1.0.tgz#274e98e591a505333b7dfb2bcaf7b4530a10b9c9"
   integrity sha512-rgBinKs07hAYyPF834mDTigH7BtPqvZ3Pryuzt1SD/lg5wEcWqvwzXXYGEDb2/cP0Sj5zSvHl3WkmMELr5kfWw==
@@ -2090,7 +2090,7 @@
   dependencies:
     vue "^3.5.13"
 
-"@vueuse/shared@14.1.0":
+"@vueuse/shared@14.1.0", "@vueuse/shared@^14.1.0":
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-14.1.0.tgz#49b2face86a9c0c52e20eaf4c732a0223276c11f"
   integrity sha512-EcKxtYvn6gx1F8z9J5/rsg3+lTQnvOruQd8fUecW99DCK04BkWD7z5KQ/wTAx+DazyoEE9dJt/zV8OIEQbM6kw==
@@ -5800,20 +5800,20 @@ regexp.prototype.flags@^1.5.1:
     gopd "^1.2.0"
     set-function-name "^2.0.2"
 
-reka-ui@^2.5.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/reka-ui/-/reka-ui-2.7.0.tgz#906697e744e9a9682f89372a46ef384d4500eae7"
-  integrity sha512-m+XmxQN2xtFzBP3OAdIafKq7C8OETo2fqfxcIIxYmNN2Ch3r5oAf6yEYCIJg5tL/yJU2mHqF70dCCekUkrAnXA==
+reka-ui@^2.9.9:
+  version "2.9.9"
+  resolved "https://registry.yarnpkg.com/reka-ui/-/reka-ui-2.9.9.tgz#8e667637d06c1b296f16a34b8cff0565f55200bc"
+  integrity sha512-/e+hdF9vP8E2kPrKR4RdgMQQsfpCr8l436Zn8GRWM3jKT9EG1lOO/UFMGBVEnrMLOVoJSjjmIFrej4tMOb+6qQ==
   dependencies:
     "@floating-ui/dom" "^1.6.13"
     "@floating-ui/vue" "^1.1.6"
     "@internationalized/date" "^3.5.0"
     "@internationalized/number" "^3.5.0"
     "@tanstack/vue-virtual" "^3.12.0"
-    "@vueuse/core" "^12.5.0"
-    "@vueuse/shared" "^12.5.0"
+    "@vueuse/core" "^14.1.0"
+    "@vueuse/shared" "^14.1.0"
     aria-hidden "^1.2.4"
-    defu "^6.1.4"
+    defu "^6.1.5"
     ohash "^2.0.11"
 
 release-zalgo@^1.0.0:


### PR DESCRIPTION
## Summary
Mouse clicks can once again focus inputs, textareas, and contenteditable regions inside a `Dialog`. reka-ui 2.9.8 shipped a regression where the dialog overlay cancelled `pointerdown` events bubbling up from dialog content, which suppressed the compatibility `mousedown` that performs focus and caret placement — so keyboard focus worked but mouse focus was dead.

## Why this matters
Reported in #766. The component nests `<DialogContent>` inside a scrollable `<DialogOverlay>` — an upstream-supported pattern for scrollable dialogs. reka-ui 2.9.8 (unovue/reka-ui#2655) added `@pointerdown.left.prevent` to `DialogOverlayImpl` to restore trigger focus after backdrop clicks, but it also cancelled pointerdowns bubbling from nested content. This was fixed upstream in 2.9.9 (unovue/reka-ui#2668) by scoping the prevention with `.self`. Only 2.9.8 was affected — frappe-ui `main`'s own lockfile resolved 2.7.0 (unaffected) — but the `^2.5.0` floor let consumer lockfiles resolve the broken 2.9.8, which is how #766 was hit.

## Changes
- Bumps the `reka-ui` dependency floor to `^2.9.9` so no consumer can resolve into the broken 2.9.8, and updates the lockfile accordingly.
- Removes the `@pointerdown.stop` workaround on `<DialogContent>`, obsolete now that the root cause is fixed upstream.
- Rewrites the dismissible dialog tests with a stateful wrapper (the previous props-only mounts could never close, making the assertions vacuous) and adds outside-click dismiss and scrollable-dialog focus coverage.

## Testing
`yarn install` resolves reka-ui to 2.9.9; verified a dialog with a text input focuses on a real mouse click (caret placed) as well as via keyboard. Full CI is green, including all Cypress component-test shards.

Fixes #766

<!-- coverage-report:start -->
Coverage: 68.75% (-0.03% vs `main`)
<!-- coverage-report:end -->
