### PR TITLE
fix(useCall)!: a throwing beforeSubmit cancels the submit

### DIFF
--- a/docs/content/docs/data-fetching/use-call.md
+++ b/docs/content/docs/data-fetching/use-call.md
@@ -78,8 +78,9 @@ async function rename(name, newName) {
 - `transform` — receives the raw response data and returns the value `data`
   should hold. Return `undefined` to leave the response untouched.
 - `beforeSubmit` — runs before a `submit()` call sends its request. Use it for
-  side effects like clearing a previous validation message; it does not stop the
-  request from being sent.
+  side effects like clearing a previous validation message; a normal return does
+  not stop the request from being sent. If it throws, the request is not sent
+  and `submit()` rejects.
 - `onSuccess` — called with the response data after a successful request.
 - `onError` — called with the error after a failed request.
 

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -1562,6 +1562,20 @@ returning `undefined` and crashing in whatever realtime handler reads it next.
 Assigning your own replaces the guard. The same applies to `$call`, the other
 global the plugin used to install — import `call` from `frappe-ui` instead.
 
+## useCall: a throwing `beforeSubmit` now cancels the submit
+
+Previously a `beforeSubmit` hook that threw was caught and logged, and the
+request was **sent anyway**. Now the throw propagates: the request is not sent
+and `submit()` rejects with the hook's error.
+
+This is a silent behavior change. If one of your `beforeSubmit` hooks can
+throw, the submit it used to let through now stops. Either handle the rejection
+at the call site or make the hook non-throwing to keep the old behavior. A
+hook that returns normally is unaffected — it still cannot stop the request.
+
+`beforeSubmit` may now be async (`() => void | Promise<void>`); it was always
+awaited, only the type said otherwise.
+
 ## pageMetaPlugin — removed
 
 `pageMetaPlugin` and the global mixin it installed are gone. A `pageMeta()`

--- a/src/data-fetching/useCall/types.ts
+++ b/src/data-fetching/useCall/types.ts
@@ -16,7 +16,7 @@ export interface UseCallOptions<
   refetch?: boolean
   baseUrl?: string
   initialData?: TResponse
-  beforeSubmit?: (params?: TParams) => void
+  beforeSubmit?: (params?: TParams) => void | Promise<void>
   transform?: (data: TResponse) => TResponse
   onSuccess?: (data: TResponse) => void
   onError?: (error: Error) => void

--- a/src/data-fetching/useCall/useCall.test.ts
+++ b/src/data-fetching/useCall/useCall.test.ts
@@ -152,6 +152,23 @@ describe('useCall', () => {
     expect(beforeSubmit).toHaveBeenCalledWith({ name: 'test' })
   })
 
+  it('does not send the request and rejects when beforeSubmit throws', async () => {
+    const call = useCall<{ success: boolean }, { name: string }>({
+      url: url('/api/v2/method/post'),
+      method: 'POST',
+      immediate: false,
+      beforeSubmit: () => {
+        throw new Error('invalid')
+      },
+    })
+
+    await expect(call.submit({ name: 'test' })).rejects.toThrow('invalid')
+
+    expect(call.loading).toBe(false)
+    expect(call.data).toBe(null)
+    expect(call.error).toBe(null)
+  })
+
   it('shows initialData before the first response arrives', () => {
     const call = useCall<{ value: string }>({
       url: url('/api/v2/method/get'),

--- a/src/data-fetching/useCall/useCall.ts
+++ b/src/data-fetching/useCall/useCall.ts
@@ -155,17 +155,10 @@ export function useCall<TResponse, TParams extends BasicParams = undefined>(
     promise.value = makePromise()
   })
 
-  let beforeSubmitError = ref<Error | null>(null)
-
   const submit = async (params?: TParams) => {
     if (beforeSubmit) {
-      beforeSubmitError.value = null
-      try {
-        await beforeSubmit(params)
-      } catch (e) {
-        console.error('Error in beforeSubmit hook:', e)
-        beforeSubmitError.value = e as Error
-      }
+      // A throw cancels the submit: the request is not sent and submit() rejects (#990)
+      await beforeSubmit(params)
     }
     if (params != null) {
       submitParams.value = params
@@ -214,7 +207,7 @@ export function useCall<TResponse, TParams extends BasicParams = undefined>(
 
   let out = reactive({
     data: _data,
-    error: readonly(beforeSubmitError.value ? beforeSubmitError : error),
+    error: readonly(error),
     loading: isFetching,
     isFetching,
     isFinished,


### PR DESCRIPTION
Decided in #990: a throwing `beforeSubmit` cancels the submit. `submit()` rejects and the request is not sent.

Before this fix, the throw was caught and logged, the stored error could never surface (`error: readonly(beforeSubmitError.value ? ... : error)` was evaluated once at setup), and the request was sent anyway.

- Remove the try/catch and the dead `beforeSubmitError` ref.
- Widen the hook type to `(params?) => void | Promise<void>`. The implementation always awaited it.
- Docs: a normal return still does not stop the request; a throw does.
- `migration.md`: silent-break entry — a throwing hook used to submit, now it does not.
- Test: a throwing hook rejects and sends nothing.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1000/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 66.68% (±0.00% vs `main`)
<!-- coverage-report:end -->
