### PR TITLE
fix(editor): keep table selection z-index inside the table

### DIFF
--- a/src/molecules/editor/style.css
+++ b/src/molecules/editor/style.css
@@ -208,6 +208,13 @@ img.ProseMirror-selectednode {
   overflow-x: auto;
   /* Positioning context for the single-box multi-cell selection overlay. */
   position: relative;
+  /* Keep the selection z-indexes below (`.selectedCell::after`,
+     `.table-selection-box`) local to the table. `position: relative` with
+     `z-index: auto` does NOT open a stacking context, so without this those
+     values compete with whatever the host app stacks around the editor — e.g.
+     Gameplan's sticky comment header (`z-[1]`), which the selection box then
+     painted straight over. */
+  isolation: isolate;
 }
 
 .prose-v3.ProseMirror[contenteditable='false']


### PR DESCRIPTION
## Problem

In the editor, selecting cells in a table draws a selection box. That box was painting on top of whatever the host app stacks around the editor.

In Gameplan, the comment header is a sticky bar. Scrolling a selected table under that header left the selection border drawn straight over the header and over the comment options button, instead of sliding behind it.

## Cause

Two rules set a z-index inside the table:

- `.table-selection-box` — `z-index: 3` (the box around a multi-cell selection)
- `.selectedCell::after` — `z-index: 2` (the ring around a single cell)

Both live inside `.tableWrapper`, which is `position: relative` with `z-index: auto`. That positions children but does **not** open a stacking context. So those two numbers were not local to the table — they ranked against the host app's own layers, and won.

## Fix

Add `isolation: isolate` to `.tableWrapper`. Both z-indexes now resolve inside the table.

`isolation` only opens a stacking context; unlike `transform` it does not create a containing block for absolute/fixed descendants, so nothing about the layout moves. The wrapper keeps painting in normal flow order, so a host's sticky chrome covers it again. The table menu is teleported to `body`, so the new stacking context cannot trap it.

## Testing

Checked in a real app (Gameplan) with a wide table in a comment:

- Selection scrolled under a sticky header — border used to run through and past the header, now stops at the header's edge.
- Single-cell ring — same behaviour, also fixed.
- Selection at normal scroll position, and on a table wide enough to scroll horizontally — unchanged.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-863/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.36% (±0.00% vs `main`)
<!-- coverage-report:end -->
