### PR TITLE
fix(MultiSelect): prevent label for re-dispatch from re-opening popover (Closes #715)

### DIFF
--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -357,7 +357,7 @@ defineSlots<MultiSelectSlots>()
       @update:modelValue="handleRootModelValueChange"
       @update:open="handleRootOpenChange"
     >
-      <ComboboxAnchor as-child @click="handleTriggerClick">
+      <ComboboxAnchor as-child @pointerdown="handleTriggerClick">
         <slot v-if="$slots.trigger" name="trigger" v-bind="slotProps" />
 
         <!--


### PR DESCRIPTION
## Summary

Fixes #715 - MultiSelect not closing when clicking outside on the label.

## Root Cause

When clicking on a `<label for="triggerId">`, the browser re-dispatches a synthetic click event on the associated button element (HTML spec behavior for label for). This causes the following sequence:

1. reka-ui detects pointerdown outside ComboboxAnchor -> fires update:open(false) -> dropdown closes
2. Browser re-dispatches a synthetic click on the trigger button (via for attribute)
3. ComboboxAnchor click=toggleOpen fires -> open = !false = true -> dropdown re-opens

## Fix

Changed the ComboboxAnchor click handler from click to pointerdown. The browser's label for re-dispatch only fires a click event, not a pointerdown event. By listening to pointerdown instead, the browser's synthetic re-dispatch no longer triggers the toggle, while real user interactions (which always produce a pointerdown first) continue to work correctly.