### PR TITLE
Two 1.0.0 freeze decisions: the at-bar checklist (ADR-0011) and the template-ref surface (ADR-0012)

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -33,11 +33,12 @@ If these disagree, update the lower-authority document or mark it historical.
 - [`at-bar.md`](./at-bar.md) — what "at bar for `1.0.0`" means. The one checklist
   every sweep ticket on the [road to `1.0.0`](https://github.com/frappe/frappe-ui/issues/864)
   applies, per public export. **Accepted.**
-- [`imperative-api.md`](./imperative-api.md) — library-wide audit of what
-  components hand back through a template ref (`defineExpose` — 28 sites, 4
-  typed). Proposes five verbs, a policy for when and how a component may hand
-  back a DOM element, and a required `*Exposed` type. Excludes `frappe/`,
-  `ListView`, and `Calendar`. **Proposed.**
+- [`imperative-api.md`](./imperative-api.md) — the contract for what components
+  hand back through a template ref (`defineExpose` — 31 sites, 4 typed). Five
+  verbs, a policy for when and how a component may hand back a DOM element, and
+  a required `*Exposed` type. A member earns its place only when parent script
+  needs it and no other surface reaches. Excludes `frappe/`, `ListView`, and
+  `Calendar`. **Accepted** — [ADR-0012](./adr/0012-template-ref-surface.md).
 
 ## ADRs
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -30,6 +30,9 @@ If these disagree, update the lower-authority document or mark it historical.
 
 ## Freeze work
 
+- [`at-bar.md`](./at-bar.md) — what "at bar for `1.0.0`" means. The one checklist
+  every sweep ticket on the [road to `1.0.0`](https://github.com/frappe/frappe-ui/issues/864)
+  applies, per public export. **Accepted.**
 - [`imperative-api.md`](./imperative-api.md) — library-wide audit of what
   components hand back through a template ref (`defineExpose` — 28 sites, 4
   typed). Proposes five verbs, a policy for when and how a component may hand

--- a/spec/adr/0011-at-bar-checklist.md
+++ b/spec/adr/0011-at-bar-checklist.md
@@ -1,0 +1,114 @@
+# What "at bar for `1.0.0`" means
+
+**Status**: accepted
+
+## Context
+
+The [Road to `frappe-ui` 1.0.0](https://github.com/frappe/frappe-ui/issues/864) map cuts
+the export surface into fourteen sweep tickets. Each one ends by claiming its family is
+"at bar". Nothing defined that phrase, so fourteen tickets shared a definition of done that
+did not exist.
+
+`v1-release/plan.md` came closest: core components must be "implemented in TypeScript,
+implemented with `<script setup>`, documented, covered by baseline stories, covered by
+baseline component tests, audited for API consistency and stability". That list predates the
+map. It does not cover the keep-or-un-export call, the docs-accuracy check, the
+`@deprecated` sweep, or the `defineExpose` surface, and every item on it is stated loosely
+enough that two people would answer it differently.
+
+The cost of that ambiguity is asymmetric. An export reviewed to a bar that turns out to be
+too low is frozen until `2.0.0` (ADR-0008's reasoning). An export held to a bar that turns
+out to be too high costs one session.
+
+## Decision
+
+The checklist lives in [`at-bar.md`](../at-bar.md). This ADR records the choices behind it
+and the alternatives rejected.
+
+### The unit is the public export
+
+Not the directory, not the family. This follows the map's Rule 2 directly: the thing that
+freezes at `1.0.0` is the thing a consumer can import, so that is the thing that must be
+reviewed or removed.
+
+It was tempting to expect this to shrink the sweep by dropping internal-only directories.
+It does not. Tracing the export graph from every entry point, only `Menu/` and `types/` are
+unreachable; `Provider`, `ScrollArea`, `CommandPalette` and `ListFilter` are all exported,
+and `InputLabeling/` and `shared/` export types. **An exported type freezes like any other
+member**, which is a consequence worth stating plainly rather than a saving.
+
+The unit was chosen for correctness, not economy. Choosing the family instead would have
+let each sweeper draw their own line around internal code — the exact incomparability the
+checklist exists to remove.
+
+### One tier, with written N/A rules
+
+The originating ticket asked whether each item is "required to tag" or "nice to have".
+Rejected: a nice-to-have item is a "ships but unreviewed" parking spot under a friendlier
+name, and it is the first thing dropped under deadline. Rule 2 forbids that spot.
+
+Instead every item is required, and each carries a written rule for when it does not apply.
+A composable has no story because stories do not apply to composables, not because a story
+was optional and someone was busy. The record distinguishes the two.
+
+### Tests are five named behaviors, not a file and not a percentage
+
+A `.cy.ts` existing is the current de-facto bar and it means almost nothing: those files
+range from 5 test cases to 29. Two alternatives were considered.
+
+**A coverage floor** was rejected despite the tooling already existing
+(`test:cypress:coverage`, `.github/scripts/merge-coverage.ts`). A component can reach a high
+line-coverage number with no keyboard test at all, so it does not deliver what P12 needs,
+and it becomes the arbitrary thing that blocks the tag on a slow week.
+
+**Five named behaviors** — renders, `v-model` round-trip, disabled and loading, P12 keyboard
+and focus, every documented slot renders — were chosen because each is a yes or no, and
+because the list makes P12 enforceable for the first time.
+
+### The audit is recorded as a P1–P15 verdict list; carve-outs go in `PHILOSOPHY.md`
+
+Recording only the violations was rejected: with no record of a pass, there is no evidence a
+principle was ever checked, and the sweeps stay incomparable.
+
+Giving every family a `spec/<family>.md` holding its full audit was rejected as too large an
+addition — ten such files exist covering roughly six families, and writing eight more inside
+the sweep would slow every ticket.
+
+The split adopted matches `spec/README.md`'s own rule that specs hold the current contract
+and ADRs hold rationale: the per-family result is evidence and lives on the ticket; a
+carve-out is durable guidance and lives in `PHILOSOPHY.md` beside the principle it bends,
+the way Button's `#icon` exception already does at P6 and P11.
+
+### "Meaningfully" is replaced by the silent-break test
+
+ADR-0008 requires a migration before/after "where the shape changed meaningfully". A
+migration entry is now required whenever the break is **silent** — old code still compiles
+and runs but behaves differently — and only a changelog line when the break is **loud**, so
+the toolchain reports it.
+
+Ticket [#868](https://github.com/frappe/frappe-ui/issues/868) supplied the evidence: on
+`Autocomplete`, `items` → `options` for grouped options renders nothing with no error, and
+`#target` → `#trigger` flips `open` from a function to a boolean. Those are the entries a
+migration guide exists for. "This import no longer exists" is not.
+
+### The bar does not bend
+
+When a family cannot reach bar in one session, the sweeper splits it into new tickets on the
+map, or un-exports the member that cannot get there. Allowing the bar to bend with a
+recorded reason was rejected for the same reason two tiers were: it recreates the parking
+spot.
+
+## Consequences
+
+- **`spec/imperative-api.md` must be signed off before checklist item 8 means anything.**
+  It is `proposed`, so there is currently nothing to check against. That is a blocking
+  ticket against the nine sweeps whose families contain a `defineExpose`.
+- **The generated API tables need a CI check.** `yarn docs:gen` runs in no workflow, so
+  `.api.md` files can drift from the source unnoticed. Without it, item 4 asks sweepers to
+  hand-verify generated output, which is the wrong division of labour.
+- **194 blank member descriptions get filled inside the sweeps**, along family lines,
+  rather than as one pass.
+- **Item 0 is real work on every sweep.** Keep-or-un-export was not on `plan.md`'s list, and
+  it is the item most likely to change the shape of a family.
+- **The bar applies after the tag too.** A component added during `1.x` meets the same list
+  before it is exported.

--- a/spec/adr/0012-template-ref-surface.md
+++ b/spec/adr/0012-template-ref-surface.md
@@ -1,0 +1,113 @@
+# What earns a place on the template-ref surface
+
+**Status**: accepted
+
+## Context
+
+Every component has four public surfaces: props, slots, emits, and whatever it hands back
+when you grab it with a template ref. The first three were reviewed component by component
+before the v1 freeze. The fourth never was.
+
+[`imperative-api.md`](../imperative-api.md) documented how bad it had got — `open` meaning
+both a function and a boolean inside one file, four names for "give me the element", three
+ways to focus and most things unfocusable, two exported types with nothing behind them. It
+proposed five verbs, an element policy, and a required type per component. It sat at
+`proposed` and so [at-bar](../at-bar.md) item 8 had nothing to check against, blocking nine
+of the map's fourteen sweeps.
+
+Its §3 put four breaking changes up for sign-off and declared everything additive exempt,
+on the grounds that additions break nobody.
+
+**That exemption was the thing worth arguing with.** Under the map's Rule 2, an added
+method is frozen until `2.0.0` exactly like a renamed one. The spec's own §2.1 concedes the
+asymmetry — "adding a verb later is a minor release" — which makes an unproven method the
+expensive direction and an omitted one cheap to fix.
+
+## Decision
+
+### A member earns its place when parent script needs it and nothing else reaches
+
+Vue already offers three ways out of a component. Slot props reach code inside the slot.
+`v-model` and emits reach state. A template ref exists for what neither can do: driving the
+component from the parent's `<script>`.
+
+So the test for putting anything on this surface is that a parent's script needs it and no
+other surface reaches. This is what the rest of the decisions below fall out of.
+
+Counting against freshly fetched app trees, the test discriminates rather than rubber-stamps:
+
+- `focus()` passes overwhelmingly. 31 sites reach through `TextInput.el` purely to call it,
+  seven more use `querySelector`/`getElementById` as a workaround (builder 5, helpdesk 2),
+  and apps call `.focus()` on their own components as a matter of habit. §1.3's gap is real:
+  the library's two most-used inputs cannot be focused at all.
+- `clear()` passes only where it already ships. Outside `Select` / `Combobox` /
+  `MultiSelect`, the whole bench has one site — builder's `propertyCombobox.value?.reset()`.
+  For a text input, `v-model` already empties the value.
+- `FileUploader.inputRef` fails. Zero sites, and its replacement was covered by a slot prop
+  the whole time.
+
+### `open` and `close` are for overlays that own their trigger
+
+Popover, HoverCard, Dropdown and the pickers all render the trigger inside themselves
+through a `trigger` slot. Code outside that slot has no handle on it, so a template ref is
+the only way in — and apps do exactly that: builder's `ColorPicker` calls `open()` and
+`close()` from a function in its `<script>`, and helpdesk opens a date picker from a menu
+item's `onClick` in three places.
+
+`Dialog` has no trigger slot. The parent decides when it appears and already holds that
+state in `v-model`, so there is nothing a ref reaches that the parent does not already have.
+
+This replaces the reasoning `imperative-api.md` §2.8 originally used, which was that nobody
+in the bench calls Dialog's `close()` through a ref. That is true, and it is weak: zero
+usage is evidence nobody hit the need, not that the need is absent. Trigger ownership is a
+property of the component, so it predicts rather than observes — and it gives the same
+answer for Dialog while keeping Popover and HoverCard, which pure usage-counting would not
+have justified as cleanly.
+
+### The four sign-off calls
+
+1. **`el` → `inputElement` on `TextInput` and `Textarea`.** Renamed, as a read-only computed
+   typed as precisely as possible. `el` says nothing about which element arrives and does
+   not match `ScrollArea`'s `viewportElement`; keeping it would freeze two naming
+   conventions for one idea. Keeping `el` alongside the new name was never available —
+   ADR-0008 bans deprecated members in `1.0.0`.
+2. **`Dialog` hands back nothing.** `defineExpose` goes and the exported `DialogExposed` is
+   deleted, per the trigger-ownership rule. Growing it to `{ open, close }` for symmetry
+   with Popover was rejected: symmetry is not the rule, trigger ownership is.
+3. **`FileUploader` hands back nothing.** `inputRef` is removed with nothing in its place.
+   The spec's proposed `open()` would have been a second public name for an action already
+   called `openFileSelector` as a slot prop in 28 app files across five apps, and the slot
+   prop reaches every real use — all 28 put the trigger button inside the slot. Renaming the
+   slot prop to match was rejected as a quiet break in 28 files, bought for nothing.
+4. **`Combobox.reset` → `clear`** was already shipped before this ADR, via
+   [`selection.md`](../selection.md). It carries one live migration site.
+
+### The additive half is bounded, not exempt
+
+- `focus(options?)` goes on everything you can type in or tab to.
+- `open` / `close` go on trigger-owning overlays only. Popover and HoverCard keep theirs;
+  the three date pickers and `TimePicker` gain both.
+- `clear()` stays on `Select`, `Combobox` and `MultiSelect` and goes nowhere new.
+- `DropdownExposed` — exported, promising a `close()` that `Dropdown.vue` never defines — is
+  **deleted**, not implemented. Implementing it would add an unproven pair of methods to
+  make a type true that no one should have been relying on.
+
+Anything else waits for a real request and arrives in a minor release.
+
+## Consequences
+
+- **`imperative-api.md` is accepted**, so [at-bar](../at-bar.md) item 8 has a contract to
+  check against and the nine blocked sweeps are unblocked.
+- **The `el` rename is the widest change in the document, and most of it is not a rename.**
+  Of 39 app sites, 31 only call `focus()` and move to the new method; 5 (all crm, doing
+  `select()` / `blur()`) take the new name; 3 read `el._value` and need rewriting against
+  the model value. Every break surfaces as a type error, not a runtime crash.
+- **Three migration entries are silent breaks** under ADR-0011's test and need a
+  before/after: the `el._value` reads in crm's and helpdesk's vendored `Autocomplete` forks,
+  builder's live `Combobox.reset()` call, and the `select()` / `blur()` sites in crm.
+  Removing `DialogExposed` and `FileUploader.inputRef` are loud breaks and need only a
+  changelog line.
+- **Each sweep does its own family's work.** This ADR sets the contract; the `defineExpose`
+  edits happen inside the sweep that owns each component, as at-bar item 8.
+- **A sixth verb, or a third element role, still needs an ADR.** That limit is what stops
+  this surface drifting back into four names for one idea.

--- a/spec/adr/README.md
+++ b/spec/adr/README.md
@@ -16,3 +16,4 @@ Specs describe the current contract. ADRs explain why decisions were made. Super
 | [0008 — No deprecated members in `1.0.0`](./0008-no-deprecated-members-in-1-0-0.md) | Accepted | Everything `@deprecated` is deleted before the stable tag. |
 | [0009 — Client filtering is opt-out](./0009-client-filtering-is-opt-out.md) | Accepted | `filterable` exists so server-driven options aren't filtered twice. |
 | [0010 — Subpath export rule](./0010-subpath-export-rule.md) | Accepted | Root is the default; a subpath is earned by cost isolation, an extensible registry, or a name collision — not part count or organization. |
+| [0011 — The at-bar checklist](./0011-at-bar-checklist.md) | Accepted | Defines "at bar for `1.0.0`" — one tier, per public export. Checklist in [`at-bar.md`](../at-bar.md). |

--- a/spec/adr/README.md
+++ b/spec/adr/README.md
@@ -17,3 +17,4 @@ Specs describe the current contract. ADRs explain why decisions were made. Super
 | [0009 — Client filtering is opt-out](./0009-client-filtering-is-opt-out.md) | Accepted | `filterable` exists so server-driven options aren't filtered twice. |
 | [0010 — Subpath export rule](./0010-subpath-export-rule.md) | Accepted | Root is the default; a subpath is earned by cost isolation, an extensible registry, or a name collision — not part count or organization. |
 | [0011 — The at-bar checklist](./0011-at-bar-checklist.md) | Accepted | Defines "at bar for `1.0.0`" — one tier, per public export. Checklist in [`at-bar.md`](../at-bar.md). |
+| [0012 — The template-ref surface](./0012-template-ref-surface.md) | Accepted | A member earns its place only when parent script needs it and no other surface reaches; `open`/`close` are for overlays that own their trigger. Contract in [`imperative-api.md`](../imperative-api.md). |

--- a/spec/at-bar.md
+++ b/spec/at-bar.md
@@ -1,0 +1,153 @@
+# The `1.0.0` at-bar checklist
+
+Status: **accepted**. Rationale in [ADR-0011](./adr/0011-at-bar-checklist.md).
+
+Every sweep ticket on the [Road to `frappe-ui` 1.0.0](https://github.com/frappe/frappe-ui/issues/864)
+map ends by claiming a family is "at bar". This is what that claim means. One list,
+applied the same way by everyone, so two people auditing two different families
+produce comparable results.
+
+## What the bar applies to
+
+**A public export** — anything a consumer can `import` from `frappe-ui` or one of its
+subpaths. Not a directory, not a file.
+
+This follows the map's Rule 2: exported at `1.0.0` means frozen until `2.0.0`, so every
+export is either reviewed to bar or removed before the tag. Code a consumer cannot reach
+is internal, carries no freeze, and needs nothing from this list.
+
+In practice that is almost everything. Of the 73 directories under `src/components`, only
+`Menu/` and `types/` contribute nothing to any entry point. Two more —
+`InputLabeling/` and `shared/` — export types but no components, so items 1, 3, 4, 5
+and 8 are N/A for them and items 0, 2, 6, 7 and 9 still apply. **An exported type is
+public surface and freezes like any other member.**
+
+Non-component exports (composables, utilities, plugins) are in scope with a shorter
+list; the N/A column says which items drop.
+
+## The checklist
+
+Items run **in order**. Item 0 gates the rest.
+
+### Item 0 — keep or un-export
+
+Record an explicit call for every export in the family. There is no third answer and no
+"decide later" — that is the parking spot Rule 2 exists to forbid.
+
+If the call is **remove**, stop. Items 1–9 do not apply. Discharge it the way the map's
+Rule 3 requires: delete the export, write the migration-guide entry, and file an issue on
+each affected app's repo. The tag does not wait on those apps.
+
+If the call is **keep**, everything below has to be true.
+
+### Items 1–9
+
+| # | Item | Not applicable when |
+| --- | --- | --- |
+| 1 | Implemented in TypeScript with `<script setup lang="ts">` | the export is not a component |
+| 2 | A `types.ts` exporting the prop, emit and slot types | the export is not a component |
+| 3 | Component tests covering the [five behaviors](#item-3-the-five-behaviors) | per-behavior, see below |
+| 4 | A `<Name>.md` page; every prop, slot and emit has a non-empty description; the prose and examples are true | non-component exports document on the utilities, composables or subpath page instead — no colocated page, no playground |
+| 5 | At least one file under `stories/` | the export is not a component |
+| 6 | Audited against `PHILOSOPHY.md`, [recorded as below](#item-6-recording-the-audit) | never |
+| 7 | Zero `@deprecated` members ([ADR-0008](./adr/0008-no-deprecated-members-in-1-0-0.md)) | never |
+| 8 | Every `defineExpose` member conforms to [`imperative-api.md`](./imperative-api.md) and is typed | the export has no `defineExpose` |
+| 9 | A changelog line, and a migration before/after when the [break is silent](#item-9-silent-vs-loud-breaks) | nothing was removed or renamed |
+
+An item is either **done** or **written down as N/A**. It is never skipped. If you find
+yourself wanting to skip one, you have hit the [out-of-session rule](#when-a-family-cannot-reach-bar-in-one-session).
+
+## Item 3: the five behaviors
+
+A `.cy.ts` file existing is not the bar — today those files range from 5 cases
+(`Tabs`) to 29 (`Select`), which is exactly the incomparability this document exists to
+remove. The bar is five named behaviors, each a yes or no:
+
+1. **Renders** with default props.
+2. **`v-model` round-trip** — a value set by the parent shows up, and a change inside
+   emits back. *N/A when the export holds no value.*
+3. **Disabled and loading** states behave. *N/A when the export has neither.*
+4. **Keyboard and focus** behavior required by P12 — tab order, the focus ring, whatever
+   keyboard interaction the component's role implies.
+5. **Every slot the docs page names** actually renders content passed to it.
+
+Deliberately not a coverage percentage. A component can reach 80% line coverage with no
+keyboard test at all, which is precisely the check P12 needs.
+
+## Item 4: docs
+
+The props, slots and emits tables are generated from the source by
+`docs/scripts/propsgen.ts` into `<Name>.api.md`. Nobody writes them by hand, so "does the
+table list every prop" is not a reviewer's job.
+
+Two things are:
+
+- **Descriptions.** The generator emits an empty description cell when the source carries
+  no JSDoc. As of writing, **194 of 953 documented members ship with a blank description**.
+  Filling a family's share of those is part of its sweep, not a separate pass.
+- **Prose and examples.** The text around the table, and the playground and story code, has
+  to describe what the component actually does now.
+
+Table freshness is CI's job, not the sweeper's — `yarn docs:gen` currently runs in no
+workflow, so the committed `.api.md` files can drift from the source silently. That job is
+tracked separately; do not spend sweep time hand-checking generated tables.
+
+## Item 6: recording the audit
+
+Post a verdict list on the sweep ticket covering **P1–P15**, one line each, with one of
+four verdicts:
+
+- **pass** — the export already conforms.
+- **fixed** — it did not; link the commit.
+- **N/A** — the principle does not reach this export; say why in a few words.
+- **carve-out** — a deliberate, permanent violation.
+
+A carve-out is additionally written **into `PHILOSOPHY.md`, under the principle it bends**.
+That is the existing convention, not a new one: Button's singular `#icon` slot is recorded
+at P6 and again at P11, and P13 carries the accepted v1 carve-out list. After the tag, the
+answer to "why is this API like this?" has to be findable next to the rule it breaks —
+not in a closed issue.
+
+## Item 9: silent vs loud breaks
+
+ADR-0008 requires a changelog entry for every removal, and a migration guide before/after
+"where the shape changed meaningfully". "Meaningfully" is the kind of judgment call this
+document replaces.
+
+**Every removal or rename gets a changelog line** in
+[`v1-release/changelog.md`](../v1-release/changelog.md).
+
+**A before/after in [`migration.md`](../docs/content/docs/migration.md) is required when
+the break is silent** — old code still compiles and runs, but behaves differently:
+
+- a renamed field inside an options object (`items` → `options` on grouped options quietly
+  renders nothing)
+- a prop or slot prop whose type changed (`#target` → `#trigger` also flips `open` from a
+  function to a boolean)
+- a default that changed
+
+**A loud break needs only the changelog line.** If the consumer's build, type-check or
+import fails, the toolchain already tells them, and a before/after adds noise to a guide
+that is 559 lines already.
+
+When in doubt about which one you have: if you can break it without the compiler noticing,
+it is silent.
+
+## When a family cannot reach bar in one session
+
+**The bar does not bend.** A bent bar means an export ships unreviewed and frozen until
+`2.0.0`, which is the thing Rule 2 forbids. There are two honest exits:
+
+1. **Split.** Cut the remainder into new child tickets on the map and wire the blocking
+   edges, so what is left is visible on the frontier rather than lost in a closed ticket.
+2. **Remove.** If a member cannot reach bar at all and splitting will not help, un-export
+   it — the Rule 2 escape valve, discharged the Rule 3 way.
+
+Both are recorded. Neither is a failure; a sweep that honestly splits is worth more than
+one that quietly lowers the bar.
+
+## After `1.0.0`
+
+The bar outlives the tag. A new component added during `1.x` meets the same list before it
+is exported — the freeze window closes at `1.0.0`, so anything shipped after it is
+committed for even longer.

--- a/spec/imperative-api.md
+++ b/spec/imperative-api.md
@@ -1,6 +1,9 @@
 # What components hand back through a template ref
 
-Status: **proposed**. Not yet accepted. Written against `1.0.0-beta.25`.
+Status: **accepted** —
+[ADR-0012](./adr/0012-template-ref-surface.md), issue
+[#916](https://github.com/frappe/frappe-ui/issues/916). First written against
+`1.0.0-beta.25`; counts re-verified at sign-off.
 
 Every component has four public surfaces: props, slots, emits, and whatever it
 hands back when you grab it with a template ref. The first three have been
@@ -8,7 +11,7 @@ reviewed component by component before the v1 freeze. The fourth never has.
 
 This document covers that fourth one. In code it's the `defineExpose` call.
 
-There are 28 of them across `src/`. Four have types. The rest were written one
+There are 31 of them across `src/`. Four have types. The rest were written one
 component at a time with no shared rule, and it shows.
 
 ## Not covered here
@@ -34,7 +37,7 @@ This document applies the same thinking to the rest of the library.
 ### 1.1 `open` means two different things
 
 Sometimes `open` is an action — you call it to open something:
-`Popover.vue:278`, `HoverCard.vue:35-42`, `PickerShell.vue:265-267`, and all
+`Popover.vue:268`, `HoverCard.vue:35-42`, `PickerShell.vue:251-255`, and all
 three date pickers (`DatePicker.vue:201`, `DateRangePicker.vue:194`,
 `DateTimePicker.vue:179`).
 
@@ -47,7 +50,7 @@ The same split runs through slot props: `Dropdown.vue:2,7` and
 it as a function and adds a separate `isOpen` for the boolean.
 
 If you write `ref.value.open`, you cannot tell whether to call it or read it.
-The types don't help, because almost none of this is typed (§1.4).
+The types don't help, because almost none of this is typed (§1.5).
 
 ### 1.2 Four names for "give me the underlying HTML element"
 
@@ -62,21 +65,28 @@ The types don't help, because almost none of this is typed (§1.4).
 (`FileUploader.vue:89-91`), so `uploader.value.inputRef.focus()` fails quietly
 while `uploader.value.inputRef().focus()` works.
 
-**`el` is the single most-used thing this library hands back.** 27 call sites
-across five apps:
+**`el` is the single most-used thing this library hands back.** 39 call sites
+across four apps, counted at sign-off against freshly fetched `upstream/develop`
+(`upstream/main` for helpdesk), git-tracked sources only:
 
 | App | Sites |
 | --- | --- |
-| crm | 19 (one inside its own vendored `Autocomplete` fork) |
-| builder | 4 |
-| insights | 2 |
-| gameplan | 1 |
-| gameplan-settings-exploration | 1 |
+| crm | 21 (two inside its own vendored `Autocomplete` fork) |
+| helpdesk | 14 (four inside two vendored `Autocomplete` forks) |
+| gameplan | 2 |
+| builder | 2 |
+| insights | 0 |
+| raven | 0 |
 
-What they do with it: **23 call `focus()`**, 2 call `select()`
-(`crm/.../DurationInput.vue:55`, `crm/.../FormattedInput.vue`), 2 call `blur()`
-(`crm/.../DurationInput.vue:74`, `crm/.../WhatsAppBox.vue`). One asks for focus
-without scrolling (`builder/.../PagePersonaSurvey.vue:198`).
+What they do with it: **31 call `focus()`**, 2 call `select()`
+(`crm/.../DurationInput.vue:55`, `crm/.../FormattedInput.vue:34`), 3 call
+`blur()` (`crm/.../DurationInput.vue:74,78`, `crm/.../WhatsAppBox.vue:118`), and
+3 read `el._value` to get at the input's current text
+(`crm/.../frappe-ui/Autocomplete.vue:128`, and both of helpdesk's
+`Autocomplete` copies) — reaching into Vue's ref internals through a surface we
+published. **Five ask for focus without scrolling** (helpdesk 4, builder 1), so
+`focus(options?)` is answering a need that already exists rather than
+anticipating one.
 
 It's used internally for the same reason — `PickerShell.vue:197,259`,
 `TimePicker.vue:286,644`, `Duration.vue:56,79,82,113`, `LinkPopup.vue:100`,
@@ -85,6 +95,13 @@ almost all of them focusing.
 
 So `el` exists mostly because `TextInput` has no `focus()`. Grabbing the raw
 element was the only way.
+
+Two entries in the original count were not ours and have been dropped:
+helpdesk's `NestedPopover` `.el` is headlessui's, and builder's
+`useCanvasMarqueeSelection` `.el` is builder's own data structure.
+`gameplan-settings-exploration` is not a git repository, so it falls outside the
+map's counting rule. insights going from 2 to 0 matches
+[#868](https://github.com/frappe/frappe-ui/issues/868) — it has fully migrated.
 
 `viewportElement` is the opposite case — a genuine need. `DesktopShell.vue:64`
 watches it and registers the real scrolling element with the app shell, and
@@ -96,53 +113,63 @@ keeping the styled scrollbar. No function replaces either of those.
 | Component | How it focuses |
 | --- | --- |
 | `Duration.vue:113` | reaches through `TextInput`'s `el` |
-| `TimePicker.vue:643-645` | same |
-| `Combobox.vue:377-383` | looks the element up by ID — already banned by the selection spec |
-| `MultiSelect.vue:222-227` | looks it up by ID, and isn't handed back at all |
+| `TimePicker.vue:636-645` | same |
+| `Select`, `Combobox`, `MultiSelect` | template ref, taking `FocusOptions` — **already fixed** by [`selection.md`](./selection.md) |
 
-None of them accept options, so you can't ask for focus without scrolling —
+The first two accept no options, so you can't ask for focus without scrolling —
 even though both the library (`IframeInsertDialog.vue:104`) and userland
-(`builder/.../PagePersonaSurvey.vue:198`) need exactly that.
+(`builder/.../PagePersonaSurvey.vue:198`) need exactly that. The selection trio
+is the shape to copy: `MultiSelect.vue:242-250` resolves the element through a
+template ref specifically so the internal id stays internal.
 
 Things you'd expect to be able to focus, but can't: `TextInput`, `Textarea`,
-`Password`, `Select`, `MultiSelect`, `FileUploader`, `Checkbox`, `Switch`,
-`Slider`, `Rating`, all three date pickers, `Tree`, `TabButtons`. The first two
-are the most-used inputs in the library.
+`Password`, `FileUploader`, `Checkbox`, `Switch`, `Slider`, `Rating`, all three
+date pickers, `Tree`, `TabButtons`. The first two are the most-used inputs in
+the library.
 
 ### 1.4 Opening and closing is inconsistent
 
 `Popover` and `HoverCard` hand back both `open` and `close`. The three date
-pickers hand back `open` only. `Dialog.vue:309` hands back `close` only.
+pickers hand back `open` only. `Dialog.vue:324` hands back `close` only.
 `Autocomplete.vue:410` hands back `togglePopover` — the only toggle in the
 library, and the only name with a component type stuck on the end.
 
-### 1.5 Only 4 of 28 are typed, in two ways that behave differently
+### 1.5 Only 4 of 31 are typed, in three ways that behave differently
 
-Typed: `Combobox.vue:421`, `Duration.vue:113`, and `Dialog.vue:309`.
+Typed: `Combobox.vue:435` and `MultiSelect.vue:330` (both `SelectionExposed`),
+`Duration.vue:113`, and `Dialog.vue:324`.
 
-The first two write `defineExpose<SomeType>(...)`. Dialog writes
+The first three write `defineExpose<SomeType>(...)`. Dialog writes
 `defineExpose(obj satisfies SomeType)`. These are **not the same thing**. The
 first publishes exactly the declared type. The second publishes whatever the
 object happens to contain and just checks it against the type — so adding a
 stray member to Dialog's object would silently grow the public surface with no
 error. For an API we're about to freeze, that matters.
 
-**Two types that promise something the code never delivers:**
+`Select.vue:277-278` is a third shape — `const exposed: SelectionExposed = {...}`
+then `defineExpose(exposed)`. It behaves correctly, because the annotated const
+is what gets published, but it is a third way to write one thing.
 
-- `DropdownExposed { close: () => void }` (`Dropdown/types.ts:80-83`) is
-  exported all the way out to consumers — but **`Dropdown.vue` never calls
-  `defineExpose`**. `close()` exists (`Dropdown.vue:86-88`) but only as a slot
-  prop. So writing `ref<DropdownExposed>()` and calling `.close()` compiles
-  cleanly and crashes at runtime.
-- `SelectExposed {}` (`Select/types.ts:146`) is an exported empty type with no
-  implementation behind it.
+**One type that promises something the code never delivers:**
+
+- `DropdownExposed { close: () => void }` (`Dropdown/types.ts:80-83`) reaches
+  consumers through `Dropdown/index.ts`'s `export * from './types'` — but
+  **`Dropdown.vue` never calls `defineExpose`**. `close()` exists
+  (`Dropdown.vue:86-88`) but only as a slot prop. So writing
+  `ref<DropdownExposed>()` and calling `.close()` compiles cleanly and crashes
+  at runtime.
+
+The second one is already fixed: `SelectExposed {}` was an exported empty type,
+and [`selection.md`](./selection.md) has since replaced it with the shared
+`SelectionExposed { clear, focus }`, implemented on all three of `Select`,
+`Combobox` and `MultiSelect`.
 
 Naming forks too: everything ends in `Exposed` except `SuggestionListExpose`
 (`molecules/editor/extensions/suggestion/suggestion-types.ts:37`).
 
 ### 1.6 Nothing marks the internal ones as internal
 
-`CalendarPanel.vue:436`, `PickerShell.vue:264`, and six editor list components
+`CalendarPanel.vue:436`, `PickerShell.vue:251`, and six editor list components
 exist purely so sibling components can talk to each other. Nothing says so. The
 only hint is that those components aren't exported, which you can't see from the
 file.
@@ -153,23 +180,61 @@ shared type to import. One contract, three copies, free to drift apart.
 
 ---
 
-## 2. The proposal
+## 2. The contract
+
+### 2.0 What earns a place here
+
+Vue offers three ways out of a component already. Slot props reach code inside
+the slot. `v-model` and emits reach state. **A template ref exists for what
+neither can do: driving the component from the parent's `<script>`.**
+
+So a member goes on this surface only when a parent's script needs it and no
+other surface reaches. If a slot prop already covers it, that's the answer.
+
+This is a real filter, not a formality. It is why `FileUploader` ends up handing
+back nothing (§2.7) even though it clearly *does* something you'd want to
+trigger — `openFileSelector` has been a slot prop all along, used in 28 files
+across five apps, and every one of them puts the trigger inside the slot.
+
+The rule cuts hardest against **additions**, which is the opposite of where it
+looks like it should. An added method freezes until `2.0.0` exactly like a
+renamed one, and the costs are lopsided: adding a verb later is a minor release,
+removing one is not. So a method with no demonstrated need is the expensive
+choice and an omitted one is cheap to fix.
 
 ### 2.1 Five verbs, and that's it
 
 | Verb | What it does | Use it when |
 | --- | --- | --- |
 | `focus(options?)` | Moves keyboard focus to the main control. | **Always**, for anything you can type in or tab to. |
-| `clear()` | Empties the value. Doesn't open, close, or focus. | The component holds a value that can be empty. |
-| `open()` | Opens the overlay. Safe to call twice. | The component owns an overlay. |
+| `clear()` | Empties the value. Doesn't open, close, or focus. | Selection components only — see below. |
+| `open()` | Opens the overlay. Safe to call twice. | The component owns an overlay **and its trigger**. |
 | `close()` | Closes the overlay. Safe to call twice. | Paired with `open()`. |
 | `reload()` | Fetches the data again. | The component owns a fetch you can't otherwise re-trigger. |
+
+**`open` and `close` are for overlays that own their trigger.** `Popover`,
+`HoverCard`, `Dropdown` and the pickers all render the trigger inside themselves
+through a `trigger` slot, so code outside that slot has no handle on it and a ref
+is the only way in. Apps do exactly this: builder's `ColorPicker` calls both from
+a function in its `<script>`, and helpdesk opens a date picker from a menu
+item's `onClick` in three places.
+
+`Dialog` has no trigger slot. The parent decides when it appears and already
+holds that state in `v-model`, so a ref reaches nothing the parent lacks — which
+is why it hands back nothing (§2.8).
+
+**`clear()` stays where it already is.** `Select`, `Combobox` and `MultiSelect`
+have it via [`selection.md`](./selection.md), and it goes nowhere new. For a
+text input, `v-model` already empties the value; across the whole bench there is
+one site that clears a component through a ref, and it is a `Combobox`.
 
 **No `toggle()`.** It's one line of caller code over `open` and `close`.
 `spec/popover.md:211-212` already decided this for `Popover`; it becomes the
 rule.
 
-**No `reset()`.** `Combobox.reset` becomes `clear` (already agreed).
+**No `reset()`.** `Combobox.reset` became `clear` in
+[`selection.md`](./selection.md) and has already shipped. One live site migrates
+(`builder/.../MoreStylesPanel.vue:179`).
 
 **`open` is always a verb here.** The boolean lives on `v-model:open` and on
 slot props as `isOpen`. Nothing handed back through a ref is ever a boolean
@@ -177,7 +242,14 @@ named `open`. This fixes §1.1 and costs nothing — no component does that toda
 
 `focus(options?)` takes the standard `FocusOptions`, so
 `focus({ preventScroll: true })` works. Both the library and userland already
-need it.
+need it — five app sites pass exactly that option today, reaching through `el`
+to do it (helpdesk 4, builder 1).
+
+`focus()` is the one verb that goes on everything you can type in or tab to,
+rather than only where it is already asked for. It clears §2.0's bar by a wide
+margin: 31 sites reach through `el` purely to call it, seven more fall back to
+`querySelector` or `getElementById` (builder 5, helpdesk 2), and §1.3's gap is
+that the library's two most-used inputs cannot be focused at all.
 
 Adding a verb later is a minor release. Adding a sixth verb to this list needs
 an ADR.
@@ -266,15 +338,21 @@ keeps this from turning back into four names for one idea.
 | `TextInput.el` | `TextInput.inputElement` (`HTMLInputElement \| null`) |
 | `Textarea.el` | `Textarea.inputElement` (`HTMLTextAreaElement \| null`) |
 | `Password` — nothing | `Password.inputElement` |
-| `FileUploader.inputRef` | removed; `open()` replaces it |
+| `FileUploader.inputRef` | removed, with nothing in its place — the `openFileSelector` slot prop already covers it (§2.7) |
 | `Autocomplete.rootRef`, `TextEditor.rootRef` | removed with the components |
 | `ScrollArea.viewportElement` | unchanged, now typed |
 | `SettingsBody.viewportElement` | unchanged, sharing ScrollArea's type |
 
-The `el` → `inputElement` rename touches 27 known sites (§1.2) — but 23 of them
+The `el` → `inputElement` rename touches 39 known sites (§1.2) — but 31 of them
 are calling `focus()`, and `focus()` is being added. Those migrate to the verb,
-not to the new name. The rename's real blast radius is the four `select()` /
-`blur()` sites, all in crm.
+not to the new name. The rename's real blast radius is two much smaller groups:
+
+- **5 sites take the new name** — the `select()` / `blur()` calls, all in crm.
+- **3 sites have no direct replacement** — the `el._value` reads in crm's and
+  helpdesk's vendored `Autocomplete` forks. Those were reading the input's
+  current text out of Vue's ref internals; they rewrite against the model value.
+
+Every one of them fails as a type error at build time, not as a runtime crash.
 
 ### 2.4 Third-party objects: one exception, and it's written down
 
@@ -294,16 +372,21 @@ that stops "just expose the reka instance" from spreading.
 
 - **Where:** the component's `types.ts`, next to its Props / Emits / Slots.
 - **How:** always `defineExpose<XExposed>({ ... })`. **Never `satisfies`** — it
-  lets the surface grow silently (§1.5).
+  lets the surface grow silently (§1.5) — and not the annotated-const form
+  either, which behaves correctly but is a third way to write one thing.
 - **Export:** from the component's `index.ts` explicit export list, not
   `export *`.
 - **Name:** always `Exposed`, never `Expose`.
 - **Shared shapes share a type:** `Select` + `Combobox` + `MultiSelect` share
-  one; `ScrollArea` + `SettingsBody` share one; the three date pickers share
-  one; `TextInput` + `Textarea` + `Password` share one.
-- **Fix the two lying types now.** `DropdownExposed` gets implemented or
-  deleted. `SelectExposed` gets `{ clear, focus }`. Shipping a type with nothing
-  behind it past `1.0.0` isn't an option.
+  one (`SelectionExposed`, already shipped); `ScrollArea` + `SettingsBody` share
+  one; the three date pickers and `TimePicker` share one; `TextInput` +
+  `Textarea` + `Password` share one.
+- **Delete `DropdownExposed`.** It promises a `close()` that `Dropdown.vue`
+  never defines, and it reaches consumers through `export * from './types'`.
+  Implementing it was rejected: that would add an unproven pair of methods
+  (§2.0) to make true a type nobody should have relied on. Shipping a type with
+  nothing behind it past `1.0.0` isn't an option either. `SelectExposed` was the
+  other one and is already fixed (§1.5).
 
 ### 2.6 Internal ones must say so
 
@@ -326,78 +409,121 @@ Applied:
 
 | Component | Today | After | Breaking |
 | --- | --- | --- | --- |
-| `Select` | nothing | `{ clear, focus }` | No |
-| `MultiSelect` | nothing | `{ clear, focus }` | No |
-| `Combobox` | `{ reset, focus }` | `{ clear, focus }` | Yes — already agreed |
-| `TextInput` | `{ el }` | `{ focus, clear, inputElement }` | **Yes — rename, needs sign-off** |
-| `Textarea` | `{ el }` | `{ focus, clear, inputElement }` | **Yes — rename, needs sign-off** |
-| `Password` | nothing | `{ focus, clear, inputElement }` | No |
-| `Duration` | `{ focus }` | `{ focus, clear }` | No |
-| `FileUploader` | `{ inputRef }` | `{ open, clear }` | **Yes — needs sign-off** |
-| `Dialog` | `{ close }` | **nothing** — see §2.8 | **Yes — needs sign-off** |
+| `Select` | `{ clear, focus }` | unchanged | No — already shipped |
+| `MultiSelect` | `{ clear, focus }` | unchanged | No — already shipped |
+| `Combobox` | `{ clear, focus }` | unchanged | No — `reset` → `clear` already shipped |
+| `TextInput` | `{ el }` | `{ focus, inputElement }` | **Yes — rename, signed off** |
+| `Textarea` | `{ el }` | `{ focus, inputElement }` | **Yes — rename, signed off** |
+| `Password` | nothing | `{ focus, inputElement }` | No |
+| `Duration` | `{ focus }` | unchanged | No |
+| `FileUploader` | `{ inputRef }` | **nothing** — see below | **Yes — signed off** |
+| `Dialog` | `{ close }` | **nothing** — see §2.8 | **Yes — signed off** |
 | `Popover` | `{ open, close }` | unchanged — the model to copy | No |
 | `HoverCard` | `{ open, close }` | same, plus a type | No |
-| `Dropdown` | nothing (but promises `close`) | `{ open, close }` | No — makes the promise true |
-| `DatePicker` | `{ open }` | `{ open, close, clear, focus }` | No |
-| `DateRangePicker` | `{ open }` | `{ open, close, clear, focus }` | No |
-| `DateTimePicker` | `{ open }` | `{ open, close, clear, focus }` | No |
-| `TimePicker` | `{ focus }` | `{ open, close, clear, focus }` | No |
+| `Dropdown` | nothing (but promises `close`) | nothing; `DropdownExposed` deleted | Yes — loud, removes a type nobody could use |
+| `DatePicker` | `{ open }` | `{ open, close, focus }` | No |
+| `DateRangePicker` | `{ open }` | `{ open, close, focus }` | No |
+| `DateTimePicker` | `{ open }` | `{ open, close, focus }` | No |
+| `TimePicker` | `{ focus }` | `{ open, close, focus }` | No |
 | `ScrollArea` | `{ viewportElement }` | same, plus a type | No |
 | `SettingsBody` | `{ viewportElement }` | same, sharing ScrollArea's type | No |
 | `Editor` | `{ editor, isEmpty }` | same, plus a type | No |
 | `Autocomplete`, `TextEditor` | various | deleted with the component | Policy |
 | `CalendarPanel`, `PickerShell`, editor lists | various | internal, shared types | No |
+| everything else you can type in or tab to | nothing | `{ focus }` | No |
+
+The last row is §1.3's list: `Checkbox`, `Switch`, `Slider`, `Rating`, `Tree`,
+`TabButtons`. Each one gets `focus()` inside its own family's sweep.
+
+**`FileUploader` hands back nothing.** `inputRef` is removed with nothing in its
+place. The spec originally proposed `{ open, clear }` here; both fail §2.0.
+`open()` would be a second public name for an action already called
+`openFileSelector` as a slot prop in 28 files across five apps, and that slot
+prop reaches every real use — all 28 put the trigger button inside the slot.
+Renaming the slot prop to match was rejected as a quiet break in 28 files bought
+for nothing. `clear()` has no site in the bench and no workaround in the bench
+either — nobody remounts a `FileUploader` with `:key` to reset it.
 
 ### 2.8 `Dialog` hands back nothing
 
-I searched every app in the bench for `.close()` called on a template ref.
-There are exactly two, and both are on `Popover`
+`Dialog` has no trigger slot. The parent decides when it appears and already
+holds that state in `v-model`, so §2.1's trigger-ownership rule says a ref
+reaches nothing the parent lacks.
+
+The usage evidence agrees. Searching every app in the bench for `.close()` on a
+template ref finds exactly two, both on `Popover`
 (`insights/frontend/src/components/UseTooltip.vue:22`,
 `builder/frontend/src/components/Controls/ColorPicker.vue:74`). **Nobody calls
 Dialog's `close()` through a ref.**
 
-That makes sense: you open a Dialog with `v-model`, so you close it the same
-way. The `close` that people *do* use is the slot prop
-(`Dialog.vue:32,73,95,113`) and the one passed to action callbacks
-(`Dialog.vue:406-419`) — both stay, and neither is affected. So `defineExpose`
-comes out of `Dialog` entirely and `DialogExposed` is deleted.
+But the rule is what decides it, not the count. Zero usage is evidence nobody
+hit the need, not that the need is absent — and counting alone would have argued
+just as well for stripping `HoverCard`, which nobody drives by ref either.
+Trigger ownership is a property of the component, so it predicts instead of
+observing, and it keeps `Popover` and `HoverCard` for the same reason it drops
+`Dialog`.
+
+The `close` that people *do* use is the slot prop (`Dialog.vue:32,73,95,113`)
+and the one passed to action callbacks (`Dialog.vue:406-419`) — both stay, and
+neither is affected. So `defineExpose` comes out of `Dialog` entirely and
+`DialogExposed` is deleted.
 
 ---
 
-## 3. Needs sign-off
+## 3. Signed off
 
-Breaking changes to things that are **not** currently deprecated, riskiest
-first:
+Resolved on [#916](https://github.com/frappe/frappe-ui/issues/916); rationale in
+[ADR-0012](./adr/0012-template-ref-surface.md). Breaking changes to things that
+are **not** currently deprecated, riskiest first:
 
-1. **`el` → `inputElement` on `TextInput` and `Textarea`.** 27 known sites.
-   Most move to `focus()` instead; ~4 need the new name. It's a rename with a
-   mechanical fix, and it surfaces as a type error rather than a runtime crash,
-   but it is the widest-reaching change in this document.
-2. **`Dialog` hands back nothing.** Verified unused in the bench (§2.8), but
-   `DialogExposed` is currently exported, so removing it is still breaking.
-3. **`FileUploader.inputRef` removed.** Its broken shape (§1.2) makes real usage
-   unlikely.
-4. **`Combobox.reset` → `clear`.** Already agreed; listed for completeness.
+1. **`el` → `inputElement` on `TextInput` and `Textarea`** — **renamed.** 39
+   known sites; 31 move to `focus()`, 5 take the new name, 3 rewrite against the
+   model value. It surfaces as a type error rather than a runtime crash, but it
+   is the widest-reaching change in this document. Keeping `el` alongside the
+   new name was never available: ADR-0008 bans deprecated members in `1.0.0`.
+2. **`Dialog` hands back nothing** — **removed**, on §2.1's trigger-ownership
+   rule. `DialogExposed` is exported, so removing it is a loud break. Growing it
+   to `{ open, close }` for symmetry with `Popover` was rejected: symmetry isn't
+   the rule, trigger ownership is.
+3. **`FileUploader.inputRef` removed**, with nothing in its place (§2.7). Zero
+   sites in the bench, and the proposed `open()` failed §2.0 — `openFileSelector`
+   already covers it as a slot prop.
+4. **`Combobox.reset` → `clear`** — already shipped via
+   [`selection.md`](./selection.md). One live migration site.
 
-Additive, no sign-off needed: every `focus` / `clear` / `open` / `close`
-addition, `Password.inputElement`, every new type, and `Dropdown` finally
-implementing what it already promises.
+**The additive half is bounded, not exempt** (§2.0). An added method freezes
+until `2.0.0` exactly like a renamed one, so:
+
+- `focus(options?)` goes on everything you can type in or tab to.
+- `open` / `close` go on trigger-owning overlays only — `Popover` and
+  `HoverCard` keep theirs, the three date pickers and `TimePicker` gain both.
+- `clear()` stays on `Select`, `Combobox` and `MultiSelect` and goes nowhere new.
+- `DropdownExposed` is **deleted**, not implemented.
+
+Everything else waits for a real request and arrives in a minor release. A sixth
+verb, or a third element role, still needs an ADR.
+
+**Where the work happens.** This document is the contract; the `defineExpose`
+edits happen inside the sweep that owns each component, as
+[at-bar](./at-bar.md) item 8.
 
 ## Task list
 
+Each item is done by the sweep that owns the component, as
+[at-bar](./at-bar.md) item 8 — not as one pass.
+
 **Types**
 - [ ] Add a `<Component>Exposed` type wherever something is handed back
-- [ ] Change `Dialog.vue:309` off `satisfies` — or delete it entirely per §2.8
-- [ ] Implement `DropdownExposed` as `{ open, close }`, or delete the type
-- [ ] Fill in `SelectExposed`
+- [ ] Delete `DialogExposed` and its `satisfies` call (`Dialog.vue:324`)
+- [ ] Delete `DropdownExposed` (`Dropdown/types.ts:80-83`)
+- [ ] Move `Select.vue:277-278` to `defineExpose<SelectionExposed>(...)`
 - [ ] Rename `SuggestionListExpose` → `SuggestionListExposed`; stop exporting it
-- [ ] Add the shared input type and the shared scroll-viewport type
+- [ ] Add the shared input type, the shared scroll-viewport type, and the shared
+      picker type
 
 **Verbs**
-- [ ] Add `focus(options?)` to every input listed in §1.3
-- [ ] Add `clear()` per the table in §2.7
-- [ ] Add `close()` to the three date pickers and `TimePicker`
-- [ ] Implement `{ open, close }` on `Dropdown`
+- [ ] Add `focus(options?)` to every input and focusable control in §1.3
+- [ ] Add `open()` / `close()` to the three date pickers and `TimePicker`
 - [ ] Replace every look-up-by-ID focus with a template ref
 
 **Elements**
@@ -406,10 +532,20 @@ implementing what it already promises.
 - [ ] Add `inputElement` to `Password`
 - [ ] Type `ScrollArea` / `SettingsBody`'s `viewportElement`
 
-**Removals (after sign-off)**
-- [ ] Remove `FileUploader.inputRef`; add `open()`
-- [ ] Remove `defineExpose` from `Dialog`; delete `DialogExposed`
+**Removals**
+- [ ] Remove `FileUploader.inputRef`, with nothing in its place
+- [ ] Remove `defineExpose` from `Dialog`
 
 **Internal**
 - [ ] Mark `CalendarPanel`, `PickerShell`, and the six editor lists `@internal`
 - [ ] Add a shared `CalendarPanelExposed`; delete the three hand-written copies
+
+**Migration guide** — silent breaks needing a before/after under
+[ADR-0011](./adr/0011-at-bar-checklist.md)'s test:
+- [ ] `el._value` → the model value (crm 1, helpdesk 2, all vendored
+      `Autocomplete` forks)
+- [ ] `Combobox.reset()` → `clear()` (builder 1)
+- [ ] `el.select()` / `el.blur()` → `inputElement.select()` / `.blur()` (crm 5)
+
+Loud breaks needing only a changelog line: `DialogExposed`, `DropdownExposed`,
+`FileUploader.inputRef`.

--- a/spec/imperative-api.md
+++ b/spec/imperative-api.md
@@ -108,7 +108,7 @@ watches it and registers the real scrolling element with the app shell, and
 `SettingsBody.vue:19-21` forwards it so a panel body can be virtualized while
 keeping the styled scrollbar. No function replaces either of those.
 
-### 1.3 Three ways to focus something, and most things can't be focused at all
+### 1.3 Focusing is inconsistent, and most things can't be focused at all
 
 | Component | How it focuses |
 | --- | --- |


### PR DESCRIPTION
Resolves #866. Resolves #916.

Two docs-only decisions from the [road to 1.0.0](https://github.com/frappe/frappe-ui/issues/864), on one branch. No code changes.

# 1. The at-bar checklist (ADR-0011)

Fourteen sweep tickets end by saying a family is "at bar". Nothing said what that meant. This adds `spec/at-bar.md` — the checklist they all use — and ADR-0011 for the reasoning.

The unit is a **public export**, because that is what freezes at 1.0.0.

Item 0 is keep or un-export. If it goes, nothing else applies. If it stays, all of this must be true:

- TypeScript and `<script setup>`
- a `types.ts`
- five named behavior tests
- a docs page with no blank descriptions
- a story
- a P1–P15 verdict list
- no `@deprecated` members
- a conforming, typed `defineExpose`
- a changelog line, plus a migration before/after when the break is silent

One tier. Every item is required. Each one says when it does not apply.

## The calls worth arguing about

- **Five named tests, not a coverage number.** A component can hit a high coverage number with no keyboard test at all, which is what P12 needs. The five: renders, `v-model` round-trip, disabled and loading, P12 keyboard and focus, every documented slot renders.
- **One tier.** A "nice-to-have" tier is a parking spot for unreviewed work, and it is the first thing dropped under deadline.
- **Migration doc when the break is silent.** Old code compiles and runs but behaves differently. A break that fails at build time needs only the changelog line.
- **The bar does not bend.** Out of session means split the ticket or un-export the member. Both get recorded.

## What this surfaced

- `spec/imperative-api.md` was still `proposed`, so item 8 had nothing to check against. That is #916, fixed below.
- `yarn docs:gen` runs in no workflow, so committed `.api.md` tables drift. 194 of 953 documented members ship with a blank description. Filed as #917.

# 2. The template-ref surface (ADR-0012)

Accepts `spec/imperative-api.md`. Unblocks eight of the nine sweeps waiting on it.

**A member belongs on a template ref only when parent script needs it and no other surface reaches.** Slot props reach code inside the slot. `v-model` and emits reach state. A template ref is for what neither can do.

For overlays that means: **`open` and `close` are for overlays that own their trigger.** Popover, HoverCard, Dropdown and the pickers render the trigger inside themselves, so a ref is the only way in. Dialog has no trigger slot — the parent already holds the state in `v-model`.

The spec's original reason for stripping Dialog was that nobody calls its `close()`. True but weak: zero usage would have argued for stripping HoverCard too.

## Sign-off calls

- `el` → `inputElement` on TextInput and Textarea
- Dialog exposes nothing
- FileUploader exposes nothing. The proposed `open()` was rejected — `openFileSelector` is already a slot prop, used in 28 files across 5 apps
- `Combobox.reset` → `clear` had already shipped

## Additions are bounded too

The spec exempted every addition from sign-off, because nothing breaks. But an added method freezes until 2.0.0 just like a renamed one. So additions are bounded:

- `focus()` everywhere you can type or tab
- `open`/`close` on trigger-owning overlays only
- `clear()` nowhere new
- `DropdownExposed` deleted, not implemented

That drops about a dozen methods the spec would have frozen.

## Counts re-verified

Against freshly fetched app trees, git-tracked sources only.

- **39 `el` sites, not 27.** 31 only call `focus()` and move to the new method. Real blast radius: 5 sites take the new name, 3 rewrite off `el._value`.
- insights is now 0, matching #868.
- 31 `defineExpose` calls, not 28.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-915/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.64% (±0.00% vs `main`)
<!-- coverage-report:end -->
