### PR TITLE
fix(Sidebar): keep icons still and centered while collapsing

### DIFF
--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -15,8 +15,13 @@
     -->
     <template v-else>
       <div class="flex h-full flex-col p-2">
+        <!-- -mx-2 cancels the wrapper's horizontal padding: SidebarHeader owns
+             the sidebar gutter itself, so letting p-2 stack on top of it would
+             push the collapsed logo to 32px, 8px past the 3rem rail's centre.
+             Undoing it here makes this path render exactly like composition. -->
         <SidebarHeader
           v-if="header"
+          class="-mx-2"
           :title="header.title"
           :subtitle="header.subtitle"
           :logo="header.logo"

--- a/src/components/Sidebar/SidebarHeader.vue
+++ b/src/components/Sidebar/SidebarHeader.vue
@@ -3,10 +3,7 @@
        (min-h-12). The trigger sits 40px tall, centered in that region, and owns
        the sidebar gutter (px-2) itself — so consumers drop it straight into
        <Sidebar> without a wrapping padding div. -->
-  <div
-    class="flex h-12 shrink-0 items-center"
-    :class="isCollapsed ? 'justify-center' : 'px-1'"
-  >
+  <div class="flex h-12 shrink-0 items-center px-1">
     <Dropdown :options="props.menuItems" match-trigger-width>
       <template v-slot="{ open }">
         <button

--- a/src/components/Sidebar/SidebarItem.vue
+++ b/src/components/Sidebar/SidebarItem.vue
@@ -24,8 +24,7 @@
       :accesskey="accessKey"
       :aria-label="tooltipText || undefined"
       :aria-current="resolvedActive ? 'page' : undefined"
-      class="flex h-full min-w-0 flex-1 items-center focus:outline-none focus-visible:ring-0"
-      :class="isCollapsed ? 'justify-center' : 'pl-2'"
+      class="flex h-full min-w-0 flex-1 items-center pl-2 focus:outline-none focus-visible:ring-0"
       @click="handleClick"
     >
       <Tooltip
@@ -33,12 +32,10 @@
         placement="right"
         :disabled="!isCollapsed || !tooltipText"
       >
-        <!-- Collapsed: the icon sits in a 28px square (matches the row height)
-             so it reads as a centered rail button, not a left-hugged glyph. -->
-        <span
-          class="grid shrink-0 place-items-center"
-          :class="isCollapsed && 'size-7'"
-        >
+        <!-- Deliberately unchanged by `isCollapsed`: the row keeps its `pl-2`
+             and the glyph its natural size, so the icon holds one position
+             through the width animation. The whole row is the hit target. -->
+        <span class="grid shrink-0 place-items-center">
           <slot name="prefix">
             <SidebarItemIcon :icon="icon" />
           </slot>
@@ -65,8 +62,7 @@
       type="button"
       :accesskey="accessKey"
       :aria-label="tooltipText || undefined"
-      class="flex h-full text-left min-w-0 flex-1 items-center focus:outline-none focus-visible:ring-0"
-      :class="isCollapsed ? 'justify-center' : 'pl-2'"
+      class="flex h-full text-left min-w-0 flex-1 items-center pl-2 focus:outline-none focus-visible:ring-0"
       @click="handleClick"
     >
       <Tooltip
@@ -74,12 +70,10 @@
         placement="right"
         :disabled="!isCollapsed || !tooltipText"
       >
-        <!-- Collapsed: the icon sits in a 28px square (matches the row height)
-             so it reads as a centered rail button, not a left-hugged glyph. -->
-        <span
-          class="grid shrink-0 place-items-center"
-          :class="isCollapsed && 'size-7'"
-        >
+        <!-- Deliberately unchanged by `isCollapsed`: the row keeps its `pl-2`
+             and the glyph its natural size, so the icon holds one position
+             through the width animation. The whole row is the hit target. -->
+        <span class="grid shrink-0 place-items-center">
           <slot name="prefix">
             <SidebarItemIcon :icon="icon" />
           </slot>


### PR DESCRIPTION
## Problem

`SidebarItem` and `SidebarHeader` swap their alignment when the rail collapses — `pl-2` / `px-1` give way to `justify-center`. That swap is instant, but the rail's width is still animating, so the contents center themselves against a 240px container and then slide back over the 300ms transition.

Measured on the Sidebar docs page, an icon's center travels:

| | before | after |
|---|---|---|
| nav icon | 24 → 78 → 23.5 px (**~54px swing**) | **0px** |
| brand logo | 24 → 111.5 → 23.5 px (**~88px swing**) | **0px** |

There's a second, static bug underneath it: the nav icons never landed centered anyway. The label wrapper keeps `flex-1` while collapsed, so it absorbs the free space `justify-center` needs, and the icon settles **2px left** of the rail's center line.

## Fix

Keep the row's `pl-2` and the glyph's natural size in **both** states, and drop the alignment swap entirely. It's a deletion — no new constants.

The geometry already works out: `pl-2` plus half a 16px glyph is 16px from the row edge, which is exactly half of the collapsed content box (a `3rem` rail less the `0.5rem` gutters). The icon is already on the center line, so it has no reason to move — and because nothing about the layout depends on `isCollapsed` any more, there is nothing left that *can* animate out of position.

Dropping the collapsed `size-7` box costs nothing: the row is `flex-1 h-full`, so the whole row was always the hit target (measured 31×28 collapsed), and the hover background lives on `[data-slot="sidebar-item"]`, not on the span.

## Verification

On the Sidebar docs page, sampling every animation frame:

- icon travel **0px** in both directions, for the nav items and the brand row
- every icon in the Collapsed story now sits at exactly **24px** — the rail's center — instead of 22px
- expanded layout is byte-identical: icon center 24px, label starts at 40px, unchanged

`vue-tsc` reports the same 80 pre-existing `src/` errors before and after, none in these files. `vitest` reports the same 33 pre-existing failures before and after, all in `src/molecules/editor/**` (a `@tiptap/markdown` resolution issue) — there are no Sidebar tests. Prettier's only complaint on `SidebarItem.vue` is a pre-existing import wrap on line 118, so I left it alone rather than add unrelated churn.

## One thing worth a maintainer's call

The centering relies on the consumer using a `px-2` gutter around the nav (which the docs and stories all do). It holds for the default `collapsedWidth: '3rem'`; a custom `collapsedWidth` or a different gutter would need the padding to follow. That assumption was already baked into the existing `pl-2` / `size-7` values — this PR doesn't add it — but if you'd like it made explicit, the icon column could be driven from a CSS variable that `Sidebar` sets from `collapsedWidth`. Happy to follow up with that if you prefer.


<!-- coverage-report:start -->
Coverage: 66.59% (+0.03% vs `main`)
<!-- coverage-report:end -->

