### PR TITLE
fix(data-fetching): stop a cached doc overwriting fresher data in docStore

### DIFF
--- a/src/data-fetching/docStore.test.ts
+++ b/src/data-fetching/docStore.test.ts
@@ -2,15 +2,35 @@
  * @vitest-environment node
  */
 import { computed, watchSyncEffect } from 'vue'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { docStore } from './docStore'
 import { idbStore } from './idbStore'
 
 const DOCTYPE = 'User'
-const identity = <T>(d: T): T => d
 
 function idbKey(name: string) {
   return `doc:${DOCTYPE}/${name}`
+}
+
+/** A promise whose settlement the test controls, to hold an IDB call open. */
+function defer<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+/** Let every pending microtask chain inside docStore run to completion. */
+function flush() {
+  return new Promise((r) => setTimeout(r, 0))
+}
+
+/** Push an entry past the cache timeout, as a long-lived useDoc would be. */
+function makeStale(name: string) {
+  ;(
+    docStore as unknown as { lastFetched: Map<string, number> }
+  ).lastFetched.set(`${DOCTYPE}/${name}`, Date.now() - 10 * 60 * 1000)
 }
 
 /**
@@ -20,7 +40,7 @@ function idbKey(name: string) {
  * this computed the instant setDoc assigns the ref — the trigger for the crash.
  */
 function subscribeLikeUseDoc(name: string) {
-  const doc = computed(() => docStore.getDoc(DOCTYPE, name, identity).value)
+  const doc = computed(() => docStore.getDoc(DOCTYPE, name).value)
   const seen: unknown[] = []
   const stop = watchSyncEffect(() => {
     seen.push(doc.value)
@@ -33,6 +53,9 @@ describe('docStore', () => {
     await docStore.clearAll()
   })
   afterEach(async () => {
+    // Restore first: a spy left in place by a failing assertion would hang the
+    // next test on an idbStore call that never settles.
+    vi.restoreAllMocks()
     await docStore.clearAll()
   })
 
@@ -65,10 +88,83 @@ describe('docStore', () => {
       docStore as unknown as { lastFetched: Map<string, number> }
     ).lastFetched.set(key, Date.now() - 10 * 60 * 1000)
 
-    const ref = docStore.getDoc(DOCTYPE, name, identity, { staleOnError: true })
+    const ref = docStore.getDoc(DOCTYPE, name, { staleOnError: true })
     expect(ref).toBeDefined()
     expect(() => ref.value).not.toThrow()
     expect(ref.value).toMatchObject(record)
     expect(await idbStore.get(idbKey(name))).toMatchObject(record)
+  })
+
+  it('a slow cached read never overwrites a newer publish', async () => {
+    const name = 'user3'
+    const stale = { doctype: DOCTYPE, name, bio: 'stale' }
+    const fresh = { doctype: DOCTYPE, name, bio: 'fresh' }
+    await idbStore.set(idbKey(name), stale)
+
+    // Hold the cached read open so the fresh copy lands first.
+    const cachedRead = defer<unknown>()
+    const getSpy = vi.spyOn(idbStore, 'get').mockReturnValue(cachedRead.promise)
+
+    const { doc, seen, stop } = subscribeLikeUseDoc(name)
+    expect(doc.value).toBe(null)
+
+    await docStore.setDoc({ ...fresh })
+    expect(doc.value).toMatchObject(fresh)
+
+    cachedRead.resolve(stale)
+    await flush()
+
+    // docRef.value must never move backwards in time.
+    expect(doc.value).toMatchObject(fresh)
+    expect(seen).not.toContainEqual(expect.objectContaining({ bio: 'stale' }))
+
+    getSpy.mockRestore()
+    stop()
+  })
+
+  it('concurrent reads of one stale key hit IDB once', async () => {
+    const name = 'user4'
+    await docStore.setDoc({ doctype: DOCTYPE, name })
+    makeStale(name)
+
+    const getSpy = vi.spyOn(idbStore, 'get')
+    for (let i = 0; i < 5; i++) {
+      docStore.getDoc(DOCTYPE, name, { staleOnError: true })
+    }
+    await flush()
+
+    expect(getSpy).toHaveBeenCalledTimes(1)
+    getSpy.mockRestore()
+  })
+
+  it('setDoc publishes before the IDB write settles', async () => {
+    const name = 'user5'
+    const record = { doctype: DOCTYPE, name, bio: 'written' }
+
+    const write = defer<void>()
+    const setSpy = vi.spyOn(idbStore, 'set').mockReturnValue(write.promise)
+
+    const pending = docStore.setDoc({ ...record })
+    // Readers see the new value even while the write is in flight — and even if
+    // it never lands. Matches setDocs, which already assigns before writing.
+    expect(docStore.getDoc(DOCTYPE, name).value).toMatchObject(record)
+
+    write.resolve()
+    await pending
+    setSpy.mockRestore()
+  })
+
+  it('publishes the cached doc raw: the store applies no transform', async () => {
+    const name = 'user6'
+    const cached = { doctype: DOCTYPE, name, count: 0 }
+    await idbStore.set(idbKey(name), cached)
+
+    const ref = docStore.getDoc(DOCTYPE, name)
+    await flush()
+
+    // Callers apply transform on read (useDoc does). If the store transformed
+    // too, a non-idempotent transform would compound across the two publishes,
+    // so the cached and fresh copies would carry different values.
+    expect(ref.value).toStrictEqual(cached)
   })
 })

