### PR TITLE
refactor(Dropdown)!: remove placement, { group, items } and component rows

### DIFF
--- a/docs/components/recipes/TasksDesktop.vue
+++ b/docs/components/recipes/TasksDesktop.vue
@@ -993,12 +993,12 @@ function addComment() {
               <span class="text-sm text-ink-gray-5">
                 {{ visibleTasks.length }} tasks
               </span>
-              <Dropdown :options="groupByDropdownOptions" placement="right">
+              <Dropdown :options="groupByDropdownOptions" align="end">
                 <Button variant="ghost" icon-left="lucide-layers">
                   Group: {{ groupByLabel }}
                 </Button>
               </Dropdown>
-              <Dropdown :options="sortDropdownOptions" placement="right">
+              <Dropdown :options="sortDropdownOptions" align="end">
                 <Button variant="ghost" icon-left="lucide-arrow-up-down">
                   {{ sortLabel }}
                 </Button>

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -137,6 +137,64 @@ Option values are `string | number` everywhere. `Select` no longer accepts
 | `displayValue` slot prop | `summary` on `#summary`, or `selectedOptions`                       |
 | `toggleOpen` slot prop   | `setOpen(boolean)`                                                  |
 
+### Dropdown and ContextMenu
+
+| Before                                     | After                            |
+| ------------------------------------------ | -------------------------------- |
+| `placement` prop, `DropdownPlacement` type | `align`                          |
+| `{ group, items }`                         | `{ group, options }`             |
+| `component:` option rows                   | `slots: { item: fn }`            |
+| `DropdownExposed` type                     | nothing — it described a template ref surface that never existed; use `v-model:open` or the `close` slot prop |
+
+All three behavioral removals are silent in plain-JS apps — the old code still
+runs and renders wrong instead of failing — so check each one. TypeScript
+callers get errors instead: the removed keys stay in the types as `never`. A
+dev-mode console warning also fires when `items` or `component` reaches the
+menu at runtime.
+
+**`placement` is ignored now.** The menu falls back to `align="start"`, so a
+right-aligned menu quietly moves left:
+
+```vue
+<!-- Before -->
+<Dropdown :options="options" placement="right" />
+<Dropdown :options="options" placement="center" />
+
+<!-- After -->
+<Dropdown :options="options" align="end" />
+<Dropdown :options="options" align="center" />
+```
+
+**A `{ group, items }` entry renders an empty menu** — the group resolves to
+zero options:
+
+```ts
+// Before
+const actions = [{ group: 'Edit', items: [{ label: 'Rename', onClick: rename }] }]
+
+// After
+const actions = [{ group: 'Edit', options: [{ label: 'Rename', onClick: rename }] }]
+```
+
+**A `component:` row renders as a plain action row** using its `label`, which
+for most of these rows is empty:
+
+```ts
+// Before
+{ component: h(Button, { theme: 'red' }, () => 'Delete') }
+
+// After
+{
+  label: 'Delete',
+  slots: {
+    item: () => h(Button, { theme: 'red' }, () => 'Delete'),
+  },
+}
+```
+
+These apply identically to `ContextMenu`, which shares the option shape
+(`ContextMenuComponentOption` is removed with `DropdownComponentOption`).
+
 ### Custom rows
 
 `Select` and `MultiSelect` lost `#option`, and `Combobox` lost `render`. They

--- a/spec/dropdown.md
+++ b/spec/dropdown.md
@@ -68,7 +68,10 @@ up along that side, `offset` the gap in px, and `portalTo` where the content is
 teleported. `start` and `end` are direction-aware and flip under `dir="rtl"`.
 These are the same four props and the same defaults the selection pickers use.
 `matchTriggerWidth` sizes the menu to the trigger element, for menus acting as
-a select-like control under a wide custom trigger.
+a select-like control under a wide custom trigger. Note the deliberate
+difference from Popover's prop of the same name: Dropdown sets an exact
+`width` (a menu should match its trigger precisely), while Popover sets
+`minWidth` (a panel may need to grow beyond it).
 
 There is no `placement` prop. It was removed before `1.0.0` per
 [ADR-0008](./adr/0008-no-deprecated-members-in-1-0-0.md); `align` covers it

--- a/spec/dropdown.md
+++ b/spec/dropdown.md
@@ -38,23 +38,18 @@ become the generic replacement for `Select`.
 ### Props
 
 ```ts
-type PopoverSide = 'top' | 'right' | 'bottom' | 'left'
-type PopoverAlign = 'start' | 'center' | 'end'
-
-/** @deprecated use `align` with start | center | end */
-type DropdownPlacement = 'left' | 'center' | 'right'
+type DropdownSide = 'top' | 'right' | 'bottom' | 'left'
+type DropdownAlign = 'start' | 'center' | 'end'
 
 interface DropdownProps {
   button?: ButtonProps
   options?: DropdownOptions
   open?: boolean
-  side?: PopoverSide
-  align?: PopoverAlign
+  side?: DropdownSide
+  align?: DropdownAlign
   offset?: number
+  matchTriggerWidth?: boolean
   portalTo?: string | HTMLElement
-  emptyText?: string
-  /** @deprecated alias for `align`; maps left→start, center→center, right→end */
-  placement?: DropdownPlacement
 }
 ```
 
@@ -65,25 +60,24 @@ Defaults:
 - `side = 'bottom'`
 - `align = 'start'`
 - `offset = 4`
+- `matchTriggerWidth = false`
 - `portalTo = 'body'`
-- `emptyText = 'No options'`
 
 `side` picks which side of the trigger the menu opens on, `align` how it lines
 up along that side, `offset` the gap in px, and `portalTo` where the content is
 teleported. `start` and `end` are direction-aware and flip under `dir="rtl"`.
 These are the same four props and the same defaults the selection pickers use.
+`matchTriggerWidth` sizes the menu to the trigger element, for menus acting as
+a select-like control under a wide custom trigger.
 
-Compatibility rules for `placement`:
+There is no `placement` prop. It was removed before `1.0.0` per
+[ADR-0008](./adr/0008-no-deprecated-members-in-1-0-0.md); `align` covers it
+(`left`→`start`, `center`→`center`, `right`→`end`).
 
-- `placement` remains supported through `v1.x`
-- if `placement` is provided without `align`, it is silently mapped:
-  - `'left'` → `align: 'start'`
-  - `'center'` → `align: 'center'`
-  - `'right'` → `align: 'end'`
-- if both `placement` and `align` are provided, `align` wins and a dev warning
-  is emitted
-- docs should show `align` in primary examples; `placement` should only appear
-  in the deprecation table
+There is no `emptyText` prop. The empty state renders fixed copy
+(`"No options"`); `#empty` replaces it entirely. An action menu is rarely
+empty by data — usually every row was `condition()`-ed away — so a copy prop
+was never earned.
 
 State conventions:
 
@@ -221,50 +215,34 @@ interface DropdownSubmenuOption extends DropdownBaseOption {
   component?: never
 }
 
-/** @deprecated use `slots: { item: fn }` */
-interface DropdownComponentOption extends DropdownBaseOption {
-  component: any
-  label?: string
-  route?: never
-  submenu?: never
-  switch?: never
-  switchValue?: never
-}
-
 interface DropdownGroupOption {
   key?: string | number
   group: string
   hideLabel?: boolean
   theme?: DropdownTheme
   options: DropdownOption[]
-  /** @deprecated alias for `options` (Dropdown previously used `items`) */
-  items?: DropdownOption[]
 }
 
 type DropdownOption =
   | DropdownActionOption
   | DropdownSwitchOption
   | DropdownSubmenuOption
-  | DropdownComponentOption
 
 type DropdownOptions = Array<DropdownOption | DropdownGroupOption>
 ```
 
-Compatibility rule for the group field:
-
-- the canonical group entry is `{ group, options }`, matching `Combobox`,
-  `MultiSelect`, and `Select`
-- `{ group, items }` (the previous Dropdown shape) keeps working through
-  `v1.x` as a deprecated alias
-- if both `options` and `items` are provided on the same group entry,
-  `options` wins and a dev warning is emitted
-- if only `items` is provided, it is silently mapped to `options`
+The group entry is `{ group, options }`, matching `Combobox`, `MultiSelect`,
+and `Select`. Dropdown's previous `{ group, items }` shape and the `component:`
+escape-hatch row were removed before `1.0.0` per
+[ADR-0008](./adr/0008-no-deprecated-members-in-1-0-0.md); each keeps a `never`
+marker in the types so passing the old key is a type error rather than a
+silently ignored extra field, and a DEV-only console warning fires when either
+arrives at runtime.
 
 Notes:
 
 - `label` is required for every standard action, switch, and submenu row
-- `label` is optional only for `component` escape-hatch rows
-- `submenu`, `switch`, and `component` are mutually exclusive item modes
+- `submenu` and `switch` are mutually exclusive item modes
 - app-defined extra fields like `value`, `id`, `image`, `shortcut`, and
   analytics metadata are allowed and must be passed through unchanged to slot
   props
@@ -318,8 +296,6 @@ nothing. Other strings still route to `FeatherIcon` for back-compat.
 - leaf action rows close the dropdown on selection through menu semantics
 - switch rows do not auto-close on toggle
 - submenu rows open nested menu content and do not call `onClick`
-- `component` rows are escape hatches for exceptional content and do not receive
-  shell-owned prefix/label/suffix regions
 
 ### Disabled handling
 
@@ -347,8 +323,6 @@ renderers below are skipped):
 
 1. `#item` slot
 2. `item.slots.item`
-3. `item.component` — kept as a deprecated alias of `item.slots.item`; if
-   both are present, `slots.item` wins and a dev warning fires
 
 Prefix region:
 
@@ -425,130 +399,25 @@ That means:
 - `selected` is visual state only; it does not change the component into a
   single-select control
 
-## Keep supported in v1.x
+## Removed before `1.0.0`
 
-These stay supported:
+Removed under [ADR-0008](./adr/0008-no-deprecated-members-in-1-0-0.md) in the
+selection-and-menus sweep
+([#871](https://github.com/frappe/frappe-ui/issues/871)); before/afters live in
+[`migration.md`](../docs/content/docs/migration.md):
 
-- `button`
-- `options`
-- `placement` (as an alias for `align`)
-- `side`
-- `offset`
-- `portalTo`
-- grouped items, including the legacy `{ group, items }` shape
-- `submenu`
-- `switch`
-- `switchValue`
-- `component`
-- `#item`
-- current default trigger slot behavior
+- `placement` prop and the `DropdownPlacement` type — `align` replaces it
+- `{ group, items }` group entries — `{ group, options }` replaces them
+- `component:` option rows and the `DropdownComponentOption` type —
+  `slots: { item: fn }` replaces them
+- `DropdownExposed` — described a template-ref surface that never existed;
+  per [ADR-0012](./adr/0012-template-ref-surface.md), `Dropdown` exposes
+  nothing (`v-model:open` and the `close` slot prop cover it)
 
-## Deprecate
+## Row customization in JS
 
-Keep working, but deprecate for ordinary row customization:
-
-- `#item` as the default recommendation
-- `item.component` in favor of `item.slots` (use `slots.item` for the
-  full-row escape hatch; use `slots.prefix` / `slots.label` /
-  `slots.suffix` for per-region customization)
-- `placement` prop in favor of `align`
-- `{ group, items }` group entries in favor of `{ group, options }` (for
-  symmetry with `Combobox` / `MultiSelect` / `Select`)
-
-Keep as escape hatches:
-
-- deeply custom rows
-- destructive full-width special rows
-- embedded app selectors or similar exceptional content
-
-Do **not** deprecate:
-
-- `onClick`
-- `condition`
-- `route`
-- `submenu`
-- `switch`
-
-## Migration path
-
-### Old
-
-```vue
-<Dropdown :options="items">
-  <template #item="{ item }">
-    <button class="flex h-7 w-full items-center justify-between rounded px-2 hover:bg-surface-gray-3">
-      <span>{{ item.label }}</span>
-      <LucideCheck v-if="active === item.value" class="size-4" />
-    </button>
-  </template>
-</Dropdown>
-```
-
-### New
-
-```vue
-<Dropdown :options="items">
-  <template #item-suffix="{ item }">
-    <LucideCheck v-if="item.selected" class="size-4" />
-  </template>
-</Dropdown>
-```
-
-### `{ group, items }` → `{ group, options }` rename
-
-Old:
-
-```ts
-const actions = [
-  {
-    group: 'Edit',
-    items: [
-      { label: 'Rename', onClick: rename },
-      { label: 'Duplicate', onClick: duplicate },
-    ],
-  },
-]
-```
-
-New:
-
-```ts
-const actions = [
-  {
-    group: 'Edit',
-    options: [
-      { label: 'Rename', onClick: rename },
-      { label: 'Duplicate', onClick: duplicate },
-    ],
-  },
-]
-```
-
-`{ group, items }` keeps working through `v1.x`; a dev warning fires if
-both `options` and `items` are provided on the same group entry.
-
-### Old: full-row escape hatch via `component`
-
-```ts
-{
-  label: 'Delete',
-  component: h(Button, { variant: 'solid', theme: 'red' }, () => 'Delete'),
-}
-```
-
-### New: full-row escape hatch via `slots.item`
-
-```ts
-{
-  label: 'Delete',
-  slots: {
-    item: () =>
-      h(Button, { variant: 'solid', theme: 'red' }, () => 'Delete'),
-  },
-}
-```
-
-### New: per-region `slots` (preferred when the shell still makes sense)
+For rows authored in JavaScript where no template is in reach, per-region
+`slots` functions are preferred when the shell still makes sense:
 
 ```ts
 import { h } from 'vue'
@@ -568,14 +437,37 @@ const options = users.map((user) => ({
 }))
 ```
 
-### v1.x stance
+`slots.item` takes over the whole row instead — reserve it for deeply custom
+rows, destructive full-width special rows, and similar exceptional content:
 
-`component` is still supported as a deprecated alias for `slots.item`. Use
-`slots.prefix` / `slots.label` / `slots.suffix` for ordinary
-icon/label/check/suffix customization authored in JS; use `slots.item`
-when the whole row needs to be taken over.
+```ts
+{
+  label: 'Delete',
+  slots: {
+    item: () =>
+      h(Button, { variant: 'solid', theme: 'red' }, () => 'Delete'),
+  },
+}
+```
 
 ## Changelog
+
+### 2026-08-08
+
+- **ADR-0008 removals.** `placement`, `{ group, items }`, `component:` rows,
+  and the phantom `DropdownExposed` type are gone (see
+  [Removed before `1.0.0`](#removed-before-100)). The spec previously
+  mandated keeping the first three as deprecated aliases through `v1.x`;
+  ADR-0008 postdates that promise and wins.
+- **`matchTriggerWidth` documented.** The prop shipped in the betas but the
+  spec predated it.
+- **`emptyText` dropped from the spec.** It was never implemented; the empty
+  state is fixed copy plus the `#empty` slot, and an action menu that is
+  empty by data rather than by `condition()` is rare enough that a copy prop
+  never earned its place.
+- **The trigger forwards `disabled` to the menu primitive.** Previously only
+  the generated `Button` was natively disabled; a custom trigger slot with a
+  `disabled` attribute could still be opened by keyboard or synthetic clicks.
 
 ### 2026-04-24
 

--- a/src/components/ContextMenu/ContextMenu.cy.ts
+++ b/src/components/ContextMenu/ContextMenu.cy.ts
@@ -204,4 +204,65 @@ describe('ContextMenu', () => {
       expect(event.defaultPrevented).to.be.false
     })
   })
+
+  it('disabled items do not fire onClick', () => {
+    const onClick = cy.stub().as('onClick')
+
+    cy.mount(ContextMenu, {
+      props: { options: [{ label: 'Delete', disabled: true, onClick }] },
+      slots: { default: trigger },
+    })
+
+    cy.get('[data-cy=trigger]').rightclick()
+    cy.get('[role=menuitem]').should('have.attr', 'data-disabled')
+    cy.get('[role=menuitem]').click({ force: true })
+    cy.get('@onClick').should('not.have.been.called')
+  })
+
+  it('supports arrow keys, Enter, and Escape', () => {
+    const onClick = cy.stub().as('onClick')
+
+    cy.mount(ContextMenu, {
+      props: {
+        options: [
+          { label: 'Open', onClick: () => {} },
+          { label: 'Rename', onClick },
+        ],
+      },
+      slots: { default: trigger },
+    })
+
+    cy.get('[data-cy=trigger]').rightclick()
+    cy.get('[role=menu]').type('{downarrow}{downarrow}')
+    cy.contains('[role=menuitem]', 'Rename').should(
+      'have.attr',
+      'data-highlighted',
+    )
+    cy.focused().type('{enter}')
+    cy.get('@onClick').should('have.been.called')
+    cy.get('[role=menu]').should('not.exist')
+
+    cy.get('[data-cy=trigger]').rightclick()
+    cy.get('[role=menu]').type('{esc}')
+    cy.get('[role=menu]').should('not.exist')
+  })
+
+  it('renders the empty state, and #empty replaces it', () => {
+    cy.mount(ContextMenu, {
+      props: { options: [] },
+      slots: { default: trigger },
+    })
+    cy.get('[data-cy=trigger]').rightclick()
+    cy.get('[data-slot=empty]').should('contain.text', 'No options')
+
+    cy.mount(ContextMenu, {
+      props: { options: [] },
+      slots: {
+        default: trigger,
+        empty: () => h('span', {}, 'Nothing here'),
+      },
+    })
+    cy.get('[data-cy=trigger]').rightclick()
+    cy.get('[data-slot=empty]').should('contain.text', 'Nothing here')
+  })
 })

--- a/src/components/ContextMenu/index.ts
+++ b/src/components/ContextMenu/index.ts
@@ -1,2 +1,20 @@
 export { default as ContextMenu } from './ContextMenu.vue'
-export * from './types'
+export type {
+  ContextMenuActionOption,
+  ContextMenuBaseOption,
+  ContextMenuGroupOption,
+  ContextMenuGroupSlotProps,
+  ContextMenuItem,
+  ContextMenuItemSlotProps,
+  ContextMenuItemSlots,
+  ContextMenuOption,
+  ContextMenuOptions,
+  ContextMenuProps,
+  ContextMenuSlotFn,
+  ContextMenuSlotProps,
+  ContextMenuSlots,
+  ContextMenuSubmenuOption,
+  ContextMenuSwitchOption,
+  ContextMenuTheme,
+  ContextMenuTriggerSlotProps,
+} from './types'

--- a/src/components/ContextMenu/types.ts
+++ b/src/components/ContextMenu/types.ts
@@ -8,7 +8,6 @@ export type {
   MenuActionOption as ContextMenuActionOption,
   MenuSwitchOption as ContextMenuSwitchOption,
   MenuSubmenuOption as ContextMenuSubmenuOption,
-  MenuComponentOption as ContextMenuComponentOption,
   MenuGroupOption as ContextMenuGroupOption,
   MenuOption as ContextMenuOption,
   MenuItem as ContextMenuItem,

--- a/src/components/Dropdown/Dropdown.api.md
+++ b/src/components/Dropdown/Dropdown.api.md
@@ -29,14 +29,8 @@
     name: 'align',
     description: 'Alignment of the dropdown content along the trigger edge.',
     required: false,
-    type: 'DropdownAlign'
-  },
-  {
-    name: 'placement',
-    description: 'Placement of the dropdown relative to the trigger.',
-    required: false,
-    type: 'DropdownPlacement',
-    deprecated: 'use `align` instead; `placement` remains as a back-compat alias through v1.x'
+    type: 'DropdownAlign',
+    default: '"start"'
   },
   {
     name: 'side',

--- a/src/components/Dropdown/Dropdown.cy.ts
+++ b/src/components/Dropdown/Dropdown.cy.ts
@@ -1,5 +1,5 @@
 import Dropdown from './Dropdown.vue'
-import { defineComponent, h } from 'vue'
+import { h } from 'vue'
 
 const options = [
   { label: 'Edit', icon: 'lucide-edit' },
@@ -64,12 +64,6 @@ const nestedSubmenuActions = [
   },
 ]
 
-const ComponentItem = defineComponent({
-  render() {
-    return h('button', { 'data-cy': 'component-item' }, 'Archive')
-  },
-})
-
 describe('Dropdown', () => {
   it('Rendering', () => {
     cy.mount(Dropdown, { props: { options } })
@@ -121,15 +115,22 @@ describe('Dropdown', () => {
     cy.get('[role=menu]').should('not.exist')
   })
 
-  it('keeps component items as the outer menuitem element', () => {
+  it('keeps slots.item rows as the outer menuitem element', () => {
     cy.mount(Dropdown, {
       props: {
-        options: [{ component: ComponentItem }],
+        options: [
+          {
+            label: 'Archive',
+            slots: {
+              item: () => h('button', { 'data-cy': 'slots-item' }, 'Archive'),
+            },
+          },
+        ],
       },
     })
 
     cy.get('[aria-haspopup=menu]').click()
-    cy.get('[data-cy="component-item"]').should('have.attr', 'role', 'menuitem')
+    cy.get('[data-cy="slots-item"]').should('have.attr', 'role', 'menuitem')
   })
 
   it('opens on pointer press, not on release', () => {
@@ -219,5 +220,133 @@ describe('Dropdown', () => {
     })
 
     cy.get('[aria-haspopup=menu]').should('have.text', 'Trigger')
+  })
+
+  it('round-trips v-model:open', () => {
+    cy.mount(Dropdown, {
+      props: {
+        options,
+        open: true,
+        'onUpdate:open': cy.spy().as('updateOpen'),
+      },
+    })
+
+    cy.get('[role=menu]').should('exist')
+    cy.get('body').type('{esc}')
+    cy.get('@updateOpen').should('have.been.calledWith', false)
+  })
+
+  it('disables the trigger via button.disabled', () => {
+    cy.mount(Dropdown, {
+      props: { options, button: { label: 'Options', disabled: true } },
+    })
+
+    cy.get('[aria-haspopup=menu]').should('be.disabled')
+    cy.get('[aria-haspopup=menu]').click({ force: true })
+    cy.get('[role=menu]').should('not.exist')
+  })
+
+  it('disabled items do not fire onClick and are skipped by the keyboard', () => {
+    const onClick = cy.spy().as('onClick')
+    cy.mount(Dropdown, {
+      props: {
+        options: [
+          { label: 'Enabled', onClick: () => {} },
+          { label: 'Disabled', disabled: true, onClick },
+        ],
+      },
+    })
+
+    cy.get('[aria-haspopup=menu]').click()
+    cy.contains('[role=menuitem]', 'Disabled').should(
+      'have.attr',
+      'data-disabled',
+    )
+    cy.contains('[role=menuitem]', 'Disabled').click({ force: true })
+    cy.get('@onClick').should('not.have.been.called')
+
+    // Arrow navigation wraps over the disabled item back to the enabled one.
+    cy.get('[role=menu]').type('{downarrow}')
+    cy.contains('[role=menuitem]', 'Enabled').should(
+      'have.attr',
+      'data-highlighted',
+    )
+    cy.get('[role=menu]').type('{downarrow}')
+    cy.contains('[role=menuitem]', 'Enabled').should(
+      'have.attr',
+      'data-highlighted',
+    )
+  })
+
+  it('supports arrow keys, Enter, and Escape', () => {
+    const onClick = cy.spy().as('onClick')
+    cy.mount(Dropdown, {
+      props: {
+        options: [
+          { label: 'Edit', onClick: () => {} },
+          { label: 'Delete', onClick },
+        ],
+      },
+    })
+
+    cy.get('[aria-haspopup=menu]').click()
+    cy.get('[role=menu]').type('{downarrow}{downarrow}')
+    cy.contains('[role=menuitem]', 'Delete').should(
+      'have.attr',
+      'data-highlighted',
+    )
+    cy.focused().type('{enter}')
+    cy.get('@onClick').should('have.been.called')
+    cy.get('[role=menu]').should('not.exist')
+
+    cy.get('[aria-haspopup=menu]').click()
+    cy.get('[role=menu]').type('{esc}')
+    cy.get('[role=menu]').should('not.exist')
+  })
+
+  it('renders group labels, and #group-label overrides them', () => {
+    const grouped = [
+      { group: 'Edit', options: [{ label: 'Rename' }] },
+    ]
+    cy.mount(Dropdown, { props: { options: grouped } })
+    cy.get('[aria-haspopup=menu]').click()
+    cy.get('[data-slot=group-label]').should('contain.text', 'Edit')
+
+    cy.mount(Dropdown, {
+      props: { options: grouped },
+      slots: {
+        'group-label': ({ group }) =>
+          h('span', { 'data-cy': 'group-label' }, group.group.toUpperCase()),
+      },
+    })
+    cy.get('[aria-haspopup=menu]').click()
+    cy.get('[data-cy=group-label]').should('have.text', 'EDIT')
+  })
+
+  it('renders the empty state, and #empty replaces it', () => {
+    cy.mount(Dropdown, {
+      props: { options: [{ label: 'Hidden', condition: () => false }] },
+    })
+    cy.get('[aria-haspopup=menu]').click()
+    cy.get('[data-slot=empty]').should('contain.text', 'No options')
+
+    cy.mount(Dropdown, {
+      props: { options: [] },
+      slots: { empty: () => h('span', {}, 'Nothing here') },
+    })
+    cy.get('[aria-haspopup=menu]').click()
+    cy.get('[data-slot=empty]').should('contain.text', 'Nothing here')
+  })
+
+  it('does not render the removed { group, items } shape', () => {
+    cy.mount(Dropdown, {
+      props: {
+        options: [{ group: 'Edit', items: [{ label: 'Rename' }] }] as any,
+      },
+    })
+
+    cy.get('[aria-haspopup=menu]').click()
+    cy.get('[role=menuitem]').should('not.exist')
+    cy.get('[data-slot=empty]').should('exist')
   })
 })

--- a/src/components/Dropdown/Dropdown.md
+++ b/src/components/Dropdown/Dropdown.md
@@ -40,6 +40,6 @@ A real workspace + profile menu — nested Apps / Theme submenus, account-group 
 ## Notes
 
 - Prefer `#item-prefix`, `#item-label`, and `#item-suffix` when you want to customize the standard dropdown row.
-- Use `#item` or `item.component` only when you need to replace the entire row. Those escape hatches own the outer menu item element, so they should be reserved for exceptional cases.
+- Use the `#item` slot, or `slots: { item: fn }` on a single option, only when you need to replace the entire row. Those escape hatches own the outer menu item element, so they should be reserved for exceptional cases.
 
 <!-- @include: ./Dropdown.api.md -->

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -63,7 +63,7 @@ import {
 import { Button } from '../Button'
 import Menu from '../Menu/Menu.vue'
 import type { DropdownProps, DropdownSlots } from './types'
-import { menuClasses, normalizeMenuOptions } from '../Menu/utils'
+import { menuClasses, normalizeMenuOptions, warnRemoved } from '../Menu/utils'
 
 defineOptions({
   inheritAttrs: false,
@@ -105,6 +105,12 @@ const triggerDisabled = computed(() => {
     (attrs.disabled !== undefined && attrs.disabled !== false)
   )
 })
+
+if (import.meta.env.DEV && 'placement' in attrs) {
+  warnRemoved(
+    '[Dropdown] `placement` is removed and ignored; use `align` (`placement="right"` → `align="end"`, `placement="center"` → `align="center"`).',
+  )
+}
 
 /**
  * Workaround for reka-ui 2.9.9: `DropdownMenuTrigger` binds only `click`, so

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -1,6 +1,10 @@
 <template>
   <DropdownMenuRoot v-model:open="openModel" v-slot="{ open }">
-    <DropdownMenuTrigger as-child @pointerdown="openOnPointerDown">
+    <DropdownMenuTrigger
+      as-child
+      :disabled="triggerDisabled"
+      @pointerdown="openOnPointerDown"
+    >
       <slot
         v-if="$slots.trigger"
         name="trigger"
@@ -72,6 +76,7 @@ const slots = useSlots()
 const props = withDefaults(defineProps<DropdownProps>(), {
   options: () => [],
   side: 'bottom',
+  align: 'start',
   offset: 4,
   portalTo: 'body',
 })
@@ -93,12 +98,6 @@ const groups = computed(() => {
   return normalizeMenuOptions(props.options)
 })
 
-const align = computed(() => {
-  if (props.align !== undefined) return props.align
-  if (props.placement === 'right') return 'end' as const
-  if (props.placement === 'center') return 'center' as const
-  return 'start' as const
-})
 
 const triggerDisabled = computed(() => {
   return (

--- a/src/components/Dropdown/index.ts
+++ b/src/components/Dropdown/index.ts
@@ -1,2 +1,23 @@
 export { default as Dropdown } from './Dropdown.vue'
-export * from './types'
+export type {
+  DropdownActionOption,
+  DropdownAlign,
+  DropdownBaseOption,
+  DropdownEmits,
+  DropdownGroupOption,
+  DropdownGroupSlotProps,
+  DropdownItem,
+  DropdownItemSlotProps,
+  DropdownItemSlots,
+  DropdownOption,
+  DropdownOptions,
+  DropdownProps,
+  DropdownSide,
+  DropdownSlotFn,
+  DropdownSlotProps,
+  DropdownSlots,
+  DropdownSubmenuOption,
+  DropdownSwitchOption,
+  DropdownTheme,
+  DropdownTriggerSlotProps,
+} from './types'

--- a/src/components/Dropdown/types.ts
+++ b/src/components/Dropdown/types.ts
@@ -9,7 +9,6 @@ export type {
   MenuActionOption as DropdownActionOption,
   MenuSwitchOption as DropdownSwitchOption,
   MenuSubmenuOption as DropdownSubmenuOption,
-  MenuComponentOption as DropdownComponentOption,
   MenuGroupOption as DropdownGroupOption,
   MenuOption as DropdownOption,
   MenuItem as DropdownItem,
@@ -19,7 +18,6 @@ export type {
   MenuGroupSlotProps as DropdownGroupSlotProps,
 } from '../Menu/types'
 
-export type DropdownPlacement = 'left' | 'right' | 'center'
 export type DropdownSide = 'top' | 'right' | 'bottom' | 'left'
 export type DropdownAlign = 'start' | 'center' | 'end'
 
@@ -35,12 +33,6 @@ export interface DropdownProps {
 
   /** Alignment of the dropdown content along the trigger edge. */
   align?: DropdownAlign
-
-  /**
-   * Placement of the dropdown relative to the trigger.
-   * @deprecated use `align` instead; `placement` remains as a back-compat alias through v1.x
-   */
-  placement?: DropdownPlacement
 
   /** Side of the trigger the dropdown appears on. */
   side?: DropdownSide
@@ -75,9 +67,4 @@ export type DropdownSlots = Omit<MenuSlots, 'default' | 'trigger'> & {
 export interface DropdownEmits {
   /** Fired when the dropdown open state changes. */
   'update:open': [value: boolean]
-}
-
-export interface DropdownExposed {
-  /** Closes the dropdown menu. */
-  close: () => void
 }

--- a/src/components/ItemListRow/ItemListRow.cy.ts
+++ b/src/components/ItemListRow/ItemListRow.cy.ts
@@ -49,4 +49,30 @@ describe('ItemListRow', () => {
 
     cy.get('[data-slot="item-list-row"]').should('have.attr', 'data-disabled')
   })
+
+  it('renders #prefix and #suffix content, and #label over the default slot', () => {
+    cy.mount(ItemListRow, {
+      slots: {
+        default: 'Default label',
+        label: 'Named label',
+        prefix: 'P',
+        suffix: 'S',
+      },
+    })
+
+    cy.get('[data-slot="item-prefix"]').should('contain.text', 'P')
+    cy.get('[data-slot="item-suffix"]').should('contain.text', 'S')
+    cy.get('[data-slot="item-label"]')
+      .should('contain.text', 'Named label')
+      .and('not.contain.text', 'Default label')
+  })
+
+  it('reflects size via data-size', () => {
+    cy.mount(ItemListRow, {
+      props: { size: 'lg' },
+      slots: { default: 'Row' },
+    })
+
+    cy.get('[data-slot="item-list-row"]').should('have.attr', 'data-size', 'lg')
+  })
 })

--- a/src/components/ItemListRow/index.ts
+++ b/src/components/ItemListRow/index.ts
@@ -1,2 +1,2 @@
 export { default as ItemListRow } from './ItemListRow.vue'
-export * from './types'
+export type { ItemListRowProps, ItemListSize } from './types'

--- a/src/components/Menu/Menu.vue
+++ b/src/components/Menu/Menu.vue
@@ -9,7 +9,6 @@ import {
   menuClasses,
   getMenuBackgroundColor,
   groupHasIcons,
-  isMenuComponentOption,
   isMenuSubmenuOption,
   isMenuSwitchOption,
   normalizeMenuOptions,
@@ -154,19 +153,6 @@ async function handleItemSelect(item: MenuOption, event: Event) {
               item.slots.item({ item, close, selected: !!item.selected })
             "
           />
-        </component>
-
-        <component
-          :is="primitives.Item"
-          v-else-if="isMenuComponentOption(item)"
-          as-child
-          data-slot="item"
-          :data-disabled="item.disabled ? '' : undefined"
-          :disabled="item.disabled"
-          class="data-[disabled]:cursor-not-allowed"
-          @select="handleItemSelect(item, $event)"
-        >
-          <component :is="item.component" :active="false" />
         </component>
 
         <component

--- a/src/components/Menu/MenuItemContent.vue
+++ b/src/components/Menu/MenuItemContent.vue
@@ -192,10 +192,9 @@ function handleSwitchChange(value: boolean) {
       <Switch
         v-else-if="trailing === 'switch'"
         class="ml-auto"
-        label-classes="cursor-pointer font-normal"
         :disabled="item.disabled"
         :model-value="item.switchValue || false"
-        @change="handleSwitchChange"
+        @update:model-value="handleSwitchChange"
       />
       <span
         v-else-if="trailing === 'submenu'"

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -96,22 +96,6 @@ export interface MenuSubmenuOption extends MenuBaseOption {
   component?: never
 }
 
-export interface MenuComponentOption extends MenuBaseOption {
-  /**
-   * Custom component rendered in place of the standard menu row.
-   * @deprecated use `slots.item` for the full-row escape hatch instead
-   */
-  component: any
-
-  /** Optional label used by custom renderers. */
-  label?: string
-
-  route?: never
-  submenu?: never
-  switch?: never
-  switchValue?: never
-}
-
 export interface MenuGroupOption {
   /** Stable key for the group wrapper. */
   key?: string | number
@@ -119,18 +103,12 @@ export interface MenuGroupOption {
   /** Label rendered above the grouped items. */
   group: string
 
-  /**
-   * Items rendered inside the group. Optional in the type so the
-   * deprecated `items` alias still typechecks; provide one of
-   * `options` or `items`.
-   */
-  options?: MenuOption[]
+  /** Items rendered inside the group. */
+  options: MenuOption[]
 
-  /**
-   * @deprecated use `options`. Accepted only as a back-compat alias for
-   * Dropdown's previous `{ group, items }` shape.
-   */
-  items?: MenuOption[]
+  // Removed `{ group, items }` shape. `never` keeps the old key a type
+  // error instead of a silently ignored extra field.
+  items?: never
 
   /** Hides the group heading while preserving grouping. */
   hideLabel?: boolean
@@ -139,11 +117,7 @@ export interface MenuGroupOption {
   theme?: MenuTheme
 }
 
-export type MenuOption =
-  | MenuActionOption
-  | MenuSwitchOption
-  | MenuSubmenuOption
-  | MenuComponentOption
+export type MenuOption = MenuActionOption | MenuSwitchOption | MenuSubmenuOption
 
 export type MenuItem = MenuOption | MenuGroupOption
 export type MenuOptions = Array<MenuItem>

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -30,9 +30,19 @@ export function isMenuGroupOption(item: MenuItem): item is MenuGroupOption {
   return 'group' in item && ('options' in item || 'items' in item)
 }
 
+// These fire from computeds on every recompute; warn once per message, not
+// once per offending row per render.
+const warned = new Set<string>()
+
+export function warnRemoved(message: string) {
+  if (!import.meta.env.DEV || warned.has(message)) return
+  warned.add(message)
+  console.warn(message)
+}
+
 function resolveGroupChildren(group: MenuGroupOption): MenuOption[] {
-  if (import.meta.env.DEV && !group.options && (group as any).items) {
-    console.warn(
+  if (!group.options && (group as any).items) {
+    warnRemoved(
       '[Menu] `{ group, items }` is not supported; this group will not render. Rename `items` to `options`.',
     )
   }
@@ -49,8 +59,8 @@ export function isMenuSubmenuOption(item: MenuOption) {
 }
 
 function shouldRenderOption(option: MenuOption) {
-  if (import.meta.env.DEV && 'component' in option && option.component) {
-    console.warn(
+  if ('component' in option && option.component) {
+    warnRemoved(
       '[Menu] `component:` rows are not supported; the row renders as a plain action. Use `slots: { item: fn }` for a full-row replacement.',
     )
   }

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -7,8 +7,8 @@ import type {
 } from './types'
 
 /**
- * Group object after normalization. `options` is guaranteed to be present
- * (the deprecated `items` alias has been resolved into it).
+ * Group object after normalization: conditions applied, themes and
+ * selection flags resolved, implicit groups materialized.
  */
 export type NormalizedMenuGroup = MenuGroupOption & {
   options: MenuOption[]
@@ -31,13 +31,13 @@ export function isMenuGroupOption(item: MenuItem): item is MenuGroupOption {
 }
 
 function resolveGroupChildren(group: MenuGroupOption): MenuOption[] {
-  if (import.meta.env.DEV && group.options && group.items) {
+  if (import.meta.env.DEV && !group.options && (group as any).items) {
     console.warn(
-      '[Menu] grouped entry has both `options` and `items`. `options` wins; `items` is the deprecated alias.',
+      '[Menu] `{ group, items }` is not supported; this group will not render. Rename `items` to `options`.',
     )
   }
 
-  return group.options ?? group.items ?? []
+  return group.options ?? []
 }
 
 export function isMenuSwitchOption(item: MenuOption) {
@@ -48,11 +48,12 @@ export function isMenuSubmenuOption(item: MenuOption) {
   return Array.isArray(item.submenu)
 }
 
-export function isMenuComponentOption(item: MenuOption) {
-  return 'component' in item && Boolean(item.component)
-}
-
 function shouldRenderOption(option: MenuOption) {
+  if (import.meta.env.DEV && 'component' in option && option.component) {
+    console.warn(
+      '[Menu] `component:` rows are not supported; the row renders as a plain action. Use `slots: { item: fn }` for a full-row replacement.',
+    )
+  }
   return option.condition ? option.condition() : true
 }
 

--- a/v1-release/changelog.md
+++ b/v1-release/changelog.md
@@ -301,27 +301,48 @@ new theme switchers, compose `Select` with the `useColorScheme` composable.
 Before/after for each silent break is in the
 [migration guide](../docs/content/docs/migration.md#autocomplete-removed).
 
-### Dropdown — group field standardized on `options`
+### Dropdown / ContextMenu — deprecated members removed (ADR-0008)
 
-Matches `Combobox`, `MultiSelect`, `Select`. Old `{ group, items }` shape
-is a deprecated alias; warns if both are provided on the same entry.
+Three surfaces that shipped as deprecated aliases in the betas are deleted,
+not aliased. All three are **silent breaks** in plain-JS apps — before/afters
+in the
+[migration guide](../docs/content/docs/migration.md#dropdown-and-contextmenu);
+TypeScript callers get compile errors (the removed keys stay typed as
+`never`), and a dev-mode console warning fires when the old shape reaches the
+menu at runtime.
 
-```ts
-// before
-{ group: 'Edit', items: [{ label: 'Rename', onClick: rename }] }
-// after
-{ group: 'Edit', options: [{ label: 'Rename', onClick: rename }] }
-```
+- **`placement` prop and `DropdownPlacement` type removed.** Use `align`
+  (`left`→`start`, `center`→`center`, `right`→`end`). A leftover `placement`
+  is ignored and the menu falls back to `align="start"`.
+- **`{ group, items }` removed.** Use `{ group, options }`, matching
+  `Combobox` / `MultiSelect` / `Select`. A leftover `items` group renders as
+  an empty menu.
+- **`component:` option rows removed** (`DropdownComponentOption`,
+  `ContextMenuComponentOption`). Use `slots: { item: fn }`. A leftover
+  `component:` row renders as a plain action row off its `label`.
+
+Also removed: the **`DropdownExposed` type** — it described a `close()`
+template-ref member that `Dropdown` never implemented ([ADR-0012] keeps
+`Dropdown`'s template-ref surface empty; `v-model:open` and the `close` slot
+prop cover it). Type-only, so the break is loud.
+
+### Dropdown — disabled state reaches the menu primitive
+
+The trigger now forwards its disabled state (from `button.disabled` or a
+`disabled` fallthrough attribute) to the underlying menu primitive.
+Previously only the generated `Button` was natively disabled; a custom
+trigger slot with a `disabled` attribute could still open the menu via
+keyboard or synthetic clicks.
 
 ### Select — `#item-*` slot prop renamed to `item`
 
-`#item-prefix`, `#item-label`, and `#item-suffix` on `Select` now expose
+`#item-prefix`, `#item-label`, and `#item-suffix` on `Select` expose
 `item` as the canonical scoped binding, matching `Combobox` and
-`MultiSelect`. The previous `option` key is retained as a silent alias
-through v1.x; no runtime warning fires (slot-prop destructuring isn't
-detectable at runtime). The `@deprecated` tag lives on the TS interface
-so editors hint at the rename. The legacy `#option` slot still passes
-`{ option }` unchanged.
+`MultiSelect`. The previous `option` key is removed with the rest of the
+deprecated surface (ADR-0008) — destructuring `{ option }` yields
+`undefined`, silently. No runtime warning is possible (slot-prop
+destructuring isn't detectable), so grep for `#item-` slots destructuring
+`option`.
 
 ```vue
 <!-- before -->
@@ -762,8 +783,11 @@ Copy the ~20 lines into your app, or use `@vueuse/core`'s `useWindowSize` /
 | `Switch.change` emit               | `update:modelValue` / `v-model`      | **Removed** — silent; listener never fires |
 | `Switch.labelClasses` prop         | `data-*` styling hooks               | **Removed** — silent; prop ignored     |
 | `Checkbox.padding` prop            | `padded` / `data-*` styling hooks    | **Removed** — silent; prop ignored     |
-| `Dropdown` `{ group, items }`      | `{ group, options }`                 | Silent alias; warns if both            |
-| Select `#item-*` slot prop `option` | `item`                              | Silent alias; JSDoc only, no runtime warning |
+| `Dropdown` `{ group, items }`      | `{ group, options }`                 | **Removed** — silent; renders empty, dev-only warning |
+| `Dropdown.placement` prop          | `align`                              | **Removed** — silent; falls back to `align="start"` |
+| `Dropdown`/`ContextMenu` `component:` rows | `slots: { item: fn }`        | **Removed** — silent; renders label-only row, dev-only warning |
+| `DropdownExposed` type             | `v-model:open` / `close` slot prop   | **Removed** — loud; described an expose that never existed |
+| Select `#item-*` slot prop `option` | `item`                              | **Removed** — silent; `{ option }` destructures to `undefined` |
 | `Input.vue`                        | `TextInput`                          | Warns on mount                         |
 | `Autocomplete`                     | `Combobox` or `MultiSelect`          | **Removed** — import fails             |
 | `FormControl type='autocomplete'`  | `type="combobox"`, or `Combobox` standalone | **Removed** — silent; dev-only `console.error` |


### PR DESCRIPTION
Part of the selection-and-menus sweep (#871) on the [Road to 1.0.0](https://github.com/frappe/frappe-ui/issues/864) map. The pickers were frozen in #858; this PR brings the menu half to bar.

## ADR-0008 removals

| Removed | Replacement |
| --- | --- |
| `placement` prop, `DropdownPlacement` type | `align` |
| `{ group, items }` group entries | `{ group, options }` |
| `component:` option rows, `DropdownComponentOption` / `ContextMenuComponentOption` | `slots: { item: fn }` |
| `DropdownExposed` type | nothing — it described an expose that never existed (ADR-0012) |

The three behavioral removals are **silent breaks** in plain JS (old code runs, renders wrong). Mitigations: the removed keys stay in the types as `never` so TS callers break loudly, a dev-only console warning fires when the old shape reaches the menu at runtime, and the migration guide has before/afters.

## Fixes

- **Disabled state now reaches reka's trigger.** Previously only the generated `Button` was natively disabled; a custom trigger slot with a `disabled` attribute could still be opened by keyboard or synthetic clicks.

## Tests

Five-behavior gaps closed (at-bar item 3): keyboard nav, disabled items + trigger, `#empty`, group labels, `v-model:open` for Dropdown and ContextMenu; `#prefix`/`#suffix`/`data-size` for ItemListRow. 37 menu-family cypress tests green, pickers re-run green (135), vitest 424 green.

## Docs

- `spec/dropdown.md` stopped mandating the deprecated aliases (it predated ADR-0008 and lost), documents `matchTriggerWidth`, and drops the never-implemented `emptyText` prop.
- Migration guide: new [Dropdown and ContextMenu](https://github.com/frappe/frappe-ui/blob/forge/sweep-selection-menus/docs/content/docs/migration.md#dropdown-and-contextmenu) section.
- Changelog entries + deprecation-log rows flipped to **Removed**; also corrected the stale claim that Select's `option` slot-prop alias still ships (it was removed in #858).
- Dropdown, ContextMenu and ItemListRow barrels spell out their exports (P15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-957/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 67.23% (-0.02% vs `main`)
<!-- coverage-report:end -->


