### PR TITLE
docs(adr-0010): frappe-ui/list stands on the extensible-family limb

### DIFF
--- a/spec/adr/0010-subpath-export-rule.md
+++ b/spec/adr/0010-subpath-export-rule.md
@@ -41,8 +41,10 @@ alone. A subpath is a permanent packaging decision — once exported at `1.0.0` 
 frozen until `2.0.0` (ADR-0008's reasoning, applied to the whole surface) — so
 "it would read better organized" doesn't clear the bar. Grouping by domain is the
 docs' job, not the module graph's. Concretely: **root staying the default means
-`SettingsDialog`, `PageHeader`/`PageHeaderMobile`, `Sidebar`, and the legacy
-`ListView` family all stay at root and freeze there.** Because a subpath is no longer
+`SettingsDialog`, `PageHeader`/`PageHeaderMobile`, and `Sidebar` all stay at root
+and freeze there.** (The legacy `ListView` family was originally in this list; it
+later moved to `frappe-ui/experimental` —
+[#985](https://github.com/frappe/frappe-ui/issues/985).) Because a subpath is no longer
 available later as a way to reorganize them, getting their names and shapes right
 before the tag matters more, not less — that responsibility passes to each family's
 own sweep ticket.
@@ -57,7 +59,7 @@ separate category, decided on their own terms.
 | Subpath | Limb(s) | Notes |
 | --- | --- | --- |
 | `frappe-ui/editor` | a + b + c | Static TipTap; open extension/menu registry (ADR-0004); `ListItem` and others already collide with root names. |
-| `frappe-ui/list` | c | `List`, `ListHeader`, `ListRow`, `ListRows` collide with the legacy `ListView` family, which stays at root undeprecated until it reaches parity. This is sufficient for `1.0.0` on its own; it does not need a second reason. If `ListView` is ever removed, whether `list` still earns a subpath is a fresh decision for that moment, not one to pre-answer now. |
+| `frappe-ui/list` | b | An extensible parts family with a composition model — individual parts that work together and grow by adding more parts, the same footing as `editor` and `charts` (maintainer call, 2026-08-09). The original `1.0.0` basis was limb (c): `List`, `ListHeader`, `ListRow`, `ListRows` collided with the legacy `ListView` family at root. That collision dissolved when [#985](https://github.com/frappe/frappe-ui/issues/985) moved `ListView` to `frappe-ui/experimental` — the "fresh decision for that moment" this row reserved is this amendment. |
 | `frappe-ui/icons` | a | `spritePlugin` statically imports the full `lucide-static` sprite; `IconPicker` reads the injected sprite DOM. Holds only while `spritePlugin` ships — a smaller cleanup (rewire `IconPicker` to the tailwind plugin's build-time icon list, delete `spritePlugin` and the duplicate `Icon.vue`) would remove the only static dependency in the subpath and fold it into root. |
 | `frappe-ui/charts` (in flight, #890) | a | Statically imports `echarts/core`. Rule-compliant as designed. |
 | `frappe-ui/experimental` | P14 | Its own rule; not judged by these limbs. Now also home to `CodeEditor` and `CodePreview` (see below). |


### PR DESCRIPTION
Amends ADR-0010's `frappe-ui/list` row. Its stated basis was the name collision with `ListView` at root, which dissolved when #985 moved ListView to `frappe-ui/experimental`.

- `list` keeps its subpath on limb (b): an extensible parts family with a composition model, same footing as `editor` and `charts` (maintainer decision).
- Drops `ListView` from the stays-at-root example list, pointing at #985.

Docs-only, no API change.

https://claude.ai/code/session_01Fc3HzRmyUEyTkctssbTPkW

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-996/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.68% (±0.00% vs `main`)
<!-- coverage-report:end -->
