### PR TITLE
test(editor): destroy the editors suggestion-open builds

### DIFF
--- a/src/molecules/editor/extensions/shared/suggestion-open.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.test.ts
@@ -5,7 +5,7 @@
  * to be typed into the document for the suggester to match, so dismissing the
  * menu must take it back out again — while a trigger the USER typed stays put.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { Editor, Extension } from '@tiptap/core'
 import { Document } from '@tiptap/extension-document'
 import { Paragraph } from '@tiptap/extension-paragraph'
@@ -50,11 +50,20 @@ const TestSuggester = Extension.create({
   },
 })
 
+/**
+ * Editors made by a test, torn down after it. `EditorView` leaves a pending
+ * `DOMObserver.flush` timeout behind; left running, it fires once jsdom is gone
+ * and throws `document is not defined` out of a test that has already passed.
+ */
+const openEditors: Editor[] = []
+
 function makeEditor(content = '') {
-  return new Editor({
+  const editor = new Editor({
     extensions: [Document, Paragraph, Text, TestSuggester],
     content: content ? `<p>${content}</p>` : '<p></p>',
   })
+  openEditors.push(editor)
+  return editor
 }
 
 const body = (editor: Editor) => editor.state.doc.textContent
@@ -69,6 +78,10 @@ const caretTo = (editor: Editor, pos: number) =>
 describe('openSuggestionMenu', () => {
   beforeEach(() => {
     allowOpen = true
+  })
+
+  afterEach(() => {
+    while (openEditors.length) openEditors.pop()?.destroy()
   })
 
   it('inserts a bare trigger in an empty paragraph and takes it back on dismiss', () => {


### PR DESCRIPTION
Follow-up to #912. The publish job for v1.0.0-beta.32 failed on `npm test`, so the version bump landed on main but never reached npm.

The cause is in the test file #912 added. Each test built an `Editor` and left it running. `EditorView` keeps a pending `DOMObserver.flush` timeout, so once vitest tore down the jsdom environment that timeout fired against a gone `document`:

```
ReferenceError: document is not defined
  at EditorView.get root [as root] prosemirror-view/dist/index.js:5665:26
  at DOMObserver.flush prosemirror-view/dist/index.js:4714:24
This error originated in "suggestion-open.test.ts"
```

All 226 tests passed either way, but the uncaught exception made the run exit non-zero, which is enough to fail the publish step.

The editors are now collected as they are built and destroyed in `afterEach`. `attachment.roundtrip.test.ts` is the only other test that builds one, and it already destroys it.

`yarn vitest run` exits 0 across 20 consecutive local runs; before the fix it failed reproducibly.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-913/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.59% (+0.03% vs `main`)
<!-- coverage-report:end -->
