### PR TITLE
Optimize first recipe with eager iframe loading for faster above-the-fold rendering

### DIFF
--- a/docs/components/recipes/RecipeExample.vue
+++ b/docs/components/recipes/RecipeExample.vue
@@ -5,7 +5,9 @@
 // slot (`#desktop` / `#mobile`) from a `<<<` include so VitePress highlights it.
 //
 // The iframe src is only set once the block scrolls near the viewport, so the
-// page doesn't boot every app shell at once.
+// page doesn't boot every app shell at once. The exception is the first recipe
+// (`eager`), which sits in the first fold: it renders its iframe straight into
+// the server HTML so the browser fetches the demo before Vue even hydrates.
 import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
 import { useMediaQuery } from '@vueuse/core'
 import { withBase } from 'vitepress'
@@ -20,6 +22,12 @@ const props = defineProps<{
   height?: string
   /** Preview height for the mobile variant. */
   mobileHeight?: string
+  /**
+   * Boot this recipe's iframe immediately instead of waiting for it to scroll
+   * near the viewport. Set on the first recipe so the above-the-fold preview
+   * starts loading with the page rather than after hydration + observer.
+   */
+  eager?: boolean
 }>()
 
 const group = computed(() => getRecipeGroup(props.base))
@@ -80,12 +88,19 @@ const tabOptions = [
   { label: 'Code', value: 'code' },
 ]
 
-// Boot the iframe only when the block nears the viewport.
+// Boot the iframe only when the block nears the viewport — except the first
+// recipe, which starts visible so its iframe is in the SSR HTML and begins
+// loading before hydration.
 const root = useTemplateRef<HTMLElement>('root')
