### PR TITLE
perf: turn off sourcemaps in builds by default

### DIFF
--- a/vite/buildConfig.js
+++ b/vite/buildConfig.js
@@ -23,7 +23,10 @@ export function buildConfig(options = {}) {
   const defaultOptions = {
     outDir,
     emptyOutDir: true,
-    sourcemap: true,
+    // Sourcemaps are the single largest build cost: generating them makes
+    // builds 18-25% slower and uses 7-31% more memory. Apps that need them
+    // can pass `sourcemap: true` to buildConfig(). See #909.
+    sourcemap: false,
     indexHtmlPath: indexHtmlPath || null,
     baseUrl: options.baseUrl || getBaseUrl(outDir),
   }


### PR DESCRIPTION
Turns off sourcemaps in production builds by default.

Generating sourcemaps is the biggest single cost in a frappe-ui app build. Measured on five real apps, turning them off makes builds 18-25% faster and cuts peak memory by 7-31%.

| App | now | after | time | peak memory |
| --- | --- | --- | --- | --- |
| builder | 10.57s / 2084 MB | 7.88s / 1625 MB | **-25%** | **-22%** |
| gameplan | 4.57s / 2091 MB | 3.44s / 1538 MB | **-25%** | **-26%** |
| suite | 8.56s / 2181 MB | 6.68s / 2024 MB | **-22%** | **-7%** |
| insights | 11.54s / 2730 MB | 9.51s / 1885 MB | **-18%** | **-31%** |
| crm | 27.59s / 3120 MB | 22.65s / 2645 MB | **-18%** | **-15%** |

Each build was run cold (removing `dist/`, the app's `public/frontend/`, and `node_modules/.vite` first), 3 times, taking the median of both time and peak memory.

Full analysis in #909.

## This is not a breaking change for apps that want sourcemaps

`buildConfig()` merges whatever the app passes over the defaults, so an app that wants them back just does:

```js
frappeui({
  buildConfig: {
    sourcemap: true,
  },
})
```

## Heads up: three apps won't see any change from this

`suite`, `insights`, and `crm` set `sourcemap: true` in their own `vite.config`, which overrides this default. They need that line removed to get the improvement. I can open PRs on those repos if we want the full benefit.

Apps that don't set it themselves — builder and gameplan among them — get it automatically.

## Why not dev sourcemaps

This only touches `build`. Dev server sourcemaps are untouched, so debugging while developing is unaffected.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-910/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.45% (±0.00% vs `main`)
<!-- coverage-report:end -->
