### PR TITLE
test(Calendar): cover the shared clock, and drop a duplicate date helper

### DIFF
--- a/src/components/Calendar/CalendarMonthly.vue
+++ b/src/components/Calendar/CalendarMonthly.vue
@@ -114,7 +114,7 @@
 import { daysList, parseDate, isWeekend } from './calendarUtils'
 import { inject } from 'vue'
 import useCalendarData from './composables/useCalendarData'
-import { isSameDay, useNow } from './composables/useNow'
+import { useNow } from './composables/useNow'
 import { computed } from 'vue'
 import ShowMoreCalendarEvent from './ShowMoreCalendarEvent.vue'
 import CalendarMonthEvent from './CalendarMonthEvent.vue'
@@ -146,7 +146,7 @@ const maxEventsInCell = computed(() =>
 const now = useNow()
 
 function isToday(date: Date) {
-  return isSameDay(date, now.value)
+  return parseDate(date) === parseDate(now.value)
 }
 
 function isCurrentMonth(date: Date) {

--- a/src/components/Calendar/CalendarTimeMarker.vue
+++ b/src/components/Calendar/CalendarTimeMarker.vue
@@ -2,7 +2,7 @@
   <div
     class="absolute top-20 w-full px-px"
     :style="setCurrentTime"
-    v-if="isSameDay(date, now)"
+    v-if="parseDate(date) === parseDate(now)"
   >
     <Tooltip :text="dayjs(now).format('ddd, MMM D, YYYY h:mm a')">
       <div class="current-time relative h-0.5 bg-[#E03636] rounded" />
@@ -14,7 +14,8 @@ import Tooltip from '../Tooltip/Tooltip.vue'
 import { dayjs } from '../../utils/dayjs'
 import { computed, inject } from 'vue'
 import { CALENDAR_CONFIG_KEY } from './types'
-import { isSameDay, useNow } from './composables/useNow'
+import { useNow } from './composables/useNow'
+import { parseDate } from './calendarUtils'
 
 const props = defineProps<{
   date: string | Date

--- a/src/components/Calendar/CalendarWeekly.vue
+++ b/src/components/Calendar/CalendarWeekly.vue
@@ -176,7 +176,7 @@ import {
 
 import { Button } from '../Button'
 import useCalendarData from './composables/useCalendarData'
-import { isSameDay, useNow } from './composables/useNow'
+import { useNow } from './composables/useNow'
 import CalendarWeekDayEvent from './CalendarWeekDayEvent.vue'
 import {
   CALENDAR_ACTIONS_KEY,
@@ -215,7 +215,7 @@ const fullDayEvents = computed(
 
 const now = useNow()
 
-const isToday = (date: Date) => isSameDay(date, now.value)
+const isToday = (date: Date) => parseDate(date) === parseDate(now.value)
 
 const currentTime = computed(() => {
   let hour = now.value.getHours()

--- a/src/components/Calendar/composables/useNow.spec.ts
+++ b/src/components/Calendar/composables/useNow.spec.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for src/components/Calendar/composables/useNow.ts
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+import { useNow } from './useNow'
+
+beforeEach(() => vi.useFakeTimers())
+
+afterEach(() => {
+  // The interval and the subscriber count live at module scope, so a test that
+  // forgets to stop its scopes would leave the timer running and break whichever
+  // test happens to run next. Fail here instead, where the blame belongs.
+  expect(vi.getTimerCount()).toBe(0)
+  vi.useRealTimers()
+})
+
+/** Runs `fn` in a scope and hands back a stop() so the subscription is released. */
+function inScope<T>(fn: () => T) {
+  const scope = effectScope()
+  const value = scope.run(fn) as T
+  return { value, stop: () => scope.stop() }
+}
+
+describe('useNow', () => {
+  it('advances with the wall clock', () => {
+    vi.setSystemTime(new Date('2026-08-06T10:00:00'))
+    const { value: now, stop } = inScope(useNow)
+    expect(now.value.getMinutes()).toBe(0)
+
+    vi.setSystemTime(new Date('2026-08-06T10:05:00'))
+    vi.advanceTimersByTime(30_000)
+
+    expect(now.value.getMinutes()).toBe(5)
+    stop()
+  })
+
+  it('crosses midnight without a refresh', () => {
+    vi.setSystemTime(new Date('2026-08-06T23:59:40'))
+    const { value: now, stop } = inScope(useNow)
+    expect(now.value.toDateString()).toBe(new Date('2026-08-06T12:00').toDateString())
+
+    vi.setSystemTime(new Date('2026-08-07T00:00:10'))
+    vi.advanceTimersByTime(30_000)
+
+    expect(now.value.toDateString()).toBe(new Date('2026-08-07T12:00').toDateString())
+    stop()
+  })
+
+  it('shares one timer across every day column', () => {
+    const scopes = Array.from({ length: 7 }, () => inScope(useNow))
+    expect(vi.getTimerCount()).toBe(1)
+    scopes.forEach((s) => s.stop())
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('stops ticking once the last consumer goes away', () => {
+    const a = inScope(useNow)
+    const b = inScope(useNow)
+    a.stop()
+    expect(vi.getTimerCount()).toBe(1) // b is still listening
+    b.stop()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('serves a current date with no document, and starts no timer', () => {
+    vi.setSystemTime(new Date('2026-08-09T17:30:00'))
+    const doc = globalThis.document
+    // @ts-expect-error - standing in for a server renderer
+    delete globalThis.document
+    try {
+      const { value: now, stop } = inScope(useNow)
+      expect(now.value.toDateString()).toBe(new Date().toDateString())
+      expect(vi.getTimerCount()).toBe(0)
+      stop()
+    } finally {
+      globalThis.document = doc
+    }
+  })
+})

--- a/src/components/Calendar/composables/useNow.ts
+++ b/src/components/Calendar/composables/useNow.ts
@@ -56,8 +56,3 @@ export function useNow() {
 
   return readonly(now)
 }
-
-/** True when `date` falls on the same calendar day as `reference`. */
-export function isSameDay(date: string | Date, reference: Date) {
-  return new Date(date).toDateString() === reference.toDateString()
-}


### PR DESCRIPTION
Follow-up to #919, which shipped `useNow.ts` — reference counting, a teardown path, a no-document path — with no tests for any of it.

Adds `useNow.spec.ts`: ticking, the midnight roll, one shared timer across seven day columns, teardown on the last consumer, and the no-document path. The interval lives at module scope, so an `afterEach` asserts the timer count is back to zero — a test that leaks blames itself rather than whichever test runs next.

Also drops `isSameDay` in favour of `parseDate()` from `calendarUtils`, which the calendar already uses as its day key and which keeps the same local-day semantics. Neither symbol is exported from the package, so this isn't a public change.

Two things from the earlier review were deliberately **not** taken:

- a `useToday()` day-granularity key, which would stop the month grid re-diffing every 30s. Real, but I have no measurement that ~42 cells twice a minute is perceptible, and it adds public surface to fix an unmeasured cost.
- a `getCurrentScope()` throw in `useNow()`. The leak it guards against has no call site today, and a hard throw would also reject a legitimate call after an `await` in async `setup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-920/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.62% (+0.06% vs `main`)
<!-- coverage-report:end -->
