### PR TITLE
fix(TextEditor): stop dragging media from duplicating it

### DIFF
--- a/src/molecules/editor/components/MediaNodeView.vue
+++ b/src/molecules/editor/components/MediaNodeView.vue
@@ -215,7 +215,11 @@ function setVideoOptions(options: {
 </script>
 
 <template>
-  <NodeViewWrapper as="div" :class="wrapperClasses(node.attrs.float)">
+  <NodeViewWrapper
+    as="div"
+    data-drag-handle
+    :class="wrapperClasses(node.attrs.float)"
+  >
     <div
       ref="containerRef"
       class="group relative isolate overflow-hidden not-prose rounded"


### PR DESCRIPTION
The image and video nodes both declare `draggable: true` and both render through `MediaNodeView`, but that NodeView never marks a drag handle. ProseMirror therefore does not recognise the gesture as an internal node drag: the browser starts a native HTML5 drag of the inner media element instead, and the drop is handled as an external insert. The node ends up duplicated — a copy at the drop position while the original stays behind, often scrolled out of view, so it looks like a move that went wrong.

Add `data-drag-handle` to the NodeViewWrapper so ProseMirror owns the drag. This stops the duplication; it does not enable free repositioning (dragging becomes inert). Resizing and the alignment controls remain the intended way to place media.

<!-- coverage-report:start -->
Coverage: 68.76% (+2.43% vs `main`)
<!-- coverage-report:end -->
