### PR TITLE
fix(Sidebar): active state never resolving from isActive/route + clipped active shadow

### DIFF
--- a/src/components/Sidebar/Sidebar.cy.ts
+++ b/src/components/Sidebar/Sidebar.cy.ts
@@ -118,6 +118,11 @@ describe('<SidebarItem />', () => {
     cy.get('[data-slot=sidebar-item][data-state=active]').should('exist')
   })
 
+  it('falls back to the deprecated `isActive` when `active` is not passed', () => {
+    cy.mount(SidebarItem, { props: { label: 'Design', isActive: true } })
+    cy.get('[data-slot=sidebar-item][data-state=active]').should('exist')
+  })
+
   it('renders #prefix, default, and #suffix slots', () => {
     cy.mount(SidebarItem, {
       slots: {

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -27,7 +27,9 @@
           </template>
         </SidebarHeader>
 
-        <div class="flex-1 overflow-y-auto overflow-x-hidden">
+        <!-- -mx/px: rows sit flush with the clip edge, so without this the
+             active item's shadow ring is cut off at both sides. -->
+        <div class="-mx-1 flex-1 overflow-y-auto overflow-x-hidden px-1">
           <SidebarSection
             v-for="section in sections"
             :key="section.label"

--- a/src/components/Sidebar/SidebarItem.vue
+++ b/src/components/Sidebar/SidebarItem.vue
@@ -127,7 +127,13 @@ import Tooltip from '../Tooltip/Tooltip.vue'
 import SidebarItemIcon from './SidebarItemIcon.vue'
 import { SidebarItemProps, sidebarCollapsedKey } from './types'
 
-const props = defineProps<SidebarItemProps>()
+// `active`/`isActive` must default to `undefined`, not Vue's implicit boolean
+// `false` — "not passed" and "passed false" are different states here: absence
+// falls through to the deprecated alias and then to route inference.
+const props = withDefaults(defineProps<SidebarItemProps>(), {
+  active: undefined,
+  isActive: undefined,
+})
 
 const isCollapsed = inject(
   sidebarCollapsedKey,


### PR DESCRIPTION
Two fixes for the current-item highlight in `Sidebar`:

1. **Active state never resolved from fallbacks.** Vue compiles absent optional boolean props to `false`, not `undefined`, so `props.active !== undefined` was always true in `resolvedActive` — the deprecated `isActive` alias and route-based inference were dead code, and any consumer not passing the new `active` prop (including the legacy `sections` adapter, which forwards `isActive`) got no highlight. Declared both props with `default: undefined` via `withDefaults`. Added a Cypress case for the `isActive` fallback.

2. **Active row's shadow clipped at both sides.** In the legacy layout, rows sit flush against the `overflow-x-hidden` scroll wrapper, so the active item's shadow ring was cut off flat on the left and right. Gave the wrapper cancelling `-mx-1`/`px-1` — row geometry is unchanged, the shadow just has room to paint.

| Before | After (fix 1) | After (fix 1 + 2) |
|---|---|---|
| no highlight on the current item | highlight, ring clipped at both edges | ring fully visible |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
Coverage: 68.79% (-0.02% vs `main`)
<!-- coverage-report:end -->
