### PR TITLE
fix: accept application/vnd.ms-excel MIME type for CSV uploads on Firefox/Windows

### DIFF
--- a/frappe/DataImport/UploadStep.vue
+++ b/frappe/DataImport/UploadStep.vue
@@ -200,7 +200,7 @@ const uploadFile = (e: Event) => {
     const file = extractFile(e)
     if (!file) return;
 
-    if (file.type !== 'text/csv') {
+    if (file.type !== 'text/csv' && file.type !== 'application/vnd.ms-excel') {
         toast.error('Please upload a valid CSV file.')
         console.error('Please upload a valid CSV file.')
         return;


### PR DESCRIPTION
## Description

Fixes CSV upload on Firefox/Windows where the browser sends `application/vnd.ms-excel` as the MIME type for `.csv` files, while Chrome/Edge send `text/csv`. The upload function now accepts both MIME types.

### Root Cause

Firefox on Windows recognises `.csv` files as `application/vnd.ms-excel` (due to Windows registry association with Excel), while the `uploadFile` function in `UploadStep.vue` strictly required `text/csv`.

### Fix

Change the MIME type check from:
```js
if (file.type !== 'text/csv')
```
to:
```js
if (file.type !== 'text/csv' && file.type !== 'application/vnd.ms-excel')
```

Closes #669

<!-- coverage-report:start -->
Coverage: 66.48% (+0.03% vs `main`)
<!-- coverage-report:end -->
