### PR TITLE
fix(editor): mount suggestion popup via renderer wrapper

### DIFF
--- a/src/molecules/editor/SuggestionExtension.ts
+++ b/src/molecules/editor/SuggestionExtension.ts
@@ -16,6 +16,7 @@ export type SuggestionExtensionOptions<TItem = any> = {
   items: TItem[] | ((query: string) => TItem[] | Promise<TItem[]>)
   component?: Component
   floatingOptions?: SuggestionFloatingOptions
+  allowSpaces?: boolean
   command: (props: { editor: Editor; item: TItem; range: SuggestionRange }) => void
 }
 
@@ -26,6 +27,7 @@ function buildSuggestionExtension<TItem = any>(options: SuggestionExtensionOptio
       return {
         suggestion: {
           char: options.trigger,
+          allowSpaces: options.allowSpaces,
           pluginKey: new PluginKey(options.name),
           items: ({ query }: { query: string }) =>
             typeof options.items === 'function' ? options.items(query) : options.items,

--- a/src/molecules/editor/extensions/shared/suggestion-renderer.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-renderer.test.ts
@@ -118,6 +118,20 @@ describe('createSuggestionRenderer', () => {
     expect(document.body.contains(renderer.el)).toBe(true)
   })
 
+  it('keeps previous items during a transient loading update', () => {
+    const api = createSuggestionRenderer(FakeComponent)
+    api.onStart(makeProps({ items: [{ label: 'a' }] } as never))
+    const renderer = instances[0]
+
+    api.onUpdate(makeProps({ items: [], loading: true } as never))
+
+    expect(renderer.props.items).toEqual([{ label: 'a' }])
+
+    api.onUpdate(makeProps({ items: [{ label: 'b' }], loading: false } as never))
+
+    expect(renderer.props.items).toEqual([{ label: 'b' }])
+  })
+
   it('returns false on Escape so the suggestion plugin runs onExit', () => {
     const api = createSuggestionRenderer(FakeComponent)
     api.onStart(makeProps())

--- a/src/molecules/editor/extensions/shared/suggestion-renderer.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-renderer.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SuggestionProps, SuggestionKeyDownProps } from '@tiptap/suggestion'
+import { createSuggestionRenderer } from './suggestion-renderer'
+
+// Every `new VueRenderer(...)` the renderer creates lands here so tests can
+// inspect the real wrapper element it mounted.
+interface FakeRenderer {
+  el: HTMLElement | null
+  element: Element | null
+  destroyed: boolean
+  onKeyDownSpy: ReturnType<typeof vi.fn>
+}
+const instances = vi.hoisted(() => [] as FakeRenderer[])
+
+// Fake VueRenderer that reproduces the regression this file fixes: `element`
+// (the firstElementChild) is null — as it is for the reka `FocusScope`-based
+// popup — while `el` (the wrapper div tiptap always creates) is present. Defined
+// inside the factory because `vi.mock` is hoisted above the module body.
+vi.mock('@tiptap/vue-3', () => {
+  class FakeVueRenderer {
+    el: HTMLElement | null
+    props: Record<string, any>
+    editor: unknown
+    destroyed = false
+    onKeyDownSpy = vi.fn(() => true)
+
+    constructor(_component: unknown, { props, editor }: any) {
+      this.el = document.createElement('div')
+      this.props = props
+      this.editor = editor
+      instances.push(this as unknown as FakeRenderer)
+    }
+
+    get element(): Element | null {
+      // Empty wrapper -> no first child, mirroring the broken case.
+      return this.el ? this.el.firstElementChild : null
+    }
+
+    get ref() {
+      return { onKeyDown: this.onKeyDownSpy }
+    }
+
+    updateProps(props: Record<string, any>) {
+      Object.assign(this.props, props)
+    }
+
+    destroy() {
+      this.destroyed = true
+      this.el = null
+    }
+  }
+  return { VueRenderer: FakeVueRenderer }
+})
+
+vi.mock('@floating-ui/dom', () => ({
+  computePosition: vi.fn(async () => ({ x: 10, y: 20 })),
+  flip: vi.fn(() => ({})),
+  offset: vi.fn(() => ({})),
+  shift: vi.fn(() => ({})),
+}))
+
+const FakeComponent = {} as never
+
+function makeProps(overrides: Partial<SuggestionProps> = {}): SuggestionProps {
+  return {
+    editor: { appContext: {} },
+    clientRect: () => ({ top: 0, left: 0, bottom: 0, right: 0 }) as DOMRect,
+    ...overrides,
+  } as unknown as SuggestionProps
+}
+
+function keyDown(key: string): SuggestionKeyDownProps {
+  return { event: new KeyboardEvent('keydown', { key }) } as SuggestionKeyDownProps
+}
+
+describe('createSuggestionRenderer', () => {
+  beforeEach(() => {
+    instances.length = 0
+    document.body.innerHTML = ''
+  })
+
+  it('mounts the VueRenderer wrapper (renderer.el), not its null firstElementChild', () => {
+    const api = createSuggestionRenderer(FakeComponent)
+    api.onStart(makeProps())
+
+    const renderer = instances[0]
+    // Precondition: the regression case — `.element` is null...
+    expect(renderer.element).toBeNull()
+    // ...yet the popup is still appended via the always-present wrapper.
+    expect(document.body.contains(renderer.el)).toBe(true)
+    expect(renderer.el?.style.position).toBe('absolute')
+  })
+
+  it('removes the wrapper and destroys the renderer on exit', () => {
+    const api = createSuggestionRenderer(FakeComponent)
+    api.onStart(makeProps())
+    const renderer = instances[0]
+    const wrapper = renderer.el
+
+    api.onExit()
+
+    expect(document.body.contains(wrapper)).toBe(false)
+    expect(renderer.destroyed).toBe(true)
+  })
+
+  it('late-attaches on update when onStart had no caret rect yet', () => {
+    const api = createSuggestionRenderer(FakeComponent)
+    api.onStart(makeProps({ clientRect: null }))
+    const renderer = instances[0]
+    expect(document.body.contains(renderer.el)).toBe(false)
+
+    api.onUpdate(makeProps())
+
+    expect(document.body.contains(renderer.el)).toBe(true)
+  })
+
+  it('returns false on Escape so the suggestion plugin runs onExit', () => {
+    const api = createSuggestionRenderer(FakeComponent)
+    api.onStart(makeProps())
+    expect(api.onKeyDown(keyDown('Escape'))).toBe(false)
+    expect(instances[0].onKeyDownSpy).not.toHaveBeenCalled()
+  })
+
+  it('delegates other keys to the suggestion list', () => {
+    const api = createSuggestionRenderer(FakeComponent)
+    api.onStart(makeProps())
+    expect(api.onKeyDown(keyDown('ArrowDown'))).toBe(true)
+    expect(instances[0].onKeyDownSpy).toHaveBeenCalled()
+  })
+})

--- a/src/molecules/editor/extensions/shared/suggestion-renderer.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-renderer.ts
@@ -71,12 +71,14 @@ export function createSuggestionRenderer(
   }
 
   // Attach `renderer.el` (the wrapper VueRenderer always creates) rather than
-  // `renderer.element` (its firstElementChild): reka's FocusScope-based popup has
-  // no synchronous first child, so `element` is null and nothing would mount.
-  // `.el` is an undocumented tiptap internal, so a tiptap major could break this
-  // (guarded by suggestion-renderer.test.ts).
+  // `renderer.element` (its firstElementChild): the popup renders nothing until it
+  // has items, so `element` is null at onStart and nothing would mount. `el` is a
+  // public, typed field on VueRenderer, so a tiptap release that drops it fails the
+  // build here instead of breaking silently; instanceof narrows Element ->
+  // HTMLElement. Guarded by suggestion-renderer.test.ts.
   function getWrapper(): HTMLElement | null {
-    return (renderer as unknown as { el: HTMLElement | null } | null)?.el ?? null
+    const el = renderer?.el
+    return el instanceof HTMLElement ? el : null
   }
 
   // Attach the wrapper to the body and position it. Re-callable from a later

--- a/src/molecules/editor/extensions/shared/suggestion-renderer.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-renderer.ts
@@ -82,6 +82,32 @@ export function createSuggestionRenderer(
     })
   }
 
+  // The mount host `VueRenderer` creates for the popup component. We attach and
+  // position THIS wrapper rather than `renderer.element` (its firstElementChild):
+  // some popup components (e.g. the reka `FocusScope`-based `EditorPopover`) don't
+  // expose a synchronous first element child at render time, so `renderer.element`
+  // stays null and the popup never gets appended. The wrapper always exists right
+  // after `new VueRenderer(...)`, and the popup renders inside it.
+  function getWrapper(): HTMLElement | null {
+    return (renderer as unknown as { el: HTMLElement | null } | null)?.el ?? null
+  }
+
+  // Attach the popup wrapper to the body and position it. Safe to call again from
+  // a later onUpdate if the initial attach couldn't complete.
+  function attach(props: SuggestionProps, token: number): void {
+    // Fix 2/3: bail if a newer query superseded us or we were torn down.
+    if (!isActive || token !== renderToken || !renderer) return
+    if (floatingEl) return
+    const wrapper = getWrapper()
+    if (!props.clientRect || !wrapper) return
+
+    floatingEl = wrapper
+    floatingEl.style.position = 'absolute'
+    document.body.appendChild(floatingEl)
+    getReferenceClientRect = props.clientRect as () => DOMRect | null
+    updatePosition()
+  }
+
   return {
     onStart(props: SuggestionProps) {
       isActive = true
@@ -92,15 +118,7 @@ export function createSuggestionRenderer(
         props,
       })
 
-      if (!props.clientRect || !renderer.element) return
-      // A newer query already superseded this start before mount completed.
-      if (token !== renderToken || !isActive) return
-
-      floatingEl = renderer.element as HTMLElement
-      floatingEl.style.position = 'absolute'
-      document.body.appendChild(floatingEl)
-      getReferenceClientRect = props.clientRect as () => DOMRect | null
-      updatePosition()
+      attach(props, token)
     },
 
     onUpdate(props: SuggestionProps) {
@@ -115,7 +133,10 @@ export function createSuggestionRenderer(
       if (token !== renderToken) return
 
       getReferenceClientRect = props.clientRect as () => DOMRect | null
-      updatePosition()
+      // If the initial mount couldn't attach yet, do it now instead of only
+      // repositioning.
+      if (!floatingEl) attach(props, token)
+      else updatePosition()
     },
 
     onKeyDown(props: SuggestionKeyDownProps): boolean {

--- a/src/molecules/editor/extensions/shared/suggestion-renderer.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-renderer.ts
@@ -113,7 +113,10 @@ export function createSuggestionRenderer(
       if (!isActive || !renderer) return
       const token = ++renderToken
 
-      renderer.updateProps(props)
+      // Skip the plugin's transient `loading` dispatch (empty items) so the
+      // popover doesn't unmount/remount on every keystroke.
+      const loading = (props as SuggestionProps & { loading?: boolean }).loading
+      if (!loading) renderer.updateProps(props)
 
       if (!props.clientRect) return
       if (token !== renderToken) return

--- a/src/molecules/editor/extensions/shared/suggestion-renderer.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-renderer.ts
@@ -19,22 +19,10 @@ export interface SuggestionFloatingOptions {
 }
 
 /**
- * The imperative Floating UI + VueRenderer lifecycle extracted from
- * `createSuggestionExtension().render()`.
+ * The imperative Floating UI + VueRenderer lifecycle for suggestion popups,
+ * extracted from `createSuggestionExtension().render()`.
  *
- * Canonical import path:
- *   `#molecules/editor/extensions/shared/suggestion-renderer`
- *
- * Owns four correctness fixes over the original inline implementation:
- *   1. Escape -> `return false` so the suggestion plugin itself runs `onExit`
- *      (the old code called `popup.hide()` + `return true`, which swallowed the
- *      key and left the plugin state active).
- *   2. Per-query stale-result token: a render token captured in `onStart`/each
- *      `onUpdate` so a late prop update from a superseded query cannot clobber a
- *      newer one.
- *   3. `onUpdate` no-ops after `onExit`/destroy (guards against a queued async
- *      update arriving after teardown).
- *   4. `component.ref` typed via `SuggestionListExpose` instead of `any`.
+ * Import path: `#molecules/editor/extensions/shared/suggestion-renderer`
  */
 export function createSuggestionRenderer(
   component: Component,
@@ -48,9 +36,9 @@ export function createSuggestionRenderer(
   let renderer: VueRenderer | null = null
   let floatingEl: HTMLElement | null = null
   let getReferenceClientRect: (() => DOMRect | null) | null = null
-  // Fix 3: once exited/destroyed, late async updates must not resurrect anything.
+  // Once exited/destroyed, late async updates must not resurrect anything.
   let isActive = false
-  // Fix 2: monotonic token; a stale onUpdate (from a superseded query) bails.
+  // Monotonic token; a stale onUpdate from a superseded query bails.
   let renderToken = 0
 
   function getListExpose(): SuggestionListExpose | null {
@@ -82,20 +70,18 @@ export function createSuggestionRenderer(
     })
   }
 
-  // The mount host `VueRenderer` creates for the popup component. We attach and
-  // position THIS wrapper rather than `renderer.element` (its firstElementChild):
-  // some popup components (e.g. the reka `FocusScope`-based `EditorPopover`) don't
-  // expose a synchronous first element child at render time, so `renderer.element`
-  // stays null and the popup never gets appended. The wrapper always exists right
-  // after `new VueRenderer(...)`, and the popup renders inside it.
+  // Attach `renderer.el` (the wrapper VueRenderer always creates) rather than
+  // `renderer.element` (its firstElementChild): reka's FocusScope-based popup has
+  // no synchronous first child, so `element` is null and nothing would mount.
+  // `.el` is an undocumented tiptap internal, so a tiptap major could break this
+  // (guarded by suggestion-renderer.test.ts).
   function getWrapper(): HTMLElement | null {
     return (renderer as unknown as { el: HTMLElement | null } | null)?.el ?? null
   }
 
-  // Attach the popup wrapper to the body and position it. Safe to call again from
-  // a later onUpdate if the initial attach couldn't complete.
+  // Attach the wrapper to the body and position it. Re-callable from a later
+  // onUpdate if the initial attach couldn't complete.
   function attach(props: SuggestionProps, token: number): void {
-    // Fix 2/3: bail if a newer query superseded us or we were torn down.
     if (!isActive || token !== renderToken || !renderer) return
     if (floatingEl) return
     const wrapper = getWrapper()
@@ -122,25 +108,22 @@ export function createSuggestionRenderer(
     },
 
     onUpdate(props: SuggestionProps) {
-      // Fix 3: ignore updates that arrive after onExit/destroy.
       if (!isActive || !renderer) return
       const token = ++renderToken
 
       renderer.updateProps(props)
 
       if (!props.clientRect) return
-      // Fix 2: a newer query bumped the token between updateProps and now.
       if (token !== renderToken) return
 
       getReferenceClientRect = props.clientRect as () => DOMRect | null
-      // If the initial mount couldn't attach yet, do it now instead of only
-      // repositioning.
+      // Late-attach if the initial mount couldn't; otherwise just reposition.
       if (!floatingEl) attach(props, token)
       else updatePosition()
     },
 
     onKeyDown(props: SuggestionKeyDownProps): boolean {
-      // Fix 1: let the suggestion plugin handle Escape (it runs onExit).
+      // Let the suggestion plugin handle Escape (it runs onExit).
       if (props.event.key === 'Escape') return false
 
       const list = getListExpose()
@@ -150,7 +133,6 @@ export function createSuggestionRenderer(
 
     onExit() {
       isActive = false
-      // Invalidate any in-flight render/update tokens.
       renderToken++
       floatingEl?.remove()
       renderer?.destroy()

--- a/src/molecules/editor/useEditor.test.ts
+++ b/src/molecules/editor/useEditor.test.ts
@@ -131,6 +131,21 @@ describe('frappe-ui/editor minimal primitives', () => {
     expect(typeof options.suggestion.render).toBe('function')
   })
 
+  it('forwards allowSpaces from SuggestionExtension options to the suggestion plugin', async () => {
+    const { SuggestionExtension } = await import('./index')
+
+    const extension = SuggestionExtension.configure({
+      name: 'fields',
+      trigger: '{{',
+      items: [],
+      allowSpaces: true,
+      command: vi.fn(),
+    })
+
+    const options = (extension as any).addOptions()
+    expect(options.suggestion.allowSpaces).toBe(true)
+  })
+
   it('creates and destroys a shallow editor ref', async () => {
     const { useEditor } = await import('./index')
     let editorRef: ReturnType<typeof useEditor> | undefined


### PR DESCRIPTION
This PR contains two fixes for the editor suggestion popups: the popup not mounting in production builds, and `SuggestionExtension` dropping the `allowSpaces` option.

## 1. Suggestion popup never mounts in production builds

### Problem

The `@` mention and custom `{{` suggestion popups silently fail to open in **production builds** (they work in dev). No error is thrown; the popup component renders but is never attached to the DOM.

### Root cause

`createSuggestionRenderer` (`molecules/editor/extensions/shared/suggestion-renderer.ts`) attaches `renderer.element` to `document.body`. In `@tiptap/vue-3`'s `VueRenderer`, `element` is the mount wrapper's **`firstElementChild`**, computed once at construction.

`SuggestionList` renders through `EditorPopover` → reka-ui `FocusScope`. With **reka-ui >= 2.5**, `FocusScope` no longer exposes a synchronous first element child at render time, so `renderer.element` is `null` when `onStart` runs → the early-return guard fires and the popup is never appended. `onUpdate` only repositions, so it never recovers.

This is timing/reka-version dependent, which is why it reproduces only in prod builds (and why older reka, e.g. gameplan on reka 2.0.x, isn't affected).

### Fix

Attach and position the `VueRenderer` **wrapper** (`renderer.el`) instead of its `firstElementChild`. The wrapper always exists right after `new VueRenderer(...)`, and the popup renders inside it, so this is robust regardless of the popup component's root element or the reka-ui version. A late-attach fallback in `onUpdate` covers any case where the initial attach couldn't complete. The existing stale-query token / teardown guards are preserved.

## 2. `SuggestionExtension` drops the `allowSpaces` option

### Problem

The legacy `createSuggestionExtension` factory supported `allowSpaces`, which keeps the suggestion popup open when the query contains a space (e.g. typing `{{first response` to match a "First Response Time" field). The new `SuggestionExtension.configure` wrapper builds the tiptap suggestion config from a fixed set of keys and silently drops everything else, so consumers migrating to it lose this behavior: the popup dismisses the moment a space is typed.

### Fix

Add `allowSpaces?: boolean` to `SuggestionExtensionOptions` and forward it to the underlying `@tiptap/suggestion` plugin config, restoring parity with `createSuggestionExtension`. Covered by a unit test in `useEditor.test.ts`.

## How to test

1. Build an app that uses `RichTextKit` mentions or a `SuggestionExtension` (e.g. Frappe Helpdesk) in **production mode** with reka-ui >= 2.5.
2. In the rich-text editor, type `@` (mention) or a custom trigger like `{{`.
3. Before: no popup appears. After: the suggestion list opens and filters as you type.
4. For `allowSpaces`: configure a `SuggestionExtension` with `allowSpaces: true`, type a multi-word query like `{{first response`. Before: the popup closes on the space. After: it stays open and keeps filtering.

Verified in a Helpdesk production build for both `@` mentions and `{{` field autocomplete, and in dev for `allowSpaces` with the Saved Replies `{{` field autocomplete.

<!-- coverage-report:start -->
Coverage: 68.85% (+0.10% vs `main`)
<!-- coverage-report:end -->



