### PR TITLE
docs(philosophy): build-time additive-only rule, P14 generalisation, ADR-0010 amendments

### DIFF
--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -480,7 +480,7 @@ Two members today:
 **Why:** First-party code needs to reuse things the public API isn't ready to freeze — internal building blocks not yet promoted (`experimental`), or a config surface shaped by a single caller that would ossify around that caller's needs the moment a second one shows up (`vitepress`). The alternative — re-exporting each of these from a public, frozen entry point, or opening a `./src/*` wildcard — either freezes something not ready to freeze or exposes everything forever. An unstable entry point is the deliberate middle: a small, curated, explicitly-unstable surface.
 
 **Mechanics:**
-1. Exposed through a single curated barrel behind its own subpath export (`experimental.ts`; `vitepress/index.ts` + `index.node.ts`) — **not** a `./src/*` wildcard. Re-export only what a first-party consumer actually needs.
+1. Exposed through a single curated barrel behind its own subpath export (`experimental.ts`; `vitepress/index.ts` + `index.node.ts` + `index.d.ts`) — **not** a `./src/*` wildcard. Re-export only what a first-party consumer actually needs.
 2. The barrel's header restates the no-promise contract at the point of use.
 3. "Private"/"unstable" is by convention — `exports` can't scope visibility to a specific consumer, so the contract is the disclaimer, not enforcement. Product/third-party code is told not to import it.
 4. To make a member stable, deliberately promote it to a public entry point (and thus under P13, or under P15's additive-only rule for a build-time member). Until then, no guarantees.
@@ -540,8 +540,8 @@ Naming the members is also what makes the export surface readable at all: `src/i
 
 **Build-time and tooling entries are a separate category.** `tailwind`, `vite`, `vitepress`, `tsconfig.base.json`, and the `*-style.css` entries aren't judged by the three bars above — they aren't importable into a component tree, so cost isolation, an extensible registry, and name collision have nothing to say about them. ADR-0010 opened this category without saying what its own terms are; [#887](https://github.com/frappe/frappe-ui/issues/887) settled them:
 
-**A build-time entry freezes additive-only.** Options, tokens, utilities, and compiler options may be *added* in a minor. Nothing may be renamed or removed before `2.0.0`.
+**A build-time entry freezes additive-only at `1.0.0`.** Options, tokens, utilities, and compiler options may be *added* in a minor. Nothing may be renamed or removed before `2.0.0`.
 
-Neither of P15's other two shapes fits. A P13-style freeze would end the design-token vocabulary the day we tag — the Figma token sync exists to keep adding tokens, and a deprecate-then-remove cycle has no answer for "add a new one." A P14-style no-promise carve-out is the other extreme, and not one six apps whose CSS and builds depend on the tailwind preset and the vite plugin would accept. Additive-only is the shape where existing names can't move and new ones can still appear.
+Neither of P15's other two shapes fits. A P13-style freeze would end the design-token vocabulary the day we tag — the Figma token sync exists to keep adding tokens, and a deprecate-then-remove cycle has no answer for "add a new one." A P14-style no-promise carve-out is the other extreme, and not one the six apps whose CSS and builds depend on the tailwind preset and the vite plugin would accept. Additive-only is the shape where existing names can't move and new ones can still appear.
 
 The one named exception is `frappe-ui/vitepress` — see P14.

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -469,17 +469,21 @@ const isDismissible = computed(() => {
 })
 ```
 
-### P14. Experimental carries no promise
+### P14. Unstable entry points carry no promise
 
-**Rule:** Code reached through the `frappe-ui/experimental` subpath is private and **exempt from P13**. It can change shape or be removed in any release — including minor/patch — with no deprecation window. Use it from first-party Frappe libraries without expecting stability.
+**Rule:** Some entry points are curated barrels that ship with **no stability promise at all** — exempt from P13. They can change shape or be removed in any release, including minor/patch, with no deprecation window.
 
-**Why:** First-party libraries need to reuse internal building blocks, composables like `useInputLabeling`, class helpers, headless logic, and components whose API is still settling — without every one being promoted to the public API and frozen under P13. `experimental` is that escape hatch: the framework gets to consume these while the *public* surface stays small and the cost of evolving them stays zero. The alternative, re-exporting each helper from the public API, or opening a `./src/*` wildcard either freezes everything under P13 or exposes everything forever. `experimental` is the deliberate middle: a small, curated, explicitly-unstable surface.
+Two members today:
+- **`frappe-ui/experimental`** — private internal building blocks: composables like `useInputLabeling`, class helpers, headless logic, and components whose API is still settling. Use it from first-party Frappe libraries without expecting stability.
+- **`frappe-ui/vitepress`** — the shared VitePress docs theme. Ships at `1.0.0`, but is exempt from both P13 and P15's build-time additive-only rule. Its only consumer today is frappe-ui's own docs site, so every field of `DefineDocsConfigOptions` was shaped by exactly one caller; the theme needs room to change shape as a second Frappe docs site adopts it.
+
+**Why:** First-party code needs to reuse things the public API isn't ready to freeze — internal building blocks not yet promoted (`experimental`), or a config surface shaped by a single caller that would ossify around that caller's needs the moment a second one shows up (`vitepress`). The alternative — re-exporting each of these from a public, frozen entry point, or opening a `./src/*` wildcard — either freezes something not ready to freeze or exposes everything forever. An unstable entry point is the deliberate middle: a small, curated, explicitly-unstable surface.
 
 **Mechanics:**
-1. Exposed through a single curated barrel (`experimental.ts`) behind the `./experimental` export **not** a `./src/*` wildcard. Re-export only what a first-party consumer actually needs.
-2. The barrel header restates the no-promise contract at the point of use.
-3. "Private" is by convention, `exports` can't scope visibility to a specific consumer so the contract is the disclaimer, not enforcement. Product/third-party code is told not to import it.
-4. To make an internal stable, deliberately promote it to a public entry point (and thus under P13). Until then, no guarantees.
+1. Exposed through a single curated barrel behind its own subpath export (`experimental.ts`; `vitepress/index.ts` + `index.node.ts`) — **not** a `./src/*` wildcard. Re-export only what a first-party consumer actually needs.
+2. The barrel's header restates the no-promise contract at the point of use.
+3. "Private"/"unstable" is by convention — `exports` can't scope visibility to a specific consumer, so the contract is the disclaimer, not enforcement. Product/third-party code is told not to import it.
+4. To make a member stable, deliberately promote it to a public entry point (and thus under P13, or under P15's additive-only rule for a build-time member). Until then, no guarantees.
 
 ---
 
@@ -533,3 +537,11 @@ export * from './components/Button'
 ```
 
 Naming the members is also what makes the export surface readable at all: `src/index.ts` becomes the list of what ships, rather than a list of directories to go and expand by hand.
+
+**Build-time and tooling entries are a separate category.** `tailwind`, `vite`, `vitepress`, `tsconfig.base.json`, and the `*-style.css` entries aren't judged by the three bars above — they aren't importable into a component tree, so cost isolation, an extensible registry, and name collision have nothing to say about them. ADR-0010 opened this category without saying what its own terms are; [#887](https://github.com/frappe/frappe-ui/issues/887) settled them:
+
+**A build-time entry freezes additive-only.** Options, tokens, utilities, and compiler options may be *added* in a minor. Nothing may be renamed or removed before `2.0.0`.
+
+Neither of P15's other two shapes fits. A P13-style freeze would end the design-token vocabulary the day we tag — the Figma token sync exists to keep adding tokens, and a deprecate-then-remove cycle has no answer for "add a new one." A P14-style no-promise carve-out is the other extreme, and not one six apps whose CSS and builds depend on the tailwind preset and the vite plugin would accept. Additive-only is the shape where existing names can't move and new ones can still appear.
+
+The one named exception is `frappe-ui/vitepress` — see P14.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -104,7 +104,6 @@ function buildSidebar(): SidebarSection[] {
         { text: 'Icons', link: '/docs/other/icons' },
         { text: 'Utilities', link: '/docs/other/utilities' },
         { text: 'Directives', link: '/docs/other/directives' },
-        { text: 'Vite Plugin', link: '/docs/other/vite' },
         { text: 'VitePress theme', link: '/docs/other/vitepress-theme' },
       ],
     },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -104,6 +104,8 @@ function buildSidebar(): SidebarSection[] {
         { text: 'Icons', link: '/docs/other/icons' },
         { text: 'Utilities', link: '/docs/other/utilities' },
         { text: 'Directives', link: '/docs/other/directives' },
+        { text: 'Vite Plugin', link: '/docs/other/vite' },
+        { text: 'VitePress theme', link: '/docs/other/vitepress-theme' },
       ],
     },
   ]

--- a/docs/content/docs/other/vitepress-theme.md
+++ b/docs/content/docs/other/vitepress-theme.md
@@ -1,0 +1,41 @@
+# VitePress theme
+
+The `frappe-ui/vitepress` subpath is the shared VitePress theme and config
+builder that renders this docs site: the layout, sidebar, search, command
+palette, and the `defineDocsConfig()` helper that wires them into a VitePress
+config.
+
+> **Unstable API** — `frappe-ui/vitepress` ships at `1.0.0` but carries no
+> stability promise. It is exempt from the usual deprecation policy and from
+> the additive-only rule that otherwise governs frappe-ui's build-time
+> entries: it can change shape or disappear in _any_ release, including minor
+> and patch releases, with no deprecation window. Its only consumer today is
+> this docs site, so `DefineDocsConfigOptions` was shaped by exactly one
+> caller — it needs room to change as a second Frappe docs site adopts it.
+
+## Usage
+
+```ts
+// .vitepress/config.ts
+import { defineDocsConfig } from 'frappe-ui/vitepress'
+
+export default defineDocsConfig({
+  rootDir: __dirname,
+  name: 'My Docs',
+  description: '…',
+  sidebar: [
+    /* … */
+  ],
+})
+```
+
+```ts
+// .vitepress/theme/index.ts
+import { theme } from 'frappe-ui/vitepress'
+
+export default theme
+```
+
+`DefineDocsConfigOptions` isn't reproduced here since it's expected to
+change — read it directly from `vitepress/index.node.ts` in the frappe-ui
+source.

--- a/docs/content/docs/other/vitepress-theme.md
+++ b/docs/content/docs/other/vitepress-theme.md
@@ -17,10 +17,17 @@ config.
 
 ```ts
 // .vitepress/config.ts
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineDocsConfig } from 'frappe-ui/vitepress'
 
+// VitePress config runs as native ESM — there's no __dirname. Derive the
+// docs root from the config file's own URL instead.
+const configDir = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(configDir, '..')
+
 export default defineDocsConfig({
-  rootDir: __dirname,
+  rootDir,
   name: 'My Docs',
   description: '…',
   sidebar: [

--- a/spec/adr/0010-subpath-export-rule.md
+++ b/spec/adr/0010-subpath-export-rule.md
@@ -63,7 +63,7 @@ separate category, decided on their own terms.
 | `frappe-ui/experimental` | P14 | Its own rule; not judged by these limbs. Now also home to `CodeEditor` and `CodePreview` (see below). |
 | `frappe-ui/code-editor` | none | Removed. `CodeEditor`'s only dependency (CodeMirror) is entirely behind `await import()` — nothing static. It is a form-field sibling of `Textarea`/`TextInput` (its own prop types are derived from the shared `InputVariant`/`InputSize` union), not a family with a composition model. `CodePreview` statically imports `marked`, which would otherwise re-enter root's dependency graph the moment ADR-0008 deletes the deprecated `TextEditor` re-export (`marked`'s only other path to root). Rather than fold `CodeEditor` into root and leave `CodePreview` behind on a single-purpose subpath, both move to `frappe-ui/experimental` together — P14 carries no stability promise, so the pair can grow into a fuller code-editing parts family later, against real usage, without needing a `2.0.0`. |
 | `frappe-ui/frappe`, `frappe-ui/drive`, `frappe-ui/drive/*` | — | Disposition is #867's decision, not this rule's. |
-| `frappe-ui/tailwind`, `frappe-ui/tailwind/tokens.js`, `frappe-ui/vite`, `frappe-ui/vitepress`, `frappe-ui/tsconfig.base.json`, `frappe-ui/hljs-theme.css` | — | Build-time/tooling category; #887's decision. |
+| `frappe-ui/tailwind`, `frappe-ui/vite`, `frappe-ui/vitepress`, `frappe-ui/tsconfig.base.json`, `frappe-ui/tailwind/tokens.js`, `frappe-ui/hljs-theme.css` | — | Build-time/tooling category, decided by #887: **a build-time entry freezes additive-only** — options, tokens, utilities, and compiler options may be added in a minor; nothing may be renamed or removed before `2.0.0` (PHILOSOPHY.md P15). Ships: `tailwind` (gains a `content` export), `vite` (gains types), `tsconfig.base.json` (cleaned), and `vitepress` under its own rule (P14 — no stability promise, exempt from the additive-only rule too). Removed: `tailwind/tokens.js` (zero importers anywhere, an `export *` leak of `colorPalette.js`) and `hljs-theme.css` (goes with the deprecated `TextEditor`). |
 
 ### What this hands to other tickets
 
@@ -141,10 +141,18 @@ separate category, decided on their own terms.
   archaeology — a new family's authors can apply P15 themselves instead of
   re-litigating the question.
 - `frappe-ui/code-editor` is removed as a subpath; `CodeEditor`, `CodePreview`, and
-  `loadLanguage` move to `frappe-ui/experimental`. No downstream app imports
-  `frappe-ui/code-editor` today (checked against freshly fetched `upstream` refs for
-  crm, helpdesk, insights, builder, gameplan, raven), so this is a zero-call-site
-  move, not a break.
+  `loadLanguage` move to `frappe-ui/experimental`. **Correction (#935):** this was
+  first written up as a zero-call-site move, checked against freshly fetched
+  `upstream` refs for crm, helpdesk, insights, builder, gameplan, and raven — but
+  that count missed frappe's own `ui/` package. `@framework/ui` imports it at
+  `ui/src/components/Fields/CodeEditorField.vue:120`
+  (`import { CodeEditor, CodePreview } from "frappe-ui/code-editor"`), the same
+  gap that made #887 initially read `frappe-ui/experimental` as unused when it
+  has 8 import sites there. The verdict doesn't change — it's a loud break in one
+  file, and that file already imports from `frappe-ui/experimental`, so the fold
+  merges two import lines into one — only the basis does. **Standing rule 5's
+  census must include frappe's `ui/` package from here on, not only the product
+  apps.**
 - `frappe-ui/list`, `frappe-ui/icons`, and the in-flight `frappe-ui/charts` all stand
   on this rule without needing a carve-out.
 - Root keeps `SettingsDialog`, `PageHeader`, `Sidebar`, and the legacy `ListView`

--- a/vitepress/index.d.ts
+++ b/vitepress/index.d.ts
@@ -9,6 +9,12 @@
 // This declaration (wired as the `types` condition) merges both surfaces so
 // editors resolve the full API regardless of context. The node-only names are
 // disjoint from the browser names, so there are no `export *` collisions.
+//
+// UNSTABLE (P14) — no backward-compatibility promise. This is the surface
+// TypeScript actually resolves for `frappe-ui/vitepress`; its only consumer
+// today is frappe-ui's own docs site, so it can change shape or disappear in
+// any release, including a patch, with no deprecation window. Do not import
+// this subpath from product apps or third-party code.
 export * from './index'
 export {
   defineDocsConfig,

--- a/vitepress/index.node.ts
+++ b/vitepress/index.node.ts
@@ -1,3 +1,13 @@
+// Node-side config builder for the reusable VitePress docs theme — the
+// `frappe-ui/vitepress` entry as seen by VitePress's Node config loader
+// (`node` export condition). The browser/SSR half (theme, components,
+// composables) lives in the sibling `index.ts`.
+//
+// UNSTABLE (P14) — no backward-compatibility promise. `DefineDocsConfigOptions`
+// was shaped by frappe-ui's own docs site, its only consumer today, and can
+// change shape or disappear in any release, including a patch, with no
+// deprecation window. Do not import this subpath from product apps or
+// third-party code.
 import path from 'node:path'
 import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'

--- a/vitepress/index.ts
+++ b/vitepress/index.ts
@@ -7,6 +7,11 @@
 // `index.node.ts`, exposed through the package's `node` export condition.
 // Named exports only. Importing `theme` also loads the stylesheet as a side
 // effect (via ./theme), so consumers don't need a separate style.css import.
+//
+// UNSTABLE (P14) — no backward-compatibility promise. This barrel's only
+// consumer today is frappe-ui's own docs site, so it can change shape or
+// disappear in any release, including a patch, with no deprecation window.
+// Do not import this subpath from product apps or third-party code.
 export { theme } from './theme'
 
 // Shared components (Layout, CommandPalette, Search, Sidebar, …) plus the


### PR DESCRIPTION
## Summary

Records the two rules #887 settled for build-time and unstable entry points, and fixes a wrong basis in ADR-0010.

- **PHILOSOPHY.md P15** gains the build-time additive-only rule: build-time entries (`tailwind`, `vite`, `vitepress`, `tsconfig.base.json`, `*-style.css`) freeze additive-only — options, tokens, utilities and compiler options may be added in a minor; nothing renamed or removed before `2.0.0`.
- **PHILOSOPHY.md P14** is generalised from "the experimental subpath" to a rule about unstable entry points, with `frappe-ui/experimental` and `frappe-ui/vitepress` as its two members. Header comments in `vitepress/index.ts` and `index.node.ts` restate the no-promise contract, and a new docs page (`docs/content/docs/other/vitepress-theme.md`) covers the shared docs theme.
- **ADR-0010**: the `code-editor` row's "zero downstream call sites" basis is corrected — `@framework/ui` imports it at `CodeEditorField.vue:120`. The fold-into-experimental verdict stands; only the basis changes, plus a note that standing rule 5's census must include frappe's `ui/` package.
- **ADR-0010**: the build-time row's "#887's decision" placeholder is replaced with the actual verdicts (ships: tailwind, vite, tsconfig.base.json, vitepress; removed: tailwind/tokens.js, hljs-theme.css).

No runtime code changes except comment headers.

Closes #935

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-968/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 67.21% (±0.00% vs `main`)
<!-- coverage-report:end -->

