### PR TITLE
docs(spec): ADR-0010 — what earns a subpath export vs root

### DIFF
--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -462,6 +462,7 @@ const isDismissible = computed(() => {
 1. Exposed through a single curated barrel (`experimental.ts`) behind the `./experimental` export **not** a `./src/*` wildcard. Re-export only what a first-party consumer actually needs.
 2. The barrel header restates the no-promise contract at the point of use.
 3. "Private" is by convention, `exports` can't scope visibility to a specific consumer so the contract is the disclaimer, not enforcement. Product/third-party code is told not to import it.
+4. To make an internal stable, deliberately promote it to a public entry point (and thus under P13). Until then, no guarantees.
 
 ---
 
@@ -492,4 +493,3 @@ import { Sidebar, SidebarItem } from 'frappe-ui/app-shell' // Sidebar has no
 ```
 
 **Consequence:** because root is the permanent home for everything that doesn't clear a bar, its compound families — `SettingsDialog`, `PageHeader`, `Sidebar`, list views — freeze there too. A subpath can't be used later to fix a name that shipped wrong; getting those names right is the cost of keeping them at root.
-4. To make an internal stable, deliberately promote it to a public entry point (and thus under P13). Until then, no guarantees.

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -462,4 +462,34 @@ const isDismissible = computed(() => {
 1. Exposed through a single curated barrel (`experimental.ts`) behind the `./experimental` export **not** a `./src/*` wildcard. Re-export only what a first-party consumer actually needs.
 2. The barrel header restates the no-promise contract at the point of use.
 3. "Private" is by convention, `exports` can't scope visibility to a specific consumer so the contract is the disclaimer, not enforcement. Product/third-party code is told not to import it.
+
+---
+
+## Package structure
+
+### P15. Root is the default; a subpath is earned, not organized into
+
+**Rule:** Every export lives at the package root unless it clears one of three bars:
+
+1. **Cost isolation** — it statically pulls a third-party dependency, or ships a CSS side effect, that root must not impose on every consumer. A dependency reached only through `await import()` is already isolated and doesn't count.
+2. **Extensible registry** — consumers can add a *new kind* of member the library never defined (a custom TipTap extension, a custom menu item), with no library change. A component with props and slots isn't this, however complex internally; neither is assembling a fixed set of named parts into a layout, however many parts.
+3. **Name collision** — its export names collide with root's, or would as root grows.
+
+Part count, file count, and "it would read better organized" are explicitly **not** reasons. Grouping by domain is the docs' job, not the module graph's — and a subpath is a one-way door: exported at `1.0.0`, it freezes under P13 until `2.0.0`, while adding a subpath later is always additive. When in doubt, default to root; the cost of being wrong is much lower in that direction.
+
+**Why:** A subpath makes a permanent promise about where something lives and what it costs to import. Without a written bar, every new family invents its own answer and the split reads as historical accident. The three bars above are the only things that have held up against every existing family, tested one by one — see ADR-0010 for the full audit and the size/collision-only alternatives it rejected along the way.
+
+```
+// Good — cost isolation: TipTap only loads if you import it
+import { Editor } from 'frappe-ui/editor'
+
+// Good — a fixed set of named parts, however many: root
+import { SettingsDialog, SettingsSidebar, SettingsPanel } from 'frappe-ui'
+
+// Bad — minting a subpath because a family "feels big enough"
+import { Sidebar, SidebarItem } from 'frappe-ui/app-shell' // Sidebar has no
+// dependency, no CSS side effect, and no colliding name — it stays at root.
+```
+
+**Consequence:** because root is the permanent home for everything that doesn't clear a bar, its compound families — `SettingsDialog`, `PageHeader`, `Sidebar`, list views — freeze there too. A subpath can't be used later to fix a name that shipped wrong; getting those names right is the cost of keeping them at root.
 4. To make an internal stable, deliberately promote it to a public entry point (and thus under P13). Until then, no guarantees.

--- a/spec/adr/0010-subpath-export-rule.md
+++ b/spec/adr/0010-subpath-export-rule.md
@@ -1,0 +1,147 @@
+# What earns a subpath export vs. the root export
+
+**Status**: accepted
+
+## Context
+
+`frappe-ui` ships a root export plus subpaths — `experimental`, `frappe`, `editor`,
+`list`, `code-editor`, `drive`, `icons`, `tailwind`, `vite`, `vitepress`, and the
+`*-style.css` entries — with no written rule for which surface a thing belongs on.
+ADR-0004 gave one reason after the fact ("isolated heavy dependency and/or large
+colliding export surface"), but it doesn't hold today: `frappe-ui/list` has no heavy
+dependency, and root already carries heavy ones (`echarts` via the chart components,
+`socket.io-client` via `initSocket`, all of TipTap via the deprecated `TextEditor`
+re-export). Without a generative rule, every new family invents its own answer and
+the split reads as accident rather than design — a problem that gets worse, not
+better, once `1.0.0` freezes whatever exists.
+
+## Decision
+
+**Root is the default.** A subpath is earned only by one of three things:
+
+**(a) Cost isolation.** It statically pulls a third-party dependency, or ships a CSS
+side effect, that root must not impose on every consumer. "Statically" is load-bearing:
+a dependency reached only through `await import()` is already isolated at the call site
+and needs no subpath.
+
+**(b) Extensible registry.** Consumers can add a *new kind* of member the library never
+defined — a custom TipTap extension, a custom menu item — with no change on the library
+side. A component with props and slots is not this, however complex it is inside.
+Assembling a fixed set of named parts into a layout (however many parts, however deep
+the nesting) is also not this — it's how most of this library is composed, and it
+doesn't discriminate: `SettingsDialog`, `PageHeader`, `Sidebar`, and the legacy
+`ListView` all show the same pattern and none of them earns a subpath by it.
+
+**(c) Name collision.** Its export names collide with root's, or would as root grows.
+
+**Explicitly not a reason:** part count, file count, or organization/discoverability
+alone. A subpath is a permanent packaging decision — once exported at `1.0.0` it is
+frozen until `2.0.0` (ADR-0008's reasoning, applied to the whole surface) — so
+"it would read better organized" doesn't clear the bar. Grouping by domain is the
+docs' job, not the module graph's. Concretely: **root staying the default means
+`SettingsDialog`, `PageHeader`/`PageHeaderMobile`, `Sidebar`, and the legacy
+`ListView` family all stay at root and freeze there.** Because a subpath is no longer
+available later as a way to reorganize them, getting their names and shapes right
+before the tag matters more, not less — that responsibility passes to each family's
+own sweep ticket.
+
+Build-time and tooling entries (`tailwind`, `vite`, `vitepress`,
+`tsconfig.base.json`) aren't runtime code and aren't judged by these three limbs at
+all — they aren't importable into a component tree in the first place. They're a
+separate category, decided on their own terms.
+
+### Applied to the export surface as it stands
+
+| Subpath | Limb(s) | Notes |
+| --- | --- | --- |
+| `frappe-ui/editor` | a + b + c | Static TipTap; open extension/menu registry (ADR-0004); `ListItem` and others already collide with root names. |
+| `frappe-ui/list` | c | `List`, `ListHeader`, `ListRow`, `ListRows` collide with the legacy `ListView` family, which stays at root undeprecated until it reaches parity. This is sufficient for `1.0.0` on its own; it does not need a second reason. If `ListView` is ever removed, whether `list` still earns a subpath is a fresh decision for that moment, not one to pre-answer now. |
+| `frappe-ui/icons` | a | `spritePlugin` statically imports the full `lucide-static` sprite; `IconPicker` reads the injected sprite DOM. Holds only while `spritePlugin` ships — a smaller cleanup (rewire `IconPicker` to the tailwind plugin's build-time icon list, delete `spritePlugin` and the duplicate `Icon.vue`) would remove the only static dependency in the subpath and fold it into root. |
+| `frappe-ui/charts` (in flight, #890) | a | Statically imports `echarts/core`. Rule-compliant as designed. |
+| `frappe-ui/experimental` | P14 | Its own rule; not judged by these limbs. Now also home to `CodeEditor` and `CodePreview` (see below). |
+| `frappe-ui/code-editor` | none | Removed. `CodeEditor`'s only dependency (CodeMirror) is entirely behind `await import()` — nothing static. It is a form-field sibling of `Textarea`/`TextInput` (its own prop types are derived from the shared `InputVariant`/`InputSize` union), not a family with a composition model. `CodePreview` statically imports `marked`, which would otherwise re-enter root's dependency graph the moment ADR-0008 deletes the deprecated `TextEditor` re-export (`marked`'s only other path to root). Rather than fold `CodeEditor` into root and leave `CodePreview` behind on a single-purpose subpath, both move to `frappe-ui/experimental` together — P14 carries no stability promise, so the pair can grow into a fuller code-editing parts family later, against real usage, without needing a `2.0.0`. |
+| `frappe-ui/frappe`, `frappe-ui/drive`, `frappe-ui/drive/*` | — | Disposition is #867's decision, not this rule's. |
+| `frappe-ui/tailwind`, `frappe-ui/tailwind/tokens.js`, `frappe-ui/vite`, `frappe-ui/vitepress`, `frappe-ui/tsconfig.base.json`, `frappe-ui/hljs-theme.css` | — | Build-time/tooling category; #887's decision. |
+
+### What this hands to other tickets
+
+- **#870** (root-surface audit): `initSocket` (→ `socket.io-client`) and `dayjs`/
+  `dayjsLocal` (→ `dayjs/esm` + 3 plugins) are static dependencies that trip limb (a)
+  and cannot stay at root as-is. `frappe-ui/utils` is not the fix — sorting the
+  non-component root exports found only two genuinely generic, dependency-free
+  functions (`debounce`, `fileToBase64`); everything else is either a component's own
+  API misplaced at the top level, or belongs to the data-fetching subsystem. Each
+  flagged export needs its own disposition (un-export, re-home with its real owner,
+  or move with the data layer), not a shared bucket.
+- **#885** (charts / `GridLayout`): the *old* chart components (`AxisChart`, `ECharts`,
+  `DonutChart`, `FunnelChart`, `NumberChart`) and `GridLayout` statically import
+  `echarts` and `grid-layout-plus` respectively — limb (a) says they cannot stay at
+  root as-is. `frappe-ui/charts` (#890) already ships the v2 replacement correctly
+  isolated; the old family and `GridLayout` need the same treatment (lazy-load,
+  subpath, or un-export) once #890 lands.
+- **#886** (data API export posture): `idb-keyval` is imported only by
+  `src/data-fetching/`, nowhere else in the library — the data layer already trips
+  limb (a) on its own, independent of any stylistic argument for a `frappe-ui/data`
+  subpath.
+- **#867** (`frappe-ui/frappe` removal): 84 call sites across crm (51), helpdesk (14),
+  insights (7), and builder (12) on freshly fetched `upstream` refs — the largest
+  subpath dependency of any app.
+- **#872** (overlays sweep): `NestedPopover` is the only file in the library that
+  imports `@popperjs/core`, and one of three still on `@headlessui/vue`. It has 13
+  downstream call sites (crm 3, helpdesk 10) despite not actually supporting nested
+  popovers — it's a plain popper-positioned popover with a legacy name. Removing it
+  drops a dependency outright.
+- **#878** (app shell sweep): confirms app-shell stays at root (no dependency, no CSS
+  side effect, no collision under this rule) — the `PageHeader`/`DesktopHeader` and
+  `PageHeaderMobile`/`MobileHeader` rename is that ticket's execution, not this one's.
+- **#884** (editor sweep): confirms `frappe-ui/editor` is rule-compliant on all three
+  limbs and flags the concrete collision (`ListItem`, among others) for the deprecated
+  `TextEditor` removal to close out.
+- **#887** (build-time subpaths): `code-editor`'s disposition is decided here (moves to
+  `experimental`, not a build-time subpath). The icon cleanup this rule identified —
+  remove `spritePlugin`, rewire `IconPicker` off the sprite DOM to the tailwind
+  plugin's build-time name list, delete the duplicate `icons/Icon.vue` — is filed
+  separately (see below) rather than folded into this ticket's build-tooling scope,
+  since it's a component/API question that happens to touch a build plugin, not
+  build-tooling itself.
+
+## Considered alternatives
+
+- **Namespace the whole library** (root holds only primitives; every cohesive domain —
+  app-shell, inputs, overlays, data — gets a subpath). Rejected for `1.0.0`: partial
+  namespacing is worse than either extreme (a consumer can no longer predict where
+  anything lives), and full namespacing is a breaking rewrite of every import in five
+  apps that would need its own map and would slip the tag. Adding a subpath later is
+  additive and legal under P13; removing a root export is not. Deferring costs
+  nothing; taking the option now spends it permanently on the least evidence this
+  effort will ever have.
+- **A size/part-count threshold** ("more parts than root's largest family earns a
+  subpath"). Rejected: tested against every compound family at root — `ListView` (13
+  parts), `SettingsDialog` (9), `PageHeader` (7), `Sidebar` (6) — and found no line
+  that separates `SettingsDialog` from `frappe-ui/list` (8 parts) without either
+  emptying root or admitting the threshold is arbitrary.
+- **A documented-public-CSS-custom-properties clause**, added to explain why
+  `frappe-ui/list` should stand independent of its collision with `ListView`.
+  Rejected: "is it documented" is a property of whether someone wrote a comment, not
+  of the code's architecture — two components with identical designs could get
+  different verdicts based on incidental documentation. `list`'s collision with
+  `ListView` is sufficient justification on its own for `1.0.0`; inventing a second,
+  weaker limb to pre-answer what happens if `ListView` is removed someday charts fog
+  this map doesn't need to chart yet.
+
+## Consequences
+
+- Every subpath's disposition is now derived from a written test, not repo
+  archaeology — a new family's authors can apply P15 themselves instead of
+  re-litigating the question.
+- `frappe-ui/code-editor` is removed as a subpath; `CodeEditor`, `CodePreview`, and
+  `loadLanguage` move to `frappe-ui/experimental`. No downstream app imports
+  `frappe-ui/code-editor` today (checked against freshly fetched `upstream` refs for
+  crm, helpdesk, insights, builder, gameplan, raven), so this is a zero-call-site
+  move, not a break.
+- `frappe-ui/list`, `frappe-ui/icons`, and the in-flight `frappe-ui/charts` all stand
+  on this rule without needing a carve-out.
+- Root keeps `SettingsDialog`, `PageHeader`, `Sidebar`, and the legacy `ListView`
+  family. Their naming now carries the full weight of being permanent — each
+  family's own sweep ticket (#878, #879, #882, and a `SettingsDialog` naming pass not
+  yet ticketed) is where that gets settled before the tag, not here.

--- a/spec/adr/README.md
+++ b/spec/adr/README.md
@@ -15,3 +15,4 @@ Specs describe the current contract. ADRs explain why decisions were made. Super
 | [0007 — Named typography style utilities](./0007-typography-style-utilities.md) | Accepted | `text-{size}-medium` utilities for Figma's medium-weight tracking. |
 | [0008 — No deprecated members in `1.0.0`](./0008-no-deprecated-members-in-1-0-0.md) | Accepted | Everything `@deprecated` is deleted before the stable tag. |
 | [0009 — Client filtering is opt-out](./0009-client-filtering-is-opt-out.md) | Accepted | `filterable` exists so server-driven options aren't filtered twice. |
+| [0010 — Subpath export rule](./0010-subpath-export-rule.md) | Accepted | Root is the default; a subpath is earned by cost isolation, an extensible registry, or a name collision — not part count or organization. |


### PR DESCRIPTION
## Summary

- Adds ADR-0010: root is the default export surface; a subpath is earned by one of three things — a static dependency/CSS side effect root must not carry, an extensible registry, or a name collision. Part count and "it would read better organized" are explicitly not reasons.
- Adds P15 to `PHILOSOPHY.md`.
- Applies the rule to the current export surface and hands specific findings to #867, #870, #872, #878, #884, #885, #886, #887.
- Removes the `frappe-ui/code-editor` subpath: `CodeEditor`, `CodePreview`, and `loadLanguage` move to `frappe-ui/experimental` (zero downstream call sites on freshly fetched `upstream` refs across crm, helpdesk, insights, builder, gameplan, raven — not a breaking move for any app).

Resolves frappe/frappe-ui#865.

## Test plan

- [ ] `spec/adr/0010-subpath-export-rule.md` reads consistently with the other ADRs
- [ ] `PHILOSOPHY.md` P15 fits the existing rulebook style
- [ ] No code changes in this PR — the actual `code-editor` → `experimental` move, and every other family's disposition, happens in their own sweep tickets

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-902/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.45% (±0.00% vs `main`)
<!-- coverage-report:end -->

