### PR TITLE
fix(ErrorMessage): sanitize rendered HTML

### DIFF
--- a/src/components/ErrorMessage/ErrorMessage.test.ts
+++ b/src/components/ErrorMessage/ErrorMessage.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createApp } from 'vue'
+import ErrorMessage from './ErrorMessage.vue'
+
+function renderErrorMessage(message: string | Error) {
+  const host = document.createElement('div')
+  const app = createApp(ErrorMessage, { message })
+  app.mount(host)
+
+  return {
+    alert: host.querySelector('[role="alert"]')!,
+    unmount: () => app.unmount(),
+  }
+}
+
+describe('ErrorMessage', () => {
+  it('keeps safe markup while removing executable HTML', () => {
+    const { alert, unmount } = renderErrorMessage(
+      '<strong>Invalid</strong><img src=x onerror=alert(1)><script>alert(2)</script>',
+    )
+
+    expect(alert.innerHTML).toContain('<strong>Invalid</strong>')
+    expect(alert.innerHTML).not.toContain('onerror')
+    expect(alert.innerHTML).not.toContain('<script')
+    expect(alert.textContent).not.toContain('alert(2)')
+
+    unmount()
+  })
+
+  it('sanitizes the non-standard messages value on Error objects', () => {
+    const error = Object.assign(new Error('Fallback message'), {
+      messages: '<a href="javascript:alert(1)">Invalid</a>',
+    })
+    const { alert, unmount } = renderErrorMessage(error)
+
+    expect(alert.textContent).toBe('Invalid')
+    expect(alert.querySelector('a')?.getAttribute('href')).toBeNull()
+
+    unmount()
+  })
+})

--- a/src/components/ErrorMessage/ErrorMessage.vue
+++ b/src/components/ErrorMessage/ErrorMessage.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script setup lang="ts">
+import DOMPurify from 'dompurify'
 import { computed } from 'vue'
 import type { ErrorMessageProps } from './types'
 
@@ -15,9 +16,13 @@ const props = defineProps<ErrorMessageProps>()
 
 const errorMessage = computed(() => {
   if (!props.message) return ''
-  if (props.message instanceof Error) {
-    return (props.message as any).messages || props.message.message
-  }
-  return props.message
+
+  const message =
+    props.message instanceof Error
+      ? (props.message as Error & { messages?: string }).messages ||
+        props.message.message
+      : props.message
+
+  return DOMPurify.sanitize(message)
 })
 </script>


### PR DESCRIPTION
## What changed

- sanitize `ErrorMessage` content with the existing DOMPurify dependency before passing it to `v-html`
- preserve support for string messages, native `Error.message`, and the existing non-standard `Error.messages` value
- add regression coverage for event-handler, script, and `javascript:` URL payloads

## Why

`ErrorMessage` rendered message content through `v-html` without sanitization. A caller that passed untrusted HTML could therefore introduce executable markup at the component's render boundary.

## Validation

- `yarn test` — 202 tests passed
- `yarn prettier --check src/components/ErrorMessage/ErrorMessage.vue src/components/ErrorMessage/ErrorMessage.test.ts`
- `yarn type-check` — currently fails on unrelated pre-existing errors across DataImport, Drive, TextEditor, and other components; no reported error points to this change

<!-- coverage-report:start -->
Coverage: 68.76% (±0.00% vs `main`)
<!-- coverage-report:end -->
