### PR TITLE
fix(docs): prevent framework↔theme circular chunks on ui.frappe.io

### DIFF
--- a/vitepress/index.node.ts
+++ b/vitepress/index.node.ts
@@ -8,6 +8,7 @@ import { lucideIcons } from 'frappe-ui/vite'
 
 import { createComponentTransformer } from './plugins/componentTransformer.ts'
 import colocatedComponentDocs from './plugins/colocatedComponentDocs.ts'
+import preventCircularChunks from './plugins/preventCircularChunks.ts'
 import type { SidebarSection } from './components/Docs/sidebarList.ts'
 
 // frappe-ui package root — this file lives at <root>/vitepress/index.node.ts.
@@ -118,6 +119,9 @@ export function defineDocsConfig(
     vite: {
       plugins: [
         lucideIcons(),
+        // Keep vue / @vueuse / vue-router in the VitePress `framework` chunk so
+        // production never ships a framework↔theme cycle (TDZ on load).
+        preventCircularChunks(),
         ...(colocatedDocs
           ? [
               colocatedComponentDocs(

--- a/vitepress/plugins/preventCircularChunks.ts
+++ b/vitepress/plugins/preventCircularChunks.ts
@@ -1,0 +1,65 @@
+import type { Plugin } from 'vite'
+
+/**
+ * VitePress places shared deps into `framework` or `theme` via `manualChunks`.
+ * When the graph is large (frappe-ui + vueuse + reka-ui), Rollup can put a
+ * module that both chunks need into `theme` while `framework` still depends on
+ * it — a cyclic ESM graph that throws at runtime:
+ *
+ *   ReferenceError: can't access lexical declaration '…' before initialization
+ *     at framework.*.js
+ *
+ * Force the Vue ecosystem into `framework` first (before VitePress's own
+ * manualChunks), and fail the build if a framework→theme edge still appears.
+ */
+const FRAMEWORK_PKG_RE =
+  /[/\\]node_modules[/\\](?:vue|@vue[/\\]|vue-router|@vueuse[/\\])/
+
+export default function preventCircularChunks(): Plugin {
+  return {
+    name: 'frappe-ui:prevent-circular-chunks',
+    apply: 'build',
+    // Runs after VitePress installs its manualChunks so we can wrap it.
+    outputOptions(options) {
+      const previous = options.manualChunks
+      options.manualChunks = (id, meta) => {
+        if (FRAMEWORK_PKG_RE.test(id)) {
+          return 'framework'
+        }
+        if (typeof previous === 'function') {
+          return previous(id, meta)
+        }
+        if (previous && typeof previous === 'object') {
+          for (const [name, pattern] of Object.entries(previous)) {
+            if (
+              pattern instanceof RegExp
+                ? pattern.test(id)
+                : Array.isArray(pattern) && pattern.some((p) => id.includes(p))
+            ) {
+              return name
+            }
+          }
+        }
+        return undefined
+      }
+      return options
+    },
+    generateBundle(_options, bundle) {
+      for (const [fileName, chunk] of Object.entries(bundle)) {
+        if (chunk.type !== 'chunk') continue
+        if (!/[/\\]framework\.[^/\\]+\.js$/.test(fileName) && chunk.name !== 'framework') {
+          continue
+        }
+        const bad = chunk.imports.filter(
+          (imp) => /theme\.[^/]+\.js$/.test(imp) || imp.includes('/theme.'),
+        )
+        if (bad.length) {
+          this.error(
+            `Circular VitePress chunks: ${fileName} imports ${bad.join(', ')}. ` +
+              'framework must not import theme (TDZ at runtime on ui.frappe.io).',
+          )
+        }
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #832 — ui.frappe.io fails to hydrate with:

```
Uncaught ReferenceError: can't access lexical declaration 'ml' before initialization
    at framework.ByyYB-NO.js
```

Root cause: production VitePress chunks form a **cycle** — `framework.*.js` imports live bindings from `theme.*.js` (VueUse helpers like `inBrowser`), while `theme` imports Vue from `framework`. On load that is a TDZ error, so the recipes homepage never boots client-side.

Verified by importing the live chunks and by browser checks:
- **Production** (`ui.frappe.io`): throws `Cannot access 'ml' before initialization`, recipes stay broken
- **Local rebuild with this fix**: no page errors; recipe iframes load

## Change

- New Vite plugin `preventCircularChunks` wired into `defineDocsConfig`
- Forces `vue` / `@vue/*` / `vue-router` / `@vueuse/*` into the `framework` chunk (before VitePress’s own `manualChunks`)
- Fails the docs build if `framework` still imports `theme`

## Test plan

- [x] `yarn docs:build` succeeds
- [x] Built `framework.*.js` does not import `theme.*.js`
- [x] `yarn docs:preview` homepage loads with recipe iframes and no console TDZ
- [ ] After merge, site-deploy updates ui.frappe.io; hard-refresh confirms no `ml` error and recipe previews hydrate

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-833/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 68.78% (±0.00% vs `main`)
<!-- coverage-report:end -->
