### PR TITLE
refactor(editor)!: open a suggestion menu with a command, not an export

### DIFF
--- a/src/molecules/editor/extensions.ts
+++ b/src/molecules/editor/extensions.ts
@@ -307,13 +307,6 @@ export const Tag = TagComposite
 
 export const Emoji = EmojiExtension
 export { SlashCommands }
-
-/**
- * Opens a suggester's menu from a toolbar button. Exported because there is no
- * imperative way to do it otherwise — see `suggestion-open` for why the trigger
- * char has to be typed into the document, and how it is cleaned up again.
- */
-export { openSuggestionMenu } from './extensions/shared/suggestion-open'
 export const Toc = TocNodeExtension
 export const ContentPaste = ContentPasteExtension
 export const StyleClipboard = StyleClipboardExtension

--- a/src/molecules/editor/extensions/shared/suggestion-helpers.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-helpers.ts
@@ -1,4 +1,5 @@
 import type { Editor, Range } from '@tiptap/core'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import type { EditorState } from '@tiptap/pm/state'
 
 /**
@@ -26,7 +27,8 @@ export function insertSuggestionNode(
 ): void {
   const { trailingSpace = true } = opts
   const content: Array<
-    { type: string; attrs: Record<string, unknown> } | { type: 'text'; text: string }
+    | { type: string; attrs: Record<string, unknown> }
+    | { type: 'text'; text: string }
   > = [{ type: nodeType, attrs }]
   if (trailingSpace) {
     content.push({ type: 'text', text: ' ' })
@@ -56,13 +58,18 @@ export function filterByQuery<T>(items: T[], query: string, key: keyof T): T[] {
  * Detection is structural: code-block nodes carry `spec.code === true`, and
  * inline code is a mark — so we walk the resolved ancestors for the former and
  * test the position's mark set for the latter.
+ *
+ * Takes the doc rather than the state so a caller mid-transaction can pass
+ * `tr.doc` and resolve a fresh position against the doc it belongs to. Passing
+ * `state.doc` with a position from a `tr` that has already edited the doc can
+ * resolve past the end and throw.
  */
-export function isInCode(state: EditorState, pos: number): boolean {
-  const $pos = state.doc.resolve(pos)
+export function isInCode(doc: ProseMirrorNode, pos: number): boolean {
+  const $pos = doc.resolve(pos)
   for (let depth = $pos.depth; depth > 0; depth--) {
     if ($pos.node(depth).type.spec.code) return true
   }
-  const codeMark = state.schema.marks.code
+  const codeMark = doc.type.schema.marks.code
   return codeMark ? codeMark.isInSet($pos.marks()) != null : false
 }
 

--- a/src/molecules/editor/extensions/shared/suggestion-open.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.test.ts
@@ -12,7 +12,12 @@ import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
 import { PluginKey } from '@tiptap/pm/state'
 import Suggestion from '@tiptap/suggestion'
-import { autoOpenCleanupPlugin, openSuggestionMenu } from './suggestion-open'
+import { Code } from '@tiptap/extension-code'
+import {
+  autoOpenCleanupPlugin,
+  insertSuggestionTrigger,
+} from './suggestion-open'
+import { createSuggestionExtension } from '../suggestion/createSuggestionExtension'
 
 const CHAR = '/'
 const suggestionKey = new PluginKey('testSuggestion')
@@ -66,6 +71,45 @@ function makeEditor(content = '') {
   return editor
 }
 
+/**
+ * A suggester built the real way, so the `openSuggestionMenu` command that
+ * `createSuggestionExtension` registers is present. The bare `TestSuggester`
+ * above wires the plugins by hand and deliberately has no command.
+ */
+function makeRealEditor(content = '') {
+  const key = new PluginKey('realSuggestion')
+  const editor = new Editor({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      Code,
+      createSuggestionExtension({
+        name: 'realSuggester',
+        char: '@',
+        pluginKey: key,
+        items: () => [],
+        command: () => {},
+        component: { render: () => null },
+      }),
+    ],
+    content: content ? `<p>${content}</p>` : '<p></p>',
+  })
+  openEditors.push(editor)
+  return { editor, key }
+}
+
+/**
+ * What the `openSuggestionMenu` command does once it has resolved the trigger
+ * char. Drives the plugin tests below against the bare fixture, which has no
+ * command of its own.
+ */
+function open(editor: Editor) {
+  const tr = editor.state.tr
+  insertSuggestionTrigger(tr, CHAR)
+  editor.view.dispatch(tr)
+}
+
 const body = (editor: Editor) => editor.state.doc.textContent
 const isOpen = (editor: Editor) =>
   (suggestionKey.getState(editor.state) as { active: boolean }).active