--- a/src/data-fetching/docStore.test.ts
+++ b/src/data-fetching/docStore.test.ts
@@ -33,6 +33,13 @@ function makeStale(name: string) {
   ).lastFetched.set(`${DOCTYPE}/${name}`, Date.now() - 10 * 60 * 1000)
 }
 
+/** Whether the store holds a slot for this key at all. */
+function hasSlot(name: string) {
+  return (docStore as unknown as { docs: Map<string, unknown> }).docs.has(
+    `${DOCTYPE}/${name}`,
+  )
+}
+
 /**
  * Mirror useDoc's `doc` computed: it calls getDoc and dereferences the returned
  * ref *without* optional chaining, so a getDoc that returns undefined throws.
@@ -82,11 +89,7 @@ describe('docStore', () => {
     const record = { doctype: DOCTYPE, name }
     await docStore.setDoc({ ...record })
 
-    // Force the entry past the cache timeout, as a long-lived useDoc would be.
-    const key = `${DOCTYPE}/${name}`
-    ;(
-      docStore as unknown as { lastFetched: Map<string, number> }
-    ).lastFetched.set(key, Date.now() - 10 * 60 * 1000)
+    makeStale(name)
 
     const ref = docStore.getDoc(DOCTYPE, name, { staleOnError: true })
     expect(ref).toBeDefined()
@@ -166,5 +169,51 @@ describe('docStore', () => {
     // too, a non-idempotent transform would compound across the two publishes,
     // so the cached and fresh copies would carry different values.
     expect(ref.value).toStrictEqual(cached)
+  })
+
+  it('a read in flight when the doc is deleted does not bring it back', async () => {
+    const name = 'user7'
+    const record = { doctype: DOCTYPE, name }
+    await idbStore.set(idbKey(name), record)
+
+    const cachedRead = defer<unknown>()
+    vi.spyOn(idbStore, 'get').mockReturnValue(cachedRead.promise)
+
+    const ref = docStore.getDoc(DOCTYPE, name)
+    await docStore.removeDoc(DOCTYPE, name)
+
+    // The read was issued before the delete, so it still answers with the row.
+    cachedRead.resolve(record)
+    await flush()
+
+    expect(ref.value).toBe(null)
+    // Publishing would re-create the slot the delete removed.
+    expect(hasSlot(name)).toBe(false)
+  })
+
+  it('a read in flight when the doc is deleted does not land in a later slot', async () => {
+    const name = 'user8'
+    const deleted = { doctype: DOCTYPE, name, bio: 'from before the delete' }
+
+    const beforeDelete = defer<unknown>()
+    const afterDelete = defer<unknown>()
+    vi.spyOn(idbStore, 'get')
+      .mockReturnValueOnce(beforeDelete.promise)
+      .mockReturnValueOnce(afterDelete.promise)
+
+    docStore.getDoc(DOCTYPE, name)
+    await docStore.removeDoc(DOCTYPE, name)
+
+    // Someone asks for the same key again, which opens a fresh slot. The read
+    // from before the delete must not be able to write into it, so the revision
+    // counter cannot restart when a key is cleaned up.
+    const ref = docStore.getDoc(DOCTYPE, name)
+    beforeDelete.resolve(deleted)
+    await flush()
+
+    expect(ref.value).toBe(null)
+
+    afterDelete.resolve(null)
+    await flush()
   })
 })

--- a/src/data-fetching/docStore.ts
+++ b/src/data-fetching/docStore.ts
@@ -12,12 +12,37 @@ type DocKey = `${string}/${string}`
 class DocStore {
   private docs: Map<DocKey, Ref<Doc | null>>
   private lastFetched: Map<DocKey, number>
+  private revisions: Map<DocKey, number>
+  private inflight: Map<DocKey, Promise<void>>
   private cacheTimeout: number = 5 * 60 * 1000 // 5 minutes
   private storePrefix = 'doc:'
 
   constructor() {
     this.docs = new Map<DocKey, Ref<Doc | null>>()
     this.lastFetched = new Map()
+    this.revisions = new Map()
+    this.inflight = new Map()
+  }
+
+  /**
+   * The single place a doc is assigned into its ref.
+   *
+   * A key is published twice by design — once from the IndexedDB cache, once
+   * from the server (stale-while-revalidate). Each publish bumps a per-key
+   * revision so a slow cached read can tell it has been overtaken and skip its
+   * write. The invariant: `docRef.value` never moves backwards in time.
+   */
+  private publish(key: DocKey, doc: Doc) {
+    if (!this.docs.has(key)) {
+      this.docs.set(key, ref(null))
+    }
+    // Mark fresh BEFORE assigning the ref. Assigning docRef.value synchronously
+    // re-runs any computed reading this doc (e.g. useDoc's `doc`), which calls
+    // getDoc again — if the entry still looked stale at that point it would kick
+    // off a needless reload that evicts the IDB copy we just wrote.
+    this.lastFetched.set(key, Date.now())
+    this.revisions.set(key, (this.revisions.get(key) ?? 0) + 1)
+    this.docs.get(key)!.value = doc
   }
 
   setCacheTimeout(minutes: number) {
@@ -33,30 +58,26 @@ class DocStore {
     }
     doc.name = doc.name.toString()
     const key = this.getKey(doc.doctype, doc.name)
+    // Publish before persisting, the way setDocs already does. Awaiting the
+    // write first would leave readers on stale data for the length of an IDB
+    // round trip, and widen the window a cached read can land in.
+    this.publish(key, doc)
     try {
       await idbStore.set(this.storePrefix + key, doc)
-      if (!this.docs.has(key)) {
-        this.docs.set(key, ref(null))
-      }
-      // Mark fresh BEFORE assigning the ref. Assigning docRef.value synchronously
-      // re-runs any computed reading this doc (e.g. useDoc's `doc`), which calls
-      // getDoc again — if the entry still looked stale at that point it would kick
-      // off a needless reload that evicts the IDB copy we just wrote.
-      this.lastFetched.set(key, Date.now())
-      const docRef = this.docs.get(key)
-      if (docRef) {
-        docRef.value = doc
-      }
     } catch (error) {
       console.error('Failed to set doc in IDB:', error)
       throw error
     }
   }
 
