### PR TITLE
fix(Dialog): restore click-to-focus for fields inside the dialog

### DIFF
--- a/src/components/Dialog/Dialog.cy.ts
+++ b/src/components/Dialog/Dialog.cy.ts
@@ -103,6 +103,10 @@ describe('Dialog', () => {
 
     cy.mount(Wrapper)
     cy.get('[role=dialog]').should('exist')
+    // `force` is required for any outside target: a modal Reka dialog sets
+    // `pointer-events: none` on <body>, so nothing outside the content is a hit
+    // target. The dismiss itself is driven by DismissableLayer's document-level
+    // pointerdown listener, which still sees the event.
     cy.get('.dialog-overlay').click(0, 0, { force: true })
     cy.get('[role=dialog]').should('not.exist')
   })
@@ -157,11 +161,21 @@ describe('Dialog', () => {
       },
     })
 
+    // Overflow lives on the scroll container, not on the overlay — the overlay
+    // is a bare backdrop so that field pointerdowns never reach its
+    // `pointerdown.left.prevent` handler.
     cy.get('.dialog-overlay').should(($overlay) => {
-      expect($overlay[0].scrollHeight).to.be.greaterThan(
-        $overlay[0].clientHeight,
+      expect($overlay[0].scrollHeight).to.equal($overlay[0].clientHeight)
+    })
+    cy.get('.dialog-scroll-container').should(($scroller) => {
+      expect($scroller[0].scrollHeight).to.be.greaterThan(
+        $scroller[0].clientHeight,
       )
     })
+    // The structural guard for the bug this test covers: nesting the content
+    // back inside the overlay would silently kill click-to-focus again.
+    cy.get('.dialog-scroll-container').find('[role=dialog]').should('exist')
+    cy.get('.dialog-overlay').find('[role=dialog]').should('not.exist')
 
     // Cypress cannot synthesize fully trusted OS-level events, so this guards
     // the click-to-focus behavior contract rather than the exact event chain.

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -2,9 +2,24 @@
   <DialogRoot v-model:open="isOpen">
     <DialogPortal>
       <DialogOverlay
-        class="fixed inset-0 bg-black-overlay-200 dark:bg-black-overlay-700 overflow-y-auto dialog-overlay outline-none"
+        class="fixed inset-0 bg-black-overlay-200 dark:bg-black-overlay-700 dialog-overlay outline-none"
         :data-dialog="resolved.title"
         @after-leave="$emit('after-leave')"
+      />
+      <!--
+        The scroll container is a plain element, NOT the DialogOverlay, and the
+        content is a sibling of the overlay (the standard reka structure).
+        reka-ui's DialogOverlay has an internal `@pointerdown.left.prevent`
+        (DialogOverlayImpl); when focusable content is nested inside the overlay,
+        a pointerdown on any field bubbles up to it and its `preventDefault()`
+        cancels the browser's native focus-on-click. The result: only the
+        auto-focused field is usable and clicking a second field (e.g. a
+        textarea) silently fails, dropping the keystrokes into the first field.
+        Keeping the content out of the overlay restores click-to-focus.
+      -->
+      <div
+        class="fixed inset-0 overflow-y-auto"
+        :class="{ 'pointer-events-none': !isOpen }"
       >
         <div
           class="flex min-h-screen flex-col items-center px-4 py-4 text-center"
@@ -155,7 +170,7 @@
             </DialogClose>
           </DialogContent>
         </div>
-      </DialogOverlay>
+      </div>
     </DialogPortal>
   </DialogRoot>
 </template>

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -18,7 +18,7 @@
         Keeping the content out of the overlay restores click-to-focus.
       -->
       <div
-        class="fixed inset-0 overflow-y-auto"
+        class="fixed inset-0 overflow-y-auto dialog-scroll-container"
         :class="{ 'pointer-events-none': !isOpen }"
       >
         <div


### PR DESCRIPTION
## Problem

Clicking a field inside a `Dialog` does not focus it. Only the element that receives programmatic focus on open (e.g. an `[autofocus]` input) is usable — clicking a second field (another input, a textarea) silently fails to focus it, and keystrokes land in the previously focused field.

Reproduces in **real Chrome** (both headless and headed), not just test runners.

## Root cause

reka-ui's `DialogOverlay` registers an internal `@pointerdown.left.prevent` (`DialogOverlayImpl`). `Dialog.vue` nested `DialogContent` — and therefore every form field — **inside** the `DialogOverlay` (the overlay doubled as the scroll container). So a pointerdown on any field bubbles up to the overlay, and its `preventDefault()` cancels the browser's native focus-on-click.

## Fix

Make `DialogContent` a **sibling** of `DialogOverlay` (the standard reka structure), inside a plain scroll container, so field pointerdowns never reach the overlay's handler. The scroll container stays mounted and is made `pointer-events-none` while closed, so it neither blocks the page nor cuts `DialogContent`'s own enter/exit animation.

```diff
-      <DialogOverlay class="... overflow-y-auto ...">
-        <div class="scroll wrapper"> ... <DialogContent/> ... </div>
-      </DialogOverlay>
+      <DialogOverlay class="..." />   <!-- backdrop only -->
+      <div class="fixed inset-0 overflow-y-auto" :class="{ 'pointer-events-none': !isOpen }">
+        <div class="scroll wrapper"> ... <DialogContent/> ... </div>
+      </div>
```

17-line change to `Dialog.vue`, no API change.

## How it was found / tested

Surfaced by Gameplan's Cypress suite and confirmed in real Chrome. Two independent real-world symptoms trace to this overlay behavior:

1. A dialog with an autofocused Title input plus a Description textarea — clicking the textarea couldn't focus it, so the description leaked into the title.
2. A `SettingsDialog` whose sidebar is a reka `Tabs` (triggers activate on `mousedown`): the overlay's `pointerdown.prevent` suppresses the click path so tabs wouldn't switch.

Both are resolved by this change.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-857/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.21% (+0.04% vs `main`)
<!-- coverage-report:end -->
