### PR TITLE
fix(Combobox): highlight the first item when options change after typing

### DIFF
--- a/src/components/Combobox/Combobox.cy.ts
+++ b/src/components/Combobox/Combobox.cy.ts
@@ -517,6 +517,42 @@ describe('Combobox', () => {
     })
   })
 
+  describe('highlighting', () => {
+    it('re-highlights the first item when options are replaced after typing', () => {
+      // A server-driven picker: a row is already visible while typing (e.g. a
+      // "create" custom row or stale results), then the debounced search
+      // resolves and replaces the list — after the keystroke's own highlight
+      // pass, so the fresh first item must be re-highlighted.
+      const AsyncSearch = defineComponent({
+        setup() {
+          const options = ref<string[]>(['Stale result'])
+          return { options }
+        },
+        render() {
+          return h(Combobox, { options: this.options, filterable: false })
+        },
+      })
+
+      cy.mount(AsyncSearch).then((mounted: any) => {
+        const vm = mounted.component ?? mounted.wrapper?.vm ?? mounted
+        cy.wrap(vm).as('vm')
+      })
+
+      cy.get('[role="combobox"]').type('ma')
+      cy.get('[role="option"]').should('have.length', 1)
+
+      cy.get('@vm').then((vm: any) => {
+        vm.options = fruits
+      })
+
+      cy.get('[role="option"]').should('have.length', 3)
+      cy.get('[role="option"]').first().should('have.attr', 'data-highlighted')
+      cy.get('[role="option"]')
+        .eq(1)
+        .should('not.have.attr', 'data-highlighted')
+    })
+  })
+
   describe('numeric option values', () => {
     const numeric = [
       { label: 'One', value: 1 },

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -230,6 +230,16 @@ const filteredGroups = useFilteredGroups<NormalizedItem, NormalizedGroup>({
 
 const hasVisibleItems = computed(() => filteredGroups.value.length > 0)
 
+// Keep the first item highlighted while the user is typing. The per-keystroke
+// highlight in handleInputChange only covers the client-filtered list — options
+// that arrive asynchronously (a debounced server search resolving) land after
+// that pass and would leave nothing highlighted. Gated to the typing path so
+// merely opening the list still lets reka highlight the committed selection.
+watch(filteredGroups, () => {
+  if (!open.value || !hasTypedSinceOpen.value) return
+  nextTick(() => rootRef.value?.highlightFirstItem?.())
+})
+
 const showEmpty = computed(() => !props.loading && !hasVisibleItems.value)
 
 // Clears the selection, and nothing else — same meaning as `clear()` on Select


### PR DESCRIPTION
Typing highlights the first match (`handleInputChange` → `highlightFirstItem`), but that pass only covers options already present at the keystroke. A server-driven picker (`filterable: false`, options fed by a debounced search) delivers its options **after** that pass — the visible list is replaced and nothing ends up highlighted, so Enter commits nothing until the user arrows down.

This adds a watcher on the visible items that re-runs `highlightFirstItem` when they change, gated to the open-and-typed state — merely opening the list still lets reka highlight the committed selection, and reka's own highlight-on-first-render (empty → items) is unaffected.

Includes a component test for the replace-after-typing case (fails without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-891/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.36% (-0.01% vs `main`)
<!-- coverage-report:end -->
