### PR TITLE
fix(Button, Checkbox): preserve caller aria-label; emit model updates once

### DIFF
--- a/spec/inputs.md
+++ b/spec/inputs.md
@@ -249,7 +249,9 @@ the model itself is documented at the component file via the
   `defineModel<boolean | 1 | 0>()` and coerce internally to `boolean` for
   the rendered control state. Document `boolean` as the canonical type;
   narrow in a future major.
-- Type emits via a `CheckboxEmits` interface.
+- Let `defineModel` own the `modelValue` prop and `update:modelValue` emit;
+  redeclaring either in the component produces duplicate model updates. Keep
+  `modelValue` on the exported public prop type for consumer compatibility.
 - Apply shared labeling props (inline-row layout).
 - Switch to `defineModel`.
 - Deprecate the `padding` prop (warn via `warnDeprecated`); keep functional

--- a/src/components/Button/Button.test.ts
+++ b/src/components/Button/Button.test.ts
@@ -1,0 +1,24 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createApp } from 'vue'
+import Button from './Button.vue'
+
+describe('Button', () => {
+  it('preserves a caller-provided accessible name', () => {
+    const host = document.createElement('div')
+    const app = createApp(Button, {
+      icon: 'lucide-x',
+      'aria-label': 'Close',
+    })
+    app.mount(host)
+
+    expect(host.querySelector('button')?.getAttribute('aria-label')).toBe(
+      'Close',
+    )
+
+    app.unmount()
+  })
+})

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -285,7 +285,7 @@ export default defineComponent({
         ...rootProps,
         ...restAttrs,
         class: [attrClass, buttonClasses.value],
-        'aria-label': props.label,
+        'aria-label': props.label ?? restAttrs['aria-label'],
         'aria-busy': props.loading || undefined,
         ref: rootRef,
       }

--- a/src/components/Checkbox/Checkbox.test.ts
+++ b/src/components/Checkbox/Checkbox.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createApp, nextTick } from 'vue'
+import Checkbox from './Checkbox.vue'
+
+describe('Checkbox', () => {
+  it('emits one model update per toggle', async () => {
+    const updates: boolean[] = []
+    const host = document.createElement('div')
+    const app = createApp(Checkbox, {
+      modelValue: false,
+      'onUpdate:modelValue': (value: boolean) => updates.push(value),
+    })
+    app.mount(host)
+
+    const input = host.querySelector(
+      'input[type="checkbox"]',
+    ) as HTMLInputElement
+    input.checked = true
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(updates).toEqual([true])
+    app.unmount()
+  })
+})

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -52,14 +52,13 @@ import { warnDeprecated } from '../../utils/warnDeprecated'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
-import type { CheckboxEmits, CheckboxProps } from './types'
+import type { CheckboxBaseProps } from './types'
 
