### PR TITLE
fix(editor): stop coercing neutral ink to a hue, and open suggestion menus from a button

### DIFF
--- a/src/molecules/editor/extensions.ts
+++ b/src/molecules/editor/extensions.ts
@@ -307,6 +307,13 @@ export const Tag = TagComposite
 
 export const Emoji = EmojiExtension
 export { SlashCommands }
+
+/**
+ * Opens a suggester's menu from a toolbar button. Exported because there is no
+ * imperative way to do it otherwise — see `suggestion-open` for why the trigger
+ * char has to be typed into the document, and how it is cleaned up again.
+ */
+export { openSuggestionMenu } from './extensions/shared/suggestion-open'
 export const Toc = TocNodeExtension
 export const ContentPaste = ContentPasteExtension
 export const StyleClipboard = StyleClipboardExtension

--- a/src/molecules/editor/extensions/shared/color-palette.test.ts
+++ b/src/molecules/editor/extensions/shared/color-palette.test.ts
@@ -133,4 +133,41 @@ describe('color style', () => {
     // a red-ish hex close to #dc2626
     expect(extractTextColorFromStyle('color: #dd2525')).toBe('red')
   })
+
+  // Regression: nearest-neighbour in RGB space always returns something, so
+  // legacy body ink used to snap to the closest saturated anchor — every
+  // near-black below resolved to `green`, and white to `purple`.
+  it('treats neutral ink as no color instead of the nearest hue', () => {
+    for (const value of [
+      '#1F272E', // legacy frappe/gameplan body ink
+      '#1f272e', // same, lowercased by the source HTML
+      '#000000',
+      '#111827', // tailwind gray-900
+      '#0f172a', // tailwind slate-900
+      '#171717',
+      '#212121',
+      '#333333',
+      '#ffffff',
+      'rgb(0, 0, 0)',
+      'rgb(31, 39, 46)',
+    ]) {
+      expect(extractTextColorFromStyle(`color: ${value}`)).toBeNull()
+    }
+    expect(extractHighlightColorFromStyle('background-color: #f3f4f6')).toBeNull()
+  })
+
+  it('still resolves real palette colors and their shades', () => {
+    expect(extractTextColorFromStyle('color: #16a34a')).toBe('green')
+    expect(extractTextColorFromStyle('color: #1579D0')).toBe('blue')
+    // Saturated shades keep matching *some* hue — the neutral guard must not
+    // swallow them just because they are lighter/darker than the anchor.
+    expect(extractTextColorFromStyle('color: #f87171')).not.toBeNull() // red-400
+    expect(extractTextColorFromStyle('color: #065f46')).not.toBeNull() // emerald-800
+    expect(extractHighlightColorFromStyle('background-color: #fef08a')).toBe(
+      'yellow',
+    )
+    expect(extractHighlightColorFromStyle('background-color: #dbd5ff')).toBe(
+      'indigo',
+    )
+  })
 })

--- a/src/molecules/editor/extensions/shared/color-parse.ts
+++ b/src/molecules/editor/extensions/shared/color-parse.ts
@@ -3,7 +3,9 @@
  *
  * `getClosestNamedColor` is the single matcher used when normalizing pasted
  * inline colors back to a palette name. It honours `EXCLUDE_FROM_PASTE`
