### PR TITLE
fix(Menu): use alpha gray for focus and open item backgrounds

### DIFF
--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -159,7 +159,7 @@ export function getMenuBackgroundColor(item: { theme?: MenuTheme }) {
   }
 
   return [
-    'focus:bg-surface-gray-2 data-[highlighted]:bg-surface-alpha-gray-2 data-[state=open]:bg-surface-gray-2',
+    'focus:bg-surface-alpha-gray-2 data-[highlighted]:bg-surface-alpha-gray-2 data-[state=open]:bg-surface-alpha-gray-2',
     'data-[state=checked]:bg-surface-gray-3',
     'data-[highlighted]:data-[state=checked]:bg-surface-gray-4',
   ].join(' ')


### PR DESCRIPTION
Focused and open submenu triggers used the opaque `surface-gray-2`, while hover used `surface-alpha-gray-2`. The background visibly shifted when a submenu opened over a still-hovered trigger. All three states now use the alpha token.

Before:

https://github.com/user-attachments/assets/4e86e51e-3ee8-417b-bbaf-9a4bc5e202e7

After:

https://github.com/user-attachments/assets/92104959-2f3a-4d9f-b2f1-f7b12b065e8e


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
Coverage: 68.78% (±0.00% vs `main`)
<!-- coverage-report:end -->
