### PR TITLE
fix(Sidebar): forward sidebar-item slot to SidebarSection

### DIFF
--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -34,7 +34,13 @@
             :label="section.label"
             :items="section.items"
             :collapsible="section.collapsible"
-          />
+          >
+            <!-- Forward the per-item slot so `:sections` consumers can customise each
+                 row (e.g. a trailing actions menu), matching SidebarSection's own slot. -->
+            <template v-if="slots['sidebar-item']" #sidebar-item="itemProps">
+              <slot name="sidebar-item" v-bind="itemProps" />
+            </template>
+          </SidebarSection>
         </div>
 
         <div class="mt-auto">


### PR DESCRIPTION
## Problem

When using the `<Sidebar :sections="…">` API, the component renders each `<SidebarSection>` **without forwarding the `sidebar-item` scoped slot**:

```vue
<SidebarSection
  v-for="section in sections"
  :label="section.label"
  :items="section.items"
  :collapsible="section.collapsible"
/>   <!-- no slot passthrough -->
```

`SidebarSection` **does** expose a `#sidebar-item` slot (with `item` / `isCollapsed`), but because `Sidebar` never passes it down, a consumer's `#sidebar-item` template supplied to `<Sidebar>` is silently ignored and the **default** `SidebarItem` (label + suffix only) renders instead.

Net effect: consumers using the `:sections` shorthand can't customise individual rows — e.g. adding a trailing actions menu (a three-dot `Dropdown`) to each item. The custom markup, and any classes on it, never make it to the DOM.

## Fix

Forward the `sidebar-item` slot from `Sidebar` to `SidebarSection`, guarded so the section's own default rendering is untouched when the consumer doesn't provide one:

```vue
<SidebarSection … >
  <template v-if="slots['sidebar-item']" #sidebar-item="itemProps">
    <slot name="sidebar-item" v-bind="itemProps" />
  </template>
</SidebarSection>
```

`slots` is already available in the component (`const slots = useSlots()`).

## Impact / risk

- No behavioural change when no `#sidebar-item` slot is passed (the `v-if` keeps `SidebarSection`'s default `SidebarItem` in place).
- Only adds passthrough for the already-supported `sidebar-item` slot, so the `:sections` API now matches what `SidebarSection` already documents/supports.

Found via a downstream bug where a folder actions menu (three-dot) never rendered in a `:sections`-driven sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
Coverage: 68.78% (+0.03% vs `main`)
<!-- coverage-report:end -->