+  /**
+   * The store holds docs exactly as the server sent them. Callers that need a
+   * `transform` apply it when they read (see useDoc), so a non-idempotent
+   * transform cannot compound across the cached and fresh publishes.
+   */
   getDoc(
     doctype: string,
     name: MaybeRefOrGetter<string>,
-    transform?: (doc: Doc) => Doc,
     options: { staleOnError?: boolean } = {},
   ): Ref<Doc | null> {
     const nameStr = toValue(name)?.trim()
@@ -67,46 +88,64 @@ class DocStore {
 
     if (!this.docs.has(key)) {
       this.docs.set(key, ref(null))
-      this.loadDoc(key, true, transform, options)
+      this.loadDoc(key, true, options)
     } else if (this.isStale(key)) {
-      this.loadDoc(key, false, transform, options)
+      this.loadDoc(key, false, options)
     }
 
     return this.docs.get(key)!
   }
 
-  private async loadDoc(
+  private loadDoc(
     key: DocKey,
     isFirstLoad: boolean,
-    transform?: (doc: Doc) => Doc,
+    options: { staleOnError?: boolean } = {},
+  ): Promise<void> {
+    // Every computed reading this doc calls getDoc, so several readers can ask
+    // for the same key in one tick. Without this, each starts its own read and
+    // each is free to assign.
+    const existing = this.inflight.get(key)
+    if (existing) return existing
+
+    const load = this.readFromCache(key, isFirstLoad, options)
+      .catch((error) => {
+        // Nothing awaits this — getDoc fires it and returns the ref straight
+        // away — so re-throwing would surface as an unhandled rejection.
+        console.error('Failed to load doc from IDB:', error)
+      })
+      .finally(() => {
+        if (this.inflight.get(key) === load) {
+          this.inflight.delete(key)
+        }
+      })
+
+    this.inflight.set(key, load)
+    return load
+  }
+
+  private async readFromCache(
+    key: DocKey,
+    isFirstLoad: boolean,
     options: { staleOnError?: boolean } = {},
   ) {
-    try {
-      if (!isFirstLoad && this.isStale(key)) {
-        this.lastFetched.delete(key)
-        if (!options.staleOnError) {
-          // Keep the IDB copy only when callers explicitly opt into stale
-          // read-only fallback, such as offline-capable routes.
-          await idbStore.delete(this.storePrefix + key)
-        }
-      }
+    // Snapshot before awaiting. Anything published while this read is in flight
+    // is newer than what the read is about to return.
+    const revisionAtStart = this.revisions.get(key) ?? 0
 
-      const idbDoc = (await idbStore.get(this.storePrefix + key)) as Doc | null
-      if (idbDoc) {
-        const docRef = this.docs.get(key)
-        if (docRef) {
-          if (transform) {
-            docRef.value = transform(idbDoc)
-          } else {
-            docRef.value = idbDoc
-          }
-        }
-        this.lastFetched.set(key, Date.now())
+    if (!isFirstLoad && this.isStale(key)) {
+      this.lastFetched.delete(key)
+      if (!options.staleOnError) {
+        // Keep the IDB copy only when callers explicitly opt into stale
+        // read-only fallback, such as offline-capable routes.
+        await idbStore.delete(this.storePrefix + key)
       }
-    } catch (error) {
-      console.error('Failed to load doc from IDB:', error)
-      throw error
     }
+
+    const idbDoc = (await idbStore.get(this.storePrefix + key)) as Doc | null
+    if (!idbDoc) return
+    if ((this.revisions.get(key) ?? 0) !== revisionAtStart) return
+
+    this.publish(key, idbDoc)
   }
 
   async setDocs(docs: Doc[]) {
@@ -115,14 +154,7 @@ class DocStore {
       if (!doc?.doctype || !doc?.name) continue
       doc.name = doc.name.toString()
       const key = this.getKey(doc.doctype, doc.name)
-      if (!this.docs.has(key)) {
-        this.docs.set(key, ref(null))
-      }
-      const docRef = this.docs.get(key)
-      if (docRef) {
-        docRef.value = doc
-      }
-      this.lastFetched.set(key, Date.now())
+      this.publish(key, doc)
       docMap[this.storePrefix + key] = doc
     }
     await idbStore.setMany(docMap)
@@ -151,6 +183,8 @@ class DocStore {
   private async cleanup(key: DocKey) {
     this.docs.delete(key)
     this.lastFetched.delete(key)
+    this.revisions.delete(key)
+    this.inflight.delete(key)
     await idbStore.delete(this.storePrefix + key)
   }
 
@@ -163,6 +197,8 @@ class DocStore {
       await Promise.all(docKeys.map((key: string) => idbStore.delete(key)))
       this.docs.clear()
       this.lastFetched.clear()
+      this.revisions.clear()
+      this.inflight.clear()
     } catch (error) {
       console.error('Failed to clear all docs:', error)
       throw error

--- a/src/data-fetching/docStore.ts
+++ b/src/data-fetching/docStore.ts
@@ -14,6 +14,10 @@ class DocStore {
   private lastFetched: Map<DocKey, number>
   private revisions: Map<DocKey, number>
   private inflight: Map<DocKey, Promise<void>>
+  // Store-wide and only ever incremented. A per-key counter that restarts at 0
+  // would let a snapshot taken before a key was cleaned up match the value a
+  // later slot starts from, which is how a deleted doc comes back to life.
+  private revisionCounter = 0
   private cacheTimeout: number = 5 * 60 * 1000 // 5 minutes
   private storePrefix = 'doc:'
 
@@ -28,7 +32,7 @@ class DocStore {
    * The single place a doc is assigned into its ref.
    *
    * A key is published twice by design — once from the IndexedDB cache, once
-   * from the server (stale-while-revalidate). Each publish bumps a per-key
+   * from the server (stale-while-revalidate). Each publish takes the next
    * revision so a slow cached read can tell it has been overtaken and skip its
    * write. The invariant: `docRef.value` never moves backwards in time.
    */
@@ -41,7 +45,7 @@ class DocStore {
     // getDoc again — if the entry still looked stale at that point it would kick
     // off a needless reload that evicts the IDB copy we just wrote.
     this.lastFetched.set(key, Date.now())
-    this.revisions.set(key, (this.revisions.get(key) ?? 0) + 1)
+    this.revisions.set(key, ++this.revisionCounter)
     this.docs.get(key)!.value = doc
   }
 
@@ -104,6 +108,12 @@ class DocStore {
     // Every computed reading this doc calls getDoc, so several readers can ask
     // for the same key in one tick. Without this, each starts its own read and
     // each is free to assign.
+    //
+    // Keyed on the document alone, so the first caller's `staleOnError` decides
+    // whether the IDB copy survives this round. Two useDocs on one document with
+    // different values for it is not a case worth splitting the read for: they
+    // share the ref either way, and the loser only sees the cached copy kept or
+    // dropped one cycle earlier than it asked for.
     const existing = this.inflight.get(key)
     if (existing) return existing
 
@@ -129,8 +139,10 @@ class DocStore {
     options: { staleOnError?: boolean } = {},
   ) {
     // Snapshot before awaiting. Anything published while this read is in flight
-    // is newer than what the read is about to return.
-    const revisionAtStart = this.revisions.get(key) ?? 0
+    // is newer than what the read is about to return. `undefined` is a value in
+    // its own right here: it means nothing has ever been published for this key,
+    // and cleanup() replaces it with a number rather than clearing it.
+    const revisionAtStart = this.revisions.get(key)
 
     if (!isFirstLoad && this.isStale(key)) {
       this.lastFetched.delete(key)
@@ -143,7 +155,11 @@ class DocStore {
 
     const idbDoc = (await idbStore.get(this.storePrefix + key)) as Doc | null
     if (!idbDoc) return
-    if ((this.revisions.get(key) ?? 0) !== revisionAtStart) return
+    // A read only ever writes into a slot that still exists. The read was issued
+    // before any delete that has since happened, so it still answers with the
+    // deleted row — publishing it would re-create the entry.
+    if (!this.docs.has(key)) return
+    if (this.revisions.get(key) !== revisionAtStart) return
 
     this.publish(key, idbDoc)
   }
@@ -183,8 +199,11 @@ class DocStore {
   private async cleanup(key: DocKey) {
     this.docs.delete(key)
     this.lastFetched.delete(key)
-    this.revisions.delete(key)
     this.inflight.delete(key)
+    // Bumped, not deleted. A delete is an event reads in flight have to notice,
+    // and clearing the entry would hand the next slot a revision an older read
+    // still matches.
+    this.revisions.set(key, ++this.revisionCounter)
     await idbStore.delete(this.storePrefix + key)
   }
 

--- a/src/data-fetching/useDoc/useDoc.test.ts
+++ b/src/data-fetching/useDoc/useDoc.test.ts
@@ -171,7 +171,7 @@ describe('useDoc', () => {
   })
 
   it('throws when getDoc is called with a whitespace-only name', () => {
-    expect(() => docStore.getDoc('User', '   ', (d) => d)).toThrow(
+    expect(() => docStore.getDoc('User', '   ')).toThrow(
       'doctype and name are required',
     )
   })

--- a/src/data-fetching/useDoc/useDoc.ts
+++ b/src/data-fetching/useDoc/useDoc.ts
@@ -166,7 +166,7 @@ export function useDoc<TDoc extends { name: string }, TMethods = {}>(
   const doc = computed<TDoc | null>(() => {
     const nameStr = toValue(name)?.trim()
     if (!nameStr) return null
-    const storeRef = docStore.getDoc(doctype, nameStr, transform as any, {
+    const storeRef = docStore.getDoc(doctype, nameStr, {
       staleOnError,
     }) as Ref<TDoc | null>
     let value = storeRef.value


### PR DESCRIPTION
## The problem

`docStore` gives a consumer the same document twice: once from the IndexedDB cache, once from the server. That part is on purpose, it is stale-while-revalidate. What is missing is any ordering between the two.

Both paths `await` IndexedDB and then assign into the same shared `Ref`. So the stale cached copy can land *after* the fresh server copy and overwrite it. `docRef.value` moves backwards in time, and the component shows old data with no way to tell.

The invariant this PR adds: **`docRef.value` never moves backwards in time.** Consumers still get two publishes. They just always arrive in order.

This is not a design choice elsewhere in the library. `useCall` and `useList` keep the cached copy in a separate ref and use a computed to pick between cached and fresh, so cached can never overwrite fresh in a shared slot. `docStore` was the only primitive merging both into one ref by blind assignment.

## What changed

All in `src/data-fetching/docStore.ts`.

**One assignment point.** Every write to a doc ref now goes through a private `publish()`, which bumps a per-key revision counter. `loadDoc` records the revision before it awaits, and after the cache read returns it only publishes if the revision has not moved. If something newer published in the meantime, the cached copy is dropped.

**`setDoc` publishes before it writes.** It used to `await idbStore.set(...)` first, so readers sat on stale data for a whole IndexedDB round trip, and a failed write hid the new value from them entirely. `setDocs` already assigned before writing, so the two paths disagreed. They agree now.

**Concurrent loads of one key are deduped.** `getDoc` fired `loadDoc` without marking it in flight, so several reads of the same key could run at once and each was free to assign. Worse, `loadDoc` deletes `lastFetched` early, which makes the key look *more* stale to the next reader in the same tick. There is now one in-flight promise per key, cleared when it settles.

**`loadDoc` logs instead of re-throwing.** Nothing awaits it, `getDoc` fires it and returns the ref, so the throw surfaced as an unhandled rejection.

**The store keeps documents raw.** On the cached path `loadDoc` stored the *transformed* doc, while `setDoc` stored raw and `useDoc` transforms on read. A cached doc was therefore transformed twice, so for a non-idempotent `transform` the two publishes carried different values. `getDoc` no longer takes a `transform` argument; callers apply it when they read, which `useDoc` already did.

## Behaviour changes for existing consumers

1. A cached publish that would have clobbered fresh data no longer fires. Anything relying on that was already broken.
2. `setDoc` updates the ref even if the IndexedDB write fails. This matches `setDocs`.
3. On the cached path the ref now holds the raw doc, not the transformed one. Visible to anyone reading `docStore` directly instead of through `useDoc`.
4. `getDoc(doctype, name, transform, options)` is now `getDoc(doctype, name, options)`. The only call site in this repo is `useDoc`, which is updated.

## Tests

Four new tests in `src/data-fetching/docStore.test.ts`. They run under `@vitest-environment node`, where `IDBStore` falls back to an in-memory map, so a controllable deferred on `idbStore.get` is enough to hold a read open.

- a slow cached read never overwrites a newer publish
- concurrent reads of one stale key hit IndexedDB once
- `setDoc` publishes before the IndexedDB write settles
- the store publishes the cached doc raw

All four fail on `main` and pass here. The first one fails with `expected bio: "fresh", received bio: "stale"`, which is the bug itself.

Full suite: 240 tests across 39 files, all passing.

Related to #692.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-921/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.64% (+0.05% vs `main`)
<!-- coverage-report:end -->

