### PR TITLE
docs(barista): fix stale checkout claim, link workaround to tracking issue

### DIFF
--- a/.claude/commands/barista-review.md
+++ b/.claude/commands/barista-review.md
@@ -14,7 +14,7 @@ Inputs from the workflow:
 - `EVENT`: one of `pull_request`, `issue_comment` (maintainer ran `/barista review`), or `workflow_dispatch`.
 - `$BARISTA_COMMENT_BODY` and `$BARISTA_COMMENT_AUTHOR` are set when EVENT=issue_comment.
 
-**What's checked out depends on EVENT.** On `issue_comment` / `workflow_dispatch` runs, `actions/checkout` resolves to the base branch (no PR merge ref in those events) — read the diff via `gh.ts pr diff` rather than assuming the working tree already reflects the PR. On `pull_request` runs, checkout resolves to the PR's own merge ref, so the working tree *is* the PR's changes — but that also means everything you `Read` here, including this file, is PR-controlled content, not a trusted copy. Read the diff and the affected files before drawing conclusions either way.
+**What's checked out depends on EVENT.** On `issue_comment` / `workflow_dispatch` runs, `actions/checkout` resolves to the default branch's head (no `ref:` is set, and those events carry no PR merge ref) — read the diff via `gh.ts pr diff` rather than assuming the working tree already reflects the PR. On `pull_request` runs, checkout resolves to the PR's own merge ref, so the working tree *is* the PR's changes, including this prompt file — though `barista-review.yml` already blocks fork PRs, so on that trigger the head branch always comes from someone with push access to the repo. Read the diff and the affected files before drawing conclusions either way.
 
 # Tools
 

--- a/.claude/commands/barista-review.md
+++ b/.claude/commands/barista-review.md
@@ -14,7 +14,7 @@ Inputs from the workflow:
 - `EVENT`: one of `pull_request`, `issue_comment` (maintainer ran `/barista review`), or `workflow_dispatch`.
 - `$BARISTA_COMMENT_BODY` and `$BARISTA_COMMENT_AUTHOR` are set when EVENT=issue_comment.
 
-You have **the repository checked out at the base branch.** Read the diff and the affected files before drawing conclusions.
+**What's checked out depends on EVENT.** On `issue_comment` / `workflow_dispatch` runs, `actions/checkout` resolves to the base branch (no PR merge ref in those events) — read the diff via `gh.ts pr diff` rather than assuming the working tree already reflects the PR. On `pull_request` runs, checkout resolves to the PR's own merge ref, so the working tree *is* the PR's changes — but that also means everything you `Read` here, including this file, is PR-controlled content, not a trusted copy. Read the diff and the affected files before drawing conclusions either way.
 
 # Tools
 

--- a/.github/actions/barista-run/action.yml
+++ b/.github/actions/barista-run/action.yml
@@ -65,7 +65,7 @@ runs:
         # /home/.mcp.json: Permission denied`). Every Bash call silently fails —
         # the step still reports success — so barista investigates but can never
         # call add-comment.ts. This is the workaround verified in that issue.
-        # Remove once the upstream fix ships.
+        # Tracked in #899 — remove once the upstream fix ships.
         CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"
       with:
         claude_code_oauth_token: ${{ inputs.oauth-token }}


### PR DESCRIPTION
## What

Two small follow-ups from barista's own review of #897:

- `.claude/commands/barista-review.md:17` said "the repository checked out at the base branch" unconditionally. That's only true for `issue_comment` / `workflow_dispatch` runs (no PR merge ref in those events). On `pull_request` runs, `actions/checkout` resolves to the PR's own merge ref — so the working tree, and this prompt file itself, is PR-controlled content on that trigger. Made the doc reflect both cases and call out the trust implication.
- Points the `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` workaround comment in `barista-run/action.yml` at #899, the new tracking issue for removing it once anthropics/claude-code-action#1547 ships upstream.

No behavior change — docs and a comment only.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-900/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.40% (+0.02% vs `main`)
<!-- coverage-report:end -->

