### PR TITLE
fix(Tabs): use index 0 as default-value instead of label string [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -70,7 +70,7 @@ defineSlots<{
     :dir="dir"
     class="flex flex-1 overflow-hidden flex-col data-[orientation=vertical]:flex-row"
     :orientation="props.vertical ? 'vertical' : 'horizontal'"
-    :default-value="props.tabs[0].label"
+    :default-value="0"
     v-model="model"
   >
     <TabsList


### PR DESCRIPTION
## Description

Fixes the ResizeObserver error thrown on mount when using `<Tabs>` without `v-model`.

### Root Cause

`TabsTrigger` is keyed by array index (`:value="i"`), but `default-value` was set to the first tab’s label string (`props.tabs[0].label`). When no `v-model` is provided, the default value (a label string) matches no trigger value (a number), so no tab is selected by default. This leaves `TabsIndicator` (from reka-ui) without a valid element to observe, triggering:

```
Uncaught (in promise) TypeError: Failed to execute ‘observe’ on ‘ResizeObserver’: parameter 1 is not of type ‘Element’.
```

### Fix

Changed `:default-value="props.tabs[0].label"` to `:default-value="0"` so the default value matches the first trigger’s index.

Closes #801