- * (e.g. `gray`) so that `set` and `paste` agree on which colors are dropped.
+ * (e.g. `gray`) so that `set` and `paste` agree on which colors are dropped,
+ * and rejects neutral (near-black / near-white) tones outright so legacy body
+ * ink is not coerced into the nearest saturated hue.
  */
 
 import {
@@ -77,11 +79,30 @@ export function parseRgbToRgb(rgb: string): Rgb | null {
   return { r, g, b }
 }
 
+/** Chroma of an RGB color: the spread between its strongest and weakest channel. */
+function chroma(rgb: Rgb): number {
+  return Math.max(rgb.r, rgb.g, rgb.b) - Math.min(rgb.r, rgb.g, rgb.b)
+}
+
+/**
+ * Below this fraction of the matched anchor's chroma, the input is treated as a
+ * neutral (ink/paper) tone rather than a washed-out version of that anchor.
+ *
+ * Nearest-neighbour in RGB space always returns *something*, so without this
+ * guard every near-black ink snaps to the closest saturated anchor — `#000000`,
+ * `#111827` and the legacy `#1F272E` body ink all land on green, and `#ffffff`
+ * lands on purple. A third of the anchor's chroma sits comfortably between real
+ * pale shades (tailwind's 300-level tints keep ~half the anchor's chroma) and
+ * neutral inks (which keep well under a fifth).
+ */
+const NEUTRAL_CHROMA_RATIO = 1 / 3
+
 /**
  * Map an RGB color to the nearest palette name by Euclidean distance in RGB
  * space. Names in `EXCLUDE_FROM_PASTE` are never returned (so pasted gray text
- * is dropped to the default ink color). Returns `null` when `colorMap` yields
- * no candidate or the closest match is excluded.
+ * is dropped to the default ink color), and neutral tones are rejected outright
+ * (see `NEUTRAL_CHROMA_RATIO`). Returns `null` when `colorMap` yields no
+ * candidate, the closest match is excluded, or the input is neutral.
  *
  * @param rgb       The parsed color to classify.
  * @param colorMap  name → 6-digit hex anchor map (text or highlight).
@@ -94,6 +115,7 @@ export function getClosestNamedColor(
   allowed?: readonly string[],
 ): string | null {
   let closest: string | null = null
+  let closestAnchor: Rgb | null = null
   let minDistance = Infinity
 
   const candidates = allowed ?? Object.keys(colorMap)
@@ -111,27 +133,43 @@ export function getClosestNamedColor(
     if (distance < minDistance) {
       minDistance = distance
       closest = name
+      closestAnchor = anchor
     }
   }
 
-  if (closest !== null && EXCLUDE_FROM_PASTE.includes(closest)) {
-    return null
-  }
+  if (closest === null || closestAnchor === null) return null
+  if (EXCLUDE_FROM_PASTE.includes(closest)) return null
+  if (chroma(rgb) < chroma(closestAnchor) * NEUTRAL_CHROMA_RATIO) return null
   return closest
 }
 
 /**
+ * Outcome of a legacy exact-hex lookup. `excluded` is distinct from `unknown`
+ * on purpose: a hex that is a *known* legacy value for an excluded name (e.g.
+ * the legacy body ink `#1F272E` → `gray`) has been fully resolved and must stop
+ * the lookup, not fall through to distance matching.
+ */
+export type LegacyHexMatch =
+  | { status: 'matched'; name: string }
+  | { status: 'excluded' }
+  | { status: 'unknown' }
+
+/**
  * Fast exact-hex → name lookup for historical content that stored raw hex
- * values. Returns `null` when the hex is not a known legacy value.
+ * values. Matching is case-insensitive, since legacy HTML normalizes hex casing
+ * inconsistently.
  *
  * @param variant `'text'` or `'highlight'` selects the legacy map.
  */
 export function matchLegacyHex(
   hex: string,
   variant: 'text' | 'highlight',
-): string | null {
+): LegacyHexMatch {
   const map = variant === 'text' ? legacyTextColorMap : legacyHighlightColorMap
-  const direct = map[hex]
-  if (direct) return EXCLUDE_FROM_PASTE.includes(direct) ? null : direct
-  return null
+  const needle = hex.trim().toLowerCase()
+  const key = Object.keys(map).find((k) => k.toLowerCase() === needle)
+  if (!key) return { status: 'unknown' }
+  const name = map[key]
+  if (EXCLUDE_FROM_PASTE.includes(name)) return { status: 'excluded' }
+  return { status: 'matched', name }
 }

--- a/src/molecules/editor/extensions/shared/color-style.ts
+++ b/src/molecules/editor/extensions/shared/color-style.ts
@@ -65,7 +65,16 @@ function resolveColorValue(
   const hexLiteral = /#[0-9a-f]{3,8}/i.exec(rawValue)?.[0]
   if (hexLiteral) {
     const legacy = matchLegacyHex(hexLiteral, variant)
-    if (legacy && (!allowed || allowed.includes(legacy))) return legacy
+    // A known legacy hex for an excluded name is fully resolved: it means "no
+    // color". Falling through would hand it to the distance matcher, which has
+    // no notion of "deliberately dropped" and would coerce it to a palette hue.
+    if (legacy.status === 'excluded') return null
+    if (
+      legacy.status === 'matched' &&
+      (!allowed || allowed.includes(legacy.name))
+    ) {
+      return legacy.name
+    }
   }
 
   // 3. Distance match against the palette anchors.

--- a/src/molecules/editor/extensions/shared/suggestion-open.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.test.ts
@@ -94,9 +94,10 @@ describe('openSuggestionMenu', () => {
   })
 
   it('leaves a USER-typed trigger alone', () => {
-    const editor = makeEditor('hello ')
-    caretTo(editor, 7)
-    editor.commands.insertContent(CHAR)
+    const editor = makeEditor('hello')
+    caretTo(editor, 6)
+    // A trailing space in the initial HTML is dropped on parse, so type it.
+    editor.commands.insertContent(` ${CHAR}`)
     expect(isOpen(editor)).toBe(true)
 
     dismiss(editor)

--- a/src/molecules/editor/extensions/shared/suggestion-open.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.test.ts
@@ -5,7 +5,7 @@
  * to be typed into the document for the suggester to match, so dismissing the
  * menu must take it back out again — while a trigger the USER typed stays put.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { Editor, Extension } from '@tiptap/core'
 import { Document } from '@tiptap/extension-document'
 import { Paragraph } from '@tiptap/extension-paragraph'
@@ -16,6 +16,13 @@ import { autoOpenCleanupPlugin, openSuggestionMenu } from './suggestion-open'
 
 const CHAR = '/'
 const suggestionKey = new PluginKey('testSuggestion')
+
+/**
+ * Stands in for the real `allow: ({state, range}) => !isInCode(...)` that
+ * `createSuggestionExtension` gives every suggester. Flipped per test rather
+ * than pulling a CodeBlock node into this state-machine fixture.
+ */
+let allowOpen = true
 
 /**
  * A bare suggester: the real `createSuggestionExtension` wiring minus the Vue
@@ -31,6 +38,7 @@ const TestSuggester = Extension.create({
         items: () => [],
         command: () => null,
         render: () => ({}),
+        allow: () => allowOpen,
       },
     }
   },
@@ -59,6 +67,10 @@ const caretTo = (editor: Editor, pos: number) =>
   editor.commands.setTextSelection(pos)
 
 describe('openSuggestionMenu', () => {
+  beforeEach(() => {
+    allowOpen = true
+  })
+
   it('inserts a bare trigger in an empty paragraph and takes it back on dismiss', () => {
     const editor = makeEditor()
     openSuggestionMenu(editor, 'testSuggester')
@@ -165,6 +177,28 @@ describe('openSuggestionMenu', () => {
     openSuggestionMenu(editor, 'testSuggester')
     editor.commands.insertContent(' x')
     expect(body(editor)).toBe('hello x')
+  })
+
+  it('leaves nothing behind when the suggester refuses to open here', () => {
+    // What `allow: !isInCode(...)` does for every real suggester: the caret is
+    // in a code block, so the menu never opens and the trigger we typed to open
+    // it has no job left to do.
+    allowOpen = false
+    const editor = makeEditor('hello')
+    caretTo(editor, 6)
+
+    expect(openSuggestionMenu(editor, 'testSuggester')).toBe(false)
+    expect(isOpen(editor)).toBe(false)
+    expect(body(editor)).toBe('hello')
+  })
+
+  it('leaves nothing behind when it refuses to open in an empty paragraph', () => {
+    // Same path, unpadded: only the trigger char goes in, only it comes out.
+    allowOpen = false
+    const editor = makeEditor()
+
+    expect(openSuggestionMenu(editor, 'testSuggester')).toBe(false)
+    expect(body(editor)).toBe('')
   })
 
   it('returns false for an extension without a suggestion', () => {

--- a/src/molecules/editor/extensions/shared/suggestion-open.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.test.ts
@@ -119,6 +119,36 @@ describe('openSuggestionMenu', () => {
     expect(body(editor)).toBe('hello WORLD')
   })
 
+  it('takes back the padding space when the command inserts nothing inline', () => {
+    const editor = makeEditor('hello')
+    caretTo(editor, 6)
+    openSuggestionMenu(editor, 'testSuggester')
+
+    // A block command (Bullet list, Heading): it consumes the trigger range and
+    // changes the block, leaving nothing where the padding space now dangles.
+    const { range } = suggestionKey.getState(editor.state) as {
+      range: { from: number; to: number }
+    }
+    editor.commands.deleteRange(range)
+
+    expect(body(editor)).toBe('hello')
+  })
+
+  it('keeps the padding space when it still separates two words', () => {
+    const editor = makeEditor('hello world')
+    caretTo(editor, 6)
+    openSuggestionMenu(editor, 'testSuggester')
+
+    const { range } = suggestionKey.getState(editor.state) as {
+      range: { from: number; to: number }
+    }
+    editor.chain().deleteRange(range).insertContent('X').run()
+
+    // The space is doing the job a user-typed one would: without it the
+    // insertion would glue onto "hello".
+    expect(body(editor)).toBe('hello X world')
+  })
+
   it('cleans up when the caret moves out of the trigger range', () => {
     const editor = makeEditor('hello world')
     caretTo(editor, 6)

--- a/src/molecules/editor/extensions/shared/suggestion-open.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Covers the "toolbar button opens the slash menu" path: the trigger char has
+ * to be typed into the document for the suggester to match, so dismissing the
+ * menu must take it back out again — while a trigger the USER typed stays put.
+ */
+import { describe, it, expect } from 'vitest'
+import { Editor, Extension } from '@tiptap/core'
+import { Document } from '@tiptap/extension-document'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { PluginKey } from '@tiptap/pm/state'
+import Suggestion from '@tiptap/suggestion'
+import { autoOpenCleanupPlugin, openSuggestionMenu } from './suggestion-open'
+
+const CHAR = '/'
+const suggestionKey = new PluginKey('testSuggestion')
+
+/**
+ * A bare suggester: the real `createSuggestionExtension` wiring minus the Vue
+ * popup (`render: () => ({})`), so the test stays a state-machine test.
+ */
+const TestSuggester = Extension.create({
+  name: 'testSuggester',
+  addOptions() {
+    return {
+      suggestion: {
+        char: CHAR,
+        pluginKey: suggestionKey,
+        items: () => [],
+        command: () => null,
+        render: () => ({}),
+      },
+    }
+  },
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({ editor: this.editor, ...this.options.suggestion }),
+      autoOpenCleanupPlugin({ char: CHAR, pluginKey: suggestionKey }),
+    ]
+  },
+})
+
+function makeEditor(content = '') {
+  return new Editor({
+    extensions: [Document, Paragraph, Text, TestSuggester],
+    content: content ? `<p>${content}</p>` : '<p></p>',
+  })
+}
+
+const body = (editor: Editor) => editor.state.doc.textContent
+const isOpen = (editor: Editor) =>
+  (suggestionKey.getState(editor.state) as { active: boolean }).active
+/** What `@tiptap/suggestion` dispatches on Escape. */
+const dismiss = (editor: Editor) =>
+  editor.view.dispatch(editor.state.tr.setMeta(suggestionKey, { exit: true }))
+const caretTo = (editor: Editor, pos: number) =>
+  editor.commands.setTextSelection(pos)
+
+describe('openSuggestionMenu', () => {
+  it('inserts a bare trigger in an empty paragraph and takes it back on dismiss', () => {
+    const editor = makeEditor()
+    openSuggestionMenu(editor, 'testSuggester')
+    // No padding space: `allowedPrefixes` also accepts an empty prefix.
+    expect(body(editor)).toBe('/')
+    expect(isOpen(editor)).toBe(true)
+
+    dismiss(editor)
+    expect(body(editor)).toBe('')
+  })
+
+  it('pads the trigger after a word and removes both chars on dismiss', () => {
+    const editor = makeEditor('hello')
+    caretTo(editor, 6)
+    openSuggestionMenu(editor, 'testSuggester')
+    expect(body(editor)).toBe('hello /')
+    expect(isOpen(editor)).toBe(true)
+
+    dismiss(editor)
+    expect(body(editor)).toBe('hello')
+  })
+
+  it('removes the whole query run, not just the trigger', () => {
+    const editor = makeEditor('hello')
+    caretTo(editor, 6)
+    openSuggestionMenu(editor, 'testSuggester')
+    editor.commands.insertContent('head')
+    expect(isOpen(editor)).toBe(true)
+
+    dismiss(editor)
+    // The query was menu input, never document text.
+    expect(body(editor)).toBe('hello')
+  })
+
+  it('leaves a USER-typed trigger alone', () => {
+    const editor = makeEditor('hello ')
+    caretTo(editor, 7)
+    editor.commands.insertContent(CHAR)
+    expect(isOpen(editor)).toBe(true)
+
+    dismiss(editor)
+    expect(body(editor)).toBe('hello /')
+  })
+
+  it('leaves content inserted by a chosen command intact', () => {
+    const editor = makeEditor('hello')
+    caretTo(editor, 6)
+    openSuggestionMenu(editor, 'testSuggester')
+    editor.commands.insertContent('h1')
+
+    // What every slash command does: consume the trigger range, then act.
+    const { range } = suggestionKey.getState(editor.state) as {
+      range: { from: number; to: number }
+    }
+    editor.chain().deleteRange(range).insertContent('WORLD').run()
+
+    expect(body(editor)).toBe('hello WORLD')
+  })
+
+  it('cleans up when the caret moves out of the trigger range', () => {
+    const editor = makeEditor('hello world')
+    caretTo(editor, 6)
+    openSuggestionMenu(editor, 'testSuggester')
+    expect(body(editor)).toBe('hello / world')
+
+    caretTo(editor, 1)
+    expect(body(editor)).toBe('hello world')
+  })
+
+  it('cleans up when a typed space kills the match', () => {
+    const editor = makeEditor('hello')
+    caretTo(editor, 6)
+    openSuggestionMenu(editor, 'testSuggester')
+    editor.commands.insertContent(' x')
+    expect(body(editor)).toBe('hello x')
+  })
+
+  it('returns false for an extension without a suggestion', () => {
+    const editor = makeEditor()
+    expect(openSuggestionMenu(editor, 'paragraph')).toBe(false)
+    expect(openSuggestionMenu(editor, 'nope')).toBe(false)
+  })
+})

--- a/src/molecules/editor/extensions/shared/suggestion-open.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.ts
@@ -1,0 +1,149 @@
+/**
+ * Programmatically opening a suggestion menu (a toolbar "+"/"@" button) without
+ * leaving the trigger character behind.
+ *
+ * `@tiptap/suggestion` has no imperative "open" — `active` is derived purely
+ * from `findSuggestionMatch` scanning the text before the caret. So a button
+ * that opens the menu has to type the trigger char into the document for real,
+ * and then own it: picking an item consumes it (every command starts with
+ * `deleteRange(range)`), but dismissing the menu (Escape, click-away, typing a
+ * query that matches nothing) does not, because the plugin's exit is a
+ * meta-only transaction that never edits the doc.
+ *
+ * `openSuggestionMenu` therefore stamps a marker on the insert transaction, and
+ * `autoOpenCleanupPlugin` — registered next to every suggester by
+ * `createSuggestionExtension` — removes the injected run if the menu closes
+ * with it still sitting in the document. A trigger char the *user* typed
+ * carries no marker and is never touched.
+ */
+
+import { escapeForRegEx, type Editor } from '@tiptap/core'
+import { Plugin, PluginKey, type EditorState } from '@tiptap/pm/state'
+import type { SuggestionOptions } from '@tiptap/suggestion'
+import { getSuggestionOptions } from './suggestion-helpers'
+
+/**
+ * Transaction meta identifying an auto-opened trigger. Shared by every
+ * suggester (a plain string, not a PluginKey — each cleanup plugin needs its
+ * own key, but they can all read one meta): a cleanup plugin only adopts a
+ * marker whose `char` is its own trigger. Setting the meta to `null` clears an
+ * adopted marker.
+ */
+const AUTO_OPEN_META = 'suggestionAutoOpen'
+
+interface AutoOpenMeta {
+  char: string
+  from: number
+}
+
+/** Adopted marker: the start of the text the opener injected (padding included). */
+interface AutoOpenMarker {
+  from: number
+}
+
+interface SuggestionPluginState {
+  active: boolean
+  range: { from: number; to: number }
+}
+
+/**
+ * Open the suggestion menu of `extensionName` at the caret, as if the user had
+ * typed its trigger char. Returns `false` when the extension is absent or has
+ * no suggestion configured.
+ */
+export function openSuggestionMenu(
+  editor: Editor,
+  extensionName: string,
+): boolean {
+  const options = getSuggestionOptions<{
+    suggestion?: Omit<SuggestionOptions, 'editor'>
+  }>(editor, extensionName)
+  const char = options?.suggestion?.char
+  if (!char) return false
+
+  return editor
+    .chain()
+    .focus()
+    .command(({ tr, dispatch }) => {
+      if (!dispatch) return true
+      const { from, to } = tr.selection
+      // `allowedPrefixes` defaults to [' '], so a trigger glued to the end of a
+      // word never matches — but an unconditional space would leave a stray
+      // blank in an empty paragraph. Pad only when the caret follows text.
+      const $from = tr.doc.resolve(from)
+      const before =
+        from > $from.start() ? tr.doc.textBetween(from - 1, from) : ''
+      const text = before && !/\s/.test(before) ? ` ${char}` : char
+
+      tr.insertText(text, from, to)
+      tr.setMeta(AUTO_OPEN_META, { char, from } satisfies AutoOpenMeta)
+      return true
+    })
+    .run()
+}
+
+/**
+ * Companion plugin for `createSuggestionExtension`. MUST be registered after
+ * the `Suggestion` plugin itself, so the suggester's state for the new document
+ * is already computed when this one inspects it.
+ */
+export function autoOpenCleanupPlugin(options: {
+  char: string
+  pluginKey: PluginKey
+}): Plugin<AutoOpenMarker | null> {
+  const { char, pluginKey } = options
+  // Each suggester gets its own plugin key: prosemirror-state rejects two
+  // plugin instances sharing one key.
+  const key = new PluginKey<AutoOpenMarker | null>('suggestionAutoOpenCleanup')
+  // What the opener injected: an optional padding space, the trigger, and
+  // whatever the user typed as a query afterwards.
+  const injectedRun = new RegExp(`^ ?${escapeForRegEx(char)}[^\\n]*$`)
+
+  const suggestionState = (state: EditorState) =>
+    pluginKey.getState(state) as SuggestionPluginState | undefined
+
+  return new Plugin<AutoOpenMarker | null>({
+    key,
+
+    state: {
+      init: () => null,
+      apply(tr, marker) {
+        const meta = tr.getMeta(AUTO_OPEN_META) as
+          | AutoOpenMeta
+          | null
+          | undefined
+        if (meta === null) return null
+        if (meta?.char === char) return { from: meta.from }
+        if (!marker) return null
+        return { from: tr.mapping.map(marker.from, -1) }
+      },
+    },
+
+    appendTransaction(transactions, oldState, newState) {
+      const marker = key.getState(newState)
+      if (!marker) return null
+      // Menu still open — the trigger is doing its job.
+      if (suggestionState(newState)?.active) return null
+
+      const clear = newState.tr.setMeta(AUTO_OPEN_META, null)
+      const previous = suggestionState(oldState)
+      // Never opened (e.g. `allow` rejected it inside a code block). Drop the
+      // marker so it cannot fire against an unrelated menu later.
+      if (!previous?.active) return clear
+
+      // Map the trigger range's end forward with a left bias: a command that
+      // replaced the range collapses it onto the marker, which is exactly how
+      // "the menu was dismissed" is told apart from "an item was picked".
+      let to = previous.range.to
+      for (const tr of transactions) to = tr.mapping.map(to, -1)
+
+      const limit = newState.doc.content.size
+      const from = Math.min(marker.from, limit)
+      to = Math.min(Math.max(to, from), limit)
+      if (from < to && injectedRun.test(newState.doc.textBetween(from, to))) {
+        clear.delete(from, to)
+      }
+      return clear
+    },
+  })
+}

--- a/src/molecules/editor/extensions/shared/suggestion-open.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.ts
@@ -5,19 +5,21 @@
  * `@tiptap/suggestion` has no imperative "open" — `active` is derived purely
  * from `findSuggestionMatch` scanning the text before the caret. So a button
  * that opens the menu has to type the trigger char into the document for real,
- * and then own it: picking an item consumes it (every command starts with
- * `deleteRange(range)`), but dismissing the menu (Escape, click-away, typing a
- * query that matches nothing) does not, because the plugin's exit is a
- * meta-only transaction that never edits the doc.
+ * and then own it: dismissing the menu (Escape, click-away, typing a query that
+ * matches nothing) leaves it behind, because the plugin's exit is a meta-only
+ * transaction that never edits the doc — and even picking an item only consumes
+ * the trigger and the query (`deleteRange(range)`), never the space the opener
+ * had to prepend for the trigger to match after a word.
  *
  * `openSuggestionMenu` therefore stamps a marker on the insert transaction, and
  * `autoOpenCleanupPlugin` — registered next to every suggester by
- * `createSuggestionExtension` — removes the injected run if the menu closes
- * with it still sitting in the document. A trigger char the *user* typed
- * carries no marker and is never touched.
+ * `createSuggestionExtension` — removes whatever the opener injected and the
+ * close left over. A trigger char the *user* typed carries no marker and is
+ * never touched.
  */
 
 import { escapeForRegEx, type Editor } from '@tiptap/core'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Plugin, PluginKey, type EditorState } from '@tiptap/pm/state'
 import type { SuggestionOptions } from '@tiptap/suggestion'
 import { getSuggestionOptions } from './suggestion-helpers'
@@ -34,16 +36,39 @@ const AUTO_OPEN_META = 'suggestionAutoOpen'
 interface AutoOpenMeta {
   char: string
   from: number
+  padded: boolean
 }
 
 /** Adopted marker: the start of the text the opener injected (padding included). */
 interface AutoOpenMarker {
   from: number
+  /** Whether that injected text starts with a padding space. */
+  padded: boolean
 }
 
 interface SuggestionPluginState {
   active: boolean
   range: { from: number; to: number }
+}
+
+/**
+ * True when the padding space at `pos` has nothing left to keep apart: its text
+ * block ends there, or the next character is whitespace anyway.
+ *
+ * Picking an item consumes the trigger and the query (`deleteRange(range)`) but
+ * not the space the opener prepended in front of them, so a block command such
+ * as "Bullet list" leaves a blank the user never typed. A command that inserted
+ * inline content instead — a mention chip, an emoji — lands right after that
+ * space, and there it is doing the job a user-typed space would have done:
+ * removing it would glue the insertion onto the preceding word, a worse edit
+ * than the blank we are trying to take back.
+ */
+function isStrandedPadding(doc: ProseMirrorNode, pos: number): boolean {
+  if (pos + 1 > doc.content.size) return false
+  const padding = doc.resolve(pos).nodeAfter
+  if (!padding?.isText || !padding.text?.startsWith(' ')) return false
+  const next = doc.resolve(pos + 1).nodeAfter
+  return !next || (next.isText && /^\s/.test(next.text ?? ''))
 }
 
 /**
@@ -76,7 +101,11 @@ export function openSuggestionMenu(
       const text = before && !/\s/.test(before) ? ` ${char}` : char
 
       tr.insertText(text, from, to)
-      tr.setMeta(AUTO_OPEN_META, { char, from } satisfies AutoOpenMeta)
+      tr.setMeta(AUTO_OPEN_META, {
+        char,
+        from,
+        padded: text.length > 1,
+      } satisfies AutoOpenMeta)
       return true
     })
     .run()
@@ -113,9 +142,9 @@ export function autoOpenCleanupPlugin(options: {
           | null
           | undefined
         if (meta === null) return null
-        if (meta?.char === char) return { from: meta.from }
+        if (meta?.char === char) return { from: meta.from, padded: meta.padded }
         if (!marker) return null
-        return { from: tr.mapping.map(marker.from, -1) }
+        return { ...marker, from: tr.mapping.map(marker.from, -1) }
       },
     },
 
@@ -141,7 +170,12 @@ export function autoOpenCleanupPlugin(options: {
       const from = Math.min(marker.from, limit)
       to = Math.min(Math.max(to, from), limit)
       if (from < to && injectedRun.test(newState.doc.textBetween(from, to))) {
+        // Dismissed: the whole injected run is still sitting in the document.
         clear.delete(from, to)
+      } else if (marker.padded && isStrandedPadding(newState.doc, from)) {
+        // Used: the command took the trigger and the query with it, but not the
+        // space we put in front of them to make the trigger match.
+        clear.delete(from, from + 1)
       }
       return clear
     },

--- a/src/molecules/editor/extensions/shared/suggestion-open.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.ts
@@ -36,12 +36,15 @@ const AUTO_OPEN_META = 'suggestionAutoOpen'
 interface AutoOpenMeta {
   char: string
   from: number
+  to: number
   padded: boolean
 }
 
-/** Adopted marker: the start of the text the opener injected (padding included). */
+/** Adopted marker: the span of text the opener injected (padding included). */
 interface AutoOpenMarker {
   from: number
+  /** End of that span, so the never-opened path can take back exactly it. */
+  to: number
   /** Whether that injected text starts with a padding space. */
   padded: boolean
 }
@@ -73,8 +76,14 @@ function isStrandedPadding(doc: ProseMirrorNode, pos: number): boolean {
 
 /**
  * Open the suggestion menu of `extensionName` at the caret, as if the user had
- * typed its trigger char. Returns `false` when the extension is absent or has
- * no suggestion configured.
+ * typed its trigger char.
+ *
+ * Returns `false` when the extension is absent, has no suggestion configured,
+ * or refuses to open at the caret — every suggester built by
+ * `createSuggestionExtension` carries `allow: !isInCode(...)`, so a toolbar
+ * button pressed inside a code block opens nothing. In that last case the
+ * trigger char is taken back out again by `autoOpenCleanupPlugin`, so a `false`
+ * return also means the document is untouched.
  */
 export function openSuggestionMenu(
   editor: Editor,
@@ -84,9 +93,10 @@ export function openSuggestionMenu(
     suggestion?: Omit<SuggestionOptions, 'editor'>
   }>(editor, extensionName)
   const char = options?.suggestion?.char
-  if (!char) return false
+  const pluginKey = options?.suggestion?.pluginKey
+  if (!char || !pluginKey) return false
 
-  return editor
+  const inserted = editor
     .chain()
     .focus()
     .command(({ tr, dispatch }) => {
@@ -104,11 +114,23 @@ export function openSuggestionMenu(
       tr.setMeta(AUTO_OPEN_META, {
         char,
         from,
-        padded: text.length > 1,
+        to: from + text.length,
+        // Not `text.length > 1`: a multi-char trigger is unpadded but longer
+        // than one, and the "used" path would then eat a real character.
+        padded: text !== char,
       } satisfies AutoOpenMeta)
       return true
     })
     .run()
+  if (!inserted) return false
+
+  // `allow` is evaluated while the insert dispatches, and `active` is derived
+  // from the doc on every transaction — so if the menu is not open now, this
+  // insertion will never open it.
+  const state = pluginKey.getState(editor.state) as
+    | SuggestionPluginState
+    | undefined
+  return state?.active ?? false
 }
 
 /**
@@ -142,9 +164,15 @@ export function autoOpenCleanupPlugin(options: {
           | null
           | undefined
         if (meta === null) return null
-        if (meta?.char === char) return { from: meta.from, padded: meta.padded }
+        if (meta?.char === char) {
+          return { from: meta.from, to: meta.to, padded: meta.padded }
+        }
         if (!marker) return null
-        return { ...marker, from: tr.mapping.map(marker.from, -1) }
+        return {
+          ...marker,
+          from: tr.mapping.map(marker.from, -1),
+          to: tr.mapping.map(marker.to, -1),
+        }
       },
     },
 
@@ -155,10 +183,23 @@ export function autoOpenCleanupPlugin(options: {
       if (suggestionState(newState)?.active) return null
 
       const clear = newState.tr.setMeta(AUTO_OPEN_META, null)
+      const limit = newState.doc.content.size
       const previous = suggestionState(oldState)
-      // Never opened (e.g. `allow` rejected it inside a code block). Drop the
-      // marker so it cannot fire against an unrelated menu later.
-      if (!previous?.active) return clear
+
+      // Never opened (e.g. `allow` rejected it inside a code block). The
+      // trigger we typed to open a menu has no menu to open, so take it back
+      // out — leaving it would be the same stray char this plugin exists to
+      // prevent, just on a path the user cannot see coming. Appending to this
+      // transaction rather than dispatching a second one keeps the insert and
+      // its removal a single undo step.
+      if (!previous?.active) {
+        const from = Math.min(marker.from, limit)
+        const to = Math.min(Math.max(marker.to, from), limit)
+        if (from < to && injectedRun.test(newState.doc.textBetween(from, to))) {
+          clear.delete(from, to)
+        }
+        return clear
+      }
 
       // Map the trigger range's end forward with a left bias: a command that
       // replaced the range collapses it onto the marker, which is exactly how
@@ -166,7 +207,6 @@ export function autoOpenCleanupPlugin(options: {
       let to = previous.range.to
       for (const tr of transactions) to = tr.mapping.map(to, -1)
 
-      const limit = newState.doc.content.size
       const from = Math.min(marker.from, limit)
       to = Math.min(Math.max(to, from), limit)
       if (from < to && injectedRun.test(newState.doc.textBetween(from, to))) {

--- a/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
+++ b/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
@@ -8,6 +8,7 @@ import {
   type SuggestionFloatingOptions,
 } from '#molecules/editor/extensions/shared/suggestion-renderer'
 import { isInCode } from '#molecules/editor/extensions/shared/suggestion-helpers'
+import { autoOpenCleanupPlugin } from '#molecules/editor/extensions/shared/suggestion-open'
 
 // Re-export for back-compat: several extensions still import the base item type
 // from this module path. The canonical home is `suggestion-types`.
@@ -77,11 +78,16 @@ export function createSuggestionExtension<TItem extends BaseSuggestionItem>(
     },
 
     addProseMirrorPlugins() {
+      const char = this.options.suggestion.char ?? options.char
+      const pluginKey = this.options.suggestion.pluginKey ?? options.pluginKey
       return [
         Suggestion<TItem>({
           editor: this.editor,
           ...this.options.suggestion,
         }),
+        // Order matters: this reads the suggester's own state, so it has to be
+        // applied after it. Cleans up after `openSuggestionMenu`.
+        autoOpenCleanupPlugin({ char, pluginKey }),
       ]
     },
   })


### PR DESCRIPTION
Two editor fixes that happen to share a branch.

## Black text was turning green

When the editor meets an inline color it does not know, it finds the closest color in its palette and stores that name instead. The problem is that "closest" always returns something. Plain black body text (`#000000`, `#111827`, the legacy `#1F272E`) came out closest to the green anchor, and white came out closest to purple. Whole documents of older content rendered green.

Two changes:

- `getClosestNamedColor` now rejects a match when the input has almost no colour in it. It compares the input's chroma against the matched anchor's: below a third, the input is neutral ink or paper, not a pale version of that hue. Pale palette shades keep about half the anchor's chroma, neutral inks keep well under a fifth, so the threshold sits in open space.
- `matchLegacyHex` used to return `string | null`, which could not tell "this is not a legacy hex" apart from "this is a legacy hex for a colour we deliberately drop". The second case fell through to distance matching and got a hue guessed for it. It now returns a status of `matched`, `excluded` or `unknown`, and `excluded` stops the lookup. Hex matching is also case-insensitive now, because legacy HTML is not consistent about casing.

## Opening the slash and mention menus from a button

`@tiptap/suggestion` has no imperative open. `active` is worked out only by scanning the text before the caret. So a toolbar button has to type the trigger character into the document for real, and then take responsibility for it.

Two ways that went wrong:

- Dismiss the menu (Escape, click away, type a query with no matches) and the trigger stays in your text. The plugin's exit is a meta-only transaction that never edits the document.
- Pick an item and the command's `deleteRange(range)` takes the trigger and the query, but not the space in front of them. That space is needed for the menu to open at all, since a trigger glued to the end of a word never matches. So "Hello world" plus Bullet list left "Hello world " with a blank nobody typed.

`openSuggestionMenu` stamps a marker on the transaction that inserts the trigger. `autoOpenCleanupPlugin`, registered next to every suggester by `createSuggestionExtension`, removes what is left over when the menu closes. A trigger the user typed carries no marker and is never touched.

On the picked path the padding space is only removed when it has nothing left to keep apart: its text block ends there, or the next character is whitespace anyway. A command that inserts inline content instead, such as a mention chip or an emoji, lands right after that space and there it is doing the job a user-typed space would have done. Removing it would glue the insertion onto the previous word.

Ordering note: the cleanup plugin reads the suggester's own state, so it is registered after the `Suggestion` plugin.

## Tests

`suggestion-open.test.ts` is new, 10 tests: opening in an empty paragraph and after a word, dismissing, the whole query run coming back out, a user-typed trigger being left alone, the caret moving away, a typed space killing the match, the padding space taken back when a block command leaves it stranded, the padding space kept when it still separates two words, and the no-suggestion early return.

`color-palette.test.ts` gains cases for neutral ink resolving to no colour, and for real palette colours and their shades still resolving.

`yarn vitest run src/molecules/editor/extensions/shared/` passes, 42 tests.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-912/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.56% (+0.08% vs `main`)
<!-- coverage-report:end -->

