### PR TITLE
fix: mention dropdown stays dead after typing a name with no match

### DIFF
--- a/src/components/TextEditor/extensions/suggestion/SuggestionList.vue
+++ b/src/components/TextEditor/extensions/suggestion/SuggestionList.vue
@@ -1,35 +1,34 @@
 <template>
-  <div
-    v-if="items.length"
-    ref="container"
-    class="relative max-h-[300px] min-w-40 overflow-y-auto rounded-lg bg-surface-base p-1 text-base shadow-lg"
-    :class="containerClass"
-  >
-    <button
-      v-for="(item, index) in items"
-      :key="index"
-      :ref="
-        (el) => {
-          if (el) itemRefs[index] = el as HTMLButtonElement
-        }
-      "
-      :class="[
-        'flex w-full items-center whitespace-nowrap rounded-md px-2 py-1.5 text-sm text-ink-gray-9',
-        index === selectedIndex ? 'bg-surface-gray-2' : '',
-        itemClass,
-      ]"
-      @click="selectItem(index)"
-      @mouseover="selectedIndex = index"
-    >
-      <slot :item="item" :index="index">
-        <span>{{ item.display || item.title || item.name }}</span>
-      </slot>
-    </button>
+  <div>
     <div
-      v-if="!items.length && showNoResults"
-      class="px-3 py-1.5 text-sm text-ink-gray-5"
+      v-if="items.length || showNoResults"
+      ref="container"
+      class="relative max-h-[300px] min-w-40 overflow-y-auto rounded-lg bg-surface-base p-1 text-base shadow-lg"
+      :class="containerClass"
     >
-      No results
+      <button
+        v-for="(item, index) in items"
+        :key="index"
+        :ref="
+          (el) => {
+            if (el) itemRefs[index] = el as HTMLButtonElement
+          }
+        "
+        :class="[
+          'flex w-full items-center whitespace-nowrap rounded-md px-2 py-1.5 text-sm text-ink-gray-9',
+          index === selectedIndex ? 'bg-surface-gray-2' : '',
+          itemClass,
+        ]"
+        @click="selectItem(index)"
+        @mouseover="selectedIndex = index"
+      >
+        <slot :item="item" :index="index">
+          <span>{{ item.display || item.title || item.name }}</span>
+        </slot>
+      </button>
+      <div v-if="!items.length" class="px-3 py-1.5 text-sm text-ink-gray-5">
+        No results
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

Mention suggestions could get stuck after typing a query with no matches, then deleting back to a matching prefix. 
For example, typing `@aarnav`, pressing space, then deleting back to `@aar` never restored the dropdown, even though matching users existed.

This happened because the suggestion panel's root element was conditionally rendered with `v-if="items.length"`. When there were no matches, Vue replaced the root with a comment node. If suggestions restarted in that state, Tippy captured the comment node as its content and continued referencing it even after Vue rendered the real panel again.

## Changes

- Keep a stable wrapper element mounted at all times, ensuring Tippy always references the same DOM node.
- Move the `v-if` to the panel inside the wrapper instead of the root element.
- Fix the **No results** state, which was previously unreachable because it was nested under the root `v-if`.

## Result

Mention suggestions now recover correctly when the query changes from no matches back to matching results, and the **No results** message is displayed as intended.

<!-- coverage-report:start -->
Coverage: 68.79% (+0.04% vs `main`)
<!-- coverage-report:end -->
