### PR TITLE
fix: mention dropdown stays dead after typing a name with no match

### DIFF
--- a/src/molecules/editor/extensions/suggestion/SuggestionList.vue
+++ b/src/molecules/editor/extensions/suggestion/SuggestionList.vue
@@ -1,49 +1,51 @@
 <template>
-  <EditorPopover
-    v-if="items.length || showNoResults"
-    dialog-label="Suggestions"
-    :autofocus="false"
-    :trapped="false"
-    :loop="false"
-    :content-class="[
-      'relative max-h-[300px] min-w-40 overflow-y-auto rounded-lg p-1 text-base',
-      containerClass,
-    ]"
-  >
-    <template v-if="items.length">
-      <template
-        v-for="(group, groupIndex) in groupedItems"
-        :key="group.label ?? groupIndex"
-      >
-        <!-- Same idiom as the Dropdown group label (`dropdownClasses.groupLabel`). -->
-        <div
-          v-if="group.label"
-          class="flex h-7 items-center px-2 text-sm-medium text-ink-gray-4"
+  <div>
+    <EditorPopover
+      v-if="items.length || showNoResults"
+      dialog-label="Suggestions"
+      :autofocus="false"
+      :trapped="false"
+      :loop="false"
+      :content-class="[
+        'relative max-h-[300px] min-w-40 overflow-y-auto rounded-lg p-1 text-base',
+        containerClass,
+      ]"
+    >
+      <template v-if="items.length">
+        <template
+          v-for="(group, groupIndex) in groupedItems"
+          :key="group.label ?? groupIndex"
         >
-          {{ group.label }}
-        </div>
-        <SuggestionListItem
-          v-for="{ item, index } in group.entries"
-          :key="index"
-          :ref="(el) => setItemRef(el, index)"
-          :item="item"
-          :selected="index === selectedIndex"
-          :item-class="itemClass"
-          @select="selectItem(index)"
-          @hover="selectedIndex = index"
-        >
-          <template #default="{ item: slotItem }">
-            <slot :item="slotItem" :index="index">
-              <span>{{
-                slotItem.display || slotItem.title || slotItem.name
-              }}</span>
-            </slot>
-          </template>
-        </SuggestionListItem>
+          <!-- Same idiom as the Dropdown group label (`dropdownClasses.groupLabel`). -->
+          <div
+            v-if="group.label"
+            class="flex h-7 items-center px-2 text-sm-medium text-ink-gray-4"
+          >
+            {{ group.label }}
+          </div>
+          <SuggestionListItem
+            v-for="{ item, index } in group.entries"
+            :key="index"
+            :ref="(el) => setItemRef(el, index)"
+            :item="item"
+            :selected="index === selectedIndex"
+            :item-class="itemClass"
+            @select="selectItem(index)"
+            @hover="selectedIndex = index"
+          >
+            <template #default="{ item: slotItem }">
+              <slot :item="slotItem" :index="index">
+                <span>{{
+                  slotItem.display || slotItem.title || slotItem.name
+                }}</span>
+              </slot>
+            </template>
+          </SuggestionListItem>
+        </template>
       </template>
-    </template>
-    <div v-else class="px-3 py-1.5 text-sm text-ink-gray-5">No results</div>
-  </EditorPopover>
+      <div v-else class="px-3 py-1.5 text-sm text-ink-gray-5">No results</div>
+    </EditorPopover>
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary

Same issue as #844, but in `frappe-ui/editor`.

Mention suggestions could get stuck after typing a query with no matches, then deleting back to a matching prefix. For example, typing `@farxyz`, pressing space, then deleting back to `@far` never restored the dropdown, even though matching users existed.

This happened because `SuggestionList.vue` conditionally rendered its root element. When the root switched between a component and a comment node, the detached popover content could no longer be updated, and if suggestions started while there were no matches, no popover was mounted at all.

## Changes

- Keep a stable wrapper element mounted at all times.
- Move the `v-if` to `EditorPopover`, ensuring the same DOM node is reused across renders.

## Result

Mention suggestions now recover correctly when the query changes from no matches back to matching results.

## Before


https://github.com/user-attachments/assets/2f9fc59a-d4a2-4674-b733-db7a6eb61a64


## After


https://github.com/user-attachments/assets/dbc39a13-b025-4836-a185-b8a1f07d9544

<!-- coverage-report:start -->
Coverage: 68.78% (+0.02% vs `main`)
<!-- coverage-report:end -->
