### PR TITLE
fix: respect document direction in RTL

### DIFF
--- a/src/components/Provider/FrappeUIProvider.vue
+++ b/src/components/Provider/FrappeUIProvider.vue
@@ -8,7 +8,7 @@
 
 <script setup lang="ts">
 import { ConfigProvider } from 'reka-ui'
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import Dialogs from '../Dialogs.vue'
 import ToastProvider from '../Toast/ToastProvider.vue'
 
@@ -20,17 +20,21 @@ const props = defineProps<{
 // reka-ui resolves every primitive's direction through useDirection(), which
 // falls back to 'ltr' when no ConfigProvider is present — and some primitives
 // write that value to the DOM as a real dir attribute (ScrollAreaRoot does),
-// which then overrides <html dir="rtl"> for their whole subtree. Seeding the
-// provider from the document keeps RTL apps correct without every call site
-// having to pass `dir` down.
-// The document is guarded because setup() also runs on the server during
-// VitePress static generation; an SSR'd RTL app should pass `dir` explicitly
-// rather than rely on the sniff. Same shape as Tabs.vue.
-const dir = computed<'rtl' | 'ltr'>(
-  () =>
-    props.dir ??
-    (typeof document !== 'undefined' && document.documentElement.dir === 'rtl'
-      ? 'rtl'
-      : 'ltr'),
-)
+// which then overrides <html dir="rtl"> for their whole subtree.
+//
+// The document is read in onMounted rather than during setup for two reasons:
+// setup() also runs on the server during VitePress static generation, where
+// there is no document; and reading it during the client's first render would
+// disagree with the server's markup and trip a hydration mismatch on exactly
+// those primitives that write dir. Deferring keeps the first client render
+// identical to the server's, then corrects it in the same flush.
+//
+// An SSR'd RTL app should pass `dir` explicitly so the server emits the right
+// direction to begin with — the document cannot be sniffed there.
+const documentDir = ref<'rtl' | 'ltr'>('ltr')
+onMounted(() => {
+  documentDir.value = document.documentElement.dir === 'rtl' ? 'rtl' : 'ltr'
+})
+
+const dir = computed<'rtl' | 'ltr'>(() => props.dir ?? documentDir.value)
 </script>

--- a/src/components/Provider/FrappeUIProvider.vue
+++ b/src/components/Provider/FrappeUIProvider.vue
@@ -1,10 +1,36 @@
 <template>
-  <slot />
-  <Dialogs />
-  <ToastProvider />
+  <ConfigProvider :dir="dir">
+    <slot />
+    <Dialogs />
+    <ToastProvider />
+  </ConfigProvider>
 </template>
 
 <script setup lang="ts">
+import { ConfigProvider } from 'reka-ui'
+import { computed } from 'vue'
 import Dialogs from '../Dialogs.vue'
 import ToastProvider from '../Toast/ToastProvider.vue'
+
+const props = defineProps<{
+  /** Direction for all reka-ui primitives. Defaults to the document's dir. */
+  dir?: 'rtl' | 'ltr'
+}>()
+
+// reka-ui resolves every primitive's direction through useDirection(), which
+// falls back to 'ltr' when no ConfigProvider is present — and some primitives
+// write that value to the DOM as a real dir attribute (ScrollAreaRoot does),
+// which then overrides <html dir="rtl"> for their whole subtree. Seeding the
+// provider from the document keeps RTL apps correct without every call site
+// having to pass `dir` down.
+// The document is guarded because setup() also runs on the server during
+// VitePress static generation; an SSR'd RTL app should pass `dir` explicitly
+// rather than rely on the sniff. Same shape as Tabs.vue.
+const dir = computed<'rtl' | 'ltr'>(
+  () =>
+    props.dir ??
+    (typeof document !== 'undefined' && document.documentElement.dir === 'rtl'
+      ? 'rtl'
+      : 'ltr'),
+)
 </script>


### PR DESCRIPTION
## Problem

`reka-ui` resolves every primitive's direction through `useDirection()`:

```js
// reka-ui/shared/useDirection.js
const context = injectConfigProviderContext({ dir: ref('ltr') })
return computed(() => dir?.value || context.dir?.value || 'ltr')
```

frappe-ui never mounts a `ConfigProvider`, so this always resolves to `'ltr'`. That is harmless for primitives that only use direction internally, but some write it to the DOM as a real `dir` attribute — `ScrollAreaRoot` passes `:dir` to `Primitive`, which doesn't declare it, so it lands on the element:

```js
// reka-ui/ScrollArea/ScrollAreaRoot.js
createBlock(unref(Primitive), { ..., dir: unref(dir), ... })
```

The result is that a `ScrollArea` silently overrides `<html dir="rtl">` for its entire subtree.

The visible symptom in an RTL app: content inside a `ScrollArea` lays out LTR while its siblings outside the `ScrollArea` flip correctly. A `Sidebar` whose nav lives in a `ScrollArea` keeps every icon and label on the left, while the footer rows below it — outside the `ScrollArea` — render RTL properly. Found while debugging an RTL regression in Helpdesk.

## Fix

Seed a `ConfigProvider` from `document.documentElement.dir` in `FrappeUIProvider`.

- `ConfigProvider` is **renderless** (`renderSlot` + `inheritAttrs: false`), so this adds no markup and cannot affect any consumer's layout.
- It fixes the direction default for *every* reka-ui primitive at once, instead of threading a `dir` prop through `ScrollArea` and every other call site.
- `FrappeUIProvider` is already the documented "wrap your app in this" component and already hosts `Dialogs` / `ToastProvider`, so consumers get the fix with no app-side change.
- `reka-ui` is already a direct dependency — no new packages.

### SSR

`setup()` also runs on the server during VitePress static generation, where there is no `document`. An unguarded read reproduces this in the real docs build:

```
[docs] demo render error in FrappeUIProvider: ReferenceError: document is not defined
```

(It does not abort the build — VitePress logs a per-demo render error and exits 0 — so the symptom is silently broken demos.)

A `typeof document` guard fixes the crash but trades it for a hydration mismatch, because the server then resolves `ltr` while the client resolves `rtl` from `<html dir>`, and `ScrollAreaRoot` writes `dir` to the DOM:

```
[Vue warn]: Hydration attribute mismatch
  - rendered on server: dir="ltr"
  - expected on client: dir="rtl"
```

So the document is read in `onMounted` instead. It never runs on the server, so no guard is needed, and the client's first render matches the server's markup before being corrected in the same flush. The optional `dir` prop is how an SSR'd RTL app emits the correct direction up front, since the document cannot be sniffed there.

`yarn docs:build` completes clean with this change. `dir` is not otherwise tracked reactively — the document's `dir` is in place before mount and switching language reloads the page; happy to add a `MutationObserver` if you want runtime switching.


## Testing

No behavioural change in LTR: `dir` resolves to `'ltr'`, which is what every primitive already defaulted to, and `ConfigProvider` renders nothing. In RTL, `ScrollArea` subtrees now inherit `rtl` instead of being reset to `ltr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
Coverage: 66.38% (+0.02% vs `main`)
<!-- coverage-report:end -->






