### PR TITLE
fix: make link mark non-inclusive so typing after a link doesn't extend it

### DIFF
--- a/src/components/TextEditor/extensions/link/link-extension.ts
+++ b/src/components/TextEditor/extensions/link/link-extension.ts
@@ -29,6 +29,10 @@ export const LinkExtension = Link.extend({
     }
   },
 
+  inclusive() {
+    return false
+  },
+
   addCommands() {
     return {
       ...this.parent?.(),

--- a/src/molecules/editor/extensions/link/link-extension.ts
+++ b/src/molecules/editor/extensions/link/link-extension.ts
@@ -45,6 +45,10 @@ export const LinkExtension = Link.extend({
     }
   },
 
+  inclusive() {
+    return false
+  },
+
   addCommands() {
     return {
       ...this.parent?.(),


### PR DESCRIPTION
## Summary

Fix the Editor/TipTap link mark so that typing directly after a link doesn't continue extending the link mark onto the new text.

### Root Cause

The Link extension's `inclusive()` method (inherited from `@tiptap/extension-link`) returns `this.options.autolink`. Since both LinkExtensions set `autolink: true`, the link mark is always inclusive. When the cursor is placed at the end boundary of a link and the user types, the new text is absorbed into the link.

### Fix

Override `inclusive()` to return `false` in both LinkExtensions:
- `src/components/TextEditor/extensions/link/link-extension.ts`
- `src/molecules/editor/extensions/link/link-extension.ts`

This ensures that typing after a link creates plain text outside the link, which is the expected behavior.

### Verification
- The `clearLinkOnBoundaryPlugin` already handles the case where a stored link mark persists without an active link at the cursor
- Making the mark non-inclusive is the correct fix per TipTap documentation

Closes #846