-const visible = ref(false)
+const visible = ref(props.eager ?? false)
+// Above-the-fold recipe: fetch its iframe with the highest priority; the rest
+// stay lazy so they don't compete for the network during first paint.
+const iframeLoading = computed(() => (props.eager ? 'eager' : 'lazy'))
 let observer: IntersectionObserver | undefined
 onMounted(() => {
   mounted.value = true
+  // Eager recipe already booted its iframe in SSR — no observer needed.
+  if (visible.value) return
   // Older browsers without IntersectionObserver can't lazy-boot; load eagerly
   // so the previews still appear instead of the callback throwing on mount.
   if (typeof IntersectionObserver === 'undefined') {
@@ -152,7 +167,7 @@ onBeforeUnmount(() => observer?.disconnect())
           v-if="visible"
           :src="src"
           :title="heading"
-          loading="lazy"
+          :loading="iframeLoading"
           class="w-[390px] rounded border bg-surface-base shadow-lg"
           :style="{ height: frameHeight }"
         />
@@ -162,7 +177,7 @@ onBeforeUnmount(() => observer?.disconnect())
           v-if="visible"
           :src="src"
           :title="heading"
-          loading="lazy"
+          :loading="iframeLoading"
           class="w-full rounded border bg-surface-base"
           :style="{ height: frameHeight }"
         />

--- a/docs/components/recipes/RecipeExample.vue
+++ b/docs/components/recipes/RecipeExample.vue
@@ -99,8 +99,14 @@ const iframeLoading = computed(() => (props.eager ? 'eager' : 'lazy'))
 let observer: IntersectionObserver | undefined
 onMounted(() => {
   mounted.value = true
-  // Eager recipe already booted its iframe in SSR — no observer needed.
-  if (visible.value) return
+  // Eager recipe already booted its iframe in SSR — no observer needed. Warm
+  // the shown variant's component chunk from here so it downloads alongside the
+  // iframe's app boot; being same-origin, the iframe reuses it from cache
+  // instead of waiting on its own dynamic import.
+  if (visible.value) {
+    variant.value?.preload?.()
+    return
+  }
   // Older browsers without IntersectionObserver can't lazy-boot; load eagerly
   // so the previews still appear instead of the callback throwing on mount.
   if (typeof IntersectionObserver === 'undefined') {

--- a/docs/components/recipes/index.ts
+++ b/docs/components/recipes/index.ts
@@ -1,4 +1,8 @@
-import { defineAsyncComponent, type Component } from 'vue'
+import {
+  defineAsyncComponent,
+  type AsyncComponentLoader,
+  type Component,
+} from 'vue'
 import { recipeSlugs } from './slugs'
 
 export type Platform = 'desktop' | 'mobile'
@@ -10,6 +14,13 @@ export interface RecipeVariant {
   /** Render the demo client-side only (e.g. the tiptap editor is not SSR-safe). */
   csr?: boolean
   component: Component
+  /**
+   * Kick off the dynamic import behind `component` without mounting it. The
+   * gallery calls this for the eager (above-the-fold) recipe so its chunk is
+   * warm in the shared same-origin HTTP cache by the time the demo iframe's
+   * own app boots and imports it — turning that import into a cache hit.
+   */
+  preload: AsyncComponentLoader
 }
 
 /**
@@ -27,19 +38,33 @@ export interface RecipeGroup {
   mobile?: RecipeVariant
 }
 
+// Take the raw dynamic-import loader (not a pre-wrapped component) so we can
+// both render it lazily and expose it as `preload` for cache-warming.
 function desktop(
   slug: string,
-  component: Component,
+  loader: AsyncComponentLoader,
   csr = false,
 ): RecipeVariant {
-  return { slug, platform: 'desktop', component, csr }
+  return {
+    slug,
+    platform: 'desktop',
+    component: defineAsyncComponent(loader),
+    preload: loader,
+    csr,
+  }
 }
 function mobile(
   slug: string,
-  component: Component,
+  loader: AsyncComponentLoader,
   csr = false,
 ): RecipeVariant {
-  return { slug, platform: 'mobile', component, csr }
+  return {
+    slug,
+    platform: 'mobile',
+    component: defineAsyncComponent(loader),
+    preload: loader,
+    csr,
+  }
 }
 
 // Full-page, copy-pastable screens. Each variant is one self-contained SFC in
@@ -62,11 +87,11 @@ export const recipeGroups: RecipeGroup[] = [
     ],
     desktop: desktop(
       'discussions-desktop',
-      defineAsyncComponent(() => import('./DiscussionsDesktop.vue')),
+      () => import('./DiscussionsDesktop.vue'),
     ),
     mobile: mobile(
       'discussions-mobile',
-      defineAsyncComponent(() => import('./DiscussionsMobile.vue')),
+      () => import('./DiscussionsMobile.vue'),
     ),
   },
   {
@@ -83,12 +108,12 @@ export const recipeGroups: RecipeGroup[] = [
     ],
     desktop: desktop(
       'compose-desktop',
-      defineAsyncComponent(() => import('./ComposeDesktop.vue')),
+      () => import('./ComposeDesktop.vue'),
       true,
     ),
     mobile: mobile(
       'compose-mobile',
-      defineAsyncComponent(() => import('./ComposeMobile.vue')),
+      () => import('./ComposeMobile.vue'),
       true,
     ),
   },
@@ -105,11 +130,11 @@ export const recipeGroups: RecipeGroup[] = [
     ],
     desktop: desktop(
       'deals-desktop',
-      defineAsyncComponent(() => import('./DealsDesktop.vue')),
+      () => import('./DealsDesktop.vue'),
     ),
     mobile: mobile(
       'deals-mobile',
-      defineAsyncComponent(() => import('./DealsMobile.vue')),
+      () => import('./DealsMobile.vue'),
     ),
   },
   {
@@ -125,11 +150,11 @@ export const recipeGroups: RecipeGroup[] = [
     ],
     desktop: desktop(
       'tickets-desktop',
-      defineAsyncComponent(() => import('./TicketsDesktop.vue')),
+      () => import('./TicketsDesktop.vue'),
     ),
     mobile: mobile(
       'tickets-mobile',
-      defineAsyncComponent(() => import('./TicketsMobile.vue')),
+      () => import('./TicketsMobile.vue'),
     ),
   },
   {
@@ -147,11 +172,11 @@ export const recipeGroups: RecipeGroup[] = [
     ],
     desktop: desktop(
       'mail-desktop',
-      defineAsyncComponent(() => import('./MailDesktop.vue')),
+      () => import('./MailDesktop.vue'),
     ),
     mobile: mobile(
       'mail-mobile',
-      defineAsyncComponent(() => import('./MailMobile.vue')),
+      () => import('./MailMobile.vue'),
     ),
   },
   {
@@ -169,11 +194,11 @@ export const recipeGroups: RecipeGroup[] = [
     ],
     desktop: desktop(
       'files-desktop',
-      defineAsyncComponent(() => import('./FilesDesktop.vue')),
+      () => import('./FilesDesktop.vue'),
     ),
     mobile: mobile(
       'files-mobile',
-      defineAsyncComponent(() => import('./FilesMobile.vue')),
+      () => import('./FilesMobile.vue'),
     ),
   },
   {
@@ -191,11 +216,11 @@ export const recipeGroups: RecipeGroup[] = [
     ],
     desktop: desktop(
       'tasks-desktop',
-      defineAsyncComponent(() => import('./TasksDesktop.vue')),
+      () => import('./TasksDesktop.vue'),
     ),
     mobile: mobile(
       'tasks-mobile',
-      defineAsyncComponent(() => import('./TasksMobile.vue')),
+      () => import('./TasksMobile.vue'),
     ),
   },
   {
@@ -212,11 +237,11 @@ export const recipeGroups: RecipeGroup[] = [
     ],
     desktop: desktop(
       'accounting-desktop',
-      defineAsyncComponent(() => import('./AccountingDesktop.vue')),
+      () => import('./AccountingDesktop.vue'),
     ),
     mobile: mobile(
       'accounting-mobile',
-      defineAsyncComponent(() => import('./AccountingMobile.vue')),
+      () => import('./AccountingMobile.vue'),
     ),
   },
 ]

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -12,7 +12,7 @@ import RecipeExample from '@/components/recipes/RecipeExample.vue'
 
 <Hero class="not-prose" />
 
-<RecipeExample base="discussions">
+<RecipeExample base="discussions" eager>
 <template #desktop>
 
 <<< ../components/recipes/DiscussionsDesktop.vue


### PR DESCRIPTION
## Summary
This PR optimizes the initial page load performance by enabling eager iframe loading for the first recipe component, which appears above the fold. Instead of waiting for the Intersection Observer to detect viewport visibility, the first recipe now renders its iframe directly into the server HTML, allowing the browser to begin fetching the demo before Vue hydration completes.

## Key Changes
- Added `eager` prop to `RecipeExample` component to control iframe loading strategy
- Modified iframe visibility initialization to respect the `eager` flag, starting visible immediately for eager recipes
- Implemented dynamic `loading` attribute on iframes: uses `"eager"` for the first recipe and `"lazy"` for others
- Updated Intersection Observer setup to skip initialization when the recipe is already visible (eager case)
- Applied the `eager` flag to the first recipe in the documentation homepage
- Enhanced code comments to explain the eager loading optimization and its rationale

## Implementation Details
- The `visible` ref now initializes to `props.eager ?? false` instead of always `false`
- A computed property `iframeLoading` determines the appropriate loading strategy based on the `eager` prop
- The observer setup includes an early return when `visible.value` is true, preventing unnecessary observer attachment for eager recipes
- Both desktop and mobile iframe elements now use the dynamic `:loading` binding instead of the static `loading="lazy"` attribute

https://claude.ai/code/session_01C5Dkri6xLianhSoB8oqhUf

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-836/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 68.78% (+0.03% vs `main`)
<!-- coverage-report:end -->

