### PR TITLE
fix(barista): work around broken bwrap sandbox (claude-code-action#1547)

### DIFF
--- a/.claude/commands/barista-review.md
+++ b/.claude/commands/barista-review.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(./.github/barista/scripts/gh.ts:*),Bash(./.github/barista/scripts/add-comment.ts:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git diff:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git ls-files:*),Bash(jq:*),Bash(wc:*),Read,Glob,Grep
+allowed-tools: Bash(./.github/barista/scripts/gh.ts:*),Bash(./.github/barista/scripts/add-comment.ts:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git diff:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git ls-files:*),Bash(wc:*),Read,Glob,Grep
 description: Review a frappe-ui pull request and post one concise comment with findings.
 ---
 
@@ -28,7 +28,6 @@ You have **the repository checked out at the base branch.** Read the diff and th
 - `./.github/barista/scripts/gh.ts release list --limit 5` / `release view <tag>` — recent releases. Useful for "is this a breaking change since the last published version?".
 - `Bash(git log:*)`, `Bash(git show:*)`, `Bash(git blame:*)`, `Bash(git diff:*)` — inspect history near changed files.
 - `Bash(git merge-base:*)`, `Bash(git rev-parse:*)`, `Bash(git ls-files:*)` — locate the base commit, resolve refs, enumerate files (e.g. `git ls-files 'src/components/Toast/**'`).
-- `Bash(jq:*)` — parse JSON output from `gh.ts ... --json …` when grepping prose is awkward.
 - `./.github/barista/scripts/gh.ts search issues "<query>"` — find related open issues (no `repo:`/`org:`/`user:` qualifiers).
 
 **Write (one call, at the end):**

--- a/.github/actions/barista-run/action.yml
+++ b/.github/actions/barista-run/action.yml
@@ -59,6 +59,14 @@ runs:
         BARISTA_COMMENT_AUTHOR: ${{ inputs.comment-author }}
         BARISTA_BRANCH: ${{ inputs.branch }}
         BARISTA_BASE: ${{ inputs.base }}
+        # TEMPORARY — anthropics/claude-code-action#1547: allowed_non_write_users
+        # turns on a bubblewrap sandbox for every Bash call, and that sandbox has
+        # been broken since Claude Code CLI 2.1.216 (`bwrap: Can't create file at
+        # /home/.mcp.json: Permission denied`). Every Bash call silently fails —
+        # the step still reports success — so barista investigates but can never
+        # call add-comment.ts. This is the workaround verified in that issue.
+        # Remove once the upstream fix ships.
+        CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"
       with:
         claude_code_oauth_token: ${{ inputs.oauth-token }}
         github_token: ${{ inputs.app-token }}


### PR DESCRIPTION
## What's wrong

Follow-up to #896, which fixed how `append-stats.ts` picks the comment to attach run stats to. While testing that fix by re-running `/barista review` on #751, every run kept posting nothing — silently.

Root cause: `barista-run/action.yml` sets `allowed_non_write_users: "*"`, which turns on `claude-code-action`'s subprocess-isolation sandbox (bubblewrap) for every Bash call the agent makes. That sandbox has been broken since Claude Code CLI 2.1.216 (we're on 2.1.221) — every Bash call fails with:

```
bwrap: Can't create file at /home/.mcp.json: Permission denied
```

...silently. The step still reports `success`, so nothing surfaces. This is a known, already-filed upstream bug: [anthropics/claude-code-action#1547](https://github.com/anthropics/claude-code-action/issues/1547). It explains why recent `/barista review` runs on #751 completed "successfully" (`is_error: false`) but with `permission_denials_count: 2-3` and zero comments posted — barista investigates the PR fine (Read/Glob/Grep aren't sandboxed) but can never reach `add-comment.ts` to actually post.

## Fix

- Set `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"` on the "Run Barista" step — the workaround verified in the upstream issue. Commented as temporary, with the issue link, to remove once the CLI fix ships.
- Drop `jq` from `barista-review`'s allowed-tools too, since with env-scrubbing off `jq -n env` would otherwise dump the step's environment (including the Claude Max OAuth token). `gh.ts` doesn't currently support `--json` output anyway, so `jq` wasn't functional to begin with — no real loss.

**Note on the actual security boundary** (barista's own review on this PR caught that I overstated this): on the `pull_request` trigger, `actions/checkout@v4` checks out the PR's own merge ref with no pinned `ref:`, so `barista-review.md` itself — allowed-tools included — comes from the PR branch, not a trusted copy. A same-repo, non-fork PR author could re-add a leaky tool in the same PR that removes it. The `jq` removal closes one gap, but it isn't the real boundary; the real ones are the same-repo/non-fork gate and the maintainer-comment gate already in `barista-review.yml`, which limit this to people who already have push access to the repo.

Also worth noting: env-scrubbing is disabled for all three barista modes (review/triage/fix), since it's set at the shared `barista-run` action level. `fix` mode is the most powerful (Write + opens PRs) — I checked its allowed-tools and `barista-triage`'s, and neither has a `jq`-style env-dump command today, so there's no equivalent leak path right now. It's still the first thing to revisit once the upstream fix lands, since it carries the same env exposure.

## Test plan

- [x] Comment `/barista review` on an open PR after merge and confirm a review comment actually posts. Confirmed on this PR itself — barista's review workflow ran against the merged fix and posted a real "Minor nits" review.
- [ ] Revert this workaround once anthropics/claude-code-action#1547 is fixed upstream (tracked in 899).
