### PR TITLE
chore: require Node >=20.19.0 via package engines

### DIFF
--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -5,6 +5,8 @@ an existing Frappe project.
 
 ## Quick start
 
+Requires **Node `>=20.19.0`**.
+
 You can quickly setup `frappe-ui` using
 [`frappe-ui-starter`](https://github.com/netchampfaris/frappe-ui-starter). If
 you already have a Frappe app for which you want to build a frontend you can

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -17,10 +17,8 @@ or visual regressions.
 
 ## Requirements
 
-v1 requires **Node `>=20.19.0`** (declared in `package.json` `engines`). This
-is a breaking floor bump from the 0.1.x line, which ran on Node 18. The floor
-comes from the current dependency tree (`unplugin-vue-components@^32`,
-`@tiptap/markdown` → `marked@17`, and related packages).
+v1 requires **Node `>=20.19.0`** (`package.json` `engines`); this is a breaking
+bump from the 0.1.x line (Node 18).
 
 ## Dialog
 

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -15,6 +15,13 @@ After each pass, `grep` for the old prop or slot name to catch anything missed,
 then test the flows you touched. Type-checking won't catch focus, slot renames,
 or visual regressions.
 
+## Requirements
+
+v1 requires **Node `>=20.19.0`** (declared in `package.json` `engines`). This
+is a breaking floor bump from the 0.1.x line, which ran on Node 18. The floor
+comes from the current dependency tree (`unplugin-vue-components@^32`,
+`@tiptap/markdown` → `marked@17`, and related packages).
+
 ## Dialog
 
 The `options` blob is flattened into top-level props. See the

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "frappe-ui",
   "version": "1.0.0-beta.29",
   "description": "A set of components and utilities for rapid UI development",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "type": "module",
   "sideEffects": [
     "**/*.css",

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,8 @@ In 2019, I began building [Frappe Books](https://github.com/frappe/books) which 
 
 ## Usage
 
+Requires **Node `>=20.19.0`**.
+
 ```sh
 npm install frappe-ui
 # or

--- a/v1-release/changelog.md
+++ b/v1-release/changelog.md
@@ -9,6 +9,12 @@ one-time dev-mode warning (unless noted). Removal is post-v1.
 
 ## Unreleased
 
+### Node.js requirement
+
+- **Breaking:** Node floor is now `>=20.19.0` (was Node 18 on 0.1.x). Declared
+  via `package.json` `engines` so installers and CI surface the requirement
+  instead of opaque transitive-dep engine errors.
+
 ### Dialog — v1 spec
 
 - Flat top-level props (`title`, `message`, `icon`, `size`, `position`,


### PR DESCRIPTION
## Problem

v1 already depends on packages that need Node 20 (`unplugin-vue-components@^32`, `@tiptap/markdown` → `marked@17`, and related deps), but `package.json` had no `engines` field. Installs on Node 18 failed with opaque transitive-dep engine errors instead of a clear floor.

Closes #840.

## Change

- Declare `"engines": { "node": ">=20.19.0" }` in `package.json`
- Document the requirement in the readme and getting-started docs
- Add a migration note explaining the breaking bump from the 0.1.x / Node 18 line
- Log it under Unreleased in `v1-release/changelog.md`

## Verification

- Confirmed the declared floor matches the current dependency tree's Node 20 requirement
- Docs and changelog wording reviewed against the existing v1 migration / Unreleased style

<!-- coverage-report:start -->
Coverage: 66.40% (±0.00% vs `main`)
<!-- coverage-report:end -->
