### PR TITLE
fix(Tree): don't apply hover bg when row is fully overriden via slot

### DIFF
--- a/src/components/Tree/TreeItem.vue
+++ b/src/components/Tree/TreeItem.vue
@@ -18,8 +18,12 @@
   >
     <div
       data-slot="row"
-      class="frappe-tree-row group/row relative flex items-center gap-1.5 rounded-md px-1.5 hover:bg-surface-gray-2"
-      :class="ctx.draggable.value && !ctx.disabled.value ? 'cursor-grab' : ''"
+      class="frappe-tree-row group/row relative flex items-center gap-1.5 rounded-md px-1.5"
+      :class="[
+        ctx.draggable.value && !ctx.disabled.value ? 'cursor-grab' : '',
+        // When the row is fully overridden via #item, the consumer owns its hover/selected surface
+        $slots.item ? '' : 'hover:bg-surface-gray-2',
+      ]"
       :draggable="ctx.draggable.value && !ctx.disabled.value"
       @click="onRowClick"
       @dragstart="ctx.onDragStart($event, node, parent)"


### PR DESCRIPTION
## Before

<img width="336" height="443" alt="image" src="https://github.com/user-attachments/assets/082759d7-8d8e-423d-a254-cba9a83e3864" />

## After

<img width="336" height="443" alt="image" src="https://github.com/user-attachments/assets/3cae23cb-46fd-4c1f-b353-4462cb941aaf" />

<!-- coverage-report:start -->
Coverage: 68.75% (±0.00% vs `main`)
<!-- coverage-report:end -->
