### PR TITLE
feat(rail): let RailItem set its own tooltip description

### DIFF
--- a/src/components/Rail/Rail.api.md
+++ b/src/components/Rail/Rail.api.md
@@ -20,6 +20,12 @@
     type: 'string'
   },
   {
+    name: 'description',
+    description: 'Second line in the tooltip, under the label — e.g. "12 members". Overrides the\nunread count a `dot` badge would otherwise spell out there.',
+    required: false,
+    type: 'string'
+  },
+  {
     name: 'icon',
     description: 'Icon CSS class, e.g. `lucide-search`, or a component. Rendered centered in the cell.\nIgnored when the default slot is used (for an image, avatar, or initials).',
     required: false,
@@ -55,7 +61,7 @@
     name: 'variant',
     description: 'Visual treatment.\n- `tile` (default): a filled cell with a left indicator bar when active —\n  for image/avatar items like communities or workspaces.\n- `ghost`: transparent until hovered, a raised highlight when active — for\n  icon shortcuts like Search or Notifications.',
     required: false,
-    type: '"ghost" | "tile"',
+    type: '"tile" | "ghost"',
     default: '"tile"'
   }
 ]
@@ -80,12 +86,13 @@
 
 ### Rail
 
-<SlotsTable :data="railSlots"/>
+<SlotsTable :data="railSlots"/> 
 
 ### RailItem
 
-<PropsTable folder="Rail" name="RailItem" :data="railItemProps"/>
+<PropsTable folder="Rail" name="RailItem" :data="railItemProps"/> 
 
-<SlotsTable :data="railItemSlots"/>
+<SlotsTable :data="railItemSlots"/> 
 
-<EmitsTable :data="railItemEmits"/>
+<EmitsTable :data="railItemEmits"/> 
+

--- a/src/components/Rail/Rail.cy.ts
+++ b/src/components/Rail/Rail.cy.ts
@@ -75,6 +75,30 @@ describe('<RailItem />', () => {
     cy.get('body').should('contain.text', '99+')
   })
 
+  it('lets `description` replace the unread line under the tooltip label', () => {
+    cy.mount(RailItem, {
+      props: { label: 'Notifications', icon: 'lucide-bell', badge: 3, badgeStyle: 'dot' },
+    })
+    cy.get('[data-slot=rail-item]').trigger('pointerenter').trigger('pointermove')
+    // The tooltip teleports to <body>.
+    cy.get('body').should('contain.text', '3 unread')
+
+    cy.mount(RailItem, {
+      props: {
+        label: 'People',
+        icon: 'lucide-users-2',
+        badge: 3,
+        badgeStyle: 'dot',
+        description: '12 members',
+      },
+    })
+    cy.get('[data-slot=rail-item]').trigger('pointerenter').trigger('pointermove')
+    cy.get('body')
+      .should('contain.text', '12 members')
+      // Only meaningful because the line above already waited for the tooltip to open.
+      .and('not.contain.text', '3 unread')
+  })
+
   it('folds the unread count into the accessible label', () => {
     cy.mount(RailItem, {
       props: { label: 'Notifications', icon: 'lucide-bell', badge: 3 },

--- a/src/components/Rail/RailItem.vue
+++ b/src/components/Rail/RailItem.vue
@@ -81,8 +81,8 @@
     <template #content>
       <div class="leading-relaxed">
         <div>{{ label }}</div>
-        <div v-if="showTooltipCount" class="text-p-sm text-ink-gray-5">
-          {{ badge }} unread
+        <div v-if="tooltipDescription" class="text-p-sm text-ink-gray-5">
+          {{ tooltipDescription }}
         </div>
       </div>
     </template>
@@ -127,8 +127,12 @@ const ariaLabel = computed(() =>
   props.badge > 0 ? `${props.label}, ${props.badge} unread` : props.label,
 )
 
-// The dot badge hides the number, so surface it in the tooltip instead.
-const showTooltipCount = computed(
-  () => props.badgeStyle === 'dot' && props.badge > 0,
-)
+// The dot badge hides the number, so spell it out in the tooltip instead — unless the
+// caller supplied its own second line, which is the more specific thing to say.
+const tooltipDescription = computed(() => {
+  if (props.description) return props.description
+  if (props.badgeStyle === 'dot' && props.badge > 0)
+    return `${props.badge} unread`
+  return null
+})
 </script>

--- a/src/components/Rail/RailItem.vue
+++ b/src/components/Rail/RailItem.vue
@@ -130,7 +130,7 @@ const ariaLabel = computed(() =>
 // The dot badge hides the number, so spell it out in the tooltip instead — unless the
 // caller supplied its own second line, which is the more specific thing to say.
 const tooltipDescription = computed(() => {
-  if (props.description) return props.description
+  if (props.description !== undefined) return props.description
   if (props.badgeStyle === 'dot' && props.badge > 0)
     return `${props.badge} unread`
   return null

--- a/src/components/Rail/types.ts
+++ b/src/components/Rail/types.ts
@@ -6,6 +6,12 @@ export interface RailItemProps {
   label: string
 
   /**
+   * Second line in the tooltip, under the label — e.g. "12 members". Overrides the
+   * unread count a `dot` badge would otherwise spell out there.
+   */
+  description?: string
+
+  /**
    * Icon CSS class, e.g. `lucide-search`, or a component. Rendered centered in the cell.
    * Ignored when the default slot is used (for an image, avatar, or initials).
    */


### PR DESCRIPTION
## What

`RailItem` shows a second line under the label in its tooltip. Today that line is hardcoded: it only appears when the item has a `dot` badge, and it always reads "N unread".

This adds a `description` prop so the caller can supply that line instead.

```vue
<RailItem label="People" icon="lucide-users-2" description="12 members" />
```

## Why

A rail item often has a count worth showing that the icon has no room for and that isn't an unread count. In Gameplan the People icon wants to say how many people are in the directory, and the Drafts icon how many drafts are waiting. There was no way to do that from outside the component: the tooltip is filled by an internal `<template #content>` with no slot for a consumer to reach.

## Behaviour

Nothing that uses `RailItem` today renders differently. When `description` is absent the tooltip falls back to the unread string exactly as before, so the old path is now just the default branch of one computed:

- `description` given, use it
- no `description`, `dot` badge, count above zero, use "N unread"
- otherwise no second line

## Testing

`Rail.cy.ts` gains a case covering both branches: the unread fallback still shows, and `description` wins over it when both apply. All 7 specs pass.

`Rail.api.md` is regenerated with `yarn docs:gen Rail`. The `variant` type reorder in that file is generator output, not a hand edit.

<!-- coverage-report:start -->
Coverage: 66.38% (+0.01% vs `main`)
<!-- coverage-report:end -->

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-898/
<!-- docs-preview:end -->
