### PR TITLE
feat: make frappe-ui embeddable in a shadow root

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
     "./vite": {
       "import": "./vite/index.js"
     },
+    "./vite/lucideIconsPlugin": {
+      "import": "./vite/lucideIconsPlugin.js"
+    },
     "./vitepress": {
       "types": "./vitepress/index.d.ts",
       "node": "./vitepress/index.node.ts",

--- a/spec/README.md
+++ b/spec/README.md
@@ -39,6 +39,9 @@ If these disagree, update the lower-authority document or mark it historical.
   a required `*Exposed` type. A member earns its place only when parent script
   needs it and no other surface reaches. Excludes `frappe/`, `ListView`, and
   `Calendar`. **Accepted** — [ADR-0012](./adr/0012-template-ref-surface.md).
+- [`portal-target.md`](./portal-target.md) — where an overlay teleports, and how
+  an embedding host redirects every overlay at once. Concerns embedded builds
+  only. A test enforces the component-side rule. **Accepted.**
 
 ## ADRs
 

--- a/spec/dropdown.md
+++ b/spec/dropdown.md
@@ -61,7 +61,8 @@ Defaults:
 - `align = 'start'`
 - `offset = 4`
 - `matchTriggerWidth = false`
-- `portalTo = 'body'`
+- `portalTo = 'body'` — the fallback when neither the prop nor an embedding
+  host names a target. See [`portal-target.md`](./portal-target.md).
 
 `side` picks which side of the trigger the menu opens on, `align` how it lines
 up along that side, `offset` the gap in px, and `portalTo` where the content is

--- a/spec/hover-card.md
+++ b/spec/hover-card.md
@@ -98,7 +98,8 @@ Defaults (aligned with `Popover` for positioning, `Tooltip` for delays):
 - `align = 'start'`
 - `offset = 4`
 - `collisionPadding = 10`
-- `portalTo = 'body'`
+- `portalTo = 'body'` — the fallback when neither the prop nor an embedding
+  host names a target. See [`portal-target.md`](./portal-target.md).
 - `hoverDelay = 0.5`
 - `leaveDelay = 0.3`
 

--- a/spec/popover.md
+++ b/spec/popover.md
@@ -111,7 +111,8 @@ Defaults:
 - `side = 'bottom'`
 - `align = 'start'`
 - `offset = 4`
-- `portalTo = 'body'`
+- `portalTo = 'body'` — the fallback when neither the prop nor an embedding
+  host names a target. See [`portal-target.md`](./portal-target.md).
 - `collisionPadding = 10`
 - `dismissible = true`
 - `matchTriggerWidth = false`

--- a/spec/portal-target.md
+++ b/spec/portal-target.md
@@ -1,0 +1,85 @@
+# Portal Target Spec
+
+Status: accepted direction for `frappe-ui` v1.
+
+An overlay teleports its content somewhere. This document says where, and how an
+embedding host redirects every overlay at once. Each component's own spec
+documents its `portalTo` prop — [`popover.md`](./popover.md),
+[`dropdown.md`](./dropdown.md), [`hover-card.md`](./hover-card.md),
+[`selection.md`](./selection.md).
+
+## The problem
+
+An overlay renders its content in a `<Teleport>`. A clipping or stacking
+ancestor then cannot cut it off. reka-ui teleports to `<body>` by default. That
+is correct for an app that mounts frappe-ui at the page root.
+
+It is wrong for an embedded app. A Frappe desk island mounts Vue inside a shadow
+root and loads frappe-ui's styles into that root. `<body>` sits outside the
+root. An overlay that lands there loses the library's styling and picks up the
+host page's CSS.
+
+The host cannot fix this one overlay at a time. An island's markup rarely names
+the Dialog that its Combobox opens.
+
+## The contract
+
+The host names one target per Vue app. Every overlay below it reads that target.
+
+```ts
+type PortalTarget = string | HTMLElement
+
+const portalTargetKey: InjectionKey<MaybeRefOrGetter<PortalTarget | undefined>>
+
+function providePortalTarget(target: MaybeRefOrGetter<PortalTarget | undefined>): void
+function usePortalTarget(
+  override?: MaybeRefOrGetter<PortalTarget | undefined>,
+): ComputedRef<PortalTarget | undefined>
+```
+
+Precedence, highest first:
+
+1. The component's own `portalTo` prop, where it has one. An explicit request
+   from the caller always wins.
+2. The host-provided target.
+3. `undefined`, which leaves reka-ui on its `'body'` default.
+
+`portalTargetKey` is `Symbol.for('frappe-ui:portal-target')`. It therefore
+resolves through the global symbol registry. A host that cannot import from
+frappe-ui still matches it, and so does a page that carries two copies of the
+package.
+
+The target is per Vue app, through provide/inject. A module-level setting would
+be wrong: one page can host several islands, each with its own shadow root and
+its own target.
+
+## Host side
+
+A host that owns the app instance provides the key before it mounts. The target
+then covers the root component too.
+
+```ts
+const portalEl = document.createElement('div')
+shadowRoot.append(portalEl)
+
+const app = createApp(Island)
+app.provide(portalTargetKey, portalEl)
+app.mount(mountEl)
+```
+
+Pass an element, not a selector, when the target lives in a shadow root. Vue
+resolves a string with `document.querySelector`, which does not cross a shadow
+boundary.
+
+## Component side
+
+Every component that teleports resolves its target through `usePortalTarget`.
+A test enforces this — see `no component teleports past the host target` in
+[`usePortalTarget.spec.ts`](../src/composables/usePortalTarget.spec.ts). It
+fails on a missing `:to` binding and on a hardcoded `'body'`.
+
+A component with a `portalTo` prop must leave that prop undefaulted. A `'body'`
+default outranks the host and defeats embedding silently.
+
+The documented default of every `portalTo` prop stays `'body'`. That is still
+what an unembedded app gets. It is now a fallback rather than a prop default.

--- a/spec/selection.md
+++ b/spec/selection.md
@@ -204,7 +204,9 @@ Four props place the popover:
 the trigger so the selected row lands on the value, macOS-style. Setting `side`,
 `align`, or `offset` switches it to ordinary placement below the trigger, and
 whichever of the three you left out falls back to the defaults above.
-`portalTo` applies in both modes.
+`portalTo` applies in both modes. `'body'` is the fallback when neither the
+prop nor an embedding host names a target — see
+[`portal-target.md`](./portal-target.md).
 
 ## Motion
 

--- a/src/components/BottomSheet/BottomSheet.vue
+++ b/src/components/BottomSheet/BottomSheet.vue
@@ -1,6 +1,6 @@
 <template>
   <DialogRoot v-model:open="isOpen">
-    <DialogPortal>
+    <DialogPortal :to="portalTarget">
       <DialogOverlay
         class="fixed inset-0 z-50 bg-black-overlay-200 dark:bg-black-overlay-700 bottom-sheet-overlay outline-none"
         @after-leave="emit('after-leave')"
@@ -66,11 +66,14 @@ import {
 } from 'reka-ui'
 import { useSheetDrag } from '../../composables/useSheetDrag'
 import type { BottomSheetProps, BottomSheetEmits } from './types'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 
 const props = withDefaults(defineProps<BottomSheetProps>(), {
   dismissible: true,
 })
 const emit = defineEmits<BottomSheetEmits>()
+
+const portalTarget = usePortalTarget()
 
 const isOpen = computed({
   get: () => props.open || false,

--- a/src/components/Breadcrumbs/Breadcrumbs.cy.ts
+++ b/src/components/Breadcrumbs/Breadcrumbs.cy.ts
@@ -42,4 +42,54 @@ describe('Breadcrumbs', () => {
     cy.get('[aria-haspopup=menu]').click()
     cy.get('[role=menuitem]').should('have.length', items.length - 2)
   })
+
+  describe('Item with both href and onClick', () => {
+    // reports what the component left on the event, see mountLinkItem()
+    const report = { defaultPrevented: (_prevented: boolean) => {} }
+
+    function mountLinkItem() {
+      const onClick = cy.stub().as('onClick')
+      const linkItems = [
+        { label: 'Home', href: '/home', onClick },
+        { label: 'Users' },
+      ]
+      cy.mount(Breadcrumbs, { props: { items: linkItems } })
+
+      cy.spy(report, 'defaultPrevented').as('defaultPrevented')
+      cy.get('a[href="/home"]').then(($link) => {
+        // runs after the component handler, because Vue bound its own first
+        $link[0].addEventListener('click', (event) => {
+          report.defaultPrevented(event.defaultPrevented)
+          // keep the test on the page whatever the component decided
+          event.preventDefault()
+        })
+      })
+    }
+
+    it('Keeps the real URL on the crumb', () => {
+      mountLinkItem()
+
+      cy.get('a').should('have.attr', 'href', '/home')
+    })
+
+    it('Runs onClick and stops the browser on a plain click', () => {
+      mountLinkItem()
+
+      cy.get('a[href="/home"]').click()
+
+      cy.get('@onClick').should('have.been.calledOnce')
+      // the handler gets the event, already prevented
+      cy.get('@onClick').its('firstCall.args.0.type').should('eq', 'click')
+      cy.get('@defaultPrevented').should('have.been.calledWith', true)
+    })
+
+    it('Leaves a modified click to the browser', () => {
+      mountLinkItem()
+
+      cy.get('a[href="/home"]').click({ metaKey: true })
+
+      cy.get('@onClick').should('not.have.been.called')
+      cy.get('@defaultPrevented').should('have.been.calledWith', false)
+    })
+  })
 })

--- a/src/components/Breadcrumbs/Breadcrumbs.md
+++ b/src/components/Breadcrumbs/Breadcrumbs.md
@@ -14,4 +14,28 @@ A navigation aid that shows the user’s current location within a hierarchy and
 
 <ComponentPreview name="Breadcrumbs-Slots" />
 
+## Item shape
+
+Each item needs a `label`. How the item navigates depends on the other fields:
+
+- `route` renders a `<router-link>`.
+- `href` renders an `<a>`.
+- Neither renders a `<button>`, so use `onClick` to navigate.
+
+Set `href` and `onClick` together when the app navigates by itself but the crumb
+must still be a real link. A plain left click runs `onClick` only. A click with
+<kbd>Cmd</kbd>, <kbd>Ctrl</kbd> or <kbd>Shift</kbd>, and a middle click, stay
+with the browser and open the URL. The context menu keeps "Copy link address".
+
+```js
+const items = [
+  {
+    label: 'Dashboards',
+    href: '/app/dashboard',
+    onClick: () => router.push('/dashboard'),
+  },
+  { label: 'Sales' },
+]
+```
+
 <!-- @include: ./Breadcrumbs.api.md -->

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -18,7 +18,7 @@
         <router-link
           v-if="item.route"
           :to="item.route"
-          @click="item.onClick ? item.onClick() : null"
+          @click="item.onClick?.($event)"
           class="flex items-center rounded px-0.5 py-1 text-lg-medium"
           :class="[
             i == crumbs.length - 1
@@ -38,7 +38,7 @@
         <a
           v-else-if="item.href"
           :href="item.href"
-          @click="item.onClick ? item.onClick() : null"
+          @click="onLinkClick(item, $event)"
           class="flex items-center rounded px-0.5 py-1 text-lg-medium"
           :class="[
             i == crumbs.length - 1
@@ -57,7 +57,7 @@
         </a>
         <button
           v-else
-          @click="item.onClick ? item.onClick() : null"
+          @click="item.onClick?.($event)"
           class="flex items-center rounded px-0.5 py-1 text-lg-medium"
           :class="[
             i == crumbs.length - 1
@@ -142,6 +142,26 @@ const dropdownItems = computed(() => {
 })
 
 const crumbs = computed(() => items.value.slice(overflowedX.value ? -2 : 0))
+
+function isModifiedClick(event: MouseEvent) {
+  return (
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey ||
+    event.button !== 0
+  )
+}
+
+// An item may set both `href` and `onClick`, so the crumb keeps a real URL for
+// new-tab clicks and "copy link address" while `onClick` does the in-app
+// navigation. Modified clicks stay with the browser.
+function onLinkClick(item: BreadcrumbItem, event: MouseEvent) {
+  if (!item.onClick) return
+  if (isModifiedClick(event)) return
+  event.preventDefault()
+  item.onClick(event)
+}
 
 defineSlots<{
   /** Content shown before each breadcrumb label */

--- a/src/components/Breadcrumbs/types.ts
+++ b/src/components/Breadcrumbs/types.ts
@@ -7,8 +7,15 @@ export interface BreadcrumbItem {
   /** Route location used when the item is a link */
   route?: RouterLinkProps['to']
 
-  /** Click handler for non-router breadcrumb items */
-  onClick?: () => void
+  /** URL used when the item is a plain link, ignored if `route` is set */
+  href?: string
+
+  /**
+   * Click handler for non-router breadcrumb items. Set it together with `href`
+   * to keep a real URL on the crumb and still navigate in-app: a plain left
+   * click runs the handler only, a modified click opens the URL as usual.
+   */
+  onClick?: (event?: MouseEvent) => void
 
   /** Allows passing additional custom fields */
   [key: string]: any

--- a/src/components/Combobox/Combobox.api.md
+++ b/src/components/Combobox/Combobox.api.md
@@ -105,10 +105,9 @@
   },
   {
     name: 'portalTo',
-    description: 'Teleport target for the popover content.',
+    description: 'Teleport target for the popover content. Unset, an embedding host\'s target is used, else `body`.',
     required: false,
-    type: 'string | HTMLElement',
-    default: '"body"'
+    type: 'string | HTMLElement'
   },
   {
     name: 'loading',

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -21,6 +21,7 @@ import OptionIcon from '../shared/selection/OptionIcon.vue'
 import PopoverPanel from '../shared/popover/PopoverPanel.vue'
 import ComboboxResults from './ComboboxResults.vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
 import { useIsModelBound } from '../shared/selection/useIsModelBound'
@@ -76,12 +77,13 @@ const props = withDefaults(defineProps<ComboboxProps>(), {
   side: 'bottom',
   align: 'start',
   offset: 4,
-  portalTo: 'body',
   loading: false,
   emptyText: 'No results',
   hideSearch: false,
   filterable: true,
 })
+
+const portalTarget = usePortalTarget(() => props.portalTo)
 
 const emit = defineEmits<ComboboxEmits>()
 const attrs = useAttrs()
@@ -646,7 +648,7 @@ defineSlots<ComboboxSlots>()
           </ComboboxAnchor>
         </template>
 
-        <ComboboxPortal :to="portalTo">
+        <ComboboxPortal :to="portalTarget">
           <ComboboxContent
             data-slot="content"
             data-selection

--- a/src/components/Combobox/types.ts
+++ b/src/components/Combobox/types.ts
@@ -132,7 +132,7 @@ export interface ComboboxProps extends InputLabelingProps {
   /** Gap between trigger and content. */
   offset?: number
 
-  /** Teleport target for the popover content. */
+  /** Teleport target for the popover content. Unset, an embedding host's target is used, else `body`. */
   portalTo?: string | HTMLElement
 
   /** Replaces the results with a loading state. */

--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -5,7 +5,7 @@
       <slot v-else :open="openModel" />
     </ContextMenuTrigger>
 
-    <ContextMenuPortal>
+    <ContextMenuPortal :to="portalTarget">
       <ContextMenuContent
         data-slot="content"
         data-motion="instant"
@@ -38,6 +38,7 @@ import {
 import Menu from '../Menu/Menu.vue'
 import { menuClasses, normalizeMenuOptions } from '../Menu/utils'
 import type { ContextMenuProps, ContextMenuSlots } from './types'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 
 const openModel = defineModel<boolean>('open', { default: false })
 
@@ -48,6 +49,8 @@ const props = withDefaults(defineProps<ContextMenuProps>(), {
 defineSlots<ContextMenuSlots>()
 
 const slots = useSlots()
+
+const portalTarget = usePortalTarget()
 
 const groups = computed(() => normalizeMenuOptions(props.options))
 

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -1,6 +1,6 @@
 <template>
   <DialogRoot v-model:open="isOpen">
-    <DialogPortal>
+    <DialogPortal :to="portalTarget">
       <DialogOverlay
         class="fixed inset-0 bg-black-overlay-200 dark:bg-black-overlay-700 dialog-overlay outline-none"
         :data-dialog="props.title"
@@ -170,6 +170,7 @@ import {
 import { computed, reactive, ref, useSlots, watchEffect } from 'vue'
 import type { ComponentPublicInstance } from 'vue'
 import { useAutofocusOnOpen } from '../../composables/useAutofocusOnOpen'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 import { Button } from '../Button'
 import FeatherIcon from '../FeatherIcon.vue'
 import {
@@ -201,6 +202,8 @@ const props = withDefaults(defineProps<DialogProps>(), {
 const emit = defineEmits<DialogEmits>()
 
 const slots = defineSlots<DialogSlots>()
+
+const portalTarget = usePortalTarget()
 
 const allSlots = useSlots()
 

--- a/src/components/Dropdown/Dropdown.api.md
+++ b/src/components/Dropdown/Dropdown.api.md
@@ -54,10 +54,9 @@
   },
   {
     name: 'portalTo',
-    description: 'Teleport target for dropdown portal content.',
+    description: 'Teleport target for dropdown portal content. Unset, an embedding host\'s target is used, else `body`.',
     required: false,
-    type: 'string | HTMLElement',
-    default: '"body"'
+    type: 'string | HTMLElement'
   }
 ]
 

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -23,7 +23,7 @@
       </Button>
     </DropdownMenuTrigger>
 
-    <DropdownMenuPortal :to="portalTo">
+    <DropdownMenuPortal :to="portalTarget">
       <DropdownMenuContent
         data-slot="content"
         data-motion="instant"
@@ -64,6 +64,7 @@ import { Button } from '../Button'
 import Menu from '../Menu/Menu.vue'
 import type { DropdownProps, DropdownSlots } from './types'
 import { menuClasses, normalizeMenuOptions, warnRemoved } from '../Menu/utils'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 
 defineOptions({
   inheritAttrs: false,
@@ -78,8 +79,9 @@ const props = withDefaults(defineProps<DropdownProps>(), {
   side: 'bottom',
   align: 'start',
   offset: 4,
-  portalTo: 'body',
 })
+
+const portalTarget = usePortalTarget(() => props.portalTo)
 
 function close() {
   openModel.value = false

--- a/src/components/Dropdown/types.ts
+++ b/src/components/Dropdown/types.ts
@@ -43,7 +43,7 @@ export interface DropdownProps {
   /** Whether the dropdown width should match the trigger element. */
   matchTriggerWidth?: boolean
 
-  /** Teleport target for dropdown portal content. */
+  /** Teleport target for dropdown portal content. Unset, an embedding host's target is used, else `body`. */
   portalTo?: string | HTMLElement
 }
 

--- a/src/components/HoverCard/HoverCard.api.md
+++ b/src/components/HoverCard/HoverCard.api.md
@@ -28,10 +28,9 @@
   },
   {
     name: 'portalTo',
-    description: 'Where the card is teleported to in the DOM.',
+    description: 'Where the card is teleported to in the DOM. Unset, an embedding host\'s target is used, else `body`.',
     required: false,
-    type: 'string | HTMLElement',
-    default: '"body"'
+    type: 'string | HTMLElement'
   },
   {
     name: 'collisionPadding',

--- a/src/components/HoverCard/HoverCard.vue
+++ b/src/components/HoverCard/HoverCard.vue
@@ -8,6 +8,7 @@ import {
 } from 'reka-ui'
 import { computed } from 'vue'
 import PopoverPanel from '../shared/popover/PopoverPanel.vue'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 import type {
   HoverCardExposed,
   HoverCardProps,
@@ -22,12 +23,13 @@ const props = withDefaults(defineProps<HoverCardProps>(), {
   side: 'bottom',
   align: 'start',
   offset: 4,
-  portalTo: 'body',
   collisionPadding: 10,
   hoverDelay: 0.3,
   leaveDelay: 0.3,
   arrow: false,
 })
+
+const portalTarget = usePortalTarget(() => props.portalTo)
 
 const open = defineModel<boolean>('open', { default: false })
 
@@ -62,7 +64,7 @@ defineSlots<{
     <HoverCardTrigger as-child>
       <slot name="trigger" :open="open" />
     </HoverCardTrigger>
-    <HoverCardPortal :to="portalTo">
+    <HoverCardPortal :to="portalTarget">
       <HoverCardContent
         data-slot="content"
         class="z-[100]"

--- a/src/components/HoverCard/types.ts
+++ b/src/components/HoverCard/types.ts
@@ -17,7 +17,7 @@ export interface HoverCardProps {
   offset?: number
 
   /**
-   * Where the card is teleported to in the DOM.
+   * Where the card is teleported to in the DOM. Unset, an embedding host's target is used, else `body`.
    */
   portalTo?: HoverCardPortalProps['to']
 

--- a/src/components/Menu/Menu.api.md
+++ b/src/components/Menu/Menu.api.md
@@ -26,10 +26,9 @@
   },
   {
     name: 'portalTo',
-    description: 'Portal target for submenu content.',
+    description: 'Portal target for submenu content. Unset, an embedding host\'s target is used, else `body`.',
     required: false,
-    type: 'string | HTMLElement',
-    default: '"body"'
+    type: 'string | HTMLElement'
   },
   {
     name: 'primitives',

--- a/src/components/Menu/Menu.vue
+++ b/src/components/Menu/Menu.vue
@@ -5,6 +5,7 @@ import MenuItemContent from './MenuItemContent.vue'
 import MenuRenderContent from './MenuRenderContent.vue'
 import MenuRenderContentAsChild from './MenuRenderContentAsChild.vue'
 import type { MenuOption, MenuProps } from './types'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 import {
   menuClasses,
   getMenuBackgroundColor,
@@ -20,8 +21,9 @@ defineOptions({
 
 const props = withDefaults(defineProps<MenuProps>(), {
   groups: () => [],
-  portalTo: 'body',
 })
+
+const portalTarget = usePortalTarget(() => props.portalTo)
 
 const router = useRouter()
 
@@ -88,7 +90,7 @@ async function handleItemSelect(item: MenuOption, event: Event) {
             />
           </component>
 
-          <component :is="primitives.Portal" :to="portalTo">
+          <component :is="primitives.Portal" :to="portalTarget">
             <component
               :is="primitives.SubContent"
               data-slot="content"

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -145,7 +145,7 @@ export interface MenuProps {
   /** Dynamic `item-*` slot implementations resolved by name. */
   slotFns?: Record<string, ((props?: any) => any) | undefined>
 
-  /** Portal target for submenu content. */
+  /** Portal target for submenu content. Unset, an embedding host's target is used, else `body`. */
   portalTo?: string | HTMLElement
 
   /** Reka-ui primitives supplied by the wrapping menu component. */

--- a/src/components/MultiSelect/MultiSelect.api.md
+++ b/src/components/MultiSelect/MultiSelect.api.md
@@ -112,10 +112,9 @@
   },
   {
     name: 'portalTo',
-    description: 'Teleport target for the popover content.',
+    description: 'Teleport target for the popover content. Unset, an embedding host\'s target is used, else `body`.',
     required: false,
-    type: 'string | HTMLElement',
-    default: '"body"'
+    type: 'string | HTMLElement'
   },
   {
     name: 'label',

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -12,6 +12,7 @@ import Button from '../Button/Button.vue'
 import LoadingIndicator from '../LoadingIndicator.vue'
 import MultiSelectResults from './MultiSelectResults.vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
 import { useIsModelBound } from '../shared/selection/useIsModelBound'
@@ -61,8 +62,9 @@ const props = withDefaults(defineProps<MultiSelectProps>(), {
   side: 'bottom',
   align: 'start',
   offset: 4,
-  portalTo: 'body',
 })
+
+const portalTarget = usePortalTarget(() => props.portalTo)
 
 const emit = defineEmits<MultiSelectEmits>()
 const attrs = useAttrs()
@@ -459,7 +461,7 @@ defineSlots<MultiSelectSlots>()
         </button>
       </ComboboxAnchor>
 
-      <ComboboxPortal :to="portalTo">
+      <ComboboxPortal :to="portalTarget">
         <ComboboxContent
           data-slot="content"
           data-selection

--- a/src/components/MultiSelect/types.ts
+++ b/src/components/MultiSelect/types.ts
@@ -111,7 +111,7 @@ export interface MultiSelectProps extends InputLabelingProps {
   /** Gap between trigger and content. */
   offset?: number
 
-  /** Teleport target for the popover content. */
+  /** Teleport target for the popover content. Unset, an embedding host's target is used, else `body`. */
   portalTo?: string | HTMLElement
 }
 

--- a/src/components/Popover/Popover.api.md
+++ b/src/components/Popover/Popover.api.md
@@ -34,10 +34,9 @@
   },
   {
     name: 'portalTo',
-    description: 'Where to portal the content.',
+    description: 'Where to portal the content. Unset, an embedding host\'s target is used, else `body`.',
     required: false,
-    type: 'string | HTMLElement',
-    default: '"body"'
+    type: 'string | HTMLElement'
   },
   {
     name: 'collisionPadding',

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -9,7 +9,7 @@
       <slot name="trigger" v-bind="slotProps" />
     </PopoverTrigger>
 
-    <PopoverPortal :to="portalTo">
+    <PopoverPortal :to="portalTarget">
       <PopoverContent
         data-slot="content"
         class="z-[100]"
@@ -49,6 +49,7 @@ import {
   PopoverTrigger,
 } from 'reka-ui'
 import PopoverPanel from '../shared/popover/PopoverPanel.vue'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 import type { PopoverEmits, PopoverProps, PopoverSlotProps } from './types'
 
 defineOptions({
@@ -60,13 +61,14 @@ const props = withDefaults(defineProps<PopoverProps>(), {
   side: 'bottom',
   align: 'start',
   offset: 4,
-  portalTo: 'body',
   collisionPadding: 10,
   dismissible: true,
   matchTriggerWidth: false,
   bare: false,
   arrow: false,
 })
+
+const portalTarget = usePortalTarget(() => props.portalTo)
 
 const emit = defineEmits<PopoverEmits>()
 

--- a/src/components/Popover/types.ts
+++ b/src/components/Popover/types.ts
@@ -14,7 +14,7 @@ export interface PopoverProps {
   /** Distance in px between the trigger and the content. */
   offset?: number
 
-  /** Where to portal the content. */
+  /** Where to portal the content. Unset, an embedding host's target is used, else `body`. */
   portalTo?: string | HTMLElement
 
   /** Padding in px kept from the viewport edge during collision handling. */

--- a/src/components/Rail/RailItemBadge.vue
+++ b/src/components/Rail/RailItemBadge.vue
@@ -18,7 +18,7 @@
     class="pointer-events-none absolute -right-0.5 -top-0.5 block size-2 rounded-full border border-[var(--surface-base)] bg-surface-red-6"
   />
 
-  <Teleport to="body">
+  <Teleport :to="portalTarget ?? 'body'">
     <span
       v-if="showCount"
       ref="floatingEl"
@@ -37,6 +37,9 @@
 import { computed, useTemplateRef } from 'vue'
 import { autoUpdate, useFloating } from '@floating-ui/vue'
 import Badge from '../Badge/Badge.vue'
+import { usePortalTarget } from '../../composables/usePortalTarget'
+
+const portalTarget = usePortalTarget()
 
 const props = defineProps<{
   count: number

--- a/src/components/Select/Select.api.md
+++ b/src/components/Select/Select.api.md
@@ -79,10 +79,9 @@
   },
   {
     name: 'portalTo',
-    description: 'Teleport target for the popover content.',
+    description: 'Teleport target for the popover content. Unset, an embedding host\'s target is used, else `body`.',
     required: false,
-    type: 'string | HTMLElement',
-    default: '"body"'
+    type: 'string | HTMLElement'
   },
   {
     name: 'label',

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, useAttrs, useSlots, useTemplateRef } from 'vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import type { SelectionExposed } from '../shared/selection/types'
 import type {
@@ -57,8 +58,9 @@ const props = withDefaults(defineProps<SelectProps>(), {
   placeholder: 'Select option',
   options: () => [],
   emptyText: 'No options',
-  portalTo: 'body',
 })
+
+const portalTarget = usePortalTarget(() => props.portalTo)
 
 const attrs = useAttrs()
 const slots = useSlots()
@@ -398,7 +400,7 @@ defineExpose(exposed)
         </template>
       </SelectTrigger>
 
-      <SelectPortal :to="portalTo">
+      <SelectPortal :to="portalTarget">
         <SelectContent
           data-slot="content"
           class="z-[100] origin-[var(--reka-select-content-transform-origin)]"

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -65,7 +65,7 @@ export interface SelectProps extends InputLabelingProps {
   /** Gap in px between trigger and content. Defaults to `4`. See `side`. */
   offset?: number
 
-  /** Teleport target for the popover content. */
+  /** Teleport target for the popover content. Unset, an embedding host's target is used, else `body`. */
   portalTo?: string | HTMLElement
 }
 

--- a/src/components/TextEditor/components/ImageViewerModal.vue
+++ b/src/components/TextEditor/components/ImageViewerModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport :to="portalTarget ?? 'body'">
     <Transition
       enter-active-class="transition-opacity duration-150 ease-in-out"
       leave-active-class="transition-opacity duration-150 ease-in-out"
@@ -163,6 +163,7 @@
 </template>
 
 <script setup lang="ts">
+import { usePortalTarget } from '../../../composables/usePortalTarget'
 import {
   ref,
   onMounted,
@@ -196,6 +197,8 @@ const props = defineProps<{
   images: ImageInfo[]
   initialIndex: number
 }>()
+
+const portalTarget = usePortalTarget()
 
 const emit = defineEmits<{
   'update:show': [value: boolean]

--- a/src/components/TextEditor/extensions/image-group/ImageGroupUploadDialog.vue
+++ b/src/components/TextEditor/extensions/image-group/ImageGroupUploadDialog.vue
@@ -228,7 +228,7 @@
       </div>
     </template>
   </Dialog>
-  <Teleport to="body">
+  <Teleport :to="portalTarget ?? 'body'">
     <Transition
       name="fade"
       enter-active-class="transition-opacity duration-200"
@@ -251,6 +251,7 @@
 </template>
 
 <script setup lang="ts">
+import { usePortalTarget } from '../../../../composables/usePortalTarget'
 import {
   computed,
   ref,
@@ -300,6 +301,8 @@ const props = withDefaults(
     mode: 'new',
   },
 )
+
+const portalTarget = usePortalTarget()
 
 const emit = defineEmits(['update:modelValue', 'close', 'update:files', 'save'])
 

--- a/src/components/TimePicker/TimePicker.vue
+++ b/src/components/TimePicker/TimePicker.vue
@@ -50,7 +50,7 @@
       </div>
     </PopoverAnchor>
 
-    <PopoverPortal>
+    <PopoverPortal :to="portalTarget">
       <PopoverContent
         data-slot="content"
         data-selection
@@ -106,6 +106,7 @@ import {
   PopoverRoot,
 } from 'reka-ui'
 import { TextInput } from '../TextInput'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 import '../shared/selection/popoverMotion.css'
 import {
   findNearestIndex,
@@ -145,6 +146,8 @@ const props = withDefaults(defineProps<TimePickerProps>(), {
 })
 
 const emit = defineEmits<TimePickerEmits>()
+
+const portalTarget = usePortalTarget()
 
 defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */

--- a/src/components/Tooltip/TooltipBubble.vue
+++ b/src/components/Tooltip/TooltipBubble.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { TooltipArrow, TooltipContent, TooltipPortal } from 'reka-ui'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 import type { TooltipSide } from './types'
 
 /**
@@ -30,6 +31,8 @@ withDefaults(
   { side: 'top', offset: 4, bare: false },
 )
 
+const portalTarget = usePortalTarget()
+
 defineSlots<{
   /** The bubble's content. Takes precedence over `text`. */
   content?: () => any
@@ -37,7 +40,7 @@ defineSlots<{
 </script>
 
 <template>
-  <TooltipPortal>
+  <TooltipPortal :to="portalTarget">
     <TooltipContent
       data-slot="content"
       :side="side"

--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -37,7 +37,7 @@
   </ul>
 
   <!-- Floating drag indicator -->
-  <Teleport to="body">
+  <Teleport :to="portalTarget ?? 'body'">
     <div
       v-if="dragLabel"
       class="frappe-tree-drag-label pointer-events-none fixed z-[1000] rounded-md bg-surface-gray-7 px-2 py-1 text-xs text-ink-white shadow-lg"
@@ -58,6 +58,7 @@
 import { computed, nextTick, provide, ref, toRef, watch } from 'vue'
 import TreeItem from './TreeItem.vue'
 import { useTreeDragDrop } from './useTreeDragDrop'
+import { usePortalTarget } from '../../composables/usePortalTarget'
 import { useTreeKeyboard, type FlatNode } from './useTreeKeyboard'
 import {
   TreeContextKey,
@@ -76,6 +77,8 @@ const props = withDefaults(defineProps<TreeProps>(), {
   guides: 'connectors',
   disabled: false,
 })
+
+const portalTarget = usePortalTarget()
 
 const emit = defineEmits<{
   'drag-start': [node: TreeNode]

--- a/src/components/shared/picker/PickerShell.vue
+++ b/src/components/shared/picker/PickerShell.vue
@@ -40,7 +40,7 @@
         </slot>
       </div>
     </PopoverAnchor>
-    <PopoverPortal>
+    <PopoverPortal :to="portalTarget">
       <PopoverContent
         data-slot="content"
         class="z-[100]"
@@ -69,6 +69,7 @@ import {
 import { TextInput } from '../../TextInput'
 import LucideChevronDown from '~icons/lucide/chevron-down'
 import PopoverPanel from '../popover/PopoverPanel.vue'
+import { usePortalTarget } from '../../../composables/usePortalTarget'
 import type { InputSize, InputVariant } from '../../../composables/inputTypes'
 import type { FrappeUIError } from '../../../composables/useInputLabeling'
 
@@ -113,6 +114,8 @@ const props = withDefaults(defineProps<Props>(), {
   displayLabel: '',
   contentClass: '',
 })
+
+const portalTarget = usePortalTarget()
 
 const emit = defineEmits<{
   (e: 'focus'): void

--- a/src/composables/usePortalTarget.spec.ts
+++ b/src/composables/usePortalTarget.spec.ts
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
+import Dialog from '../components/Dialog/Dialog.vue'
+import Popover from '../components/Popover/Popover.vue'
+import {
+  portalTargetKey,
+  providePortalTarget,
+  usePortalTarget,
+  type PortalTarget,
+} from './usePortalTarget'
+
+const mounted: Array<{ app: App; host: HTMLElement }> = []
+
+afterEach(() => {
+  while (mounted.length) {
+    const { app, host } = mounted.pop()!
+    app.unmount()
+    host.remove()
+  }
+})
+
+function mount(app: App) {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  app.mount(host)
+  mounted.push({ app, host })
+  return host
+}
+
+/** Mount a component that only reports what `usePortalTarget` resolved. */
+function resolve(
+  override?: PortalTarget,
+  provided?: PortalTarget,
+): PortalTarget | undefined {
+  let resolved: PortalTarget | undefined
+  const app = createApp(
+    defineComponent({
+      setup() {
+        resolved = usePortalTarget(() => override).value
+        return () => null
+      },
+    }),
+  )
+  if (provided !== undefined) app.provide(portalTargetKey, provided)
+  mount(app)
+  return resolved
+}
+
+/** A body-level element standing in for a host's portal container. */
+function portalElement(id: string) {
+  const el = document.createElement('div')
+  el.id = id
+  document.body.appendChild(el)
+  return el
+}
+
+describe('usePortalTarget', () => {
+  it('resolves to undefined so reka keeps its own body default', () => {
+    expect(resolve()).toBeUndefined()
+  })
+
+  it('resolves the host-provided target when the caller passes nothing', () => {
+    const el = portalElement('host-portal')
+    expect(resolve(undefined, el)).toBe(el)
+    el.remove()
+  })
+
+  it('lets an explicit override win over the host-provided target', () => {
+    const el = portalElement('host-portal')
+    expect(resolve('#explicit', el)).toBe('#explicit')
+    el.remove()
+  })
+
+  it('tracks a reactive target', async () => {
+    const target = ref<PortalTarget | undefined>('#first')
+    let resolved!: { value: PortalTarget | undefined }
+    const app = createApp(
+      defineComponent({
+        setup() {
+          resolved = usePortalTarget(target)
+          return () => null
+        },
+      }),
+    )
+    mount(app)
+
+    expect(resolved.value).toBe('#first')
+    target.value = '#second'
+    expect(resolved.value).toBe('#second')
+  })
+
+  it('resolves the key through the global symbol registry', () => {
+    // A host that cannot import from frappe-ui provides by name instead.
+    expect(portalTargetKey).toBe(Symbol.for('frappe-ui:portal-target'))
+  })
+
+  it('provides to descendants via providePortalTarget', () => {
+    let resolved: PortalTarget | undefined
+    const Child = defineComponent({
+      setup() {
+        resolved = usePortalTarget().value
+        return () => null
+      },
+    })
+    const app = createApp(
+      defineComponent({
+        setup() {
+          providePortalTarget('#from-ancestor')
+          return () => h(Child)
+        },
+      }),
+    )
+    mount(app)
+
+    expect(resolved).toBe('#from-ancestor')
+  })
+})
+
+describe('overlays honour the host target', () => {
+  it('teleports a Dialog into the host target instead of body', async () => {
+    const portal = portalElement('dialog-portal')
+    const app = createApp(Dialog, { open: true, title: 'Embedded' })
+    app.provide(portalTargetKey, portal)
+    mount(app)
+    // reka's portal only renders once mounted, one tick after app.mount().
+    await nextTick()
+
+    expect(portal.querySelector('[role="dialog"]')).not.toBeNull()
+    portal.remove()
+  })
+
+  it('lets a Popover portalTo prop outrank the host target', async () => {
+    const host = portalElement('popover-host-portal')
+    const explicit = portalElement('popover-explicit-portal')
+    const app = createApp(Popover, {
+      open: true,
+      portalTo: '#popover-explicit-portal',
+    })
+    app.provide(portalTargetKey, host)
+    mount(app)
+    await nextTick()
+
+    expect(explicit.querySelector('[data-slot="content"]')).not.toBeNull()
+    expect(host.querySelector('[data-slot="content"]')).toBeNull()
+    host.remove()
+    explicit.remove()
+  })
+})
+
+describe('no component teleports past the host target', () => {
+  // The rule has no compiler behind it. A new component that hardcodes its
+  // target still builds, still passes its own tests, and only fails once
+  // someone embeds the library — where the overlay lands outside the styles.
+
+  // Read with fs, not import.meta.glob: a `?raw` glob puts every .vue file in
+  // the module graph as a one-statement string module, and v8 coverage then
+  // attributes that to the component's own path. It cost 14 points.
+  const SRC = join(process.cwd(), 'src')
+
+  function vueFiles(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) return vueFiles(full)
+      return entry.name.endsWith('.vue') ? [full] : []
+    })
+  }
+
+  const TELEPORTING_TAG = /<([A-Z]\w*Portal|Teleport)\b[^>]*>/g
+  const BOUND_TARGET = /(?::|v-bind:)to=/
+  const LITERAL_BODY = /(?::|v-bind:)to="\s*'body'\s*"|(?<!:)\bto="body"/
+
+  it('binds every portal and Teleport to a resolved target', () => {
+    const offenders: string[] = []
+    let scanned = 0
+
+    for (const file of vueFiles(SRC)) {
+      if (/\.(story|playground)\.vue$/.test(file)) continue
+      const path = relative(SRC, file)
+
+      for (const [tag, name] of readFileSync(file, 'utf8').matchAll(
+        TELEPORTING_TAG,
+      )) {
+        scanned++
+        if (!BOUND_TARGET.test(tag)) {
+          offenders.push(`${path}: <${name}> has no :to binding`)
+        } else if (LITERAL_BODY.test(tag)) {
+          offenders.push(`${path}: <${name}> hardcodes 'body'`)
+        }
+      }
+    }
+
+    // A broken scan would find nothing and pass. There were 20 teleporting
+    // tags when this landed, so a collapse to near-zero means the walk broke,
+    // not that the components changed.
+    expect(scanned).toBeGreaterThan(15)
+
+    // Call usePortalTarget() and bind its result, so an embedding host can
+    // redirect the overlay. See spec/portal-target.md.
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/composables/usePortalTarget.spec.ts
+++ b/src/composables/usePortalTarget.spec.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
 import Dialog from '../components/Dialog/Dialog.vue'
 import Popover from '../components/Popover/Popover.vue'
+import RailItemBadge from '../components/Rail/RailItemBadge.vue'
 import {
   portalTargetKey,
   providePortalTarget,
@@ -147,6 +148,18 @@ describe('overlays honour the host target', () => {
     expect(host.querySelector('[data-slot="content"]')).toBeNull()
     host.remove()
     explicit.remove()
+  })
+
+  it('routes a hand-rolled Teleport to the host target', async () => {
+    // The Rail badge pill teleports itself rather than through a reka portal,
+    // so it spells out the 'body' fallback and would miss an inject it forgot.
+    const portal = portalElement('rail-portal')
+    const app = createApp(RailItemBadge, { count: 3, variant: 'count' })
+    app.provide(portalTargetKey, portal)
+    mount(app)
+    await nextTick()
+
+    expect(portal.textContent).toContain('3')
   })
 })
 

--- a/src/composables/usePortalTarget.ts
+++ b/src/composables/usePortalTarget.ts
@@ -1,0 +1,49 @@
+import {
+  computed,
+  inject,
+  provide,
+  toValue,
+  type ComputedRef,
+  type InjectionKey,
+  type MaybeRefOrGetter,
+} from 'vue'
+
+/** Anything reka-ui's `<*Portal to>` (a Vue `<Teleport>`) accepts. */
+export type PortalTarget = string | HTMLElement
+
+/**
+ * Injection key a host uses to name where every frappe-ui overlay teleports.
+ *
+ * `Symbol.for`, not a fresh `Symbol`: a host that cannot import from frappe-ui,
+ * or a page carrying two copies of it, still matches through the global
+ * registry.
+ */
+export const portalTargetKey = Symbol.for(
+  'frappe-ui:portal-target',
+) as InjectionKey<MaybeRefOrGetter<PortalTarget | undefined>>
+
+/**
+ * Name the portal target for every overlay below this component. A host that
+ * owns the app instance should `app.provide(portalTargetKey, el)` instead, so
+ * the target covers the root component too.
+ */
+export function providePortalTarget(
+  target: MaybeRefOrGetter<PortalTarget | undefined>,
+): void {
+  provide(portalTargetKey, target)
+}
+
+/**
+ * Resolve where an overlay teleports: `override` (the component's own
+ * `portalTo`), else the host's target, else undefined — which leaves reka-ui on
+ * its `'body'` default. See [the spec](../../spec/portal-target.md).
+ *
+ * A `portalTo` prop must stay undefaulted. A `'body'` default outranks the host
+ * and silently defeats embedding.
+ */
+export function usePortalTarget(
+  override?: MaybeRefOrGetter<PortalTarget | undefined>,
+): ComputedRef<PortalTarget | undefined> {
+  const hostTarget = inject(portalTargetKey, undefined)
+  return computed(() => toValue(override) ?? toValue(hostTarget))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,14 @@ export {
   type UseSheetDragOptions,
 } from './composables/useSheetDrag'
 
+// Embedding: name one portal target for every overlay under a Vue app
+export {
+  portalTargetKey,
+  providePortalTarget,
+  usePortalTarget,
+} from './composables/usePortalTarget'
+export type { PortalTarget } from './composables/usePortalTarget'
+
 // Directives
 export { vFocus } from './directives/focus'
 export { vOnOutsideClick } from './directives/onOutsideClick'

--- a/src/molecules/editor/EditorTableMenu.vue
+++ b/src/molecules/editor/EditorTableMenu.vue
@@ -13,6 +13,7 @@ import { verticalScrollParent } from './extensions/table/drag-scroll'
 import MenuItems from './MenuItems.vue'
 import TableContextMenu from './components/TableContextMenu.vue'
 import { tableToolbar } from './menu'
+import { usePortalTarget } from '#composables/usePortalTarget'
 import type { Editor } from './useEditor'
 import { useResolvedEditor } from './editor-context'
 import {
@@ -34,6 +35,8 @@ import {
  * self-prune when the Table extension is absent, so it's inert in a comment
  * editor.
  */
+const portalTarget = usePortalTarget()
+
 const props = defineProps<{
   // Optional inside <Editor> — falls back to the provided editor context.
   editor?: Editor | null
@@ -266,7 +269,7 @@ onBeforeUnmount(closeContextMenu)
 </script>
 
 <template>
-  <Teleport to="body">
+  <Teleport :to="portalTarget ?? 'body'">
     <Transition name="table-menu">
       <div
         v-show="visible && editor"

--- a/src/molecules/editor/components/ImageViewerModal.vue
+++ b/src/molecules/editor/components/ImageViewerModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport :to="portalTarget ?? 'body'">
     <Transition
       enter-active-class="transition-opacity duration-150 ease-in-out"
       leave-active-class="transition-opacity duration-150 ease-in-out"
@@ -72,6 +72,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, toRef, watch } from 'vue'
 import { useTouchHandler } from '#composables/useTouchHandler'
+import { usePortalTarget } from '#composables/usePortalTarget'
 import { useImageNavigation } from '#composables/useImageNavigation'
 import { useZoomPan } from '#composables/useZoomPan'
 import { useControlsAutoHide } from '#molecules/editor/composables/useControlsAutoHide'
@@ -87,6 +88,8 @@ const props = defineProps<{
   images: ViewableImage[]
   initialIndex: number
 }>()
+
+const portalTarget = usePortalTarget()
 
 const emit = defineEmits<{
   'update:show': [value: boolean]

--- a/src/molecules/editor/extensions/image-group/ImageGroupUploadDialog.vue
+++ b/src/molecules/editor/extensions/image-group/ImageGroupUploadDialog.vue
@@ -122,7 +122,7 @@
       </div>
     </template>
   </Dialog>
-  <Teleport to="body">
+  <Teleport :to="portalTarget ?? 'body'">
     <Transition
       name="fade"
       enter-active-class="transition-opacity duration-200"
@@ -150,6 +150,7 @@ import Dialog from '#components/Dialog/Dialog.vue'
 import Button from '#components/Button/Button.vue'
 import Select from '#components/Select/Select.vue'
 import { ErrorMessage } from '#components/ErrorMessage'
+import { usePortalTarget } from '#composables/usePortalTarget'
 import type { Editor } from '@tiptap/core'
 import { useScopedFileDrop } from '#molecules/editor/composables/useScopedFileDrop'
 import {
@@ -173,6 +174,8 @@ const props = withDefaults(
   }>(),
   { mode: 'new' },
 )
+
+const portalTarget = usePortalTarget()
 
 const emit = defineEmits(['update:modelValue', 'close', 'update:files', 'save'])
 

--- a/v1-release/changelog.md
+++ b/v1-release/changelog.md
@@ -38,6 +38,15 @@ and `Rating` exports `RatingEmits`.
   via `package.json` `engines` so installers and CI surface the requirement
   instead of opaque transitive-dep engine errors.
 
+### Portal target for embedded apps
+
+- `portalTo` on `Popover`, `HoverCard`, `Dropdown`, `Select`, `Combobox` and
+  `MultiSelect` no longer declares a `'body'` prop default. An unembedded app
+  still gets `'body'`, now as a fallback. No existing call behaves differently.
+- New `usePortalTarget` / `providePortalTarget` / `portalTargetKey` exports let
+  an embedding host redirect every overlay at once. See
+  [`spec/portal-target.md`](../spec/portal-target.md).
+
 ### Dialog — v1 spec
 
 - Flat top-level props (`title`, `message`, `icon`, `size`, `position`,

--- a/vite/README.md
+++ b/vite/README.md
@@ -106,6 +106,22 @@ standardized stroke-width of 1.5.
 import LucideArrowRight from '~icons/lucide/arrow-right'
 ```
 
+**Resolver only** — a build that imports every icon explicitly gets no value
+from auto-import, and paying for `unplugin-auto-import` and
+`unplugin-vue-components` to have it is waste. Import the resolver on its own:
+
+```javascript
+import { lucideIconsPlugin } from 'frappe-ui/vite/lucideIconsPlugin'
+
+export default defineConfig({
+  plugins: [lucideIconsPlugin(), vue()],
+})
+```
+
+`~icons/lucide/<name>` still resolves; `<LucideArrowRight />` without an import
+does not. `frappe-ui/vite` re-exports the same plugin for callers already
+importing from there.
+
 ### Frappe Types
 
 Auto-generates TypeScript interfaces from Frappe DocType JSON files. Interfaces

--- a/vite/index.js
+++ b/vite/index.js
@@ -76,4 +76,5 @@ function frappeuiPlugin(options = {}) {
 
 export default frappeuiPlugin
 export { lucideIcons } from './lucideIcons.js'
+export { lucideIconsPlugin } from './lucideIconsPlugin.js'
 export { barrelImports } from './barrelImports.js'

--- a/vite/lucideIcons.js
+++ b/vite/lucideIcons.js
@@ -1,11 +1,9 @@
-import * as LucideIcons from 'lucide-static'
 import AutoImport from 'unplugin-auto-import/vite'
 import Components from 'unplugin-vue-components/vite'
 import IconsResolver from 'unplugin-icons/resolver'
+import { getIcons, lucideIconsPlugin } from './lucideIconsPlugin.js'
 
-const VIRTUAL_PREFIX = '~icons/lucide/'
-const RESOLVED_PREFIX = 'virtual:frappe-ui-lucide/'
-
+// The resolver plus the unplugins, so `<LucideStar />` needs no import at all.
 export function lucideIcons(options = {}) {
   const resolverObj = {
     resolvers: [
@@ -26,143 +24,6 @@ export function lucideIcons(options = {}) {
   return [
     AutoImport(resolverObj),
     Components(componentOptions),
-    LucideIconsPlugin(icons),
+    lucideIconsPlugin(icons),
   ]
-}
-
-// Fallback SVG used when an icon is missing from lucide-static
-// (e.g. brand icons removed in lucide v1: youtube, github, twitter, ...).
-// Matches lucide's "circle-help" so it's visually identifiable as a placeholder.
-const FALLBACK_INNER_HTML =
-  '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/>'
-
-const warnedIcons = new Set()
-
-function LucideIconsPlugin(icons) {
-  return {
-    name: 'frappe-ui-lucide-icons',
-    resolveId(id) {
-      if (id.startsWith(VIRTUAL_PREFIX)) {
-        return RESOLVED_PREFIX + id.slice(VIRTUAL_PREFIX.length)
-      }
-    },
-    load(id) {
-      const normalizedId = id.split('?', 1)[0]
-      if (!normalizedId.startsWith(RESOLVED_PREFIX)) return
-      const iconName = normalizedId.slice(RESOLVED_PREFIX.length)
-      const svg = icons[iconName]
-      if (!svg) {
-        if (!warnedIcons.has(iconName)) {
-          warnedIcons.add(iconName)
-          this.warn(
-            `[frappe-ui-lucide-icons] icon "${iconName}" not found in lucide-static ` +
-              `(brand icons were removed in lucide v1). Rendering a placeholder. ` +
-              `Replace ~icons/lucide/${iconName} with an SVG asset or a different icon.`,
-          )
-        }
-        return generateFallbackModule(iconName)
-      }
-      return generateIconModule(svg)
-    },
-  }
-}
-
-function generateFallbackModule(iconName) {
-  return `
-import { h } from 'vue'
-export default {
-  name: 'LucideMissing_${iconName.replace(/[^a-zA-Z0-9_]/g, '_')}',
-  inheritAttrs: false,
-  render() {
-    return h('svg', {
-      xmlns: 'http://www.w3.org/2000/svg',
-      width: '24',
-      height: '24',
-      viewBox: '0 0 24 24',
-      fill: 'none',
-      stroke: 'currentColor',
-      'stroke-width': '1.5',
-      'stroke-linecap': 'round',
-      'stroke-linejoin': 'round',
-      'data-lucide-missing': ${JSON.stringify(iconName)},
-      ...this.$attrs,
-      innerHTML: ${JSON.stringify(FALLBACK_INNER_HTML)},
-    })
-  }
-}
-`
-}
-
-function generateIconModule(svg) {
-  if (!svg) return null
-
-  const innerMatch = svg.match(/<svg[^>]*>([\s\S]*)<\/svg>/)
-  const innerHTML = innerMatch
-    ? innerMatch[1].replace(/>\s+</g, '><').trim()
-    : ''
-
-  return `
-import { h } from 'vue'
-export default {
-  inheritAttrs: false,
-  render() {
-    return h('svg', {
-      xmlns: 'http://www.w3.org/2000/svg',
-      width: '24',
-      height: '24',
-      viewBox: '0 0 24 24',
-      fill: 'none',
-      stroke: 'currentColor',
-      'stroke-width': '1.5',
-      'stroke-linecap': 'round',
-      'stroke-linejoin': 'round',
-      ...this.$attrs,
-      innerHTML: ${JSON.stringify(innerHTML)},
-    })
-  }
-}
-`
-}
-
-function getIcons() {
-  let icons = {}
-  for (const icon in LucideIcons) {
-    if (icon === 'default') {
-      continue
-    }
-    let iconSvg = LucideIcons[icon]
-
-    // set stroke-width to 1.5
-    if (typeof iconSvg === 'string' && iconSvg.includes('stroke-width')) {
-      iconSvg = iconSvg.replace(/stroke-width="2"/g, 'stroke-width="1.5"')
-    }
-    icons[icon] = iconSvg
-
-    let dashKeys = camelToDash(icon)
-    for (let dashKey of dashKeys) {
-      if (dashKey !== icon) {
-        icons[dashKey] = iconSvg
-      }
-    }
-  }
-  return icons
-}
-
-function camelToDash(key) {
-  // barChart2 -> bar-chart-2
-  let withNumber = key.replace(/[A-Z0-9]/g, (m) => '-' + m.toLowerCase())
-  if (withNumber.startsWith('-')) {
-    withNumber = withNumber.substring(1)
-  }
-  // barChart2 -> bar-chart2
-  let withoutNumber = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase())
-  if (withoutNumber.startsWith('-')) {
-    withoutNumber = withoutNumber.substring(1)
-  }
-
-  if (withNumber !== withoutNumber) {
-    // both are required because unplugin icon resolver doesn't put a dash before numbers
-    return [withNumber, withoutNumber]
-  }
-  return [withNumber]
 }

--- a/vite/lucideIconsPlugin.js
+++ b/vite/lucideIconsPlugin.js
@@ -1,0 +1,144 @@
+import * as LucideIcons from 'lucide-static'
+
+// Resolves `~icons/lucide/<name>` to a render-function component, plus the icon
+// map it reads. Split from `lucideIcons.js` so a build wanting only the resolver
+// need not pull in the unplugins — see "Resolver only" in ./README.md.
+
+const VIRTUAL_PREFIX = '~icons/lucide/'
+const RESOLVED_PREFIX = 'virtual:frappe-ui-lucide/'
+
+// Shown when lucide-static has no such icon — brand icons went in lucide v1.
+// Lucide's own "circle-help", so a placeholder is recognisable on the page.
+const FALLBACK_INNER_HTML =
+  '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/>'
+
+const warnedIcons = new Set()
+
+export function lucideIconsPlugin(icons = getIcons()) {
+  return {
+    name: 'frappe-ui-lucide-icons',
+    resolveId(id) {
+      if (id.startsWith(VIRTUAL_PREFIX)) {
+        return RESOLVED_PREFIX + id.slice(VIRTUAL_PREFIX.length)
+      }
+    },
+    load(id) {
+      const normalizedId = id.split('?', 1)[0]
+      if (!normalizedId.startsWith(RESOLVED_PREFIX)) return
+      const iconName = normalizedId.slice(RESOLVED_PREFIX.length)
+      const svg = icons[iconName]
+      if (!svg) {
+        if (!warnedIcons.has(iconName)) {
+          warnedIcons.add(iconName)
+          this.warn(
+            `[frappe-ui-lucide-icons] icon "${iconName}" not found in lucide-static ` +
+              `(brand icons were removed in lucide v1). Rendering a placeholder. ` +
+              `Replace ~icons/lucide/${iconName} with an SVG asset or a different icon.`,
+          )
+        }
+        return generateFallbackModule(iconName)
+      }
+      return generateIconModule(svg)
+    },
+  }
+}
+
+function generateFallbackModule(iconName) {
+  return `
+import { h } from 'vue'
+export default {
+  name: 'LucideMissing_${iconName.replace(/[^a-zA-Z0-9_]/g, '_')}',
+  inheritAttrs: false,
+  render() {
+    return h('svg', {
+      xmlns: 'http://www.w3.org/2000/svg',
+      width: '24',
+      height: '24',
+      viewBox: '0 0 24 24',
+      fill: 'none',
+      stroke: 'currentColor',
+      'stroke-width': '1.5',
+      'stroke-linecap': 'round',
+      'stroke-linejoin': 'round',
+      'data-lucide-missing': ${JSON.stringify(iconName)},
+      ...this.$attrs,
+      innerHTML: ${JSON.stringify(FALLBACK_INNER_HTML)},
+    })
+  }
+}
+`
+}
+
+function generateIconModule(svg) {
+  if (!svg) return null
+
+  const innerMatch = svg.match(/<svg[^>]*>([\s\S]*)<\/svg>/)
+  const innerHTML = innerMatch
+    ? innerMatch[1].replace(/>\s+</g, '><').trim()
+    : ''
+
+  return `
+import { h } from 'vue'
+export default {
+  inheritAttrs: false,
+  render() {
+    return h('svg', {
+      xmlns: 'http://www.w3.org/2000/svg',
+      width: '24',
+      height: '24',
+      viewBox: '0 0 24 24',
+      fill: 'none',
+      stroke: 'currentColor',
+      'stroke-width': '1.5',
+      'stroke-linecap': 'round',
+      'stroke-linejoin': 'round',
+      ...this.$attrs,
+      innerHTML: ${JSON.stringify(innerHTML)},
+    })
+  }
+}
+`
+}
+
+export function getIcons() {
+  let icons = {}
+  for (const icon in LucideIcons) {
+    if (icon === 'default') {
+      continue
+    }
+    let iconSvg = LucideIcons[icon]
+
+    // set stroke-width to 1.5
+    if (typeof iconSvg === 'string' && iconSvg.includes('stroke-width')) {
+      iconSvg = iconSvg.replace(/stroke-width="2"/g, 'stroke-width="1.5"')
+    }
+    icons[icon] = iconSvg
+
+    let dashKeys = camelToDash(icon)
+    for (let dashKey of dashKeys) {
+      if (dashKey !== icon) {
+        icons[dashKey] = iconSvg
+      }
+    }
+  }
+  return icons
+}
+
+function camelToDash(key) {
+  // barChart2 -> bar-chart-2
+  let withNumber = key.replace(/[A-Z0-9]/g, (m) => '-' + m.toLowerCase())
+  if (withNumber.startsWith('-')) {
+    withNumber = withNumber.substring(1)
+  }
+  // barChart2 -> bar-chart2
+  let withoutNumber = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase())
+  if (withoutNumber.startsWith('-')) {
+    withoutNumber = withoutNumber.substring(1)
+  }
+
+  if (withNumber !== withoutNumber) {
+    // both are required because unplugin icon resolver doesn't put a dash before numbers
+    return [withNumber, withoutNumber]
+  }
+  return [withNumber]
+}


### PR DESCRIPTION
A shadow root breaks frappe-ui overlays. They teleport to `<body>`, outside the
styles that the root loads. The host cannot fix this one overlay at a time. Its
markup rarely names the Dialog that its Combobox opens.

So the host names one portal target. Every overlay below it reads that target.
The order is the explicit `portalTo` prop, then the host target, then reka's
`'body'`. This PR exports `providePortalTarget`, `usePortalTarget` and
`portalTargetKey`. `spec/portal-target.md` gives the reasoning. Without a host
target, nothing changes.

Three smaller fixes follow, one commit each:

1. Overlays that teleport themselves now use the same target.
2. The lucide resolver moves to `frappe-ui/vite/lucideIconsPlugin`, so a build
   can import it without the auto-import plugins.
3. A breadcrumb with both `href` and `onClick` no longer reloads the page.

<!-- coverage-report:start -->
Coverage: 67.07% (-0.14% vs `main`)
<!-- coverage-report:end -->


