### PR TITLE
fix(Calendar): keep the clock live so today moves at midnight

### DIFF
--- a/src/components/Calendar/CalendarMonthly.vue
+++ b/src/components/Calendar/CalendarMonthly.vue
@@ -114,6 +114,7 @@
 import { daysList, parseDate, isWeekend } from './calendarUtils'
 import { inject } from 'vue'
 import useCalendarData from './composables/useCalendarData'
+import { isSameDay, useNow } from './composables/useNow'
 import { computed } from 'vue'
 import ShowMoreCalendarEvent from './ShowMoreCalendarEvent.vue'
 import CalendarMonthEvent from './CalendarMonthEvent.vue'
@@ -142,8 +143,10 @@ const maxEventsInCell = computed(() =>
   props.currentMonthDates.length > 35 ? 1 : 2,
 )
 
+const now = useNow()
+
 function isToday(date: Date) {
-  return date.toDateString() === new Date().toDateString()
+  return isSameDay(date, now.value)
 }
 
 function isCurrentMonth(date: Date) {

--- a/src/components/Calendar/CalendarTimeMarker.vue
+++ b/src/components/Calendar/CalendarTimeMarker.vue
@@ -2,9 +2,9 @@
   <div
     class="absolute top-20 w-full px-px"
     :style="setCurrentTime"
-    v-if="new Date(date).toDateString() === new Date().toDateString()"
+    v-if="isSameDay(date, now)"
   >
-    <Tooltip :text="dayjs().format('ddd, MMM D, YYYY h:mm a')">
+    <Tooltip :text="dayjs(now).format('ddd, MMM D, YYYY h:mm a')">
       <div class="current-time relative h-0.5 bg-[#E03636] rounded" />
     </Tooltip>
   </div>
@@ -14,6 +14,7 @@ import Tooltip from '../Tooltip/Tooltip.vue'
 import { dayjs } from '../../utils/dayjs'
 import { computed, inject } from 'vue'
 import { CALENDAR_CONFIG_KEY } from './types'
+import { isSameDay, useNow } from './composables/useNow'
 
 const props = defineProps<{
   date: string | Date
@@ -26,10 +27,11 @@ if (!config) {
 const hourHeight = config.hourHeight
 const minuteHeight = hourHeight / 60
 
+const now = useNow()
+
 const setCurrentTime = computed(() => {
-  let d = new Date()
-  let hour = d.getHours()
-  let minutes = d.getMinutes()
+  let hour = now.value.getHours()
+  let minutes = now.value.getMinutes()
   let top = (hour * 60 + minutes) * minuteHeight + 'px'
   return { top }
 })

--- a/src/components/Calendar/CalendarWeekly.vue
+++ b/src/components/Calendar/CalendarWeekly.vue
@@ -176,6 +176,7 @@ import {
 
 import { Button } from '../Button'
 import useCalendarData from './composables/useCalendarData'
+import { isSameDay, useNow } from './composables/useNow'
 import CalendarWeekDayEvent from './CalendarWeekDayEvent.vue'
 import {
   CALENDAR_ACTIONS_KEY,
@@ -212,13 +213,13 @@ const fullDayEvents = computed(
   () => useCalendarData(props.events).fullDayEvents.value,
 )
 
-const isToday = (date: Date) =>
-  new Date(date).toDateString() === new Date().toDateString()
+const now = useNow()
+
+const isToday = (date: Date) => isSameDay(date, now.value)
 
 const currentTime = computed(() => {
-  let d = new Date()
-  let hour = d.getHours()
-  let minutes = d.getMinutes()
+  let hour = now.value.getHours()
+  let minutes = now.value.getMinutes()
   let top = (hour * 60 + minutes) * minuteHeight + 'px'
   return { top }
 })

--- a/src/components/Calendar/composables/useNow.ts
+++ b/src/components/Calendar/composables/useNow.ts
@@ -1,0 +1,59 @@
+import { onScopeDispose, readonly, ref } from 'vue'
+
+// One clock for the whole calendar. Everything that renders "what time is it" —
+// the red time marker, and every isToday() check — reads from this instead of
+// calling new Date() inside a computed, which never re-evaluates: the marker
+// only moved when something else happened to re-render, and a tab left open
+// past midnight kept highlighting yesterday until it was refreshed.
+//
+// Module scope, reference-counted: a week view mounts one marker per day column,
+// and none of them should own a separate interval.
+
+const now = ref(new Date())
+
+let timer: ReturnType<typeof setInterval> | undefined
+let subscribers = 0
+
+const tick = () => (now.value = new Date())
+
+// Background tabs throttle timers heavily (and may park them altogether), so the
+// interval alone can leave the clock hours behind. Re-read on the way back in.
+const tickIfVisible = () => {
+  if (document.visibilityState === 'visible') tick()
+}
+
+function start() {
+  if (timer || typeof document === 'undefined') return
+  tick()
+  // 30s keeps the minute-resolution marker within half a minute of the truth
+  // without waking the page every second.
+  timer = setInterval(tick, 30_000)
+  document.addEventListener('visibilitychange', tickIfVisible)
+  window.addEventListener('focus', tick)
+}
+
+function stop() {
+  if (timer) clearInterval(timer)
+  timer = undefined
+  if (typeof document === 'undefined') return
+  document.removeEventListener('visibilitychange', tickIfVisible)
+  window.removeEventListener('focus', tick)
+}
+
+/** A `Date` ref that keeps up with the wall clock while the calendar is mounted. */
+export function useNow() {
+  subscribers += 1
+  start()
+
+  onScopeDispose(() => {
+    subscribers -= 1
+    if (subscribers === 0) stop()
+  })
+
+  return readonly(now)
+}
+
+/** True when `date` falls on the same calendar day as `reference`. */
+export function isSameDay(date: string | Date, reference: Date) {
+  return new Date(date).toDateString() === reference.toDateString()
+}

--- a/src/components/Calendar/composables/useNow.ts
+++ b/src/components/Calendar/composables/useNow.ts
@@ -23,8 +23,12 @@ const tickIfVisible = () => {
 }
 
 function start() {
-  if (timer || typeof document === 'undefined') return
+  if (timer) return
+  // Refresh before the environment check, not after: with no document there is
+  // no interval to keep this current, so a server renderer would otherwise hand
+  // every request the date its process happened to boot on.
   tick()
+  if (typeof document === 'undefined') return
   // 30s keeps the minute-resolution marker within half a minute of the truth
   // without waking the page every second.
   timer = setInterval(tick, 30_000)


### PR DESCRIPTION
The time marker and every `isToday()` check called `new Date()` inside a computed, which never re-evaluates. Two visible effects:

- the red current-time line only moved when something else happened to re-render
- a tab left open past midnight kept highlighting yesterday until it was refreshed

Both now read from one shared ticking ref (`composables/useNow.ts`). It's module-scoped and reference-counted, so a week's day columns share a single interval, and it re-reads on `visibilitychange` and `focus` — background tabs throttle timers, so an overnight tab corrects itself as soon as it's looked at rather than up to a tick later.

Navigation state (`currentDate`/`currentMonth`/`currentYear`) is deliberately untouched — making it live would move the view under the user at midnight.

Kept as a `Date` rather than a dayjs object on purpose: Vue leaves `Date` alone but deep-proxies a dayjs instance, and this value is read on every render of every day cell.

Tested: clock advances; rolls 23:59:40 → 00:00:10 and `isToday` follows without a refresh; the interval is torn down when the last consumer unmounts; seven day columns share one timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-919/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.56% (±0.00% vs `main`)
<!-- coverage-report:end -->

