### PR TITLE
feat(charts): combo series — one chart, mixed shapes

### DIFF
--- a/spec/charts-parity.md
+++ b/spec/charts-parity.md
@@ -2,17 +2,18 @@
 
 Audited 2026-08-01, comparing `src/components/Charts` (v1) against `src/charts` (v2).
 Dual axis (`y2Axis` + `series.axis`) has landed since the audit, as has `HeatmapChart`,
-which v1 never had.
+which v1 never had. **Combo charts have landed too** ([#941](https://github.com/frappe/frappe-ui/issues/941)):
+`seriesConfig.<key>.type` draws a series as a bar, line or area whichever axis chart
+hosts it, so v1's mixed `AxisChart.series` has a shape to convert to. See
+[`charts.md`](./charts.md) for the API and the decisions behind it.
 
 ## Missing components
 
 1. **Raw `ECharts` wrapper** — v1's documented escape hatch for chart types we don't
    ship (gauge, sankey, …). v2 only has the `useChart` composable. Low effort, high
-   importance.
-2. **Combo charts** — v1's `AxisChart` mixed `bar`/`line`/`area` series in one chart;
-   v2 components are homogeneous. Combo + y2 is the canonical "sales vs growth rate"
-   chart and the main reason y2 exists. Medium-high effort, high importance.
-3. `useAxisChartOptions` export — replaced by per-chart builders with a different
+   importance. [#885](https://github.com/frappe/frappe-ui/issues/885) found it has no
+   real consumer: all 3 helpdesk sites draw plain bar charts `BarChart` covers.
+2. `useAxisChartOptions` export — replaced by per-chart builders with a different
    signature. Document the rename.
 
 ## Missing / changed config API
@@ -20,7 +21,8 @@ which v1 never had.
 - `xAxis.type: 'value'` (numeric x) — **missing**; v2 supports category|time only.
   Hit-testing assumes category index or timestamp. Medium effort/importance.
 - `yAxis.yMin/yMax` → renamed `min`/`max`; `swapXY` → `horizontal` (bar-only, matches
-  v1's real support).
+  v1's real support). v2 is **ahead** here: v1 threw on `swapXY` with a non-bar series,
+  where v2 draws the recast line or band along the value axis.
 - `connectNulls` default flipped: v1 always `true`, v2 `false` with opt-in.
   **Migration-visible.**
 - `showDataLabels` no longer implies visible line points.
@@ -53,8 +55,10 @@ which v1 never had.
 
 1. **Not exported from main entry** — v2 is `frappe-ui/charts` subpath only
    (deliberate: keeps echarts out of the main bundle; decide + document).
-2. **No docs page / stories** — `src/charts` is in neither `sourceRoots` nor
-   `colocatedRoots` in docs/.vitepress/config.ts. Biggest adoption blocker.
+2. ~~**No docs page / stories**~~ — landed in `c75d39296`: `src/charts` is a `sourceRoot`
+   and every chart has a page under `src/charts/docs`. Noticed while adding the combo
+   example; the rest of this section is unre-verified and belongs to
+   [#944](https://github.com/frappe/frappe-ui/issues/944).
 3. `frappe-ui/charts-style.css` import requirement undocumented.
 4. Stale v1 references: `docs/content/public/llms.txt`, `docs/components/Home/ComponentGroups.vue`.
 5. No `@deprecated` tags or legacy.md entry for v1 exports.

--- a/spec/charts.md
+++ b/spec/charts.md
@@ -1,8 +1,8 @@
 # Charts v2 public API
 
-**Status:** implemented as of 2026-08-03. The charts in `src/charts` take the
-flat props below, and the barrel exports the surface listed here. This is the
-API reference.
+**Status:** implemented as of 2026-08-03, combo series added 2026-08-07. The
+charts in `src/charts` take the flat props below, and the barrel exports the
+surface listed here. This is the API reference.
 
 Alternatives considered and rejected: composition (one child component per
 series, Recharts-style), grammar-of-graphics channel bindings (Plot,
@@ -29,6 +29,9 @@ from a saved object — which is the evidence.dev flavor.
   `series` column — to `{ label, color, ... }`, after shadcn's `ChartConfig`.
   It replaces the v1 `series[]` array and ends the name-doubles-as-key flaw:
   the map key is the identity, `label` is the display name.
+- A series is drawn as its chart's own shape unless its `seriesConfig` entry
+  names a `type`. `BarChart`, `LineChart` and `AreaChart` differ only in that
+  default, so a combo chart is one tag whose series disagree — see below.
 - Formatting is a function, not a format code: axis objects and part-to-whole
   charts take `format: (value: number) => string`.
 - `palette` is the only color input: `'sequential' | 'categorical' |
@@ -73,6 +76,20 @@ Long data — one row per point, a column splits rows into series:
 <LineChart :data="tidyRows" x="month" y="amount" series="region" />
 ```
 
+Combo — bars for the amounts, a line for the rate they imply, on the second
+axis because the units differ:
+
+```vue
+<BarChart
+  :data="rows"
+  x="month"
+  :y="['revenue', 'expenses']"
+  y2="margin"
+  :series-config="{ margin: { type: 'line', label: 'Gross margin' } }"
+  :y2-axis="{ title: 'Margin', format: (v) => `${v}%` }"
+/>
+```
+
 | Prop | Type | Charts | Notes |
 | --- | --- | --- | --- |
 | `data` | `Record<string, any>[]` | all | |
@@ -91,10 +108,32 @@ Long data — one row per point, a column splits rows into series:
 
 `SeriesStyle` (all values optional — every series renders with defaults):
 
-- Base: `{ label, color, showDataLabels, echartOptions }`
+- Base: `{ type, label, color, showDataLabels, echartOptions }`
 - Bar adds `stackName`
 - Line adds `lineType`, `lineWidth`, `showDataPoints`, `smooth`
 - Area adds `stackName`, `fillOpacity`
+
+`type` is `'bar' | 'line' | 'area'` and decides which of those key sets the
+entry carries, defaulting to the chart's own shape. The three per-chart unions
+(`BarChartSeriesStyle`, `LineChartSeriesStyle`, `AreaChartSeriesStyle`) are what
+the props take; the shape-specific styles above are their branches, and both
+are exported.
+
+What the mix decides, it decides over every series rather than the visible
+ones, so a legend click never reflows the plot:
+
+- any bar in the chart → the axis pointer is a shaded band and the category
+  axis takes the half-slot inset; otherwise a rule, running edge to edge
+- the data-label gutter is the widest any labelled series needs
+- `stacked` sums each shape into a stack of its own — a band never lands on top
+  of a column — and a line never stacks, since a stacked line reads as an area
+- a line is drawn over the bars and bands it is read against, whatever order
+  the series were declared in
+
+Chart-level props stay on the chart that owns them: `stacked` and `horizontal`
+on `BarChart`, `connectNulls` on the line family, `fillOpacity` on `AreaChart`.
+A recast series reads the host chart's value and overrides it through its own
+style keys or `echartOptions`.
 
 Model, emits, slots:
 
@@ -189,9 +228,9 @@ Exposes nothing.
 
 - Components: `BarChart`, `LineChart`, `AreaChart`, `DonutChart`,
   `FunnelChart`, `HeatmapChart`, `NumberCard`
-- Props and event types: `*ChartProps`, `NumberCardProps`, `SeriesStyle`,
-  axis option types,
-  `ChartDatapointEvent`, `DonutSliceEvent`, `FunnelStageEvent`,
+- Props and event types: `*ChartProps`, `NumberCardProps`, `SeriesStyle` and
+  the per-shape and per-chart series styles, `AxisSeriesType`, axis option
+  types, `ChartDatapointEvent`, `DonutSliceEvent`, `FunnelStageEvent`,
   `HeatmapCellEvent`, `ChartPalette`
 - Composables: `useChart`, `registerChartModules`
 - Theme: `useChartTheme`, `resolveChartTheme`, `paletteColors`,
@@ -225,3 +264,25 @@ Settled 2026-08-03:
    warning that names the colliding cell.
 6. **Emit naming.** Per-shape names stay: `datapointClick`, `sliceClick`,
    `stageClick`, `cellClick`. The payloads differ for good reason.
+
+Settled 2026-08-07 ([#941](https://github.com/frappe/frappe-ui/issues/941)):
+
+7. **Combo lives in `seriesConfig`, not in a new component or prop.** `type`
+   travels with the rest of a series' look, so a saved combo config is still
+   one object spread into one tag — which is what a dashboard builder stores.
+   A fourth `ComboChart` component would have had to re-declare every axis
+   prop, and a parallel `seriesTypes` prop would have split one series'
+   settings across two props keyed the same way.
+8. **The tag keeps naming the chart.** Recasting is per series, so the
+   component names the shape the rest of the series take rather than becoming
+   a neutral `AxisChart` — v1's shape, rejected when v2 was designed. Any of
+   the three can host the same combo; converting a saved v1 config picks the
+   tag from the majority series and recasts the rest.
+9. **Bars and lines are registered by all three axis charts.** A component can
+   no longer register only what its own name draws, since `seriesConfig`
+   decides that at runtime. The area shape adds nothing — it is the line
+   module with a fill.
+10. **Horizontal combo draws, `y2` still does not.** A recast line or band on a
+    horizontal bar chart runs along the value axis and labels past its end.
+    The second value axis stays out, unchanged: two value axes along the top
+    and bottom of a plot are unreadable, whatever shape is drawn between them.

--- a/src/charts/AreaChart.vue
+++ b/src/charts/AreaChart.vue
@@ -46,27 +46,34 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-// An area is a line series with a fill, so it needs no module of its own.
-import { LineChart as LineSeries } from 'echarts/charts'
+// An area is a line series with a fill, so it needs no module of its own. The
+// bar module comes along because `seriesConfig` may recast any series as a bar.
+import { BarChart as BarSeries, LineChart as LineSeries } from 'echarts/charts'
 import { GridComponent, TooltipComponent } from 'echarts/components'
 import { LabelLayout } from 'echarts/features'
 import { registerChartModules } from './core/useChart'
 import { useAxisChart } from './core/useAxisChart'
-import { buildAreaChartOption } from './areaChartOptions'
+import { buildAreaChartOption } from './axisChartOptions'
 import { normalizeAxisChartProps } from './seriesData'
 import { chartAriaLabel } from './utils'
 import ChartContainer from './components/ChartContainer.vue'
 import ChartLegend from './components/ChartLegend.vue'
 import ChartTooltip from './components/ChartTooltip.vue'
-import type { AreaChartProps, AreaSeriesStyle } from './props'
+import type { AreaChartProps, AreaChartSeriesStyle } from './props'
 import type {
-  AreaChartConfig,
+  AxisChartConfig,
   ChartDatapointEvent,
   ChartExposed,
   ChartTooltipItem,
 } from './types'
 
-registerChartModules([LineSeries, GridComponent, TooltipComponent, LabelLayout])
+registerChartModules([
+  LineSeries,
+  BarSeries,
+  GridComponent,
+  TooltipComponent,
+  LabelLayout,
+])
 
 const props = defineProps<AreaChartProps>()
 
@@ -84,9 +91,9 @@ defineSlots<{
 }>()
 
 const normalized = computed(() =>
-  normalizeAxisChartProps<AreaSeriesStyle>(props),
+  normalizeAxisChartProps<AreaChartSeriesStyle>(props),
 )
-const config = computed<AreaChartConfig>(() => ({
+const config = computed<AxisChartConfig>(() => ({
   ...normalized.value.config,
   stacked: props.stacked,
   connectNulls: props.connectNulls,

--- a/src/charts/BarChart.cy.ts
+++ b/src/charts/BarChart.cy.ts
@@ -32,8 +32,15 @@ function mountChart(props: Record<string, any> = {}) {
   )
 }
 
-/** The bars, in series order. Gridlines are paths too, but unfilled. */
-const bars = () => cy.get('[data-slot="chart-plot"] svg path[fill^="#"]')
+/**
+ * The bars, in series order. Gridlines are paths too, but unfilled, and a line
+ * series brings a filled clip rect along with it.
+ */
+const bars = () =>
+  cy.get('[data-slot="chart-plot"] svg path[fill^="#"]:not(clipPath > path)')
+
+/** The series strokes. Gridlines are stroked too, but in a theme oklch. */
+const lines = () => cy.get('[data-slot="chart-plot"] svg path[stroke^="#"]')
 
 describe('BarChart', () => {
   it('paints a bar per datapoint, and labels the categories', () => {
@@ -126,6 +133,50 @@ describe('BarChart', () => {
     it('keeps the legend out of a single-series chart', () => {
       mountChart({ y: 'sales' })
       cy.get('[data-slot="chart-legend"]').should('not.exist')
+    })
+  })
+
+  describe('combo series', () => {
+    /** Value against rate: the chart combo and the second axis both exist for. */
+    function mountCombo(props: Record<string, any> = {}) {
+      return mountChart({
+        y: 'sales',
+        y2: 'refunds',
+        y2Axis: { title: 'Rate (%)' },
+        seriesConfig: { refunds: { type: 'line' } },
+        ...props,
+      })
+    }
+
+    it('draws the recast series as a line and the rest as bars', () => {
+      mountCombo()
+      bars().should('have.length', data.length)
+      lines().should('have.length', 1)
+    })
+
+    it('measures the line against the second axis', () => {
+      mountCombo()
+      // The second axis titles itself in the chrome above the plot, and only
+      // once a series is actually measured against it.
+      cy.get('[data-slot="chart-card"]').should('contain.text', 'Rate (%)')
+    })
+
+    it('reads both shapes out of one tooltip and one legend', () => {
+      mountCombo()
+      lines().should('have.length', 1)
+      cy.get('[data-slot="chart-legend"] button').should('have.length', 2)
+      cy.get('[data-slot="chart-plot"]').trigger('mousemove', 100, 150)
+      cy.get('[data-slot="chart-tooltip"]')
+        .should('contain.text', 'Sales')
+        .and('contain.text', 'Refunds')
+    })
+
+    it('drops the line from the plot when its legend entry is pressed', () => {
+      mountCombo()
+      lines().should('have.length', 1)
+      cy.get('[aria-label="Hide Refunds"]').click()
+      lines().should('not.exist')
+      bars().should('have.length', data.length)
     })
   })
 

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -47,26 +47,34 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { BarChart as BarSeries } from 'echarts/charts'
+import { BarChart as BarSeries, LineChart as LineSeries } from 'echarts/charts'
 import { GridComponent, TooltipComponent } from 'echarts/components'
 import { LabelLayout } from 'echarts/features'
 import { registerChartModules } from './core/useChart'
 import { useAxisChart } from './core/useAxisChart'
-import { buildBarChartOption } from './barChartOptions'
+import { buildBarChartOption } from './axisChartOptions'
 import { normalizeAxisChartProps } from './seriesData'
 import { chartAriaLabel } from './utils'
 import ChartContainer from './components/ChartContainer.vue'
 import ChartLegend from './components/ChartLegend.vue'
 import ChartTooltip from './components/ChartTooltip.vue'
-import type { BarChartProps, BarSeriesStyle } from './props'
+import type { BarChartProps, BarChartSeriesStyle } from './props'
 import type {
-  BarChartConfig,
+  AxisChartConfig,
   ChartDatapointEvent,
   ChartExposed,
   ChartTooltipItem,
 } from './types'
 
-registerChartModules([BarSeries, GridComponent, TooltipComponent, LabelLayout])
+// The line module comes along because `seriesConfig` may recast any series as a
+// line or an area, which is the same echarts module.
+registerChartModules([
+  BarSeries,
+  LineSeries,
+  GridComponent,
+  TooltipComponent,
+  LabelLayout,
+])
 
 const props = defineProps<BarChartProps>()
 
@@ -84,9 +92,9 @@ defineSlots<{
 }>()
 
 const normalized = computed(() =>
-  normalizeAxisChartProps<BarSeriesStyle>(props),
+  normalizeAxisChartProps<BarChartSeriesStyle>(props),
 )
-const config = computed<BarChartConfig>(() => ({
+const config = computed<AxisChartConfig>(() => ({
   ...normalized.value.config,
   stacked: props.stacked,
   horizontal: props.horizontal,

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -46,26 +46,34 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { LineChart as LineSeries } from 'echarts/charts'
+import { BarChart as BarSeries, LineChart as LineSeries } from 'echarts/charts'
 import { GridComponent, TooltipComponent } from 'echarts/components'
 import { LabelLayout } from 'echarts/features'
 import { registerChartModules } from './core/useChart'
 import { useAxisChart } from './core/useAxisChart'
-import { buildLineChartOption } from './lineChartOptions'
+import { buildLineChartOption } from './axisChartOptions'
 import { normalizeAxisChartProps } from './seriesData'
 import { chartAriaLabel } from './utils'
 import ChartContainer from './components/ChartContainer.vue'
 import ChartLegend from './components/ChartLegend.vue'
 import ChartTooltip from './components/ChartTooltip.vue'
-import type { LineChartProps, LineSeriesStyle } from './props'
+import type { LineChartProps, LineChartSeriesStyle } from './props'
 import type {
+  AxisChartConfig,
   ChartDatapointEvent,
   ChartExposed,
   ChartTooltipItem,
-  LineChartConfig,
 } from './types'
 
-registerChartModules([LineSeries, GridComponent, TooltipComponent, LabelLayout])
+// The bar module comes along because `seriesConfig` may recast any series as a
+// bar.
+registerChartModules([
+  LineSeries,
+  BarSeries,
+  GridComponent,
+  TooltipComponent,
+  LabelLayout,
+])
 
 const props = defineProps<LineChartProps>()
 
@@ -83,9 +91,9 @@ defineSlots<{
 }>()
 
 const normalized = computed(() =>
-  normalizeAxisChartProps<LineSeriesStyle>(props),
+  normalizeAxisChartProps<LineChartSeriesStyle>(props),
 )
-const config = computed<LineChartConfig>(() => ({
+const config = computed<AxisChartConfig>(() => ({
   ...normalized.value.config,
   connectNulls: props.connectNulls,
 }))

--- a/src/charts/areaChartOptions.test.ts
+++ b/src/charts/areaChartOptions.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
+import { buildAreaChartOption } from './axisChartOptions'
 import {
-  buildAreaChartOption,
   DEFAULT_FILL_OPACITY,
   DEFAULT_STACKED_FILL_OPACITY,
 } from './areaChartOptions'
 import type { ChartTheme } from './theme'
-import type { AreaChartConfig } from './types'
+import type { AxisChartConfig } from './types'
 
 const theme: ChartTheme = {
   palette: ['#111111', '#222222', '#333333'],
@@ -20,7 +20,7 @@ const theme: ChartTheme = {
   cellGap: '#ffffff',
 }
 
-function config(overrides: Partial<AreaChartConfig> = {}): AreaChartConfig {
+function config(overrides: Partial<AxisChartConfig> = {}): AxisChartConfig {
   return {
     data: [
       { month: 'Jan', sales: 10, refunds: 2 },
@@ -33,7 +33,7 @@ function config(overrides: Partial<AreaChartConfig> = {}): AreaChartConfig {
 }
 
 function build(
-  overrides: Partial<AreaChartConfig> = {},
+  overrides: Partial<AxisChartConfig> = {},
   hiddenSeries?: string[],
 ) {
   return buildAreaChartOption(config(overrides), { theme, hiddenSeries }) as any
@@ -117,10 +117,12 @@ describe('buildAreaChartOption', () => {
     ])
   })
 
+  // The shape prefixes every stack name so that a combo chart stacking both
+  // bands and columns never sums one on top of the other.
   it('stacks series under one stack, or under named ones', () => {
     expect(build({ stacked: true }).series.map((s: any) => s.stack)).toEqual([
-      'stack',
-      'stack',
+      'area:stack',
+      'area:stack',
     ])
     expect(build().series[0].stack).toBeUndefined()
     expect(
@@ -131,7 +133,7 @@ describe('buildAreaChartOption', () => {
           { name: 'refunds', stackName: 'right' },
         ],
       }).series.map((s: any) => s.stack),
-    ).toEqual(['left', 'right'])
+    ).toEqual(['area:left', 'area:right'])
   })
 
   it('takes fillOpacity from the series, then the chart', () => {

--- a/src/charts/areaChartOptions.ts
+++ b/src/charts/areaChartOptions.ts
@@ -1,9 +1,5 @@
-import type { EChartsCoreOption } from 'echarts/core'
-import { BLUR_OPACITY, type AxisChartOptionContext } from './axisChartCommon'
-import { buildLineLikeOption } from './lineChartOptions'
-import type { AreaChartConfig, AreaSeriesConfig } from './types'
-
-export type AreaChartOptionContext = AxisChartOptionContext
+import { BLUR_OPACITY } from './axisChartCommon'
+import type { AxisChartConfig, AxisSeriesConfig } from './types'
 
 /** A wash that shows the trend without swallowing the gridlines behind it. */
 export const DEFAULT_FILL_OPACITY = 0.16
@@ -12,33 +8,38 @@ export const DEFAULT_STACKED_FILL_OPACITY = 0.75
 /** Where the gradient lands by the time it reaches the axis. */
 const GRADIENT_FADE = 0.1
 
-export function buildAreaChartOption(
-  config: AreaChartConfig,
-  context: AreaChartOptionContext,
-): EChartsCoreOption {
-  return buildLineLikeOption(config, context, (series, color) => ({
-    stack: stackNameOf(series, config),
-    areaStyle: fillStyle(series, config, color),
-    blur: { areaStyle: { opacity: blurOpacity(series, config) } },
-  }))
+/** The keys that turn a line series into an area: the fill, and how it blurs. */
+export function areaSeriesExtra(
+  series: AxisSeriesConfig,
+  config: AxisChartConfig,
+  color: string,
+  opts: { horizontal: boolean; isRTL: boolean; stacked: boolean },
+) {
+  return {
+    areaStyle: fillStyle(series, config, color, opts),
+    blur: { areaStyle: { opacity: blurOpacity(series, config, opts.stacked) } },
+  }
 }
 
-function stackNameOf(series: AreaSeriesConfig, config: AreaChartConfig) {
-  if (!config.stacked) return undefined
-  return series.stackName || 'stack'
-}
-
-function fillOpacityOf(series: AreaSeriesConfig, config: AreaChartConfig) {
+function fillOpacityOf(
+  series: AxisSeriesConfig,
+  config: AxisChartConfig,
+  stacked: boolean,
+) {
   return (
     series.fillOpacity ??
     config.fillOpacity ??
-    (config.stacked ? DEFAULT_STACKED_FILL_OPACITY : DEFAULT_FILL_OPACITY)
+    (stacked ? DEFAULT_STACKED_FILL_OPACITY : DEFAULT_FILL_OPACITY)
   )
 }
 
 /** The blur state has to dim the fill relative to its own opacity, not to 1. */
-function blurOpacity(series: AreaSeriesConfig, config: AreaChartConfig) {
-  return fillOpacityOf(series, config) * BLUR_OPACITY
+function blurOpacity(
+  series: AxisSeriesConfig,
+  config: AxisChartConfig,
+  stacked: boolean,
+) {
+  return fillOpacityOf(series, config, stacked) * BLUR_OPACITY
 }
 
 /**
@@ -47,32 +48,46 @@ function blurOpacity(series: AreaSeriesConfig, config: AreaChartConfig) {
  * block each, so they take a flat fill instead.
  */
 function fillStyle(
-  series: AreaSeriesConfig,
-  config: AreaChartConfig,
+  series: AxisSeriesConfig,
+  config: AxisChartConfig,
   color: string,
+  opts: { horizontal: boolean; isRTL: boolean; stacked: boolean },
 ) {
-  const opacity = fillOpacityOf(series, config)
-  if (config.stacked) return { color, opacity }
+  const opacity = fillOpacityOf(series, config, opts.stacked)
+  if (opts.stacked) return { color, opacity }
 
-  const top = withAlpha(color, opacity)
-  const bottom = withAlpha(color, opacity * GRADIENT_FADE)
-  if (!top || !bottom) return { color, opacity }
+  const near = withAlpha(color, opacity)
+  const far = withAlpha(color, opacity * GRADIENT_FADE)
+  if (!near || !far) return { color, opacity }
 
   return {
     color: {
       type: 'linear',
-      x: 0,
-      y: 0,
-      x2: 0,
-      y2: 1,
+      ...gradientAxis(opts),
       colorStops: [
-        { offset: 0, color: top },
-        { offset: 1, color: bottom },
+        { offset: 0, color: near },
+        { offset: 1, color: far },
       ],
     },
     // The stops carry the alpha; a second multiplier here would double-dip.
     opacity: 1,
   }
+}
+
+/**
+ * Which way the wash fades: from the line towards the axis it is measured from.
+ * That is downwards on a column chart, and along X once the category axis has
+ * moved to Y — the other way again in RTL, where the value axis is inverted.
+ */
+function gradientAxis({
+  horizontal,
+  isRTL,
+}: {
+  horizontal: boolean
+  isRTL: boolean
+}) {
+  if (!horizontal) return { x: 0, y: 0, x2: 0, y2: 1 }
+  return isRTL ? { x: 0, y: 0, x2: 1, y2: 0 } : { x: 1, y: 0, x2: 0, y2: 0 }
 }
 
 /**

--- a/src/charts/axisChartCommon.ts
+++ b/src/charts/axisChartCommon.ts
@@ -13,7 +13,10 @@ import { paletteColors, pickSeriesColor, type ChartTheme } from './theme'
 import { mergeDeep } from './utils'
 import type {
   AxisChartBaseConfig,
+  AxisChartConfig,
   AxisChartSeriesConfig,
+  AxisSeriesConfig,
+  AxisSeriesType,
   ChartPaletteName,
 } from './types'
 
@@ -27,6 +30,14 @@ export type AxisChartOptionContext = {
 
 export const AXIS_LABEL_FONT_SIZE = 11
 export const DATA_LABEL_FONT_SIZE = 11
+
+/**
+ * Bars and bands share one plane, and a line is drawn over them: in a combo
+ * chart the line is read against the columns, so declaration order must not
+ * decide whether a column hides it. echarts' own default for a series is 2.
+ */
+export const MARK_Z = 2
+export const LINE_Z = 3
 /** How far the other series drop back while one is hovered in the legend. */
 export const BLUR_OPACITY = 0.75
 
@@ -96,6 +107,21 @@ export function visibleSeries<T extends AxisChartSeriesConfig>(
   hiddenSeries: string[],
 ): T[] {
   return series.filter((s) => !hiddenSeries.includes(s.name))
+}
+
+/**
+ * The echarts stack a series joins, namespaced by the shape it is drawn as:
+ * bars stack with bars and areas with areas, so a combo chart that stacks both
+ * never sums a band on top of a column. A line never stacks — a stacked line is
+ * an area, and drawing one as a line hides that the values are cumulative.
+ */
+export function stackNameOf(
+  series: AxisSeriesConfig,
+  config: AxisChartConfig,
+  type: AxisSeriesType,
+): string | undefined {
+  if (!config.stacked || type === 'line') return undefined
+  return `${type}:${series.stackName || 'stack'}`
 }
 
 /** Option keys that hold for any cartesian chart, whatever it draws. */

--- a/src/charts/axisChartOptions.test.ts
+++ b/src/charts/axisChartOptions.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAreaChartOption,
+  buildAxisChartOption,
+  buildBarChartOption,
+  buildLineChartOption,
+} from './axisChartOptions'
+import { LINE_Z, MARK_Z } from './axisChartCommon'
+import { BAR_DATA_LABEL_GUTTER } from './barChartOptions'
+import { LINE_DATA_LABEL_GUTTER } from './lineChartOptions'
+import type { ChartTheme } from './theme'
+import type { AxisChartConfig, AxisSeriesType } from './types'
+
+const theme: ChartTheme = {
+  palette: ['#111111', '#222222', '#333333'],
+  sequential: ['#000011', '#000022', '#000033'],
+  diverging: ['#001100', '#002200', '#003300'],
+  axisLabel: 'ink-5',
+  axisTitle: 'ink-7',
+  axisLine: 'outline-2',
+  splitLine: 'outline-1',
+  dataLabel: 'ink-6',
+  insideLabel: 'ink-8',
+  cellGap: '#ffffff',
+}
+
+/** Revenue in currency against a rate: the chart combo and y2 both exist for. */
+function config(overrides: Partial<AxisChartConfig> = {}): AxisChartConfig {
+  return {
+    data: [
+      { month: 'Jan', revenue: 100, growth: 4 },
+      { month: 'Feb', revenue: 140, growth: 6 },
+    ],
+    xAxis: { key: 'month', type: 'category' },
+    series: [{ name: 'revenue' }, { name: 'growth', type: 'line' }],
+    ...overrides,
+  }
+}
+
+function build(
+  overrides: Partial<AxisChartConfig> = {},
+  defaultType: AxisSeriesType = 'bar',
+  hiddenSeries?: string[],
+) {
+  return buildAxisChartOption(
+    config(overrides),
+    { theme, hiddenSeries },
+    defaultType,
+  ) as any
+}
+
+const typesOf = (option: any) => option.series.map((s: any) => s.type)
+const valuesOf = (series: any) =>
+  series.data.map((item: any) => (Array.isArray(item) ? item : item.value))
+
+describe('combo series', () => {
+  it('draws each series as the type it names', () => {
+    expect(typesOf(build())).toEqual(['bar', 'line'])
+  })
+
+  it('falls back to the shape of the chart it was handed to', () => {
+    const plain = { series: [{ name: 'revenue' }, { name: 'growth' }] }
+    expect(typesOf(build(plain, 'bar'))).toEqual(['bar', 'bar'])
+    expect(typesOf(build(plain, 'line'))).toEqual(['line', 'line'])
+    // An area is a line series with a fill, so echarts still calls it a line.
+    const area = build(plain, 'area')
+    expect(typesOf(area)).toEqual(['line', 'line'])
+    expect(area.series[0].areaStyle).toBeTruthy()
+  })
+
+  it('recasts a series in any of the three charts', () => {
+    const recast = config({
+      series: [{ name: 'revenue' }, { name: 'growth', type: 'bar' }],
+    })
+    expect(typesOf(buildLineChartOption(recast, { theme }))).toEqual([
+      'line',
+      'bar',
+    ])
+
+    const area = buildAreaChartOption(recast, { theme }) as any
+    expect(typesOf(area)).toEqual(['line', 'bar'])
+    expect(area.series[1].areaStyle).toBeUndefined()
+  })
+
+  it('gives a recast series the keys of the shape it is drawn as', () => {
+    const option = build({
+      series: [
+        { name: 'revenue' },
+        { name: 'growth', type: 'line', lineType: 'dashed', smooth: true },
+      ],
+    })
+    expect(option.series[1].lineStyle.type).toBe('dashed')
+    expect(option.series[1].smooth).toBe(true)
+  })
+
+  it('keeps the per-series escape hatch on a recast series', () => {
+    const option = build({
+      series: [
+        { name: 'revenue' },
+        { name: 'growth', type: 'line', echartOptions: { symbol: 'triangle' } },
+      ],
+    })
+    expect(option.series[1].symbol).toBe('triangle')
+  })
+
+  it('measures a recast series against the second value axis', () => {
+    const option = build({
+      series: [
+        { name: 'revenue' },
+        { name: 'growth', type: 'line', axis: 'y2' },
+      ],
+      y2Axis: { max: 10 },
+    })
+    expect(option.yAxis).toHaveLength(2)
+    expect(option.yAxis[1].max).toBe(10)
+    expect(option.series.map((s: any) => s.yAxisIndex)).toEqual([0, 1])
+  })
+
+  it('draws a line over the marks it is read against', () => {
+    const option = build()
+    expect(option.series[0].z).toBeUndefined()
+    expect(option.series[1].z).toBe(LINE_Z)
+  })
+
+  it('leaves a band on the same plane as the columns', () => {
+    const option = build({
+      series: [{ name: 'revenue' }, { name: 'growth', type: 'area' }],
+    })
+    expect(option.series[1].z).toBe(MARK_Z)
+  })
+})
+
+describe('combo axes', () => {
+  it('shades the pointer and insets the categories when anything is a bar', () => {
+    const option = build()
+    expect(option.tooltip.axisPointer.type).toBe('shadow')
+    expect(option.xAxis.boundaryGap).toBe(true)
+  })
+
+  it('rules the pointer and runs edge to edge when nothing is', () => {
+    const option = build(
+      { series: [{ name: 'revenue' }, { name: 'growth', type: 'area' }] },
+      'line',
+    )
+    expect(option.tooltip.axisPointer.type).toBe('line')
+    expect(option.xAxis.boundaryGap).toBe(false)
+  })
+
+  // Hiding the last bar must not re-space the axis under the remaining line:
+  // the plot would reflow on a legend click.
+  it('holds the inset and the pointer when the only bar is hidden', () => {
+    const option = build({}, 'bar', ['revenue'])
+    expect(option.series).toHaveLength(1)
+    expect(option.xAxis.boundaryGap).toBe(true)
+    expect(option.tooltip.axisPointer.type).toBe('shadow')
+  })
+
+  it('reserves the widest gutter the labelled series need', () => {
+    expect(
+      build({
+        series: [
+          { name: 'revenue', showDataLabels: true },
+          { name: 'growth', type: 'line', showDataLabels: true },
+        ],
+      }).grid.top,
+    ).toBe(8 + BAR_DATA_LABEL_GUTTER)
+
+    expect(
+      build({
+        series: [
+          { name: 'revenue' },
+          { name: 'growth', type: 'line', showDataLabels: true },
+        ],
+      }).grid.top,
+    ).toBe(8 + LINE_DATA_LABEL_GUTTER)
+  })
+})
+
+describe('combo stacking', () => {
+  const stacks = (option: any) => option.series.map((s: any) => s.stack)
+
+  it('never stacks a line, whatever the chart says', () => {
+    expect(stacks(build({ stacked: true }))).toEqual(['bar:stack', undefined])
+  })
+
+  it('keeps columns and bands in stacks of their own', () => {
+    const option = build({
+      data: [{ month: 'Jan', revenue: 100, refunds: 20, growth: 4 }],
+      stacked: true,
+      series: [
+        { name: 'revenue' },
+        { name: 'growth', type: 'area' },
+        { name: 'refunds' },
+      ],
+    })
+    expect(stacks(option)).toEqual(['bar:stack', 'area:stack', 'bar:stack'])
+  })
+
+  it('namespaces a named stack by its shape too', () => {
+    expect(
+      stacks(
+        build({
+          stacked: true,
+          series: [
+            { name: 'revenue', stackName: 'left' },
+            { name: 'growth', type: 'area', stackName: 'left' },
+          ],
+        }),
+      ),
+    ).toEqual(['bar:left', 'area:left'])
+  })
+
+  it('rounds the outermost column without counting the line', () => {
+    const option = build({
+      stacked: true,
+      data: [{ month: 'Jan', revenue: 100, refunds: 20, growth: 4 }],
+      series: [
+        { name: 'revenue' },
+        { name: 'growth', type: 'line' },
+        { name: 'refunds' },
+      ],
+    })
+    // The last *bar* tops the column; the line after it is not part of the stack.
+    expect(option.series[0].data[0].itemStyle.borderRadius).toBe(0)
+    expect(option.series[2].data[0].itemStyle.borderRadius).toEqual([
+      4, 4, 0, 0,
+    ])
+  })
+})
+
+describe('combo on a horizontal chart', () => {
+  const horizontal = {
+    horizontal: true,
+    series: [
+      { name: 'revenue' },
+      { name: 'growth', type: 'line' as const, showDataLabels: true },
+    ],
+  }
+
+  it('runs a recast line along the value axis', () => {
+    const option = build(horizontal)
+    expect(valuesOf(option.series[0])).toEqual([
+      [100, 'Jan'],
+      [140, 'Feb'],
+    ])
+    expect(valuesOf(option.series[1])).toEqual([
+      [4, 'Jan'],
+      [6, 'Feb'],
+    ])
+  })
+
+  it('labels past the end of the line, and the other way in RTL', () => {
+    expect(build(horizontal).series[1].label.position).toBe('right')
+    expect(build({ ...horizontal, dir: 'rtl' }).series[1].label.position).toBe(
+      'left',
+    )
+  })
+
+  it('fades a recast band towards the axis it is measured from', () => {
+    const vertical = build({
+      series: [{ name: 'growth', type: 'area' }],
+    }).series[0].areaStyle.color
+    expect([vertical.x, vertical.y, vertical.x2, vertical.y2]).toEqual([
+      0, 0, 0, 1,
+    ])
+
+    const sideways = build({
+      horizontal: true,
+      series: [{ name: 'growth', type: 'area' }],
+    }).series[0].areaStyle.color
+    expect([sideways.x, sideways.y, sideways.x2, sideways.y2]).toEqual([
+      1, 0, 0, 0,
+    ])
+  })
+})
+
+describe('buildAxisChartOption entry points', () => {
+  it('hands each chart its own default shape', () => {
+    const plain = config({ series: [{ name: 'revenue' }] })
+    const seriesOf = (option: any) => option.series[0]
+
+    expect(seriesOf(buildBarChartOption(plain, { theme })).type).toBe('bar')
+    expect(seriesOf(buildLineChartOption(plain, { theme })).type).toBe('line')
+
+    const area = seriesOf(buildAreaChartOption(plain, { theme }))
+    expect(area.type).toBe('line')
+    expect(area.areaStyle).toBeTruthy()
+  })
+})

--- a/src/charts/axisChartOptions.ts
+++ b/src/charts/axisChartOptions.ts
@@ -1,0 +1,149 @@
+import type { EChartsCoreOption } from 'echarts/core'
+import {
+  axisChartBase,
+  buildAxisGrid,
+  buildCategoryAxis,
+  buildValueAxes,
+  hasSecondaryValueAxis,
+  resolveSeriesColors,
+  stackNameOf,
+  valueAxisIndex,
+  visibleSeries,
+  LINE_Z,
+  MARK_Z,
+  type AxisChartOptionContext,
+} from './axisChartCommon'
+import { areaSeriesExtra } from './areaChartOptions'
+import {
+  barTipResolver,
+  buildBarSeries,
+  BAR_DATA_LABEL_GUTTER,
+} from './barChartOptions'
+import { buildLineSeries, LINE_DATA_LABEL_GUTTER } from './lineChartOptions'
+import { mergeDeep } from './utils'
+import type { AxisChartConfig, AxisSeriesConfig, AxisSeriesType } from './types'
+
+/**
+ * The option behind every cartesian chart. Each series is drawn as its own
+ * `type`, falling back to `defaultType` — the shape of the chart it was handed
+ * to — so one config draws bars, lines, areas, or any mix of the three.
+ *
+ * What the mix decides, it decides over *every* series rather than the visible
+ * ones: switching the last bar off in the legend should not re-space the
+ * category axis or swap the pointer out from under the remaining lines.
+ */
+export function buildAxisChartOption(
+  config: AxisChartConfig,
+  { theme, hiddenSeries = [], width }: AxisChartOptionContext,
+  defaultType: AxisSeriesType,
+): EChartsCoreOption {
+  const isRTL = config.dir === 'rtl'
+  const horizontal = Boolean(config.horizontal)
+  const rows = config.data ?? []
+  const colors = resolveSeriesColors(config, theme)
+
+  const typeOf = (series: AxisSeriesConfig) => series.type ?? defaultType
+  const hasBars = config.series.some((series) => typeOf(series) === 'bar')
+
+  const visible = visibleSeries(config.series, hiddenSeries)
+  const categories = rows.map((row) => row[config.xAxis.key])
+
+  const categoryAxis = buildCategoryAxis(config, theme, {
+    categories,
+    horizontal,
+    isRTL,
+    // A bar is drawn across its slot, so it needs the half-slot inset at each
+    // end of the axis. A chart of lines alone runs edge to edge instead.
+    boundaryGap: hasBars,
+    width,
+  })
+  const valueAxis = buildValueAxes(config, theme, { horizontal, isRTL })
+  const hasSecondary = hasSecondaryValueAxis(config, horizontal)
+
+  const carriesTip = barTipResolver(
+    visible.filter((series) => typeOf(series) === 'bar'),
+    config,
+    rows,
+  )
+
+  const option = {
+    // A bar has a width for the pointer to shade; a line has none, so its
+    // crosshair is a rule. A chart with any bar in it takes the band.
+    ...axisChartBase(theme, hasBars ? 'shadow' : 'line'),
+    grid: buildAxisGrid(config, {
+      horizontal,
+      isRTL,
+      labelGutter: dataLabelGutter(config, typeOf),
+    }),
+    xAxis: horizontal ? valueAxis : categoryAxis,
+    yAxis: horizontal ? categoryAxis : valueAxis,
+    series: visible.map((series) => {
+      const type = typeOf(series)
+      const color = colors[series.name]
+      const shared = {
+        theme,
+        rows,
+        horizontal,
+        isRTL,
+        color,
+        yAxisIndex: valueAxisIndex(series, hasSecondary),
+        stack: stackNameOf(series, config, type),
+      }
+
+      if (type === 'bar') {
+        return buildBarSeries(series, config, { ...shared, carriesTip })
+      }
+      return buildLineSeries(series, config, {
+        ...shared,
+        z: type === 'area' ? MARK_Z : LINE_Z,
+        extra:
+          type === 'area'
+            ? areaSeriesExtra(series, config, color, {
+                horizontal,
+                isRTL,
+                stacked: Boolean(shared.stack),
+              })
+            : undefined,
+      })
+    }),
+  }
+
+  return mergeDeep(option, config.echartOptions)
+}
+
+/**
+ * Room for the data labels that sit past the end of a mark. Bars need the most,
+ * and stacked ones none at all — they label inside the fill.
+ */
+function dataLabelGutter(
+  config: AxisChartConfig,
+  typeOf: (series: AxisSeriesConfig) => AxisSeriesType,
+) {
+  const gutters = config.series.map((series) => {
+    if (!series.showDataLabels) return 0
+    if (typeOf(series) !== 'bar') return LINE_DATA_LABEL_GUTTER
+    return config.stacked ? 0 : BAR_DATA_LABEL_GUTTER
+  })
+  return Math.max(0, ...gutters)
+}
+
+export function buildBarChartOption(
+  config: AxisChartConfig,
+  context: AxisChartOptionContext,
+): EChartsCoreOption {
+  return buildAxisChartOption(config, context, 'bar')
+}
+
+export function buildLineChartOption(
+  config: AxisChartConfig,
+  context: AxisChartOptionContext,
+): EChartsCoreOption {
+  return buildAxisChartOption(config, context, 'line')
+}
+
+export function buildAreaChartOption(
+  config: AxisChartConfig,
+  context: AxisChartOptionContext,
+): EChartsCoreOption {
+  return buildAxisChartOption(config, context, 'area')
+}

--- a/src/charts/axisFormat.test.ts
+++ b/src/charts/axisFormat.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { applyAxisFormatters } from './axisFormat'
-import { buildBarChartOption } from './barChartOptions'
+import { buildBarChartOption } from './axisChartOptions'
 import type { ChartTheme } from './theme'
-import type { BarChartConfig } from './types'
+import type { AxisChartConfig } from './types'
 
 const theme: ChartTheme = {
   palette: ['#111111', '#222222', '#333333'],
@@ -17,7 +17,7 @@ const theme: ChartTheme = {
   cellGap: '#ffffff',
 }
 
-function config(overrides: Partial<BarChartConfig> = {}): BarChartConfig {
+function config(overrides: Partial<AxisChartConfig> = {}): AxisChartConfig {
   return {
     data: [
       { month: 'Jan', sales: 10, refunds: 2 },
@@ -34,7 +34,7 @@ const currency = (value: number) => `$${value}`
 /** As a chart does it: formats applied to the config, then built. */
 function build(
   formats: Parameters<typeof applyAxisFormatters>[1] = {},
-  overrides: Partial<BarChartConfig> = {},
+  overrides: Partial<AxisChartConfig> = {},
 ) {
   return buildBarChartOption(applyAxisFormatters(config(overrides), formats), {
     theme,

--- a/src/charts/barChartOptions.test.ts
+++ b/src/charts/barChartOptions.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildBarChartOption, resolveSeriesColors } from './barChartOptions'
-import { AXIS_LABEL_FONT_SIZE } from './axisChartCommon'
+import { buildBarChartOption } from './axisChartOptions'
+import { resolveSeriesColors, AXIS_LABEL_FONT_SIZE } from './axisChartCommon'
 import { estimateTextWidth } from './format'
 import type { ChartTheme } from './theme'
-import type { BarChartConfig } from './types'
+import type { AxisChartConfig } from './types'
 
 const theme: ChartTheme = {
   palette: ['#111111', '#222222', '#333333'],
@@ -19,7 +19,7 @@ const theme: ChartTheme = {
   cellGap: '#ffffff',
 }
 
-function config(overrides: Partial<BarChartConfig> = {}): BarChartConfig {
+function config(overrides: Partial<AxisChartConfig> = {}): AxisChartConfig {
   return {
     data: [
       { month: 'Jan', sales: 10, refunds: 2 },
@@ -32,7 +32,7 @@ function config(overrides: Partial<BarChartConfig> = {}): BarChartConfig {
 }
 
 function build(
-  overrides: Partial<BarChartConfig> = {},
+  overrides: Partial<AxisChartConfig> = {},
   hiddenSeries?: string[],
   width?: number,
 ) {
@@ -43,7 +43,7 @@ function build(
   }) as any
 }
 
-function colorsFor(overrides: Partial<BarChartConfig> = {}) {
+function colorsFor(overrides: Partial<AxisChartConfig> = {}) {
   return resolveSeriesColors(config(overrides), theme)
 }
 
@@ -327,7 +327,12 @@ describe('buildBarChartOption series', () => {
 
   it('stacks series and rounds only the outermost bar', () => {
     const option = build({ stacked: true })
-    expect(option.series.map((s: any) => s.stack)).toEqual(['stack', 'stack'])
+    // The shape prefixes every stack name so that a combo chart stacking both
+    // columns and bands never sums one on top of the other.
+    expect(option.series.map((s: any) => s.stack)).toEqual([
+      'bar:stack',
+      'bar:stack',
+    ])
     expect(radiiOf(option.series[0])).toEqual([0, 0])
     expect(radiiOf(option.series[1])).toEqual([
       [4, 4, 0, 0],

--- a/src/charts/barChartOptions.ts
+++ b/src/charts/barChartOptions.ts
@@ -1,110 +1,56 @@
-import type { EChartsCoreOption } from 'echarts/core'
 import { formatValue } from './format'
 import { insideLabelColor, type ChartTheme } from './theme'
-import {
-  axisChartBase,
-  buildAxisGrid,
-  buildCategoryAxis,
-  buildValueAxes,
-  hasSecondaryValueAxis,
-  resolveSeriesColors,
-  toNumber,
-  valueAxisIndex,
-  visibleSeries,
-  DATA_LABEL_FONT_SIZE,
-  BLUR_OPACITY,
-  type AxisChartOptionContext,
-} from './axisChartCommon'
+import { toNumber, BLUR_OPACITY, DATA_LABEL_FONT_SIZE } from './axisChartCommon'
 import { mergeDeep } from './utils'
-import type { BarChartConfig, BarSeriesConfig } from './types'
-
-export type BarChartOptionContext = AxisChartOptionContext
-
-export { resolveSeriesColors }
+import type {
+  AxisChartConfig,
+  AxisSeriesConfig,
+  BarSeriesConfig,
+} from './types'
 
 const BAR_MAX_WIDTH = 32
 /** Slim bars with an airy gap between categories. */
 const BAR_CATEGORY_GAP = '38%'
 /** Room for a data label sitting past the end of a bar. */
-const DATA_LABEL_GUTTER = 40
+export const BAR_DATA_LABEL_GUTTER = 40
 const BAR_RADIUS = 4
 
-export function buildBarChartOption(
-  config: BarChartConfig,
-  { theme, hiddenSeries = [], width }: BarChartOptionContext,
-): EChartsCoreOption {
-  const isRTL = config.dir === 'rtl'
-  const horizontal = Boolean(config.horizontal)
-  const rows = config.data ?? []
-  const colors = resolveSeriesColors(config, theme)
-
-  const visible = visibleSeries(config.series, hiddenSeries)
-  const categories = rows.map((row) => row[config.xAxis.key])
-
-  const categoryAxis = buildCategoryAxis(config, theme, {
-    categories,
-    horizontal,
-    isRTL,
-    boundaryGap: true,
-    width,
-  })
-  const valueAxis = buildValueAxes(config, theme, { horizontal, isRTL })
-  const hasSecondary = hasSecondaryValueAxis(config, horizontal)
-
-  const option = {
-    ...axisChartBase(theme, 'shadow'),
-    grid: buildAxisGrid(config, {
-      horizontal,
-      isRTL,
-      labelGutter: dataLabelGutter(config),
-    }),
-    xAxis: horizontal ? valueAxis : categoryAxis,
-    yAxis: horizontal ? categoryAxis : valueAxis,
-    series: visible.map((series) =>
-      buildSeries(series, config, {
-        theme,
-        rows,
-        horizontal,
-        isRTL,
-        color: colors[series.name],
-        yAxisIndex: valueAxisIndex(series, hasSecondary),
-        carriesTip: tipResolver(visible, config, rows),
-      }),
-    ),
-  }
-
-  return mergeDeep(option, config.echartOptions)
-}
-
-/** Stacked labels sit inside the fill, so they need no gutter. */
-function dataLabelGutter(config: BarChartConfig) {
-  return !config.stacked && config.series.some((s) => s.showDataLabels)
-    ? DATA_LABEL_GUTTER
-    : 0
-}
+/** Whether a bar ends its column, in the direction that row runs. */
+export type BarTipResolver = (
+  series: BarSeriesConfig,
+  rowIndex: number,
+  value: number,
+) => boolean
 
 /**
  * Whether a bar carries its column's rounded tip, asked per row rather than per
  * series: a stack runs away from the baseline in both directions at once, so
  * which segment ends the column depends on the sign of the number in that row.
  * Only that end is rounded — rounding the segments underneath carves notches
- * out of the middle of the column.
+ * out of the middle of the column. Reads the bar series alone: a line crossing
+ * the chart is drawn over the columns, not stacked into them.
  */
-function tipResolver(
-  visible: BarSeriesConfig[],
-  config: BarChartConfig,
+export function barTipResolver(
+  visibleBars: AxisSeriesConfig[],
+  config: AxisChartConfig,
   rows: Record<string, any>[],
-) {
+): BarTipResolver {
   if (!config.stacked) return () => true
 
   return (series: BarSeriesConfig, rowIndex: number, value: number) => {
-    const stack = stackNameOf(series, config)
-    const outermost = visible
-      .filter((s) => stackNameOf(s, config) === stack)
+    const stack = stackKeyOf(series, config)
+    const outermost = visibleBars
+      .filter((s) => stackKeyOf(s, config) === stack)
       .filter((s) => sameDirection(toNumber(rows[rowIndex]?.[s.name]), value))
       .at(-1)
     return outermost?.name === series.name
   }
+}
+
+/** Which stack a bar belongs to, before the shape namespace is applied. */
+function stackKeyOf(series: BarSeriesConfig, config: AxisChartConfig) {
+  if (!config.stacked) return undefined
+  return series.stackName || 'stack'
 }
 
 function sameDirection(a: number | null, b: number) {
@@ -131,40 +77,34 @@ function borderRadius(value: number, horizontal: boolean, isRTL: boolean) {
     : [BAR_RADIUS, 0, 0, BAR_RADIUS]
 }
 
-function stackNameOf(series: BarSeriesConfig, config: BarChartConfig) {
-  if (!config.stacked) return undefined
-  return series.stackName || 'stack'
-}
-
 /** Every segment of a stack labels itself in place; only a free bar labels outside. */
 function dataLabelPosition(
-  config: BarChartConfig,
+  stacked: boolean,
   horizontal: boolean,
   isRTL: boolean,
 ) {
-  if (config.stacked) return 'inside'
+  if (stacked) return 'inside'
   if (horizontal) return isRTL ? 'left' : 'right'
   return 'top'
 }
 
-function buildSeries(
-  series: BarSeriesConfig,
-  config: BarChartConfig,
-  ctx: {
-    theme: ChartTheme
-    rows: Record<string, any>[]
-    horizontal: boolean
-    isRTL: boolean
-    color: string
-    /** Entry of the value-axis array this series is measured against. */
-    yAxisIndex: number
-    /** Whether this bar ends its column, in the direction that row runs. */
-    carriesTip: (
-      series: BarSeriesConfig,
-      rowIndex: number,
-      value: number,
-    ) => boolean
-  },
+export type BarSeriesContext = {
+  theme: ChartTheme
+  rows: Record<string, any>[]
+  horizontal: boolean
+  isRTL: boolean
+  color: string
+  /** Entry of the value-axis array this series is measured against. */
+  yAxisIndex: number
+  /** The echarts stack this bar joins, or undefined when it stands alone. */
+  stack?: string
+  carriesTip: BarTipResolver
+}
+
+export function buildBarSeries(
+  series: AxisSeriesConfig,
+  config: AxisChartConfig,
+  ctx: BarSeriesContext,
 ) {
   const { rows, horizontal, isRTL, color, theme, carriesTip, yAxisIndex } = ctx
 
@@ -181,14 +121,14 @@ function buildSeries(
     return { value: point, itemStyle: { borderRadius: rounded } }
   })
 
-  const position = dataLabelPosition(config, horizontal, isRTL)
+  const position = dataLabelPosition(Boolean(ctx.stack), horizontal, isRTL)
 
   const base = {
     type: 'bar',
     name: series.name,
     data,
     yAxisIndex,
-    stack: stackNameOf(series, config),
+    stack: ctx.stack,
     barMaxWidth: BAR_MAX_WIDTH,
     barCategoryGap: BAR_CATEGORY_GAP,
     itemStyle: { color },

--- a/src/charts/charts.md
+++ b/src/charts/charts.md
@@ -15,8 +15,16 @@ The stylesheet carries the `--chart-*` color tokens. See
 rebrand them. `palette` picks a ramp by name — `categorical`, `sequential` or
 `diverging` — or takes an explicit list of colors.
 
-Each component registers only the echarts modules it draws, so a page with one
-BarChart pays for bars and nothing else.
+Each component registers only the echarts modules it can draw. The three axis
+charts share bars and lines, because `seriesConfig` can recast any of their
+series into another shape; a page with only a DonutChart pays for none of it.
+
+## Mixing shapes
+
+`BarChart`, `LineChart` and `AreaChart` differ in one thing: the shape their
+series take by default. A `seriesConfig` entry can name a `type` of its own,
+which is how one chart draws bars against a line — see
+[combo charts](/docs/charts/bar-chart#mixing-shapes-combo-charts).
 
 ## Data shapes
 

--- a/src/charts/docs/AreaChart.api.md
+++ b/src/charts/docs/AreaChart.api.md
@@ -67,9 +67,9 @@
   },
   {
     name: 'seriesConfig',
-    description: 'Keyed by series identity: a `y` column, or a value of the `series` column.',
+    description: 'Keyed by series identity: a `y` column, or a value of the `series`\ncolumn. Carries the per-series look, and the `type` that draws a series\nas a shape other than the chart\'s own.',
     required: false,
-    type: 'Record<string, AreaSeriesStyle>'
+    type: 'Record<string, AreaChartSeriesStyle>'
   },
   {
     name: 'xAxis',

--- a/src/charts/docs/AreaChart.md
+++ b/src/charts/docs/AreaChart.md
@@ -16,4 +16,11 @@ chart-level alpha; a `seriesConfig` entry overrides it per series.
 
 <ComponentPreview name="Charts-AreaLatency" csr="true" self-layout />
 
+## Mixing shapes
+
+A `seriesConfig` entry can name a `type` of its own, drawing that series as a
+bar or a plain line instead of a band. Each shape stacks into a stack of its
+own, so `stacked` never sums a band on top of a column. See
+[combo charts](/docs/charts/bar-chart#mixing-shapes-combo-charts).
+
 <!-- @include: ./AreaChart.api.md -->

--- a/src/charts/docs/BarChart.api.md
+++ b/src/charts/docs/BarChart.api.md
@@ -67,9 +67,9 @@
   },
   {
     name: 'seriesConfig',
-    description: 'Keyed by series identity: a `y` column, or a value of the `series` column.',
+    description: 'Keyed by series identity: a `y` column, or a value of the `series`\ncolumn. Carries the per-series look, and the `type` that draws a series\nas a shape other than the chart\'s own.',
     required: false,
-    type: 'Record<string, BarSeriesStyle>'
+    type: 'Record<string, BarChartSeriesStyle>'
   },
   {
     name: 'xAxis',
@@ -103,7 +103,7 @@
   },
   {
     name: 'stacked',
-    description: '',
+    description: 'Series of the same shape sum on top of each other. Lines never stack.',
     required: false,
     type: 'boolean'
   },

--- a/src/charts/docs/BarChart.md
+++ b/src/charts/docs/BarChart.md
@@ -19,6 +19,25 @@ category.
 
 <ComponentPreview name="Charts-BarStackedLong" csr="true" self-layout />
 
+## Mixing shapes: combo charts
+
+A series is drawn as its chart's own shape until `seriesConfig` gives it a
+`type` of its own. That is what a combo chart is — bars for the amounts, a line
+for the rate they imply — and the recast series takes the style keys of the
+shape it names, `lineType` and `showDataPoints` here rather than `stackName`.
+
+Two units belong on two axes, so `y2` puts the rate on the second value axis
+with a format of its own. Combo and `y2` are the same chart: the rate is the
+reason the second axis exists.
+
+<ComponentPreview name="Charts-BarCombo" csr="true" self-layout />
+
+The tag names the shape the rest of the series take, so the same chart can be
+written from any of the three: `<LineChart>` with `revenue` and `expenses`
+recast to `type: 'bar'` draws exactly this plot. Lines are drawn over bars and
+bands whatever order the series were declared in, and `stacked` sums each shape
+into a stack of its own — a line never joins one.
+
 ## Horizontal bars
 
 `horizontal` moves the category axis to Y, which is how long labels stay

--- a/src/charts/docs/LineChart.api.md
+++ b/src/charts/docs/LineChart.api.md
@@ -67,9 +67,9 @@
   },
   {
     name: 'seriesConfig',
-    description: 'Keyed by series identity: a `y` column, or a value of the `series` column.',
+    description: 'Keyed by series identity: a `y` column, or a value of the `series`\ncolumn. Carries the per-series look, and the `type` that draws a series\nas a shape other than the chart\'s own.',
     required: false,
-    type: 'Record<string, LineSeriesStyle>'
+    type: 'Record<string, LineChartSeriesStyle>'
   },
   {
     name: 'xAxis',

--- a/src/charts/docs/LineChart.md
+++ b/src/charts/docs/LineChart.md
@@ -18,6 +18,10 @@ trend.
 
 <ComponentPreview name="Charts-LineDualAxis" csr="true" self-layout />
 
+A `seriesConfig` entry can also name a `type` of its own, which draws that
+series as a bar or an area instead — the amount as columns under the rate it
+implies. See [combo charts](/docs/charts/bar-chart#mixing-shapes-combo-charts).
+
 ## Gaps
 
 Null readings break the line, because a gap in the data should read as a gap.

--- a/src/charts/index.ts
+++ b/src/charts/index.ts
@@ -33,9 +33,11 @@ export {
 
 export type {
   AreaChartProps,
+  AreaChartSeriesStyle,
   AreaSeriesStyle,
   AxisChartProps,
   BarChartProps,
+  BarChartSeriesStyle,
   BarSeriesStyle,
   ChartBaseProps,
   ChartCategoryFormatter,
@@ -46,6 +48,7 @@ export type {
   FunnelChartProps,
   HeatmapChartProps,
   LineChartProps,
+  LineChartSeriesStyle,
   LineSeriesStyle,
   NumberCardProps,
   SeriesStyle,
@@ -54,6 +57,7 @@ export type {
 // Only what the props, emits, slots and template refs above reach for; the
 // config shapes the option builders read stay internal.
 export type {
+  AxisSeriesType,
   ChartDatapointEvent,
   ChartDir,
   ChartExposed,

--- a/src/charts/lineChartOptions.test.ts
+++ b/src/charts/lineChartOptions.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { buildLineChartOption } from './lineChartOptions'
+import { buildLineChartOption } from './axisChartOptions'
 import type { ChartTheme } from './theme'
-import type { LineChartConfig } from './types'
+import type { AxisChartConfig } from './types'
 
 const theme: ChartTheme = {
   palette: ['#111111', '#222222', '#333333'],
@@ -16,7 +16,7 @@ const theme: ChartTheme = {
   cellGap: '#ffffff',
 }
 
-function config(overrides: Partial<LineChartConfig> = {}): LineChartConfig {
+function config(overrides: Partial<AxisChartConfig> = {}): AxisChartConfig {
   return {
     data: [
       { month: 'Jan', sales: 10, refunds: 2 },
@@ -29,7 +29,7 @@ function config(overrides: Partial<LineChartConfig> = {}): LineChartConfig {
 }
 
 function build(
-  overrides: Partial<LineChartConfig> = {},
+  overrides: Partial<AxisChartConfig> = {},
   hiddenSeries?: string[],
 ) {
   return buildLineChartOption(config(overrides), { theme, hiddenSeries }) as any
@@ -240,7 +240,7 @@ describe('buildLineChartOption chrome', () => {
 })
 
 describe('buildLineChartOption second value axis', () => {
-  function dual(overrides: Partial<LineChartConfig> = {}) {
+  function dual(overrides: Partial<AxisChartConfig> = {}) {
     return build({
       y2Axis: { title: 'rate' },
       series: [{ name: 'sales' }, { name: 'refunds', axis: 'y2' }],

--- a/src/charts/lineChartOptions.ts
+++ b/src/charts/lineChartOptions.ts
@@ -1,89 +1,19 @@
-import type { EChartsCoreOption } from 'echarts/core'
 import { formatValue } from './format'
 import type { ChartTheme } from './theme'
 import {
-  axisChartBase,
-  buildAxisGrid,
-  buildCategoryAxis,
-  buildValueAxes,
-  hasSecondaryValueAxis,
-  resolveSeriesColors,
   toNumber,
-  valueAxisIndex,
-  visibleSeries,
   BLUR_OPACITY,
   DATA_LABEL_FONT_SIZE,
-  type AxisChartOptionContext,
+  LINE_Z,
 } from './axisChartCommon'
 import { mergeDeep } from './utils'
-import type { LineChartConfig, LineSeriesConfig } from './types'
-
-export type LineChartOptionContext = AxisChartOptionContext
+import type { AxisChartConfig, AxisSeriesConfig } from './types'
 
 const DEFAULT_LINE_WIDTH = 2
 /** Big enough to hit with a pointer, small enough not to read as a scatter plot. */
 const SYMBOL_SIZE = 6
 /** Room for a data label sitting above a point. */
-const DATA_LABEL_GUTTER = 24
-
-export function buildLineChartOption(
-  config: LineChartConfig,
-  context: LineChartOptionContext,
-): EChartsCoreOption {
-  return buildLineLikeOption(config, context)
-}
-
-/**
- * The line option, with a hook for the keys an area series adds on top. Area is
- * a line with a fill, so it shares the axes, the grid and the series entirely.
- */
-export function buildLineLikeOption<C extends LineChartConfig>(
-  config: C,
-  { theme, hiddenSeries = [] }: LineChartOptionContext,
-  seriesExtra?: (
-    series: C['series'][number],
-    color: string,
-  ) => Record<string, any>,
-): EChartsCoreOption {
-  const isRTL = config.dir === 'rtl'
-  const rows = config.data ?? []
-  const colors = resolveSeriesColors(config, theme)
-  const visible = visibleSeries(config.series, hiddenSeries)
-  const categories = rows.map((row) => row[config.xAxis.key])
-
-  const option = {
-    // A line has no width of its own to anchor the pointer to, so the crosshair
-    // is a rule rather than the band a bar chart shades.
-    ...axisChartBase(theme, 'line'),
-    grid: buildAxisGrid(config, {
-      horizontal: false,
-      isRTL,
-      labelGutter: config.series.some((s) => s.showDataLabels)
-        ? DATA_LABEL_GUTTER
-        : 0,
-    }),
-    // A line starts at the plot edge; the half-slot inset bars need would leave
-    // it floating away from the axis.
-    xAxis: buildCategoryAxis(config, theme, {
-      categories,
-      horizontal: false,
-      isRTL,
-      boundaryGap: false,
-    }),
-    yAxis: buildValueAxes(config, theme, { horizontal: false, isRTL }),
-    series: visible.map((series) =>
-      buildLineSeries(series, config, {
-        theme,
-        rows,
-        color: colors[series.name],
-        yAxisIndex: valueAxisIndex(series, hasSecondaryValueAxis(config)),
-        extra: seriesExtra?.(series, colors[series.name]),
-      }),
-    ),
-  }
-
-  return mergeDeep(option, config.echartOptions)
-}
+export const LINE_DATA_LABEL_GUTTER = 24
 
 export type LineSeriesContext = {
   theme: ChartTheme
@@ -91,27 +21,50 @@ export type LineSeriesContext = {
   color: string
   /** Entry of the value-axis array this series is measured against. */
   yAxisIndex?: number
+  /** True when the category axis is the Y axis, as on a horizontal bar chart. */
+  horizontal?: boolean
+  isRTL?: boolean
+  /** The echarts stack this series joins. Only an area ever gets one. */
+  stack?: string
+  /** Drawing plane. A line sits above the marks it is read against. */
+  z?: number
   /** Extra option keys layered on before the per-series escape hatch. */
   extra?: Record<string, any>
 }
 
 export function buildLineSeries(
-  series: LineSeriesConfig,
-  config: LineChartConfig,
+  series: AxisSeriesConfig,
+  config: AxisChartConfig,
   ctx: LineSeriesContext,
 ) {
-  const { rows, color, theme, extra, yAxisIndex = 0 } = ctx
+  const {
+    rows,
+    color,
+    theme,
+    extra,
+    yAxisIndex = 0,
+    horizontal = false,
+    isRTL = false,
+    z = LINE_Z,
+  } = ctx
 
-  const data = rows.map((row) => [
-    row[config.xAxis.key],
-    toNumber(row[series.name]),
-  ])
+  const data = rows.map((row) => {
+    const category = row[config.xAxis.key]
+    const value = toNumber(row[series.name])
+    return horizontal ? [value, category] : [category, value]
+  })
+
+  // On a horizontal chart the value runs along X, so the label clears the end
+  // of the line rather than sitting above it.
+  const position = horizontal ? (isRTL ? 'left' : 'right') : 'top'
 
   const base = {
     type: 'line',
     name: series.name,
     data,
     yAxisIndex,
+    stack: ctx.stack,
+    z,
     // Nulls read as gaps: bridging them invents data that was never measured.
     connectNulls: Boolean(config.connectNulls),
     smooth: Boolean(series.smooth),
@@ -134,10 +87,11 @@ export function buildLineSeries(
     },
     label: {
       show: Boolean(series.showDataLabels),
-      position: 'top',
+      position,
       color: theme.dataLabel,
       fontSize: DATA_LABEL_FONT_SIZE,
-      formatter: (params: any) => formatValue(params.value?.[1], 1, true),
+      formatter: (params: any) =>
+        formatValue(params.value?.[horizontal ? 0 : 1], 1, true),
     },
     labelLayout: { hideOverlap: true },
   }

--- a/src/charts/props.ts
+++ b/src/charts/props.ts
@@ -1,5 +1,6 @@
 import type { TimeGrain } from './format'
 import type {
+  AxisSeriesType,
   ChartDir,
   ChartPalette,
   DonutVariant,
@@ -71,6 +72,33 @@ export type AreaSeriesStyle = LineSeriesStyle & {
   fillOpacity?: number
 }
 
+/**
+ * One `seriesConfig` entry of a `BarChart`: bar keys, or another shape's keys
+ * once `type` names that shape. A chart whose series disagree about `type` is a
+ * combo chart — bars against a line, say — and the tag names the shape the rest
+ * of the series take.
+ */
+export type BarChartSeriesStyle =
+  | (BarSeriesStyle & { type?: 'bar' })
+  | (LineSeriesStyle & { type: 'line' })
+  | (AreaSeriesStyle & { type: 'area' })
+
+/** One `seriesConfig` entry of a `LineChart`. Line keys unless `type` says otherwise. */
+export type LineChartSeriesStyle =
+  | (LineSeriesStyle & { type?: 'line' })
+  | (BarSeriesStyle & { type: 'bar' })
+  | (AreaSeriesStyle & { type: 'area' })
+
+/** One `seriesConfig` entry of an `AreaChart`. Area keys unless `type` says otherwise. */
+export type AreaChartSeriesStyle =
+  | (AreaSeriesStyle & { type?: 'area' })
+  | (BarSeriesStyle & { type: 'bar' })
+  | (LineSeriesStyle & { type: 'line' })
+
+/** Every style key any shape understands, as the normalizer reads one. */
+export type AxisSeriesStyle = BarSeriesStyle &
+  AreaSeriesStyle & { type?: AxisSeriesType }
+
 export type AxisChartProps<Style extends SeriesStyle = SeriesStyle> =
   ChartBaseProps & {
     data: Record<string, any>[]
@@ -82,7 +110,11 @@ export type AxisChartProps<Style extends SeriesStyle = SeriesStyle> =
     y2?: string | string[]
     /** Grouping column, i.e. long data. Use with a single `y`. */
     series?: string
-    /** Keyed by series identity: a `y` column, or a value of the `series` column. */
+    /**
+     * Keyed by series identity: a `y` column, or a value of the `series`
+     * column. Carries the per-series look, and the `type` that draws a series
+     * as a shape other than the chart's own.
+     */
     seriesConfig?: Record<string, Style>
     xAxis?: ChartXAxisOptions
     yAxis?: ChartValueAxisOptions
@@ -92,17 +124,18 @@ export type AxisChartProps<Style extends SeriesStyle = SeriesStyle> =
     echartOptions?: EchartOptionsOverride
   }
 
-export type BarChartProps = AxisChartProps<BarSeriesStyle> & {
+export type BarChartProps = AxisChartProps<BarChartSeriesStyle> & {
+  /** Series of the same shape sum on top of each other. Lines never stack. */
   stacked?: boolean
   /** Bars run left-to-right; the category axis moves to Y. */
   horizontal?: boolean
 }
 
-export type LineChartProps = AxisChartProps<LineSeriesStyle> & {
+export type LineChartProps = AxisChartProps<LineChartSeriesStyle> & {
   connectNulls?: boolean
 }
 
-export type AreaChartProps = AxisChartProps<AreaSeriesStyle> & {
+export type AreaChartProps = AxisChartProps<AreaChartSeriesStyle> & {
   stacked?: boolean
   connectNulls?: boolean
   /** Chart-level default; `seriesConfig` overrides it per series. */

--- a/src/charts/seriesData.test.ts
+++ b/src/charts/seriesData.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { normalizeAxisChartProps } from './seriesData'
 import type { AxisChartProps, BarSeriesStyle, LineSeriesStyle } from './props'
-import type { BarChartConfig, LineChartConfig } from './types'
+import type { AxisChartConfig } from './types'
 
 const wideRows = [
   { month: 'Jan', sales: 10, refunds: 2 },
@@ -72,14 +72,14 @@ describe('normalizeAxisChartProps', () => {
   // What wave-2 components do: spread the normalized config, add the chart's own
   // props. Typechecked, so a drift from the internal config types fails the build.
   it('produces a config the chart-specific configs accept', () => {
-    const bar: BarChartConfig = {
+    const bar: AxisChartConfig = {
       ...normalize<BarSeriesStyle>({
         seriesConfig: { sales: { stackName: 'a' } },
       }).config,
       stacked: true,
       horizontal: true,
     }
-    const line: LineChartConfig = {
+    const line: AxisChartConfig = {
       ...normalize<LineSeriesStyle>({
         seriesConfig: { sales: { smooth: true } },
       }).config,

--- a/src/charts/seriesData.test.ts
+++ b/src/charts/seriesData.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { normalizeAxisChartProps } from './seriesData'
-import type { AxisChartProps, BarSeriesStyle, LineSeriesStyle } from './props'
+import type {
+  AxisChartProps,
+  BarChartSeriesStyle,
+  BarSeriesStyle,
+  LineSeriesStyle,
+} from './props'
 import type { AxisChartConfig } from './types'
 
 const wideRows = [
@@ -151,6 +156,43 @@ describe('normalizeAxisChartProps: seriesConfig', () => {
       seriesConfig: { sales: { label: 'Net sales' } },
     })
     expect(config.series[0].name).toBe('sales')
+  })
+
+  // The shape travels with the rest of the per-series look, so a saved combo
+  // config is one object spread into one tag.
+  it('carries the shape a series is recast to, and its style keys', () => {
+    const { config } = normalize<BarChartSeriesStyle>({
+      seriesConfig: {
+        refunds: { type: 'line', lineType: 'dashed', label: 'Refund rate' },
+      },
+    })
+    expect(config.series).toEqual([
+      { name: 'sales' },
+      {
+        name: 'refunds',
+        type: 'line',
+        lineType: 'dashed',
+        label: 'Refund rate',
+      },
+    ])
+  })
+
+  it('leaves the shape unset when nothing recasts the series', () => {
+    const { config } = normalize({ y: 'sales' })
+    expect(config.series[0].type).toBeUndefined()
+  })
+
+  it('recasts a series that sits on the second axis', () => {
+    const { config } = normalize<BarChartSeriesStyle>({
+      y: 'sales',
+      y2: 'refunds',
+      seriesConfig: { refunds: { type: 'line' } },
+    })
+    expect(config.series[1]).toEqual({
+      name: 'refunds',
+      type: 'line',
+      axis: 'y2',
+    })
   })
 })
 

--- a/src/charts/stories/BarCombo.vue
+++ b/src/charts/stories/BarCombo.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { BarChart } from 'frappe-ui/charts'
+import type { BarChartProps } from 'frappe-ui/charts'
+
+const monthly = [
+  { month: '2025-08-01', revenue: 144500, expenses: 121300, margin: 16.1 },
+  { month: '2025-09-01', revenue: 150700, expenses: 124800, margin: 17.2 },
+  { month: '2025-10-01', revenue: 157400, expenses: 129100, margin: 18.0 },
+  { month: '2025-11-01', revenue: 172700, expenses: 138600, margin: 19.7 },
+  { month: '2025-12-01', revenue: 188600, expenses: 152400, margin: 19.2 },
+  { month: '2026-01-01', revenue: 171700, expenses: 149900, margin: 12.7 },
+  { month: '2026-02-01', revenue: 177100, expenses: 151200, margin: 14.6 },
+  { month: '2026-03-01', revenue: 186700, expenses: 155800, margin: 16.6 },
+  { month: '2026-04-01', revenue: 193600, expenses: 159400, margin: 17.7 },
+  { month: '2026-05-01', revenue: 202100, expenses: 164300, margin: 18.7 },
+  { month: '2026-06-01', revenue: 209500, expenses: 168700, margin: 19.5 },
+  { month: '2026-07-01', revenue: 220200, expenses: 173500, margin: 21.2 },
+]
+
+// Amounts as columns, the rate they imply as a line over them: two units, so
+// the rate takes the second axis and its own format.
+const revenueAndMargin: BarChartProps = {
+  data: monthly,
+  x: 'month',
+  y: ['revenue', 'expenses'],
+  y2: 'margin',
+  xAxis: { type: 'time', timeGrain: 'month' },
+  yAxis: {
+    title: 'Amount',
+    format: (value) => `$${(value / 1000).toFixed(0)}k`,
+  },
+  y2Axis: {
+    title: 'Margin',
+    min: 0,
+    max: 30,
+    format: (value) => `${value.toFixed(1)}%`,
+  },
+  palette: 'categorical',
+  seriesConfig: {
+    expenses: { label: 'Operating expenses' },
+    margin: { type: 'line', label: 'Gross margin', showDataPoints: true },
+  },
+  title: 'Revenue against margin',
+  subtitle: 'Last 12 months',
+}
+</script>
+
+<template>
+  <div class="h-80 w-full">
+    <BarChart v-bind="revenueAndMargin" />
+  </div>
+</template>

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -42,12 +42,20 @@ export type ChartYAxisConfig = {
   echartOptions?: EchartOptionsOverride
 }
 
+/** The shape a series is drawn as. Mixing shapes in one chart is a combo chart. */
+export type AxisSeriesType = 'bar' | 'line' | 'area'
+
 export type AxisChartSeriesConfig = {
   /** Key in each data row that holds this series' value, and its identity. */
   name: string
   /** Display name. Falls back to the formatted `name`. */
   label?: string
   color?: string
+  /**
+   * Shape this series is drawn as. Unset draws it as the chart's own shape, so
+   * a `LineChart` series is a line until it says otherwise.
+   */
+  type?: AxisSeriesType
   /**
    * Which value axis this series is measured against. `'y2'` gives a series in
    * a different unit or magnitude its own scale, opposite the primary. Ignored
@@ -89,12 +97,6 @@ export type BarSeriesConfig = AxisChartSeriesConfig & {
   stackName?: string
 }
 
-export type BarChartConfig = AxisChartBaseConfig<BarSeriesConfig> & {
-  stacked?: boolean
-  /** Bars run left-to-right; the category axis moves to Y. */
-  horizontal?: boolean
-}
-
 export type LineSeriesConfig = AxisChartSeriesConfig & {
   /** Dash pattern of the line itself. Defaults to a solid stroke. */
   lineType?: 'solid' | 'dashed' | 'dotted'
@@ -109,14 +111,6 @@ export type LineSeriesConfig = AxisChartSeriesConfig & {
   smooth?: boolean
 }
 
-export type LineChartConfig = AxisChartBaseConfig<LineSeriesConfig> & {
-  /**
-   * Bridges gaps left by null or non-numeric values. Off by default: a break in
-   * the line is how missing data should read.
-   */
-  connectNulls?: boolean
-}
-
 export type AreaSeriesConfig = LineSeriesConfig & {
   /** Groups series into separate stacks. Only read when `stacked` is on. */
   stackName?: string
@@ -124,12 +118,33 @@ export type AreaSeriesConfig = LineSeriesConfig & {
   fillOpacity?: number
 }
 
-export type AreaChartConfig = AxisChartBaseConfig<AreaSeriesConfig> & {
-  connectNulls?: boolean
-  /** Areas sum on top of each other, drawn as opaque bands. */
-  stacked?: boolean
+/**
+ * One series as the option builder reads it. Every shape's style keys are here
+ * together because any cartesian chart may draw any of them — the keys that
+ * apply are the ones belonging to the series' own `type`.
+ */
+export type AxisSeriesConfig = BarSeriesConfig & AreaSeriesConfig
+
+/**
+ * The config behind every cartesian chart. Bar, line and area differ only in
+ * the shape their series default to, so one config covers all three — and a
+ * combo chart, which is a config whose series do not agree on a shape.
+ */
+export type AxisChartConfig = AxisChartBaseConfig<AxisSeriesConfig> & {
   /**
-   * Alpha of the fill under each line. Defaults to a faint wash that fades out
+   * Series of the same shape sum on top of each other: bars into columns,
+   * areas into bands. Lines never stack — a stacked line reads as an area.
+   */
+  stacked?: boolean
+  /** Bars run left-to-right; the category axis moves to Y. */
+  horizontal?: boolean
+  /**
+   * Bridges gaps left by null or non-numeric values. Off by default: a break in
+   * the line is how missing data should read.
+   */
+  connectNulls?: boolean
+  /**
+   * Alpha of the fill under each area. Defaults to a faint wash that fades out
    * towards the axis; stacked areas default to a solid band instead.
    */
   fillOpacity?: number


### PR DESCRIPTION
One chart can now draw bars, lines and areas together. This was the last thing the old charts
could do that charts v2 could not.

Targets `charts-v2` (#890), not `main`. Does #941. Decided on #885.

## What changed

A series is drawn as its chart's own shape, unless its `seriesConfig` entry names a `type`:

```vue
<BarChart
  :data="rows"
  x="month"
  :y="['revenue', 'expenses']"
  y2="margin"
  :series-config="{ margin: { type: 'line', label: 'Gross margin' } }"
  :y2-axis="{ title: 'Margin', format: (v) => `${v}%` }"
/>
```

`type` goes in `seriesConfig` rather than in a new prop or a fourth component. That way a saved
chart stays one object spread into one tag, which is how crm and helpdesk actually store them.
The three axis charts differ only in the default shape they hand their series, so any of them
can host the same mix.

Underneath, the three option builders became one. Anything the mix decides is decided across
every series, not just the visible ones, so clicking the legend never reshuffles the plot: any
bar means a shaded hover pointer, the label gutter is as wide as the widest series needs,
`stacked` adds each shape into its own stack, and a line always draws on top of the bars it is
read against.

It works with the second axis, and on a horizontal bar chart — where the old charts threw an
error, so this is better than what came before rather than equal to it.

Tests: 20 option tests and 4 component tests. Docs: a revenue-against-margin story on the
BarChart page. `spec/charts.md` has the API and the four decisions behind it.

## What this breaks

**Nothing that ships today.** `charts-v2` has never been released.

- **Nothing fails to build.** `seriesConfig` was widened, so configs written before this still
  type-check.
- **One quiet change inside the branch:** echarts stack names now carry the shape as a prefix
  (`stack` becomes `bar:stack`). You can only reach this through per-series `echartOptions`.
- **A cost, not a break:** all three axis charts now load both the bar and line echarts modules,
  because `seriesConfig` decides the shape while the page runs. A page using only `LineChart`
  now also carries the bar module. `charts.md` said the opposite and is corrected.

## What I did not do

- **The legend still draws a dot for every series.** The old charts used echarts' own legend,
  which draws a different icon per type. Making a mixed chart the one exception seemed worse than
  keeping it consistent. Flagged for #944.
- **`connectNulls` and `fillOpacity` stay chart-wide.** A line inside a bar chart can only reach
  them through per-series `echartOptions`. Not worth freezing a wider set of props at 1.0.0 for a
  rare case.
- **No changelog entry.** The whole v2 surface gets one entry when #890 merges.

## Checks

`yarn test` — 544 pass across 52 files.

`yarn type-check` — no new errors.

`yarn test:cypress` on `src/charts/*.cy.ts` — 67 pass.

`yarn docs:build` runs out of memory on this machine both before and after the change, so the new
docs page was checked through the dev server instead.

<!-- coverage-report:start -->
Coverage: 68.05% (+1.39% vs `main`)
<!-- coverage-report:end -->
