### PR TITLE
fix(Menu, docs, Switch): repair switch menu items after #958, close out review nits

### DIFF
--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -469,7 +469,8 @@ Covers `TextInput`, `Textarea`, `Password`, `Checkbox`, `Switch`, `Rating`,
 | `Rating` `:rating_from`                    | `:max`                 |
 | `Rating` `:readonly`                       | `:disabled`            |
 | `Switch` `@change`                         | `@update:modelValue`   |
-| `Switch.labelClasses` / `Checkbox.padding` | `data-*` styling hooks |
+| `Switch.labelClasses`                      | `data-*` styling hooks |
+| `Checkbox.padding`                         | `padded`               |
 | `Password` `:value` + `@input` workaround  | `v-model` (now works)  |
 
 The first four rows are **removed**, not aliased. The old names are silently

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -473,7 +473,7 @@ Covers `TextInput`, `Textarea`, `Password`, `Checkbox`, `Switch`, `Rating`,
 | `Checkbox.padding`                         | `padded`               |
 | `Password` `:value` + `@input` workaround  | `v-model` (now works)  |
 
-The first four rows are **removed**, not aliased. The old names are silently
+The first five rows are **removed**, not aliased. The old names are silently
 ignored: a `Rating` with `:rating_from="10"` renders 5 stars, a `:readonly`
 Rating becomes interactive, a `Switch` `@change` handler never fires, and
 `labelClasses` / `Checkbox.padding` stop styling anything. Nothing breaks at

--- a/skills/frappe-ui/COMPONENTS.md
+++ b/skills/frappe-ui/COMPONENTS.md
@@ -102,10 +102,10 @@ Inline banner. `<Alert :title variant theme>` + slot for body.
 
 ### `Tooltip` — see Overlays.
 
-### `Progress` / `CircularProgressBar` / `Spinner` / `LoadingIndicator` / `LoadingText`
+### `Progress` / `Spinner` / `LoadingIndicator` / `LoadingText`
 - `Spinner` / `LoadingIndicator` for inline loading.
 - `LoadingText` for skeleton-style text placeholder.
-- `Progress` linear; `CircularProgressBar` radial.
+- `Progress` linear; `intervals` turns it into a step indicator. (No radial variant — `CircularProgressBar` was removed before 1.0.0.)
 
 ### `Divider`
 Horizontal/vertical rule. Prefer over `<hr class="..." />`.

--- a/src/components/Menu/MenuItemContent.vue
+++ b/src/components/Menu/MenuItemContent.vue
@@ -192,10 +192,9 @@ function handleSwitchChange(value: boolean) {
       <Switch
         v-else-if="trailing === 'switch'"
         class="ml-auto"
-        label-classes="cursor-pointer font-normal"
         :disabled="item.disabled"
         :model-value="item.switchValue || false"
-        @change="handleSwitchChange"
+        @update:model-value="handleSwitchChange"
       />
       <span
         v-else-if="trailing === 'submenu'"

--- a/src/components/Switch/Switch.cy.ts
+++ b/src/components/Switch/Switch.cy.ts
@@ -62,8 +62,14 @@ describe('Switch', () => {
       },
     })
 
+    // Enter is handled by reka's own keydown listener.
     cy.get('[role="switch"]').focus().trigger('keydown', { key: 'Enter' })
     cy.get('@onUpdate').should('have.been.calledWith', true)
+
+    // Space activation is native button behavior, which synthetic events
+    // can't drive — assert the control is a real <button> so the browser
+    // guarantees it.
+    cy.get('[role="switch"]').should('match', 'button')
   })
 
   it('renders the label and description slots', () => {


### PR DESCRIPTION
Follow-up to #958, now carrying a real regression fix:

**`Menu/MenuItemContent.vue` was the one internal consumer of the removed `Switch.change` emit** — switch menu items in `ContextMenu`/`Dropdown` stopped firing `onClick`, which is the ContextMenu failure on main's CI (`Component Tests (Cypress) - 1`). It now binds `@update:model-value`; the `label-classes` it also passed was a no-op (no label rendered). #958's census counted consumer apps but not `src/` itself — lesson noted.

Plus the review nits from both bots on #958/#959:

- `skills/frappe-ui/COMPONENTS.md` no longer lists `CircularProgressBar`.
- Migration table: `Checkbox.padding` → `padded`, and the prose now says "first **five** rows" after the row split (barista's catch).
- Switch keyboard test: Enter asserted via reka's keydown handler; Space is native `<button>` activation that synthetic events can't drive, so the test asserts the control is a real button and documents why.

ContextMenu 11/11, Dropdown 10/10, Switch 21/21 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-959/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 67.25% (-0.08% vs `main`)
<!-- coverage-report:end -->
