### PR TITLE
docs(data-fetching): v2 composable pages, split sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -90,6 +90,16 @@ function buildSidebar(): SidebarSection[] {
     {
       text: 'Data Fetching',
       items: [
+        { text: 'useCall', link: '/docs/data-fetching/use-call' },
+        { text: 'useDoc', link: '/docs/data-fetching/use-doc' },
+        { text: 'useList', link: '/docs/data-fetching/use-list' },
+        { text: 'useDoctype', link: '/docs/data-fetching/use-doctype' },
+        { text: 'useNewDoc', link: '/docs/data-fetching/use-new-doc' },
+      ],
+    },
+    {
+      text: 'Resources',
+      items: [
         { text: 'Resource', link: '/docs/data-fetching/resource' },
         { text: 'List Resource', link: '/docs/data-fetching/list-resource' },
         {

--- a/docs/content/docs/data-fetching/resource.md
+++ b/docs/content/docs/data-fetching/resource.md
@@ -1,5 +1,9 @@
 # Resource
 
+Resources are fully supported through `1.x`. For new code, see
+[Data Fetching](./use-call.md) — `useCall`, `useDoc`, `useList`, `useDoctype`
+and `useNewDoc` are the recommended layer.
+
 Resource is a feature to manage async data fetching and mutations in your Vue
 frontend. It will fetch, cache and keep data up-to-date from the server.
 

--- a/docs/content/docs/data-fetching/use-call.md
+++ b/docs/content/docs/data-fetching/use-call.md
@@ -1,0 +1,126 @@
+# useCall
+
+`useCall`, `useDoc`, `useList`, `useDoctype` and `useNewDoc` are the recommended
+data-fetching layer for new code. If you're maintaining an app still on the
+older resource API, see [Resources](./resource.md) — it stays fully supported
+through `1.x`.
+
+`useCall` calls a whitelisted Frappe method or a REST endpoint and gives you
+back a reactive object with the response, loading and error state.
+
+## Basic example
+
+```vue
+<template>
+  <Button @click="ping.reload()" :loading="ping.loading"> Ping </Button>
+  <pre>{{ ping.data }}</pre>
+</template>
+
+<script setup>
+import { useCall } from 'frappe-ui'
+
+const ping = useCall({
+  url: '/api/method/ping',
+})
+</script>
+```
+
+By default the request fires immediately and uses `GET`.
+
+## Submitting with params
+
+Set `method` and call `submit()` for anything that isn't a plain `GET`:
+
+```vue
+<script setup>
+import { useCall } from 'frappe-ui'
+
+const renameTodo = useCall({
+  url: '/api/method/frappe.client.rename_doc',
+  method: 'POST',
+  immediate: false,
+})
+
+async function rename(name, newName) {
+  await renameTodo.submit({
+    doctype: 'ToDo',
+    old_name: name,
+    new_name: newName,
+  })
+}
+</script>
+```
+
+## Options
+
+- `url` — the endpoint to call. A REST path or a whitelisted method dotted path.
+  Accepts a `Ref<string>` for a URL that changes reactively.
+- `method` — the HTTP method: `'GET' | 'POST' | 'PUT' | 'DELETE'`. Defaults to
+  `'GET'`.
+- `params` — the request params. Either a plain object, or a function returning
+  one, read fresh on every request — use the function form so reactive values
+  inside are re-read on each call.
+- `immediate` — fire the first request automatically when `useCall` is set up.
+  Defaults to `true`.
+- `refetch` — automatically fire a new request whenever a reactive `url` or
+  `params` dependency changes. Defaults to `false`.
+- `baseUrl` — prefix prepended to `url`. Useful when the Frappe site isn't
+  served from the same origin as the frontend.
+- `initialData` — the value `data` holds before the first response arrives.
+- `cacheKey` — a string, or array of primitives, that persists the response in
+  memory and IndexedDB under that key. A second `useCall` with the same
+  `cacheKey` shows the cached value immediately while it refetches in the
+  background.
+- `staleOnError` — when `true` and `cacheKey` is set, a failed refetch keeps
+  showing the last cached `data` instead of clearing it. Defaults to `false`.
+- `transform` — receives the raw response data and returns the value `data`
+  should hold. Return `undefined` to leave the response untouched.
+- `beforeSubmit` — runs before a `submit()` call sends its request. Use it for
+  side effects like clearing a previous validation message; it does not stop the
+  request from being sent.
+- `onSuccess` — called with the response data after a successful request.
+- `onError` — called with the error after a failed request.
+
+## Return value
+
+- `data` — the response data, or `null` before the first successful response.
+- `error` — the error from the last request, or `null`.
+- `loading` (alias `isFetching`) — `true` while a request is in flight.
+- `isFinished` — `true` once the current request has settled, either way.
+- `params` — the params that were sent with the last request.
+- `url` — the fully resolved URL, including `baseUrl` and, for `GET` requests,
+  the serialized query string.
+- `promise` — the in-flight request's promise. Resolves (it never rejects) once
+  the request settles, whether it succeeded or failed — check `error` after
+  awaiting it.
+- `canAbort` — `true` while a request that can still be aborted is in flight.
+- `aborted` — `true` if the last request was aborted.
+- `execute()` (aliases `fetch()`, `reload()`) — fires a request using the
+  current `params`, ignoring `immediate`/`refetch`. Returns a promise that
+  resolves with the response data, or rejects if the request fails.
+- `submit(params?)` — runs `beforeSubmit`, then sends a request with the given
+  params (or the configured `params` if omitted). Resolves with the response
+  data, or rejects with the error.
+- `reset()` — clears any params set by a previous `submit()` call.
+- `abort()` — aborts the in-flight request.
+
+## Errors
+
+A Frappe error response rejects `submit()`/`execute()` and sets `error` to a
+[`FrappeResponseError`](../other/utilities.md#frapperesponseerror), which
+carries `title`, `type`, `exception` and `indicator` from the server's response
+— narrow a catch block with `error instanceof FrappeResponseError` to read them.
+
+## Caching
+
+Pass `cacheKey` to persist the response. The cached value is read from IndexedDB
+and shown immediately on the next `useCall` with the same key, while a fresh
+request runs in the background and replaces it once it resolves.
+
+```js
+const todo = useCall({
+  url: '/api/method/frappe.client.get',
+  params: { doctype: 'ToDo', name: 'todo-1' },
+  cacheKey: ['todo', 'todo-1'],
+})
+```

--- a/docs/content/docs/data-fetching/use-call.md
+++ b/docs/content/docs/data-fetching/use-call.md
@@ -72,7 +72,9 @@ async function rename(name, newName) {
   `cacheKey` shows the cached value immediately while it refetches in the
   background.
 - `staleOnError` — when `true` and `cacheKey` is set, a failed refetch keeps
-  showing the last cached `data` instead of clearing it. Defaults to `false`.
+  showing the last cached `data` instead of clearing it. Does not apply when
+  the failure is a Frappe error response (`FrappeResponseError`) — that still
+  clears the cache. Defaults to `false`.
 - `transform` — receives the raw response data and returns the value `data`
   should hold. Return `undefined` to leave the response untouched.
 - `beforeSubmit` — runs before a `submit()` call sends its request. Use it for

--- a/docs/content/docs/data-fetching/use-doc.md
+++ b/docs/content/docs/data-fetching/use-doc.md
@@ -1,0 +1,121 @@
+# useDoc
+
+`useDoc` fetches a single Frappe document and keeps it reactive. Documents are
+shared across every `useDoc` call for the same `doctype`/`name` — two components
+rendering the same document read the same cached copy and update together.
+
+## Basic example
+
+```vue
+<template>
+  <div v-if="todo.doc">
+    {{ todo.doc.description }}
+  </div>
+  <Button @click="todo.setValue.submit({ status: 'Closed' })"> Close </Button>
+</template>
+
+<script setup>
+import { useDoc } from 'frappe-ui'
+
+const todo = useDoc({
+  doctype: 'ToDo',
+  name: 'TODO-0001',
+})
+</script>
+```
+
+## Reactive name
+
+`name` accepts a `Ref` or a getter, so `useDoc` can follow a document that
+changes — e.g. a `name` coming from the route:
+
+```vue
+<script setup>
+import { useRoute } from 'vue-router'
+import { useDoc } from 'frappe-ui'
+
+const route = useRoute()
+const todo = useDoc({
+  doctype: 'ToDo',
+  name: () => route.params.name,
+})
+</script>
+```
+
+The request refires automatically whenever `name` resolves to a new value.
+
+## Document methods
+
+`methods` exposes whitelisted document methods (`doc.run_method(...)` on the
+server) as their own `useCall`-shaped members:
+
+```vue
+<script setup>
+import { useDoc } from 'frappe-ui'
+
+const todo = useDoc({
+  doctype: 'ToDo',
+  name: 'TODO-0001',
+  methods: {
+    // shorthand: the server method name
+    markDone: 'mark_done',
+    // full options, same shape as useCall (minus url/method/immediate)
+    reassign: {
+      name: 'reassign',
+      onSuccess: () => console.log('reassigned'),
+    },
+  },
+})
+
+todo.markDone.submit()
+todo.reassign.submit({ allocated_to: 'jane@example.com' })
+</script>
+```
+
+## Options
+
+- `doctype` — the DocType of the document.
+- `name` — the document's name. Accepts a plain string, a `Ref<string>` or a
+  getter for a reactively-changing document.
+- `baseUrl` — prefix prepended to the generated request URLs.
+- `url` — overrides the default `/api/v2/document/<doctype>/<name>` GET URL.
+- `methods` — a map of member name to either a server method name (string), or a
+  [`useCall`](./use-call.md) options object (minus `url` and `baseUrl`) plus a
+  required `name` naming the server method. Defaults to `method: 'POST'` and
+  `immediate: false`; both can be overridden per method. Each becomes a
+  `useCall`-shaped member on the returned object.
+- `immediate` — fire the initial GET automatically once `name` resolves.
+  Defaults to `true`.
+- `staleOnError` — when `true`, a failed refetch keeps showing the last known
+  `doc` instead of clearing it. Defaults to `false`.
+- `transform` — receives the fetched document (with `doctype` set) and returns
+  the value `doc` should hold.
+
+## Return value
+
+- `doc` — the document, or `null` before it has been fetched.
+- `error` — the error from the last fetch, or `null`.
+- `loading` (alias `isFetching`) — `true` while the document is being fetched.
+- `isFinished` — `true` once the current fetch has settled, either way.
+- `canAbort` — `true` while a fetch that can still be aborted is in flight.
+- `aborted` — `true` if the last fetch was aborted.
+- `execute()` (aliases `fetch()`, `reload()`) — refetches the document. Returns
+  a promise that resolves with the response, or rejects if the fetch fails.
+- `abort()` — aborts the in-flight fetch.
+- `setValue` — a [`useCall`](./use-call.md)-shaped member;
+  `setValue.submit(values)` `PUT`s a partial update and writes the response back
+  into `doc`.
+- `delete` — a `useCall`-shaped member; `delete.submit()` deletes the document
+  and clears it from every `useDoc`/`useList` reading it.
+- `onSuccess(callback)` — registers a callback that runs with the document every
+  time _this_ `useDoc` call's own fetch (the initial load, or a `reload()`)
+  succeeds. Returns an unsubscribe function.
+- one member per entry in `methods`, each a `useCall`-shaped object.
+
+## Shared cache
+
+Every `useDoc` (and matching row in a [`useList`](./use-list.md)) for the same
+`doctype`/`name` reads from one shared, reactive store. Calling `setValue` or
+`delete` from any of them updates `doc` everywhere that document is being read,
+and a document written by `useNewDoc` is immediately readable through `useDoc`
+under its returned `name`.

--- a/docs/content/docs/data-fetching/use-doctype.md
+++ b/docs/content/docs/data-fetching/use-doctype.md
@@ -1,0 +1,91 @@
+# useDoctype
+
+`useDoctype` groups the write operations for a DocType — insert, delete, set a
+field, run a method — without fetching or holding any document itself. Use it
+alongside [`useDoc`](./use-doc.md) or [`useList`](./use-list.md) for reads.
+
+## Basic example
+
+```vue
+<script setup>
+import { useDoctype } from 'frappe-ui'
+
+const todo = useDoctype('ToDo')
+
+async function create(description) {
+  const doc = await todo.insert.submit({ description })
+  console.log(doc.name)
+}
+
+async function close(name) {
+  await todo.setValue.submit({ name, status: 'Closed' })
+}
+</script>
+```
+
+Every submit runs independently — closing two documents at once, or one document
+twice, does not cancel either request.
+
+## Running a method
+
+```vue
+<script setup>
+import { useDoctype } from 'frappe-ui'
+
+const user = useDoctype('User')
+
+async function resetPassword(name) {
+  await user.runDocMethod.submit({
+    name,
+    method: 'reset_password',
+    params: { send_email: true },
+  })
+}
+
+async function ping() {
+  // a method on the DocType itself, not one document
+  await user.runMethod.submit({ method: 'get_online_users' })
+}
+</script>
+```
+
+## Options
+
+`useDoctype(doctype, options?)` — the DocType is a positional argument, not a
+field on the options object.
+
+- `doctype` — the DocType every member acts on.
+- `options.baseUrl` — prefix prepended to the generated request URLs.
+
+## Return value
+
+Every member below shares the same shape: `data`, `error`, `loading` (`true`
+while any submit for that member is in flight), `submit(params)`, and
+`isLoading(...)` reporting on one target so a list can show a spinner on the row
+it belongs to.
+
+- `insert` — `insert.submit(values)` creates a document. `insert.isLoading()`
+  takes no argument — a new document has no name yet to key on.
+- `delete` — `delete.submit({ name })` deletes a document.
+  `delete.isLoading(name)` reports on one document.
+- `setValue` — `setValue.submit({ name, ...values })` updates one or more fields
+  on a document. `setValue.isLoading(name)` reports on one document.
+- `runDocMethod` — `runDocMethod.submit({ name, method, params?, validate? })`
+  calls a whitelisted method on one document. `validate` runs first and, if it
+  returns a string, rejects the submit with that message instead of sending a
+  request. `runDocMethod.isLoading(name, method)` reports on one document/method
+  pair.
+- `runMethod` — `runMethod.submit({ method, params?, validate? })` calls a
+  whitelisted method on the DocType itself, not a specific document.
+  `runMethod.isLoading(method)` reports on one method.
+
+`data` and `error` on each member belong to that member's most recently
+_started_ submit, not the one that settles last — a slower, older submit still
+resolves or rejects its own caller, but does not overwrite a newer submit's
+`data`/`error`.
+
+## Errors
+
+`submit()` rejects with a
+[`FrappeResponseError`](../other/utilities.md#frapperesponseerror) on a Frappe
+error response, or with the `validate` message on `runDocMethod`/ `runMethod`.

--- a/docs/content/docs/data-fetching/use-list.md
+++ b/docs/content/docs/data-fetching/use-list.md
@@ -1,0 +1,150 @@
+# useList
+
+`useList` fetches a list of documents for a DocType and keeps it reactive —
+pagination, filters and write helpers included. Rows it fetches are shared with
+[`useDoc`](./use-doc.md): updating a document through either updates the other.
+
+## Basic example
+
+```vue
+<template>
+  <div v-for="todo in todos.data" :key="todo.name">
+    {{ todo.description }} — {{ todo.status }}
+  </div>
+  <Button @click="todos.next()" :disabled="!todos.hasNextPage"> Next </Button>
+</template>
+
+<script setup>
+import { useList } from 'frappe-ui'
+
+const todos = useList({
+  doctype: 'ToDo',
+  fields: ['name', 'description', 'status'],
+  orderBy: 'creation desc',
+  limit: 20,
+})
+</script>
+```
+
+## Filters
+
+`filters` accepts a value per field, or a `[operator, value]` tuple for anything
+other than equality. Values can be `Ref`s or getters, so changing a filter
+refetches automatically:
+
+```vue
+<script setup>
+import { ref } from 'vue'
+import { useList } from 'frappe-ui'
+
+const status = ref('Open')
+const todos = useList({
+  doctype: 'ToDo',
+  filters: {
+    status,
+    priority: ['in', ['High', 'Urgent']],
+    description: ['like', '%deploy%'],
+  },
+})
+</script>
+```
+
+## Write methods
+
+`insert`, `setValue` and `delete` write to the DocType `useList` was created
+for. Unlike `useCall`, each is a leaner shape — see
+[Return value](#return-value) — because every submit runs independently: two
+rows can be saved or deleted at the same time without one aborting the other.
+
+```vue
+<script setup>
+import { useList } from 'frappe-ui'
+
+const todos = useList({ doctype: 'ToDo' })
+
+async function close(name) {
+  await todos.setValue.submit({ name, status: 'Closed' })
+}
+</script>
+
+<template>
+  <div v-for="todo in todos.data" :key="todo.name">
+    {{ todo.description }}
+    <Button
+      :loading="todos.setValue.isLoading(todo.name)"
+      @click="close(todo.name)"
+    >
+      Close
+    </Button>
+  </div>
+</template>
+```
+
+## Options
+
+- `doctype` — the DocType to list.
+- `fields` — the fields to fetch per row. Accepts plain field names,
+  `"field as alias"`, `"link_field.fieldname"` for a linked doc's field, or a
+  child table map (`{ items: ['item_code', 'qty'] }`).
+- `filters` — a map of field name to a value (equality) or a `[operator, value]`
+  tuple. Accepts `Ref`s/getters for reactive values.
+- `orderBy` — `"<field> asc"` or `"<field> desc"`. Accepts a `Ref`/getter.
+- `start` — the offset of the first row. Defaults to `0`.
+- `limit` — the page size. Defaults to `20`.
+- `groupBy` — a field to group results by.
+- `parent` — for a child table DocType, the parent DocType to scope rows to.
+- `debug` — when `true`, asks the server to include debug info in the response,
+  logged to the console.
+- `cacheKey` — a string, or array of primitives, that persists the current page
+  in memory and IndexedDB under that key, shown immediately on the next
+  `useList` with the same key while it refetches in the background.
+- `staleOnError` — when `true` and `cacheKey` is set, a failed refetch keeps
+  showing the last cached `data` instead of clearing it. Defaults to `false`.
+- `initialData` — the value `data` holds before the first response.
+- `immediate` — fire the first request automatically. Defaults to `true`.
+- `refetch` — automatically refetch when a reactive filter/sort dependency
+  changes. Defaults to `true`.
+- `baseUrl` — prefix prepended to the generated request URLs.
+- `url` — overrides the default `/api/v2/document/<doctype>` list URL.
+- `transform` — receives the fetched rows and returns the array `data` should
+  hold.
+- `onSuccess` — called with the full row array after a successful fetch.
+- `onError` — called with the error after a failed fetch.
+
+## Return value
+
+- `data` — the current page's rows.
+- `error` — the error from the last fetch, or `null`.
+- `loading` (alias `isFetching`) — `true` while a fetch is in flight.
+- `isFinished` — `true` once the current fetch has settled, either way.
+- `hasNextPage` / `hasPreviousPage` — whether `next()`/`previous()` has anywhere
+  to go.
+- `start` / `limit` — the current page's offset and size.
+- `url` — the fully resolved request URL.
+- `canAbort` — `true` while a fetch that can still be aborted is in flight.
+- `aborted` — `true` if the last fetch was aborted.
+- `execute()` (aliases `fetch()`, `reload()`) — refetches the current page.
+- `abort()` — aborts the in-flight fetch.
+- `next()` / `previous()` — moves `start` by one page and, when `refetch` is
+  `false`, fetches it.
+- `updateRow(doc)` / `removeRow(name)` — update or remove a row in `data` by
+  `name`, without a request. Used internally to keep rows in sync with `useDoc`;
+  call directly to patch `data` optimistically.
+- `insert`, `setValue`, `delete` — write helpers, each with `data`, `error`,
+  `loading` (true while any submit for that method is in flight),
+  `submit(params)` and `isLoading(...)`:
+  - `insert.submit(values)` creates a row. `insert.isLoading()` takes no
+    argument — a new row has no name yet to key on.
+  - `setValue.submit({ name, ...values })` updates a row by name.
+    `setValue.isLoading(name)` reports on one row.
+  - `delete.submit({ name })` deletes a row by name. `delete.isLoading(name)`
+    reports on one row.
+
+  All three refetch the current page on success when `refetch` is `true` (the
+  default).
+
+## Shared cache
+
+A row fetched by `useList` and a document fetched by `useDoc` for the same
+`doctype`/`name` are kept in sync: saving or deleting through one updates the
+other everywhere it's rendered.

--- a/docs/content/docs/data-fetching/use-list.md
+++ b/docs/content/docs/data-fetching/use-list.md
@@ -99,7 +99,9 @@ async function close(name) {
   in memory and IndexedDB under that key, shown immediately on the next
   `useList` with the same key while it refetches in the background.
 - `staleOnError` — when `true` and `cacheKey` is set, a failed refetch keeps
-  showing the last cached `data` instead of clearing it. Defaults to `false`.
+  showing the last cached `data` instead of clearing it. Does not apply when
+  the failure is a Frappe error response (`FrappeResponseError`) — that still
+  clears the cache. Defaults to `false`.
 - `initialData` — the value `data` holds before the first response.
 - `immediate` — fire the first request automatically. Defaults to `true`.
 - `refetch` — automatically refetch when a reactive filter/sort dependency

--- a/docs/content/docs/data-fetching/use-new-doc.md
+++ b/docs/content/docs/data-fetching/use-new-doc.md
@@ -1,0 +1,62 @@
+# useNewDoc
+
+`useNewDoc` holds a reactive draft of a document you haven't created yet, and
+submits it as an insert. Use it for a "new document" form; once submitted, read
+the created document through [`useDoc`](./use-doc.md).
+
+## Basic example
+
+```vue
+<template>
+  <TextInput v-model="todo.doc.description" label="Description" />
+  <Button :loading="todo.loading" @click="save"> Create </Button>
+</template>
+
+<script setup>
+import { useNewDoc } from 'frappe-ui'
+
+const todo = useNewDoc('ToDo', { status: 'Open' })
+
+async function save() {
+  const doc = await todo.submit()
+  console.log(doc.name)
+}
+</script>
+```
+
+## Options
+
+`useNewDoc(doctype, initialValues?, options?)`
+
+- `doctype` — the DocType to create a document for.
+- `initialValues` — the draft's starting field values, made reactive as `doc`.
+  Server-managed fields (`creation`, `modified`, `owner`, `modified_by`) are
+  excluded from the type.
+- `options` — the same options as [`useCall`](./use-call.md), minus `url`,
+  `method`, `params` and `immediate` (all fixed: a `POST` to create a document
+  from `doc`, not fired until `submit()` is called).
+
+## Return value
+
+Everything [`useCall`](./use-call.md) returns — `data`, `error`, `loading`,
+`execute`/`fetch`/`reload`, `reset`, `abort`, and so on — for the underlying
+insert request, plus:
+
+- `doc` — the reactive draft. Bind form fields to it directly; `submit()` reads
+  whatever it currently holds.
+- `submit()` — inserts `doc`, ignoring any params argument. On success, the
+  created document (including server-assigned fields like `name`) is written
+  into the shared store `useDoc` reads from, and the promise resolves with it.
+
+```vue
+<script setup>
+import { useDoc, useNewDoc } from 'frappe-ui'
+
+const draft = useNewDoc('ToDo', { description: 'Ship the release' })
+const created = await draft.submit()
+
+// created.name is already in the shared cache, so `todo.doc` reads it
+// straight away — useDoc still fires its own GET in the background
+const todo = useDoc({ doctype: 'ToDo', name: created.name })
+</script>
+```

--- a/docs/content/docs/other/utilities.md
+++ b/docs/content/docs/other/utilities.md
@@ -138,6 +138,31 @@ to `credentials: 'include'`, so the server has to send
 authenticate with a token header instead, pass `credentials: 'omit'` per
 request.
 
+## FrappeResponseError
+
+The error [`useCall`](../data-fetching/use-call.md),
+[`useDoc`](../data-fetching/use-doc.md) and
+[`useList`](../data-fetching/use-list.md) raise on a Frappe error response — set
+on `.error` and the reason `submit()`/`execute()` rejects with. An `Error` with
+`title`, `type`, `exception` and `indicator` from the server's response.
+
+```vue
+<script setup>
+import { FrappeResponseError, useCall } from 'frappe-ui'
+
+const rename = useCall({
+  url: '/api/method/frappe.client.rename_doc',
+  method: 'POST',
+  immediate: false,
+  onError(error) {
+    if (error instanceof FrappeResponseError) {
+      console.log(error.title, error.type)
+    }
+  },
+})
+</script>
+```
+
 ## FrappeUI plugin
 
 An optional Vue plugin with one option. It installs the v1 resources Options API

--- a/docs/content/public/llms.txt
+++ b/docs/content/public/llms.txt
@@ -68,15 +68,17 @@ Two cross-cutting conventions to know before reading anything else:
 
 ## Data fetching
 
-Recommended (v3 composables, in the `frappe-ui` exports):
+Recommended layer for new code, in the `frappe-ui` exports:
 
-- `useCall` — Vue composable for any whitelisted Frappe method. Options: `url`, `method`, `params` (object or function for reactivity), `immediate`, `refetch`, `cacheKey` (IndexedDB persistence), `transform`, `beforeSubmit`, `onSuccess`, `onError`. Returns a reactive object with `data`, `error`, `loading`, `isFinished`, `promise`, `execute`/`fetch`/`reload`, `submit(params)`, `reset`, `abort`. Use `immediate: false` + `submit()` for writes. Source: https://github.com/frappe/frappe-ui/blob/main/src/data-fetching/useCall/useCall.ts.
-- `useList` — paginated list composable on top of `useCall`. Source: https://github.com/frappe/frappe-ui/tree/main/src/data-fetching/useList.
-- `useDoc` — single doctype document composable. Source: https://github.com/frappe/frappe-ui/tree/main/src/data-fetching/useDoc.
-- `useDoctype` — doctype metadata composable. Source: https://github.com/frappe/frappe-ui/tree/main/src/data-fetching/useDoctype.
-- `useNewDoc` — scaffolding for new-doc forms. Source: https://github.com/frappe/frappe-ui/tree/main/src/data-fetching/useNewDoc.
+- [useCall](https://ui.frappe.io/docs/data-fetching/use-call): Vue composable for any whitelisted Frappe method. Options: `url`, `method`, `params` (object or function for reactivity), `immediate`, `refetch`, `cacheKey` (IndexedDB persistence), `transform`, `beforeSubmit`, `onSuccess`, `onError`. Returns a reactive object with `data`, `error`, `loading`, `isFinished`, `promise`, `execute`/`fetch`/`reload`, `submit(params)`, `reset`, `abort`. Use `immediate: false` + `submit()` for writes.
+- [useDoc](https://ui.frappe.io/docs/data-fetching/use-doc): fetches and keeps one document reactive, shared with `useList` for the same `doctype`/`name`.
+- [useList](https://ui.frappe.io/docs/data-fetching/use-list): paginated, filterable list for a doctype, with `insert`/`setValue`/`delete` write helpers.
+- [useDoctype](https://ui.frappe.io/docs/data-fetching/use-doctype): write-only helpers for a doctype — `insert`, `delete`, `setValue`, `runDocMethod`, `runMethod` — with no read/fetch of its own.
+- [useNewDoc](https://ui.frappe.io/docs/data-fetching/use-new-doc): a reactive draft for a new document, submitted as an insert.
 
-Legacy (still exported for migration, not recommended for new code):
+## Resources
+
+Fully supported through `1.x`; use Data Fetching above for new code.
 
 - [Resource](https://ui.frappe.io/docs/data-fetching/resource): `createResource` — base data fetcher.
 - [List resource](https://ui.frappe.io/docs/data-fetching/list-resource): `createListResource` — paginated list.

--- a/v1-release/changelog.md
+++ b/v1-release/changelog.md
@@ -829,6 +829,19 @@ error response and put it on `.error`, and `submit()` rejects with it, but
 nothing exported the class, so a consumer could not narrow the error. Same gap
 `FrappeRequestError` closed for `frappeRequest`.
 
+### Data fetching (v2) — docs, and the sidebar splits from Resources
+
+`useCall`, `useDoc`, `useList`, `useDoctype` and `useNewDoc` each get a docs
+page for the first time, under a new **Data Fetching** sidebar section —
+`useCall` for a whitelisted method, `useDoc` for one document, `useList` for
+a query, `useDoctype` for write-only access to a DocType, `useNewDoc` for a
+draft-and-insert form.
+
+The old **Data Fetching** section is renamed **Resources** and keeps its
+three pages (Resource, List Resource, Document Resource) unchanged. Both
+sections link to each other: Resources stays fully supported through `1.x`;
+the new composables are the recommended layer for new code.
+
 ### Root composables and directives — renamed and shrunk
 
 Every change below is a **loud break**: the import line fails, so the build,


### PR DESCRIPTION
Adds docs pages for useCall, useDoc, useList, useDoctype and useNewDoc — none
existed before. Splits the Data Fetching sidebar section into two: Data
Fetching (the five v2 composables, recommended for new code) and Resources
(the three existing v1 pages, fully supported through 1.x). Every prop,
option and return member on the new pages has a description. Documents
FrappeResponseError on the utilities page.

The export changes this ticket asked for (un-export useFrappeFetch, export
FrappeResponseError) already landed on main in 3c0d9442f — this PR is the
remaining docs work.

- Non-breaking: docs-only, no source changes.

Closes #932

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-972/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 67.17% (±0.00% vs `main`)
<!-- coverage-report:end -->

