### PR TITLE
feat(Sidebar): bindable section collapse state (v-model:collapsed)

### DIFF
--- a/src/components/Sidebar/Sidebar.api.md
+++ b/src/components/Sidebar/Sidebar.api.md
@@ -244,6 +244,14 @@
     type: '{ item: SidebarItemProps; isCollapsed: boolean; }'
   }
 ]
+
+  const sidebarSectionEmits = [
+  {
+    name: 'update:collapsed',
+    description: 'Fired when the section is collapsed or expanded.',
+    type: '[value: boolean]'
+  }
+]
 </script>
 ## API Reference
 
@@ -278,3 +286,5 @@
 <PropsTable folder="Sidebar" name="SidebarSection" :data="sidebarSectionProps"/>
 
 <SlotsTable :data="sidebarSectionSlots"/>
+
+<EmitsTable :data="sidebarSectionEmits"/>

--- a/src/components/Sidebar/Sidebar.api.md
+++ b/src/components/Sidebar/Sidebar.api.md
@@ -228,6 +228,12 @@
     description: '',
     required: false,
     type: 'boolean'
+  },
+  {
+    name: 'collapsed',
+    description: 'v-model. Whether the section is collapsed. Bind it to own the state (start a section collapsed, persist the choice); left unbound the section manages it internally, starting expanded.',
+    required: false,
+    type: 'boolean'
   }
 ]
 

--- a/src/components/Sidebar/Sidebar.cy.ts
+++ b/src/components/Sidebar/Sidebar.cy.ts
@@ -3,6 +3,7 @@ import { createMemoryHistory, createRouter } from 'vue-router'
 import Sidebar from './Sidebar.vue'
 import SidebarItem from './SidebarItem.vue'
 import SidebarLabel from './SidebarLabel.vue'
+import SidebarSection from './SidebarSection.vue'
 
 function createTestRouter() {
   return createRouter({
@@ -96,6 +97,39 @@ describe('<Sidebar /> legacy config API (compat layer)', () => {
 
     cy.get('[data-test=legacy-logo]').should('contain.text', 'L')
     cy.get('[data-test=legacy-footer]').should('contain.text', 'Invite')
+  })
+})
+
+describe('<SidebarSection />', () => {
+  const items = [{ label: 'Junk' }, { label: 'Trash' }]
+
+  it('collapsible: toggles its own state when `collapsed` is unbound', () => {
+    cy.mount(SidebarSection, {
+      props: { label: 'More', collapsible: true, items },
+    })
+    cy.get("[aria-label='Junk']").should('exist')
+    cy.contains('More').click()
+    cy.get("[aria-label='Junk']").should('not.exist')
+    cy.contains('More').click()
+    cy.get("[aria-label='Junk']").should('exist')
+  })
+
+  it('collapsible: bound `collapsed` model lets the app own the state', () => {
+    const onUpdate = cy.stub().as('update')
+    cy.mount(SidebarSection, {
+      props: {
+        label: 'More',
+        collapsible: true,
+        items,
+        collapsed: true,
+        'onUpdate:collapsed': onUpdate,
+      },
+    })
+    // Starts collapsed because the bound model says so — the app can default a
+    // section closed, which the internal-state version could not.
+    cy.get("[aria-label='Junk']").should('not.exist')
+    cy.contains('More').click()
+    cy.get('@update').should('have.been.calledWith', false)
   })
 })
 

--- a/src/components/Sidebar/SidebarSection.vue
+++ b/src/components/Sidebar/SidebarSection.vue
@@ -1,7 +1,9 @@
 <template>
   <!--
-    Legacy adapter for `Sidebar`'s deprecated `sections` config prop. New code
-    composes `SidebarLabel` + `SidebarItem` directly instead of this component.
+    Adapter for `Sidebar`'s deprecated `sections` config prop, and the direct
+    building block for collapsible groups: bind `v-model:collapsed` to own a
+    section's state. Plain (non-collapsible) groups compose `SidebarLabel` +
+    `SidebarItem` directly instead of this component.
   -->
   <div class="mt-2 flex flex-col">
     <div
@@ -68,7 +70,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, ref, toValue } from 'vue'
+import { computed, inject, toValue } from 'vue'
 import SidebarItem from './SidebarItem.vue'
 import { SidebarSectionProps, sidebarCollapsedKey } from './types'
 
@@ -79,8 +81,10 @@ const isSidebarCollapsed = inject(
   computed(() => false),
 )
 // Per-section open/closed state for `collapsible` sections — distinct from the
-// whole-sidebar collapse above.
-const isSectionCollapsed = ref(false)
+// whole-sidebar collapse above. A model so apps can own it (start a section
+// collapsed, persist the choice); left unbound it behaves as before — local
+// state starting expanded.
+const isSectionCollapsed = defineModel<boolean>('collapsed', { default: false })
 
 const visibleItems = computed(() =>
   props.items.filter((item) => toValue(item.condition) !== false),


### PR DESCRIPTION
SidebarSection kept its per-section collapsed state in an internal ref, so apps could neither start a section collapsed nor persist the user's choice across reloads.

This exposes the state as an optional model:

```vue
<SidebarSection label="More" collapsible :items="items" v-model:collapsed="collapsed" />
```

Left unbound, behavior is unchanged: local state, starts expanded. The legacy `sections` config path is untouched.

Also documents the model in Sidebar.api.md and adds component tests for both the unbound and bound cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-888/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.37% (+0.01% vs `main`)
<!-- coverage-report:end -->

