### PR TITLE
docs(philosophy): record the data-fetching naming carve-out under P1

### DIFF
--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -20,7 +20,7 @@ This is the rulebook that governs API design across `frappe-ui`. Every principle
 
 ### P1. Name behaviors, not interactions
 
-**Rule:** Event and slot names describe what happened to the component's state, not the physical input that produced it. Prefer `change`, `open`, `select`, `submit`, `dismiss` over `toggle`, `clickOutside`, `keydownEnter`.
+**Rule:** Event and slot names describe what happened to the component's state, not the physical input that produced it. The same holds for every name an export hands back — composable return members, `defineExpose` members, utility and plugin export names. Prefer `change`, `open`, `select`, `submit`, `dismiss` over `toggle`, `clickOutside`, `keydownEnter`.
 
 Exception: when the DOM event *is* the behavior (e.g. `click` on a `Button`), don't rename it. The principle applies when the component layers its own state or intent above the raw event.
 

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -38,6 +38,11 @@ Exception: when the DOM event *is* the behavior (e.g. `click` on a `Button`), do
 <TextInput @submit="..." />
 ```
 
+Accepted v1 carve-outs:
+- The v1 resource surface (`createResource`, `createListResource`, `createDocumentResource`) and the v2 data-fetching composables (`useCall`, `useDoc`, `useList`, `useDoctype`, `useNewDoc`) keep every member name they ship today — including three names for one fetch (v1 `fetch` / `reload` / `submit`, v2 `execute` / `fetch` / `reload`) and two for one loading ref (v2 `loading` / `isFetching`). These names don't meet the rule; renaming them costs every consumer a migration and buys a tidier surface, and that trade is worse than the violation.
+
+P13 freezes them at the v1 tag and ADR-0008 leaves no room for a compatible rename, so they ship as-is until `2.0.0`.
+
 ---
 
 ## Prop design


### PR DESCRIPTION
Two edits to P1.

Widens the rule to cover the names an export hands back — composable return members, `defineExpose` members, utility and plugin export names — not only events and slots. P1 was already applied that way (#946, and the carve-out below), but the written rule stopped at events and slots.

Adds a carve-out under P1 for the v1 resource surface and the v2 data-fetching composables. Both keep every member name they ship today, aliases included — three names for one fetch, two for one loading ref.

This is not a break, so it does not belong in the P13 list. It is a permanent naming violation, kept because renaming costs every consumer a migration for a cosmetic gain.

Records the read-side verdict from #933.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-955/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 67.47% (+0.03% vs `main`)
<!-- coverage-report:end -->