-const props = withDefaults(defineProps<CheckboxProps>(), {
+const props = withDefaults(defineProps<CheckboxBaseProps>(), {
   size: 'sm',
   padding: false,
 })
 
-const emit = defineEmits<CheckboxEmits>()
 const model = defineModel<boolean | 1 | 0>()
 const attrs = useAttrs()
 
@@ -72,9 +71,7 @@ watchEffect(() => {
 const checked = computed(() => Boolean(model.value))
 
 function onChange(e: Event) {
-  const next = (e.target as HTMLInputElement).checked
-  model.value = next
-  emit('update:modelValue', next)
+  model.value = (e.target as HTMLInputElement).checked
 }
 
 defineSlots<{

--- a/src/components/Checkbox/types.ts
+++ b/src/components/Checkbox/types.ts
@@ -1,7 +1,7 @@
 import type { ToggleSize } from '../../composables/inputTypes'
 import type { InputLabelingProps } from '../../composables/useInputLabeling'
 
-export interface CheckboxProps extends InputLabelingProps {
+export interface CheckboxBaseProps extends InputLabelingProps {
   /** Controls the size of the checkbox */
   size?: ToggleSize
 
@@ -14,9 +14,6 @@ export interface CheckboxProps extends InputLabelingProps {
    */
   padding?: boolean
 
-  /** Checked state of the checkbox. `boolean` is canonical; `1`/`0` are kept for v1 backwards compatibility. */
-  modelValue?: boolean | 1 | 0
-
   /**
    * Renders the mixed "—" state (e.g. a select-all that's partially selected).
    * Purely visual — the native `indeterminate` DOM property is not reflected as
@@ -25,7 +22,8 @@ export interface CheckboxProps extends InputLabelingProps {
   indeterminate?: boolean
 }
 
-export interface CheckboxEmits {
-  /** Fired when the checkbox value changes. */
-  'update:modelValue': [value: boolean]
+/** Public prop shape; the component itself declares this model through `defineModel`. */
+export type CheckboxProps = CheckboxBaseProps & {
+  /** Checked state. `boolean` is canonical; `1`/`0` remain supported throughout v1. */
+  modelValue?: boolean | 1 | 0
 }


### PR DESCRIPTION
Two independent accessibility/correctness fixes in the input family, each with a
regression test. Both were found while building an accessibility-focused test suite in
a downstream app, and both still reproduce on `main`.

## 1. `Button` silently discards a caller-provided `aria-label`

`mergedProps` spreads `restAttrs` and then unconditionally overwrites the result:

```js
...restAttrs,
'aria-label': props.label,
```

So `<Button icon="lucide-x" aria-label="Close" />` — with no `label` prop — sets
`aria-label` to `undefined`, Vue drops the attribute, and the button renders with **no
accessible name**. The caller passed one explicitly and it is thrown away with no warning.

Counting rendered nodes in a downstream app, an icon-only close button written exactly
that way had zero `aria-label` attributes in the DOM.

The fix keeps `label` authoritative and falls back to the native attribute:

```js
'aria-label': props.label ?? restAttrs['aria-label'],
```

Note this is a fallback, not a behaviour change for existing callers: when `label` is
set, it still wins. Passing `label` on an icon button remains the idiomatic way to name
it (it renders `sr-only`); this only stops an explicitly-passed `aria-label` from being
discarded when there is no `label`.

## 2. `Checkbox` emits `update:modelValue` twice per toggle

`defineModel()` already declares the `modelValue` prop and the `update:modelValue` emit,
so assigning `model.value` emits. `onChange` then emits a second time by hand:

```js
const emit = defineEmits<CheckboxEmits>()
const model = defineModel<boolean | 1 | 0>()

function onChange(e: Event) {
  const next = (e.target as HTMLInputElement).checked
  model.value = next              // emits 'update:modelValue'
  emit('update:modelValue', next) // ...and again
}
```

Every click fires the handler twice. `v-model` consumers are unaffected (the second
assignment is identical), but any consumer with a side effect in
`@update:modelValue` — a save, an analytics event, a counter — runs it twice.

`CheckboxProps` and `CheckboxEmits` also redundantly re-declared the prop and emit that
`defineModel` owns. The fix lets `defineModel` own both and splits the type so the
**public API is unchanged**: `CheckboxProps` still exports with `modelValue`, still
accepting `boolean | 1 | 0` for v1 compatibility. `CheckboxEmits` was not re-exported
from `src/components/Checkbox/index.ts`, so removing it is not a public break.

## Tests

New: `src/components/Button/Button.test.ts`, `src/components/Checkbox/Checkbox.test.ts`.

Both were mutation-checked against the unfixed code:

- Button: `null` instead of `'Close'`
- Checkbox: `[true, true]` instead of `[true]`

`yarn test` — **37 files, 211 tests, all passing.**

`spec/inputs.md` is updated to record the `defineModel` guidance. That file is not
prettier-clean on `main` today, so this PR leaves its formatting alone rather than
burying a 3-line change in a ~400-line reflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-859/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.33% (±0.00% vs `main`)
<!-- coverage-report:end -->
