### PR TITLE
fix(TextEditor): keep media toolbar icons legible in dark mode

### DIFF
--- a/src/molecules/editor/components/MediaToolbar.vue
+++ b/src/molecules/editor/components/MediaToolbar.vue
@@ -87,7 +87,7 @@ onUnmounted(() => {
       >
         <span
           class="lucide-captions size-4"
-          :class="[showCaption ? 'text-ink-base' : 'text-ink-gray-4']"
+          :class="[showCaption ? 'text-white' : 'text-white/60']"
         />
       </button>
     </Tooltip>
@@ -99,7 +99,7 @@ onUnmounted(() => {
         @click.stop="emit('replace')"
       >
         <span
-          class="size-4 text-ink-gray-4 hover:text-ink-base"
+          class="size-4 text-white/60 hover:text-white"
           :class="mediaType === 'embed' ? 'lucide-link' : 'lucide-refresh-cw'"
         />
       </button>
@@ -113,9 +113,9 @@ onUnmounted(() => {
     >
       <button
         type="button"
-        class="hover:text-ink-base"
+        class="hover:text-white"
         :class="
-          node.attrs.align === align.value ? 'text-ink-base' : 'text-ink-gray-4'
+          node.attrs.align === align.value ? 'text-white' : 'text-white/60'
         "
         :aria-label="align.label"
         :aria-pressed="node.attrs.align === align.value"
@@ -128,8 +128,8 @@ onUnmounted(() => {
     <button
       v-if="isVideo"
       type="button"
-      class="hover:text-ink-base"
-      :class="showVideoOptions ? 'text-ink-base' : 'text-ink-gray-4'"
+      class="hover:text-white"
+      :class="showVideoOptions ? 'text-white' : 'text-white/60'"
       aria-label="Video options"
       @click.stop="toggleVideoOptions"
     >
@@ -145,7 +145,7 @@ onUnmounted(() => {
         v-for="option in videoOptionKeys"
         :key="option"
         type="button"
-        class="flex w-full items-center justify-between rounded px-2 py-1 text-left text-xs text-ink-gray-2 hover:bg-white/10 hover:text-ink-base"
+        class="flex w-full items-center justify-between rounded px-2 py-1 text-left text-xs text-white/80 hover:bg-white/10 hover:text-white"
         :aria-pressed="Boolean(node.attrs[option])"
         @click.stop="toggleVideoOption(option)"
       >


### PR DESCRIPTION
The floating toolbar on images and videos sits on a `bg-black/65` scrim. That dark scrim is theme-independent on purpose: the toolbar overlays the media content, not the app background, so it must stay legible over both light and dark images. Its icons, however, used theme-aware `ink-*` tokens, so in dark mode the foreground turned dark-on-dark and the controls became nearly invisible.

Pin the icon colours to white (full white for the active/hover state, white/60 and white/80 for idle) to match the theme-independent scrim, so contrast is identical in light and dark mode.

Before:
<img width="265" height="122" alt="before" src="https://github.com/user-attachments/assets/317b3e2b-f007-4e6f-b226-3b18909a2cdf" />

After:
<img width="210" height="99" alt="after" src="https://github.com/user-attachments/assets/c4735653-d9fa-46e8-9e04-68e1e661357b" />

<!-- coverage-report:start -->
Coverage: 68.76% (+2.43% vs `main`)
<!-- coverage-report:end -->