@@ -86,7 +130,7 @@ describe('openSuggestionMenu', () => {
 
   it('inserts a bare trigger in an empty paragraph and takes it back on dismiss', () => {
     const editor = makeEditor()
-    openSuggestionMenu(editor, 'testSuggester')
+    open(editor)
     // No padding space: `allowedPrefixes` also accepts an empty prefix.
     expect(body(editor)).toBe('/')
     expect(isOpen(editor)).toBe(true)
@@ -98,7 +142,7 @@ describe('openSuggestionMenu', () => {
   it('pads the trigger after a word and removes both chars on dismiss', () => {
     const editor = makeEditor('hello')
     caretTo(editor, 6)
-    openSuggestionMenu(editor, 'testSuggester')
+    open(editor)
     expect(body(editor)).toBe('hello /')
     expect(isOpen(editor)).toBe(true)
 
@@ -109,7 +153,7 @@ describe('openSuggestionMenu', () => {
   it('removes the whole query run, not just the trigger', () => {
     const editor = makeEditor('hello')
     caretTo(editor, 6)
-    openSuggestionMenu(editor, 'testSuggester')
+    open(editor)
     editor.commands.insertContent('head')
     expect(isOpen(editor)).toBe(true)
 
@@ -132,7 +176,7 @@ describe('openSuggestionMenu', () => {
   it('leaves content inserted by a chosen command intact', () => {
     const editor = makeEditor('hello')
     caretTo(editor, 6)
-    openSuggestionMenu(editor, 'testSuggester')
+    open(editor)
     editor.commands.insertContent('h1')
 
     // What every slash command does: consume the trigger range, then act.
@@ -147,7 +191,7 @@ describe('openSuggestionMenu', () => {
   it('takes back the padding space when the command inserts nothing inline', () => {
     const editor = makeEditor('hello')
     caretTo(editor, 6)
-    openSuggestionMenu(editor, 'testSuggester')
+    open(editor)
 
     // A block command (Bullet list, Heading): it consumes the trigger range and
     // changes the block, leaving nothing where the padding space now dangles.
@@ -162,7 +206,7 @@ describe('openSuggestionMenu', () => {
   it('keeps the padding space when it still separates two words', () => {
     const editor = makeEditor('hello world')
     caretTo(editor, 6)
-    openSuggestionMenu(editor, 'testSuggester')
+    open(editor)
 
     const { range } = suggestionKey.getState(editor.state) as {
       range: { from: number; to: number }
@@ -177,7 +221,7 @@ describe('openSuggestionMenu', () => {
   it('cleans up when the caret moves out of the trigger range', () => {
     const editor = makeEditor('hello world')
     caretTo(editor, 6)
-    openSuggestionMenu(editor, 'testSuggester')
+    open(editor)
     expect(body(editor)).toBe('hello / world')
 
     caretTo(editor, 1)
@@ -187,36 +231,69 @@ describe('openSuggestionMenu', () => {
   it('cleans up when a typed space kills the match', () => {
     const editor = makeEditor('hello')
     caretTo(editor, 6)
-    openSuggestionMenu(editor, 'testSuggester')
+    open(editor)
     editor.commands.insertContent(' x')
     expect(body(editor)).toBe('hello x')
   })
 
-  it('leaves nothing behind when the suggester refuses to open here', () => {
-    // What `allow: !isInCode(...)` does for every real suggester: the caret is
-    // in a code block, so the menu never opens and the trigger we typed to open
-    // it has no job left to do.
+  it('takes the trigger back out when the suggester never opens', () => {
+    // The safety net behind the command's own pre-check: whatever the reason a
+    // menu does not open, the char typed to open it has no job left to do.
     allowOpen = false
     const editor = makeEditor('hello')
     caretTo(editor, 6)
 
-    expect(openSuggestionMenu(editor, 'testSuggester')).toBe(false)
+    open(editor)
     expect(isOpen(editor)).toBe(false)
     expect(body(editor)).toBe('hello')
   })
 
-  it('leaves nothing behind when it refuses to open in an empty paragraph', () => {
+  it('takes it back out in an empty paragraph too', () => {
     // Same path, unpadded: only the trigger char goes in, only it comes out.
     allowOpen = false
     const editor = makeEditor()
 
-    expect(openSuggestionMenu(editor, 'testSuggester')).toBe(false)
+    open(editor)
     expect(body(editor)).toBe('')
   })
+})
 
-  it('returns false for an extension without a suggestion', () => {
-    const editor = makeEditor()
-    expect(openSuggestionMenu(editor, 'paragraph')).toBe(false)
-    expect(openSuggestionMenu(editor, 'nope')).toBe(false)
+describe('the openSuggestionMenu command', () => {
+  afterEach(() => {
+    while (openEditors.length) openEditors.pop()?.destroy()
+  })
+
+  it('opens the named suggester', () => {
+    // The wiring consumers actually use: there is no package export, so the
+    // command registered by createSuggestionExtension is the whole surface.
+    const { editor, key } = makeRealEditor()
+
+    expect(editor.commands.openSuggestionMenu('realSuggester')).toBe(true)
+    expect((key.getState(editor.state) as { active: boolean }).active).toBe(true)
+    expect(editor.state.doc.textContent).toBe('@')
+  })
+
+  it('returns false for a suggester that is not there', () => {
+    const { editor } = makeRealEditor()
+    expect(editor.commands.openSuggestionMenu('nope')).toBe(false)
+    expect(editor.state.doc.textContent).toBe('')
+  })
+
+  it('returns false for an extension with no suggestion configured', () => {
+    const { editor } = makeRealEditor()
+    expect(editor.commands.openSuggestionMenu('paragraph')).toBe(false)
+    expect(editor.state.doc.textContent).toBe('')
+  })
+
+  it('refuses inside code without touching the document', () => {
+    // Checked before inserting, so unlike the plugin's safety net there is no
+    // insert-then-remove round trip to undo.
+    const { editor } = makeRealEditor('hello')
+    editor.commands.setTextSelection({ from: 1, to: 6 })
+    editor.commands.setMark('code')
+    editor.commands.setTextSelection(6)
+
+    expect(editor.commands.openSuggestionMenu('realSuggester')).toBe(false)
+    expect(editor.state.doc.textContent).toBe('hello')
   })
 })

--- a/src/molecules/editor/extensions/shared/suggestion-open.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.test.ts
@@ -61,6 +61,8 @@ const TestSuggester = Extension.create({
  * and throws `document is not defined` out of a test that has already passed.
  */
 const openEditors: Editor[] = []
+/** Host elements for the attached editors, removed with them. */
+const openElements: HTMLElement[] = []
 
 function makeEditor(content = '') {
   const editor = new Editor({
@@ -78,7 +80,12 @@ function makeEditor(content = '') {
  */
 function makeRealEditor(content = '') {
   const key = new PluginKey('realSuggestion')
+  // Attached to the document: `isFocused` is `document.activeElement === view.dom`,
+  // which can never be true for a detached element.
+  const element = document.createElement('div')
+  document.body.appendChild(element)
   const editor = new Editor({
+    element,
     extensions: [
       Document,
       Paragraph,
@@ -96,6 +103,7 @@ function makeRealEditor(content = '') {
     content: content ? `<p>${content}</p>` : '<p></p>',
   })
   openEditors.push(editor)
+  openElements.push(element)
   return { editor, key }
 }
 
@@ -126,6 +134,7 @@ describe('openSuggestionMenu', () => {
 
   afterEach(() => {
     while (openEditors.length) openEditors.pop()?.destroy()
+    while (openElements.length) openElements.pop()?.remove()
   })
 
   it('inserts a bare trigger in an empty paragraph and takes it back on dismiss', () => {
@@ -261,6 +270,7 @@ describe('openSuggestionMenu', () => {
 describe('the openSuggestionMenu command', () => {
   afterEach(() => {
     while (openEditors.length) openEditors.pop()?.destroy()
+    while (openElements.length) openElements.pop()?.remove()
   })
 
   it('opens the named suggester', () => {
@@ -269,7 +279,9 @@ describe('the openSuggestionMenu command', () => {
     const { editor, key } = makeRealEditor()
 
     expect(editor.commands.openSuggestionMenu('realSuggester')).toBe(true)
-    expect((key.getState(editor.state) as { active: boolean }).active).toBe(true)
+    expect((key.getState(editor.state) as { active: boolean }).active).toBe(
+      true,
+    )
     expect(editor.state.doc.textContent).toBe('@')
   })
 
@@ -283,6 +295,36 @@ describe('the openSuggestionMenu command', () => {
     const { editor } = makeRealEditor()
     expect(editor.commands.openSuggestionMenu('paragraph')).toBe(false)
     expect(editor.state.doc.textContent).toBe('')
+  })
+
+  it('focuses the editor, so the menu gets the next keystroke', async () => {
+    // A toolbar button has taken focus by the time this runs.
+    const { editor } = makeRealEditor()
+    editor.commands.blur()
+    expect(editor.isFocused).toBe(false)
+
+    editor.commands.openSuggestionMenu('realSuggester')
+    // tiptap's focus() defers the DOM call to the next frame.
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(editor.isFocused).toBe(true)
+  })
+
+  it('reads the caret against the pending doc, not the stale one', () => {
+    // Chained after a command that already grew the doc: resolving the new
+    // position against the old doc runs past its end and throws.
+    const { editor, key } = makeRealEditor()
+
+    expect(() =>
+      editor
+        .chain()
+        .insertContent('a much longer line than the doc started with')
+        .openSuggestionMenu('realSuggester')
+        .run(),
+    ).not.toThrow()
+    expect((key.getState(editor.state) as { active: boolean }).active).toBe(
+      true,
+    )
   })
 
   it('refuses inside code without touching the document', () => {

--- a/src/molecules/editor/extensions/shared/suggestion-open.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.ts
@@ -2,6 +2,10 @@
  * Programmatically opening a suggestion menu (a toolbar "+"/"@" button) without
  * leaving the trigger character behind.
  *
+ * Internal to the package: `createSuggestionExtension` exposes this as
+ * `editor.commands.openSuggestionMenu(extensionName)`, which is how callers
+ * should reach it. Nothing here is exported from `frappe-ui/editor`.
+ *
  * `@tiptap/suggestion` has no imperative "open" — `active` is derived purely
  * from `findSuggestionMatch` scanning the text before the caret. So a button
  * that opens the menu has to type the trigger char into the document for real,
@@ -11,18 +15,21 @@
  * the trigger and the query (`deleteRange(range)`), never the space the opener
  * had to prepend for the trigger to match after a word.
  *
- * `openSuggestionMenu` therefore stamps a marker on the insert transaction, and
- * `autoOpenCleanupPlugin` — registered next to every suggester by
- * `createSuggestionExtension` — removes whatever the opener injected and the
+ * `insertSuggestionTrigger` therefore stamps a marker on the insert
+ * transaction, and `autoOpenCleanupPlugin` — registered next to every suggester
+ * by `createSuggestionExtension` — removes whatever the opener injected and the
  * close left over. A trigger char the *user* typed carries no marker and is
  * never touched.
  */
 
-import { escapeForRegEx, type Editor } from '@tiptap/core'
+import { escapeForRegEx } from '@tiptap/core'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
-import { Plugin, PluginKey, type EditorState } from '@tiptap/pm/state'
-import type { SuggestionOptions } from '@tiptap/suggestion'
-import { getSuggestionOptions } from './suggestion-helpers'
+import {
+  Plugin,
+  PluginKey,
+  type EditorState,
+  type Transaction,
+} from '@tiptap/pm/state'
 
 /**
  * Transaction meta identifying an auto-opened trigger. Shared by every
@@ -75,62 +82,31 @@ function isStrandedPadding(doc: ProseMirrorNode, pos: number): boolean {
 }
 
 /**
- * Open the suggestion menu of `extensionName` at the caret, as if the user had
- * typed its trigger char.
+ * Type `char` into `tr` at the caret so the suggester matches it, and mark the
+ * insertion so `autoOpenCleanupPlugin` can take it back out again.
  *
- * Returns `false` when the extension is absent, has no suggestion configured,
- * or refuses to open at the caret — every suggester built by
- * `createSuggestionExtension` carries `allow: !isInCode(...)`, so a toolbar
- * button pressed inside a code block opens nothing. In that last case the
- * trigger char is taken back out again by `autoOpenCleanupPlugin`, so a `false`
- * return also means the document is untouched.
+ * Writes to the caller's transaction rather than dispatching its own: the
+ * `openSuggestionMenu` command runs mid-dispatch, and a nested `editor.chain()`
+ * there throws `Applying a mismatched transaction`.
  */
-export function openSuggestionMenu(
-  editor: Editor,
-  extensionName: string,
-): boolean {
-  const options = getSuggestionOptions<{
-    suggestion?: Omit<SuggestionOptions, 'editor'>
-  }>(editor, extensionName)
-  const char = options?.suggestion?.char
-  const pluginKey = options?.suggestion?.pluginKey
-  if (!char || !pluginKey) return false
+export function insertSuggestionTrigger(tr: Transaction, char: string): void {
+  const { from, to } = tr.selection
+  // `allowedPrefixes` defaults to [' '], so a trigger glued to the end of a
+  // word never matches — but an unconditional space would leave a stray blank
+  // in an empty paragraph. Pad only when the caret follows text.
+  const $from = tr.doc.resolve(from)
+  const before = from > $from.start() ? tr.doc.textBetween(from - 1, from) : ''
+  const text = before && !/\s/.test(before) ? ` ${char}` : char
 
-  const inserted = editor
-    .chain()
-    .focus()
-    .command(({ tr, dispatch }) => {
-      if (!dispatch) return true
-      const { from, to } = tr.selection
-      // `allowedPrefixes` defaults to [' '], so a trigger glued to the end of a
-      // word never matches — but an unconditional space would leave a stray
-      // blank in an empty paragraph. Pad only when the caret follows text.
-      const $from = tr.doc.resolve(from)
-      const before =
-        from > $from.start() ? tr.doc.textBetween(from - 1, from) : ''
-      const text = before && !/\s/.test(before) ? ` ${char}` : char
-
-      tr.insertText(text, from, to)
-      tr.setMeta(AUTO_OPEN_META, {
-        char,
-        from,
-        to: from + text.length,
-        // Not `text.length > 1`: a multi-char trigger is unpadded but longer
-        // than one, and the "used" path would then eat a real character.
-        padded: text !== char,
-      } satisfies AutoOpenMeta)
-      return true
-    })
-    .run()
-  if (!inserted) return false
-
-  // `allow` is evaluated while the insert dispatches, and `active` is derived
-  // from the doc on every transaction — so if the menu is not open now, this
-  // insertion will never open it.
-  const state = pluginKey.getState(editor.state) as
-    | SuggestionPluginState
-    | undefined
-  return state?.active ?? false
+  tr.insertText(text, from, to)
+  tr.setMeta(AUTO_OPEN_META, {
+    char,
+    from,
+    to: from + text.length,
+    // Not `text.length > 1`: a multi-char trigger is unpadded but longer than
+    // one, and the "used" path would then eat a real character.
+    padded: text !== char,
+  } satisfies AutoOpenMeta)
 }
 
 /**

--- a/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
+++ b/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
@@ -23,6 +23,19 @@ declare module '@tiptap/core' {
        * Open a suggester's menu at the caret, as if its trigger char had been
        * typed — for a toolbar button, since `@tiptap/suggestion` has no
        * imperative open. Names the suggester to open, e.g. `'slashCommands'`.
+       *
+       * Focuses the editor first, so a click on the button does not swallow
+       * the keystrokes meant for the menu.
+       *
+       * `false` means nothing was inserted: no such extension, it has no
+       * suggestion configured, or the caret is inside code. `true` means the
+       * trigger was inserted — not that a menu is showing. A suggester can
+       * still decline for its own reasons (a custom `allow`, `startOfLine`),
+       * and `autoOpenCleanupPlugin` takes the char back out when it does.
+       *
+       * Registered by `createSuggestionExtension`, so it exists only when at
+       * least one suggester built by that factory is loaded — the same
+       * conditional availability as every other extension command here.
        */
       openSuggestionMenu: (extensionName: string) => ReturnType
     }
@@ -82,7 +95,7 @@ export function createSuggestionExtension<TItem extends BaseSuggestionItem>(
           command: options.command,
           // Stay inert inside code blocks / inline code, where a trigger char
           // (`:`/`#`/`@`) is literal source the author is typing — not a cue.
-          allow: ({ state, range }) => !isInCode(state, range.from),
+          allow: ({ state, range }) => !isInCode(state.doc, range.from),
           allowSpaces: options.allowSpaces,
           startOfLine: options.startOfLine,
           decorationTag: options.decorationTag || 'span',
@@ -104,19 +117,26 @@ export function createSuggestionExtension<TItem extends BaseSuggestionItem>(
       return {
         openSuggestionMenu:
           (extensionName: string) =>
-          ({ editor, tr, dispatch }) => {
+          ({ editor, tr, commands, dispatch }) => {
             const target = getSuggestionOptions<{
               suggestion?: { char?: string }
             }>(editor, extensionName)
             const char = target?.suggestion?.char
             if (!char) return false
-            // Same test as the `allow` above. Checking it before inserting
-            // rather than cleaning up after means the document is never
-            // touched when no menu can open, and the caller gets a `false`
-            // it can act on.
-            if (isInCode(editor.state, tr.selection.from)) return false
+            // Same test as the `allow` above, against `tr.doc` rather than
+            // `editor.state.doc`: an earlier command in the chain may already
+            // have edited the doc, and resolving a fresh position against the
+            // stale one can run past its end. Checking before inserting rather
+            // than cleaning up after leaves the document untouched when no
+            // menu can open.
+            if (isInCode(tr.doc, tr.selection.from)) return false
             if (!dispatch) return true
 
+            // A toolbar button takes focus on click, so the menu would open
+            // with the next keystroke going to the button. `commands.focus()`
+            // shares this transaction — only `editor.chain()` would start a
+            // rival one and throw.
+            commands.focus()
             insertSuggestionTrigger(tr, char)
             return true
           },

--- a/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
+++ b/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
@@ -7,8 +7,27 @@ import {
   createSuggestionRenderer,
   type SuggestionFloatingOptions,
 } from '#molecules/editor/extensions/shared/suggestion-renderer'
-import { isInCode } from '#molecules/editor/extensions/shared/suggestion-helpers'
-import { autoOpenCleanupPlugin } from '#molecules/editor/extensions/shared/suggestion-open'
+import {
+  isInCode,
+  getSuggestionOptions,
+} from '#molecules/editor/extensions/shared/suggestion-helpers'
+import {
+  autoOpenCleanupPlugin,
+  insertSuggestionTrigger,
+} from '#molecules/editor/extensions/shared/suggestion-open'
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    suggestion: {
+      /**
+       * Open a suggester's menu at the caret, as if its trigger char had been
+       * typed — for a toolbar button, since `@tiptap/suggestion` has no
+       * imperative open. Names the suggester to open, e.g. `'slashCommands'`.
+       */
+      openSuggestionMenu: (extensionName: string) => ReturnType
+    }
+  }
+}
 
 // Re-export for back-compat: several extensions still import the base item type
 // from this module path. The canonical home is `suggestion-types`.
@@ -74,6 +93,33 @@ export function createSuggestionExtension<TItem extends BaseSuggestionItem>(
               options.floatingOptions,
             ),
         } as Omit<SuggestionOptions<TItem>, 'editor'>,
+      }
+    },
+
+    // Every suggester registers the same generic command. Tiptap keeps the last
+    // registration of a name, and these are identical — the command takes the
+    // suggester to open as an argument rather than belonging to any one of
+    // them, so whichever instance wins behaves the same.
+    addCommands() {
+      return {
+        openSuggestionMenu:
+          (extensionName: string) =>
+          ({ editor, tr, dispatch }) => {
+            const target = getSuggestionOptions<{
+              suggestion?: { char?: string }
+            }>(editor, extensionName)
+            const char = target?.suggestion?.char
+            if (!char) return false
+            // Same test as the `allow` above. Checking it before inserting
+            // rather than cleaning up after means the document is never
+            // touched when no menu can open, and the caller gets a `false`
+            // it can act on.
+            if (isInCode(editor.state, tr.selection.from)) return false
+            if (!dispatch) return true
+
+            insertSuggestionTrigger(tr, char)
+            return true
+          },
       }
     },
 

--- a/src/molecules/editor/menu.test.ts
+++ b/src/molecules/editor/menu.test.ts
@@ -4,6 +4,12 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import { createApp, defineComponent, h } from 'vue'
+// At module scope rather than `await import('./index')` inside each test.
+// `vi.mock` below is hoisted above imports either way, so the stubs still
+// apply — but pulling the whole editor barrel is slow enough under coverage
+// that the first test to do it was blowing the 5s per-test timeout on CI.
+// Collection is where that cost belongs.
+import * as editorMenu from './index'
 
 const menuProps = vi.hoisted(() => ({
   bubble: [] as any[],
@@ -103,7 +109,7 @@ function fakeEditor(
 describe('editor menu primitives and presets', () => {
   it('renders command items, separators, groups, active state, and disabled state in a fixed menu', async () => {
     const { EditorFixedMenu, Bold, Italic, HeadingGroup, Separator } =
-      await import('./index')
+      editorMenu
     const { editor, calls } = fakeEditor()
     editor.canRun = false
 
@@ -128,7 +134,7 @@ describe('editor menu primitives and presets', () => {
   })
 
   it('command item actions call the editor chain', async () => {
-    const { EditorFixedMenu, Bold } = await import('./index')
+    const { EditorFixedMenu, Bold } = editorMenu
     const { editor, calls } = fakeEditor()
 
     const root = mount(EditorFixedMenu, { editor, items: [Bold] })
@@ -139,8 +145,7 @@ describe('editor menu primitives and presets', () => {
   })
 
   it('hides items whose mark/node/extension is absent (self-pruning)', async () => {
-    const { EditorFixedMenu, Bold, InsertTable, AlignLeft } =
-      await import('./index')
+    const { EditorFixedMenu, Bold, InsertTable, AlignLeft } = editorMenu
     // A trimmed editor: no table node, no textAlign extension.
     const { editor } = fakeEditor({ nodes: ['paragraph'], extensions: [] })
 
@@ -155,7 +160,7 @@ describe('editor menu primitives and presets', () => {
   })
 
   it('drops a group whose every item is unavailable', async () => {
-    const { EditorFixedMenu, HeadingGroup } = await import('./index')
+    const { EditorFixedMenu, HeadingGroup } = editorMenu
     const { editor } = fakeEditor({ nodes: ['paragraph'] }) // no heading node
 
     const root = mount(EditorFixedMenu, { editor, items: [HeadingGroup] })
@@ -166,7 +171,7 @@ describe('editor menu primitives and presets', () => {
 
   it('collapses separators orphaned by pruning (no leading, doubled, or trailing dividers)', async () => {
     const { EditorFixedMenu, Bold, Italic, InsertTable, AlignLeft, Separator } =
-      await import('./index')
+      editorMenu
     // A trimmed editor: no table node, no textAlign extension — so the align and
     // table buttons (and the separators bracketing them) should be pruned.
     const { editor } = fakeEditor({
@@ -200,8 +205,7 @@ describe('editor menu primitives and presets', () => {
   })
 
   it('renders bubble and floating menus with the shared item shape', async () => {
-    const { EditorBubbleMenu, EditorFloatingMenu, Bold } =
-      await import('./index')
+    const { EditorBubbleMenu, EditorFloatingMenu, Bold } = editorMenu
     const { editor, calls } = fakeEditor()
 
     // Items render their icon (not label text), so assert the button by aria-label.
@@ -222,8 +226,7 @@ describe('editor menu primitives and presets', () => {
   })
 
   it('passes shouldShow as a menu prop instead of nesting it in Floating UI options', async () => {
-    const { EditorBubbleMenu, EditorFloatingMenu, Bold } =
-      await import('./index')
+    const { EditorBubbleMenu, EditorFloatingMenu, Bold } = editorMenu
     const { editor } = fakeEditor()
     const shouldShow = vi.fn(() => false)
 
@@ -245,8 +248,7 @@ describe('editor menu primitives and presets', () => {
   })
 
   it('wires image, video, and link menu items through editor actions', async () => {
-    const { EditorFixedMenu, InsertImage, InsertVideo, InsertLink } =
-      await import('./index')
+    const { EditorFixedMenu, InsertImage, InsertVideo, InsertLink } = editorMenu
     const { editor, calls } = fakeEditor()
 
     const root = mount(EditorFixedMenu, {
@@ -266,7 +268,7 @@ describe('editor menu primitives and presets', () => {
   })
 
   it('opens the font color picker from the menu action with the trigger anchor', async () => {
-    const { EditorFixedMenu, FontColor } = await import('./index')
+    const { EditorFixedMenu, FontColor } = editorMenu
     const { editor } = fakeEditor({ extensions: ['namedColor'] })
 
     const root = mount(EditorFixedMenu, { editor, items: [FontColor] })
@@ -282,8 +284,7 @@ describe('editor menu primitives and presets', () => {
   })
 
   it('exports menu presets as plain arrays', async () => {
-    const { commentToolbar, articleToolbar, minimalToolbar } =
-      await import('./index')
+    const { commentToolbar, articleToolbar, minimalToolbar } = editorMenu
 
     expect(Array.isArray(commentToolbar)).toBe(true)
     expect(Array.isArray(articleToolbar)).toBe(true)


### PR DESCRIPTION
Follow-up to #912, which added `openSuggestionMenu` as a package export under `frappe-ui/editor`. It should not be one. The function acts on a single editor and belongs with the other editor verbs, so it is now:

```ts
editor.commands.openSuggestionMenu('slashCommands')
// or, from a toolbar button:
editor.chain().focus().openSuggestionMenu('mentionSuggestion').run()
```

`createSuggestionExtension` registers it, next to the cleanup plugin it depends on. Every suggester registers the same generic command; tiptap keeps the last registration of a name and they are identical, because the command takes the suggester to open as an argument rather than belonging to any one of them.

## The insert had to move onto the caller's transaction

A command runs mid-dispatch, and a nested `editor.chain()` there throws `Applying a mismatched transaction`. So the insert is now `insertSuggestionTrigger(tr, char)`, internal to the module, and the command writes to the `tr` it is handed.

## It now decides before inserting

The command runs the same `isInCode` test the suggester's `allow` uses. Pressing the button inside code returns `false` with the document untouched, instead of typing a char and having the plugin take it back out on the next transaction. No insert-then-remove round trip, and no undo-history noise.

The plugin's never-opened branch stays as the safety net for every other reason a match can fail.

## Breaking

`openSuggestionMenu` is no longer exported from `frappe-ui/editor`. Still beta, and the export shipped in `1.0.0-beta.33` less than an hour ago, so nothing outside this repo should be on it yet.

## Tests

15 tests. The plugin behaviours drive `insertSuggestionTrigger` against a hand-wired suggester; a second block drives the command against a real `createSuggestionExtension`, covering open, unknown suggester, an extension with no suggestion, and the refusal inside code.

`yarn vitest run` and `yarn build` both clean.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-914/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.56% (±0.00% vs `main`)
<!-- coverage-report:end -->

