### PR TITLE
fix(barista): stop re-stamping a stale comment when a run posts nothing

### DIFF
--- a/.github/barista/scripts/add-comment.test.ts
+++ b/.github/barista/scripts/add-comment.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { parseCommentId, resolveMarkerFile } from "./add-comment.ts";
+
+describe("parseCommentId", () => {
+  test("extracts the id from a gh issue comment URL", () => {
+    expect(parseCommentId("https://github.com/frappe/frappe-ui/issues/751#issuecomment-4603536352"))
+      .toBe("4603536352");
+  });
+
+  test("extracts the id from a PR-thread comment URL", () => {
+    expect(parseCommentId("https://github.com/frappe/frappe-ui/pull/896#issuecomment-5178987334"))
+      .toBe("5178987334");
+  });
+
+  test("returns undefined for output with no comment id", () => {
+    expect(parseCommentId("")).toBeUndefined();
+    expect(parseCommentId("gh: something went wrong")).toBeUndefined();
+  });
+});
+
+describe("resolveMarkerFile", () => {
+  test("uses BARISTA_COMMENT_ID_FILE when set", () => {
+    expect(resolveMarkerFile({ BARISTA_COMMENT_ID_FILE: "/tmp/custom-marker" } as NodeJS.ProcessEnv))
+      .toBe("/tmp/custom-marker");
+  });
+
+  test("falls back to /tmp/barista-comment-id", () => {
+    expect(resolveMarkerFile({} as NodeJS.ProcessEnv)).toBe("/tmp/barista-comment-id");
+  });
+});

--- a/.github/barista/scripts/add-comment.ts
+++ b/.github/barista/scripts/add-comment.ts
@@ -14,43 +14,55 @@
 import { $ } from "bun";
 import { readFileSync } from "node:fs";
 
-let issue = process.env.BARISTA_ISSUE ?? "";
-if (!/^\d+$/.test(issue)) {
-  const eventPath = process.env.GITHUB_EVENT_PATH;
-  if (!eventPath) {
-    console.error("Error: GITHUB_EVENT_PATH not set");
+// Exported for tests — pure parsing, no I/O.
+export function parseCommentId(ghOutputUrl: string): string | undefined {
+  return ghOutputUrl.match(/issuecomment-(\d+)/)?.[1];
+}
+
+export function resolveMarkerFile(env: NodeJS.ProcessEnv = process.env): string {
+  return env.BARISTA_COMMENT_ID_FILE || "/tmp/barista-comment-id";
+}
+
+async function main() {
+  let issue = process.env.BARISTA_ISSUE ?? "";
+  if (!/^\d+$/.test(issue)) {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath) {
+      console.error("Error: GITHUB_EVENT_PATH not set");
+      process.exit(1);
+    }
+    const event = JSON.parse(readFileSync(eventPath, "utf8"));
+    issue = String(event?.issue?.number ?? "");
+  }
+  if (!/^\d+$/.test(issue)) {
+    console.error("Error: no issue number resolved");
     process.exit(1);
   }
-  const event = JSON.parse(readFileSync(eventPath, "utf8"));
-  issue = String(event?.issue?.number ?? "");
-}
-if (!/^\d+$/.test(issue)) {
-  console.error("Error: no issue number resolved");
-  process.exit(1);
-}
 
-const argv = process.argv.slice(2);
-let url: string;
-if (argv[0] === "--file") {
-  const file = argv[1];
-  if (!file) { console.error("Error: --file requires a path"); process.exit(1); }
-  if (!(await Bun.file(file).exists())) {
-    console.error(`Error: file not found: ${file}`);
-    process.exit(1);
+  const argv = process.argv.slice(2);
+  let url: string;
+  if (argv[0] === "--file") {
+    const file = argv[1];
+    if (!file) { console.error("Error: --file requires a path"); process.exit(1); }
+    if (!(await Bun.file(file).exists())) {
+      console.error(`Error: file not found: ${file}`);
+      process.exit(1);
+    }
+    url = (await $`gh issue comment ${issue} --body-file ${file}`.text()).trim();
+  } else {
+    const body = argv[0];
+    if (!body) { console.error("Error: body required"); process.exit(1); }
+    url = (await $`gh issue comment ${issue} --body ${body}`.text()).trim();
   }
-  url = (await $`gh issue comment ${issue} --body-file ${file}`.text()).trim();
-} else {
-  const body = argv[0];
-  if (!body) { console.error("Error: body required"); process.exit(1); }
-  url = (await $`gh issue comment ${issue} --body ${body}`.text()).trim();
+
+  const commentId = parseCommentId(url);
+  if (commentId) {
+    await Bun.write(resolveMarkerFile(), commentId);
+  } else {
+    console.error(`Warning: couldn't parse comment id from gh output: ${url}`);
+  }
+
+  console.log(`Commented on #${issue}`);
 }
 
-const commentId = url.match(/issuecomment-(\d+)/)?.[1];
-if (commentId) {
-  const markerFile = process.env.BARISTA_COMMENT_ID_FILE || "/tmp/barista-comment-id";
-  await Bun.write(markerFile, commentId);
-} else {
-  console.error(`Warning: couldn't parse comment id from gh output: ${url}`);
-}
-
-console.log(`Commented on #${issue}`);
+if (import.meta.main) await main();

--- a/.github/barista/scripts/add-comment.ts
+++ b/.github/barista/scripts/add-comment.ts
@@ -2,6 +2,11 @@
 // Posts a single comment on the current issue. Issue number is sourced from
 // $BARISTA_ISSUE with a fallback to the event payload.
 //
+// Records the posted comment's id to a marker file on disk (path from
+// $BARISTA_COMMENT_ID_FILE, default /tmp/barista-comment-id) so a later
+// step in the same job — append-stats.ts — can attach the run's stats to
+// the comment this run actually posted, instead of guessing.
+//
 // Usage:
 //   ./add-comment.ts "Body text, multi-line OK"
 //   ./add-comment.ts --file body.md
@@ -25,6 +30,7 @@ if (!/^\d+$/.test(issue)) {
 }
 
 const argv = process.argv.slice(2);
+let url: string;
 if (argv[0] === "--file") {
   const file = argv[1];
   if (!file) { console.error("Error: --file requires a path"); process.exit(1); }
@@ -32,11 +38,19 @@ if (argv[0] === "--file") {
     console.error(`Error: file not found: ${file}`);
     process.exit(1);
   }
-  await $`gh issue comment ${issue} --body-file ${file}`;
+  url = (await $`gh issue comment ${issue} --body-file ${file}`.text()).trim();
 } else {
   const body = argv[0];
   if (!body) { console.error("Error: body required"); process.exit(1); }
-  await $`gh issue comment ${issue} --body ${body}`;
+  url = (await $`gh issue comment ${issue} --body ${body}`.text()).trim();
+}
+
+const commentId = url.match(/issuecomment-(\d+)/)?.[1];
+if (commentId) {
+  const markerFile = process.env.BARISTA_COMMENT_ID_FILE || "/tmp/barista-comment-id";
+  await Bun.write(markerFile, commentId);
+} else {
+  console.error(`Warning: couldn't parse comment id from gh output: ${url}`);
 }
 
 console.log(`Commented on #${issue}`);

--- a/.github/barista/scripts/append-stats.test.ts
+++ b/.github/barista/scripts/append-stats.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyFooter,
+  buildFooter,
+  extractStats,
+  fmtK,
+  resolveMarkerFile,
+  STATS_MARKER,
+  type Stats,
+} from "./append-stats.ts";
+
+// Loosely mirrors claude-code-action's execution JSON: usage is nested a
+// few levels deep inside per-turn message objects, and duration/cost/model
+// live at the top-level result object.
+const SAMPLE_EXECUTION = {
+  type: "result",
+  subtype: "success",
+  duration_ms: 41118,
+  total_cost_usd: 0.363063,
+  model: "claude-opus-5",
+  turns: [
+    { role: "assistant", message: { usage: { input_tokens: 20, output_tokens: 1200, cache_read_input_tokens: 400000 } } },
+    { role: "assistant", message: { usage: { input_tokens: 30, output_tokens: 1600, cache_read_input_tokens: 425000 } } },
+  ],
+};
+
+describe("extractStats", () => {
+  test("sums usage fields across nested turns", () => {
+    const stats = extractStats(SAMPLE_EXECUTION);
+    expect(stats.inputTokens).toBe(50);
+    expect(stats.outputTokens).toBe(2800);
+    expect(stats.cacheRead).toBe(825000);
+  });
+
+  test("picks up the first top-level cost/duration/model", () => {
+    const stats = extractStats(SAMPLE_EXECUTION);
+    expect(stats.totalCost).toBeCloseTo(0.363063);
+    expect(stats.durationMs).toBe(41118);
+    expect(stats.model).toBe("claude-opus-5");
+  });
+
+  test("defaults gracefully on a shape with no usage/cost data", () => {
+    const stats = extractStats({ foo: "bar" });
+    expect(stats.inputTokens).toBe(0);
+    expect(stats.outputTokens).toBe(0);
+    expect(stats.cacheRead).toBe(0);
+    expect(stats.totalCost).toBeNull();
+    expect(stats.durationMs).toBe(0);
+    expect(stats.model).toBe("claude");
+  });
+});
+
+describe("fmtK", () => {
+  test("leaves small numbers as-is", () => {
+    expect(fmtK(50)).toBe("50");
+    expect(fmtK(0)).toBe("0");
+  });
+
+  test("formats thousands with one decimal below 10k", () => {
+    expect(fmtK(2800)).toBe("2.8k");
+  });
+
+  test("rounds to whole k at 10k and above", () => {
+    expect(fmtK(825000)).toBe("825k");
+    expect(fmtK(10500)).toBe("11k"); // Math.round(10500/1000) = 11 (round-half-up)
+  });
+
+  test("guards against negative/non-finite input", () => {
+    expect(fmtK(-5)).toBe("0");
+    expect(fmtK(NaN)).toBe("0");
+  });
+});
+
+describe("buildFooter / applyFooter", () => {
+  const stats: Stats = {
+    inputTokens: 50,
+    outputTokens: 2800,
+    cacheRead: 825000,
+    totalCost: 0.363063,
+    durationMs: 41118,
+    model: "claude-opus-5",
+  };
+
+  test("footer contains the marker and formatted stats", () => {
+    const footer = buildFooter(stats);
+    expect(footer).toContain(STATS_MARKER);
+    expect(footer).toContain("claude-opus-5");
+    expect(footer).toContain("50 in / 2.8k out");
+    expect(footer).toContain("825k cached");
+    expect(footer).toContain("41s");
+    expect(footer).toContain("$0.363");
+  });
+
+  test("falls back to an em dash when cost is missing", () => {
+    const footer = buildFooter({ ...stats, totalCost: null });
+    expect(footer).toContain("—");
+  });
+
+  test("appends to a body with no existing footer", () => {
+    const body = applyFooter("Looks good, small change.", stats);
+    expect(body.startsWith("Looks good, small change.")).toBe(true);
+    expect(body).toContain(STATS_MARKER);
+  });
+
+  test("replaces a previous footer instead of double-appending (idempotent)", () => {
+    const firstPass = applyFooter("Looks good, small change.", stats);
+    const staleStats: Stats = { ...stats, durationMs: 999999, totalCost: 9.999 };
+    const secondPass = applyFooter(firstPass, staleStats);
+
+    expect(secondPass.match(new RegExp(STATS_MARKER, "g"))?.length).toBe(1);
+    expect(secondPass).toContain("$9.999");
+    expect(secondPass).not.toContain("$0.363");
+    expect(secondPass.startsWith("Looks good, small change.")).toBe(true);
+  });
+});
+
+describe("resolveMarkerFile", () => {
+  test("uses BARISTA_COMMENT_ID_FILE when set", () => {
+    expect(resolveMarkerFile({ BARISTA_COMMENT_ID_FILE: "/tmp/custom-marker" } as NodeJS.ProcessEnv))
+      .toBe("/tmp/custom-marker");
+  });
+
+  test("falls back to /tmp/barista-comment-id", () => {
+    expect(resolveMarkerFile({} as NodeJS.ProcessEnv)).toBe("/tmp/barista-comment-id");
+  });
+});

--- a/.github/barista/scripts/append-stats.ts
+++ b/.github/barista/scripts/append-stats.ts
@@ -20,29 +20,16 @@
 
 import { $ } from "bun";
 
-const executionFile = process.env.EXECUTION_FILE;
-const issueNumber = process.env.ISSUE_NUMBER;
-const repo = process.env.REPO;
-if (!executionFile) { console.error("EXECUTION_FILE not set"); process.exit(1); }
-if (!issueNumber) { console.error("ISSUE_NUMBER not set"); process.exit(1); }
-if (!repo) { console.error("REPO not set"); process.exit(1); }
+export const STATS_MARKER = "<!-- barista-stats -->";
 
-const file = Bun.file(executionFile);
-if (!(await file.exists())) {
-  console.error(`No execution file at ${executionFile} — skipping stats footer.`);
-  process.exit(0);
-}
-
-const data = await file.json();
-
-function* walk(obj: unknown): Generator<Record<string, unknown>> {
+export function* walk(obj: unknown): Generator<Record<string, unknown>> {
   if (obj && typeof obj === "object") {
     if (!Array.isArray(obj)) yield obj as Record<string, unknown>;
     for (const v of Array.isArray(obj) ? obj : Object.values(obj)) yield* walk(v);
   }
 }
 
-function sumUsage(field: string): number {
+export function sumUsage(data: unknown, field: string): number {
   let total = 0;
   for (const o of walk(data)) {
     const usage = o.usage as Record<string, unknown> | undefined;
@@ -51,55 +38,101 @@ function sumUsage(field: string): number {
   return total;
 }
 
-function firstField<T = unknown>(field: string): T | null {
+export function firstField<T = unknown>(data: unknown, field: string): T | null {
   for (const o of walk(data)) {
     if (o[field] !== undefined && o[field] !== null) return o[field] as T;
   }
   return null;
 }
 
-const inputTokens = sumUsage("input_tokens");
-const outputTokens = sumUsage("output_tokens");
-const cacheRead = sumUsage("cache_read_input_tokens");
-const totalCost = firstField<number>("total_cost_usd");
-const durationMs = firstField<number>("duration_ms") ?? 0;
-const model = firstField<string>("model") ?? "claude";
-
-function fmtK(n: number): string {
+export function fmtK(n: number): string {
   if (!Number.isFinite(n) || n < 0) return "0";
   if (n < 1000) return String(n);
   if (n < 10000) return (n / 1000).toFixed(1) + "k";
   return Math.round(n / 1000) + "k";
 }
 
-const inputFmt = fmtK(inputTokens);
-const outputFmt = fmtK(outputTokens);
-const cacheReadFmt = fmtK(cacheRead);
-const durationFmt = durationMs > 0 ? `${Math.floor(durationMs / 1000)}s` : "?";
-const costFmt = typeof totalCost === "number" ? `$${totalCost.toFixed(3)}` : "—";
-
-const markerFile = process.env.BARISTA_COMMENT_ID_FILE || "/tmp/barista-comment-id";
-const markerFileHandle = Bun.file(markerFile);
-if (!(await markerFileHandle.exists())) {
-  console.log(`No comment posted this run (no ${markerFile}) — skipping stats footer.`);
-  process.exit(0);
+export interface Stats {
+  inputTokens: number;
+  outputTokens: number;
+  cacheRead: number;
+  totalCost: number | null;
+  durationMs: number;
+  model: string;
 }
-const commentId = (await markerFileHandle.text()).trim();
-if (!/^\d+$/.test(commentId)) {
-  console.error(`Invalid comment id in ${markerFile}: ${commentId}`);
-  process.exit(1);
+
+// Pulls run stats out of claude-code-action's execution JSON. The shape
+// isn't stable across nested tool-call/result objects, so we walk the
+// whole tree rather than assume a fixed path.
+export function extractStats(data: unknown): Stats {
+  return {
+    inputTokens: sumUsage(data, "input_tokens"),
+    outputTokens: sumUsage(data, "output_tokens"),
+    cacheRead: sumUsage(data, "cache_read_input_tokens"),
+    totalCost: firstField<number>(data, "total_cost_usd"),
+    durationMs: firstField<number>(data, "duration_ms") ?? 0,
+    model: firstField<string>(data, "model") ?? "claude",
+  };
 }
-const currentBody = await $`gh api repos/${repo}/issues/comments/${commentId} --jq .body`.text();
 
-const MARKER = "<!-- barista-stats -->";
-const idx = currentBody.indexOf(MARKER);
-const stripped = (idx >= 0 ? currentBody.slice(0, idx) : currentBody).replace(/\s+$/, "");
+// Pure formatting — no I/O — so it's cheap to test against known-shape
+// execution JSON without touching the network or the filesystem.
+export function buildFooter(stats: Stats): string {
+  const inputFmt = fmtK(stats.inputTokens);
+  const outputFmt = fmtK(stats.outputTokens);
+  const cacheReadFmt = fmtK(stats.cacheRead);
+  const durationFmt = stats.durationMs > 0 ? `${Math.floor(stats.durationMs / 1000)}s` : "?";
+  const costFmt = typeof stats.totalCost === "number" ? `$${stats.totalCost.toFixed(3)}` : "—";
+  return `\n\n${STATS_MARKER}\n<sub><i>barista · ${stats.model} · ${inputFmt} in / ${outputFmt} out · ${cacheReadFmt} cached · ${durationFmt} · ${costFmt}</i></sub>`;
+}
 
-const footer = `\n\n${MARKER}\n<sub><i>barista · ${model} · ${inputFmt} in / ${outputFmt} out · ${cacheReadFmt} cached · ${durationFmt} · ${costFmt}</i></sub>`;
-const newBody = stripped + footer;
+// Idempotent: strips a previous footer (if any) before appending the new
+// one, so re-running on the same comment doesn't double-append.
+export function applyFooter(currentBody: string, stats: Stats): string {
+  const idx = currentBody.indexOf(STATS_MARKER);
+  const stripped = (idx >= 0 ? currentBody.slice(0, idx) : currentBody).replace(/\s+$/, "");
+  return stripped + buildFooter(stats);
+}
 
-const tmp = `/tmp/barista-stats-${commentId}.json`;
-await Bun.write(tmp, JSON.stringify({ body: newBody }));
-await $`gh api -X PATCH repos/${repo}/issues/comments/${commentId} --input ${tmp}`.quiet();
+export function resolveMarkerFile(env: NodeJS.ProcessEnv = process.env): string {
+  return env.BARISTA_COMMENT_ID_FILE || "/tmp/barista-comment-id";
+}
 
-console.log(`Appended stats footer to comment ${commentId} on #${issueNumber}`);
+async function main() {
+  const executionFile = process.env.EXECUTION_FILE;
+  const issueNumber = process.env.ISSUE_NUMBER;
+  const repo = process.env.REPO;
+  if (!executionFile) { console.error("EXECUTION_FILE not set"); process.exit(1); }
+  if (!issueNumber) { console.error("ISSUE_NUMBER not set"); process.exit(1); }
+  if (!repo) { console.error("REPO not set"); process.exit(1); }
+
+  const file = Bun.file(executionFile);
+  if (!(await file.exists())) {
+    console.error(`No execution file at ${executionFile} — skipping stats footer.`);
+    process.exit(0);
+  }
+
+  const stats = extractStats(await file.json());
+
+  const markerFile = resolveMarkerFile();
+  const markerFileHandle = Bun.file(markerFile);
+  if (!(await markerFileHandle.exists())) {
+    console.log(`No comment posted this run (no ${markerFile}) — skipping stats footer.`);
+    process.exit(0);
+  }
+  const commentId = (await markerFileHandle.text()).trim();
+  if (!/^\d+$/.test(commentId)) {
+    console.error(`Invalid comment id in ${markerFile}: ${commentId}`);
+    process.exit(1);
+  }
+  const currentBody = await $`gh api repos/${repo}/issues/comments/${commentId} --jq .body`.text();
+  const newBody = applyFooter(currentBody, stats);
+
+  const tmp = `/tmp/barista-stats-${commentId}.json`;
+  await Bun.write(tmp, JSON.stringify({ body: newBody }));
+  await $`gh api -X PATCH repos/${repo}/issues/comments/${commentId} --input ${tmp}`.quiet();
+
+  console.log(`Appended stats footer to comment ${commentId} on #${issueNumber}`);
+}
+
+if (import.meta.main) await main();

--- a/.github/barista/scripts/append-stats.ts
+++ b/.github/barista/scripts/append-stats.ts
@@ -1,6 +1,13 @@
 #!/usr/bin/env bun
 // Reads the claude-code-action execution file and appends a one-line
-// stats footer to barista's most recent comment on the issue.
+// stats footer to the comment THIS run posted, per the marker file
+// add-comment.ts writes when it posts (path from $BARISTA_COMMENT_ID_FILE,
+// default /tmp/barista-comment-id).
+//
+// If no marker file exists, this run didn't post a comment (e.g. triage
+// deciding there's nothing worth saying, or a bug that stopped it before
+// posting) — skip rather than guessing at "the most recent barista
+// comment", which could be a stale comment from an earlier run.
 //
 // Expected env:
 //   EXECUTION_FILE  — path to action's JSON output
@@ -71,23 +78,17 @@ const cacheReadFmt = fmtK(cacheRead);
 const durationFmt = durationMs > 0 ? `${Math.floor(durationMs / 1000)}s` : "?";
 const costFmt = typeof totalCost === "number" ? `$${totalCost.toFixed(3)}` : "—";
 
-const commentsJson = await $`gh api repos/${repo}/issues/${issueNumber}/comments --paginate`.text();
-const comments = JSON.parse(commentsJson) as Array<{
-  id: number;
-  created_at: string;
-  user?: { type?: string; login?: string };
-}>;
-const last = comments
-  .filter(c => c.user?.type === "Bot" && c.user.login?.startsWith("barista"))
-  .sort((a, b) => a.created_at.localeCompare(b.created_at))
-  .at(-1);
-
-if (!last) {
-  console.log(`No barista comment found on #${issueNumber} — nothing to append stats to.`);
+const markerFile = process.env.BARISTA_COMMENT_ID_FILE || "/tmp/barista-comment-id";
+const markerFileHandle = Bun.file(markerFile);
+if (!(await markerFileHandle.exists())) {
+  console.log(`No comment posted this run (no ${markerFile}) — skipping stats footer.`);
   process.exit(0);
 }
-
-const commentId = last.id;
+const commentId = (await markerFileHandle.text()).trim();
+if (!/^\d+$/.test(commentId)) {
+  console.error(`Invalid comment id in ${markerFile}: ${commentId}`);
+  process.exit(1);
+}
 const currentBody = await $`gh api repos/${repo}/issues/comments/${commentId} --jq .body`.text();
 
 const MARKER = "<!-- barista-stats -->";

--- a/.github/workflows/barista-scripts-test.yml
+++ b/.github/workflows/barista-scripts-test.yml
@@ -1,0 +1,24 @@
+name: Barista — Scripts Test
+
+on:
+  pull_request:
+    paths:
+      - '.github/barista/scripts/**'
+      - '.github/workflows/barista-scripts-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Run tests
+        run: bun test ./.github/barista/scripts

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, mergeConfig } from 'vitest/config'
+import { configDefaults, defineConfig, mergeConfig } from 'vitest/config'
 import viteConfig from './vite.config'
 
 export default mergeConfig(
@@ -8,6 +8,11 @@ export default mergeConfig(
       globals: true,
       root: __dirname,
       setupFiles: ['./vitest.setup.ts'],
+      // .github/barista/scripts/*.test.ts are bun:test files for the barista
+      // GitHub Action scripts, run by `bun test` in a separate CI job — not
+      // valid vitest specs (they import from 'bun:test', which vitest can't
+      // resolve).
+      exclude: [...configDefaults.exclude, '.github/**'],
       coverage: {
         provider: 'v8',
         reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## What broke

Run [30905700908](https://github.com/frappe/frappe-ui/actions/runs/30905700908?pr=751#issuecomment-4603536352): a `/barista review` re-run on #751 did its work (11 turns, $0.36) but never posted a new comment. The "Append run-stats footer" step ran anyway. It picks a comment by scanning the issue for "barista's most recent comment" — since no new comment existed, it found the old comment from June 2 and patched it with today's cost/duration footer. That made a two-month-stale review look like it had just run, with no sign the run actually produced nothing new.

## Fix

- `add-comment.ts` now records the id of the comment it actually posts to a marker file (`/tmp/barista-comment-id`, shared across steps in the job).
- `append-stats.ts` reads that marker instead of guessing from comment history. If no marker exists, this run didn't post anything (legitimate for triage, or a bug like this one) — it logs that and skips, instead of touching an unrelated stale comment.

This is shared by `barista-review`, `barista-triage`, and `barista-fix`, so all three get the fix.

## Test plan

- [x] Dry-ran `add-comment.ts` against a fake `gh` binary — confirms it parses the posted comment's id from `gh issue comment`'s output URL and writes it to the marker file.
- [x] Dry-ran `append-stats.ts` with the marker present — patches the right comment.
- [x] Dry-ran `append-stats.ts` with the marker absent — skips cleanly, no stale comment touched.
- [ ] Verify on a real PR after merge (trigger `/barista review`, confirm the footer lands on a fresh comment or is skipped, never on an old one).

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-896/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.37% (±0.00% vs `main`)
<!-- coverage-report:end -->

