### PR TITLE
feat(data-fetching): scope docStore's cache to the signed-in user automatically

### DIFF
--- a/src/data-fetching/docStore.test.ts
+++ b/src/data-fetching/docStore.test.ts
@@ -3,13 +3,17 @@
  */
 import { computed, watchSyncEffect } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { docStore } from './docStore'
+import { docStore, DocStore } from './docStore'
 import { idbStore } from './idbStore'
 
 const DOCTYPE = 'User'
 
 function idbKey(name: string) {
   return `doc:${DOCTYPE}/${name}`
+}
+
+function namespacedIdbKey(namespace: string, name: string) {
+  return `doc:${namespace}::${DOCTYPE}/${name}`
 }
 
 /** A promise whose settlement the test controls, to hold an IDB call open. */
@@ -215,5 +219,122 @@ describe('docStore', () => {
 
     afterDelete.resolve(null)
     await flush()
+  })
+
+  // DocStore derives its namespace automatically from the `user_id` cookie
+  // every logged-in Frappe session already sets — there is no app-facing API
+  // to drive it, so these tests stub `document.cookie` (this file runs with
+  // `@vitest-environment node`, where `document` does not exist unless a test
+  // defines it) and construct a fresh `DocStore`, one per stub, to stand in
+  // for what a real page load — cookie already set, module re-evaluated —
+  // would produce. The module-level `docStore` singleton was already
+  // constructed with no `document` at all when this file loaded, which is
+  // exactly the case the "no cookie" test below also covers directly.
+  describe('cache namespacing (derived from the user_id cookie)', () => {
+    /** Stubs `document.cookie` for one DocStore construction, then restores it. */
+    function newStoreWithCookie(cookie: string | undefined): DocStore {
+      const original = (globalThis as { document?: unknown }).document
+      ;(globalThis as { document?: unknown }).document =
+        cookie === undefined ? undefined : { cookie }
+      try {
+        return new DocStore()
+      } finally {
+        ;(globalThis as { document?: unknown }).document = original
+      }
+    }
+
+    /** `newStoreWithCookie`, but also lets the constructor's fire-and-forget
+     * IDB reconciliation (and any purge it triggers) settle before returning. */
+    async function initStore(cookie: string | undefined): Promise<DocStore> {
+      const store = newStoreWithCookie(cookie)
+      await flush()
+      return store
+    }
+
+    afterEach(() => {
+      delete (globalThis as { document?: unknown }).document
+    })
+
+    it('no cookie, and an explicit Guest cookie, behave byte-identically to before this feature', async () => {
+      const noDocument = await initStore(undefined)
+      const guestCookie = await initStore('user_id=Guest; sid=abc')
+
+      for (const [store, name] of [
+        [noDocument, 'no-document-doc'],
+        [guestCookie, 'guest-cookie-doc'],
+      ] as const) {
+        const record = { doctype: DOCTYPE, name, bio: 'unscoped' }
+        await store.setDoc({ ...record })
+        // Same bare key `doctype/name` this store always used, pre-dating
+        // namespacing entirely.
+        expect(await idbStore.get(idbKey(name))).toMatchObject(record)
+        expect(store.getDoc(DOCTYPE, name).value).toMatchObject(record)
+      }
+    })
+
+    it('a signed-in user gets keys prefixed with their cookie value', async () => {
+      const store = await initStore('user_id=alice%40example.com; sid=abc123')
+      const name = 'namespaced-doc'
+      const record = { doctype: DOCTYPE, name, bio: 'alice doc' }
+
+      await store.setDoc({ ...record })
+
+      // The cookie value arrives URL-encoded, as Frappe sets it for an email
+      // address — the namespace is the decoded form.
+      expect(
+        await idbStore.get(namespacedIdbKey('alice@example.com', name)),
+      ).toMatchObject(record)
+      expect(await idbStore.get(idbKey(name))).toBeNull()
+    })
+
+    it('the same user across two inits keeps their cache', async () => {
+      const name = 'returning-alice'
+      const record = { doctype: DOCTYPE, name, bio: 'alice persisted' }
+
+      const firstLoad = await initStore('user_id=alice')
+      await firstLoad.setDoc({ ...record })
+
+      // A second "page load" for the same account — a fresh instance, same
+      // cookie, so its in-memory maps start empty and it has to read IDB.
+      const secondLoad = await initStore('user_id=alice')
+      secondLoad.getDoc(DOCTYPE, name)
+      await flush()
+
+      expect(secondLoad.getDoc(DOCTYPE, name).value).toMatchObject(record)
+    })
+
+    it('a different user across inits purges the outgoing account and cannot read its docs', async () => {
+      const name = 'handoff-doc'
+      const aliceRecord = { doctype: DOCTYPE, name, bio: 'alice secret' }
+
+      const aliceLoad = await initStore('user_id=alice')
+      await aliceLoad.setDoc({ ...aliceRecord })
+      expect(await idbStore.get(namespacedIdbKey('alice', name))).toMatchObject(
+        aliceRecord,
+      )
+
+      // Bob opens the same (shared) browser next.
+      const bobLoad = await initStore('user_id=bob')
+
+      // Bob's read is a fresh slot: no cross-account read of alice's doc.
+      expect(bobLoad.getDoc(DOCTYPE, name).value).toBe(null)
+      // The handoff also purges alice's doc from IDB rather than leaving it
+      // to rot behind its own prefix indefinitely.
+      expect(await idbStore.get(namespacedIdbKey('alice', name))).toBeNull()
+    })
+
+    it('the first namespaced init does not purge data cached before any user was known', async () => {
+      const name = 'pre-login-doc'
+      const record = { doctype: DOCTYPE, name, bio: 'cached before login' }
+      // Written by the unnamespaced module-level store, as if fetched before
+      // the app resolved who was signed in.
+      await docStore.setDoc({ ...record })
+
+      // First time this "browser" has ever recorded a namespace: nothing to
+      // distrust yet, so the existing unscoped cache must survive.
+      await initStore('user_id=alice')
+
+      expect(await idbStore.get(idbKey(name))).toMatchObject(record)
+    })
   })
 })

--- a/src/data-fetching/docStore.ts
+++ b/src/data-fetching/docStore.ts
@@ -9,7 +9,12 @@ type Doc = {
 
 type DocKey = `${string}/${string}`
 
-class DocStore {
+// Reserved key for the last-seen namespace record — not a `doc:`-prefixed
+// entry, so it never turns up in a scan for actual document keys (clearAll,
+// purgeStoredNamespace) and a doctype can never collide with it.
+const NAMESPACE_META_KEY = 'docStore:lastNamespace'
+
+export class DocStore {
   private docs: Map<DocKey, Ref<Doc | null>>
   private lastFetched: Map<DocKey, number>
   private revisions: Map<DocKey, number>
@@ -20,12 +25,95 @@ class DocStore {
   private revisionCounter = 0
   private cacheTimeout: number = 5 * 60 * 1000 // 5 minutes
   private storePrefix = 'doc:'
+  // Prefixes every key with the signed-in user, read once at construction
+  // from the `user_id` cookie every logged-in Frappe session already carries
+  // — no app wiring required. `null` (Guest, no cookie, or SSR) keeps keys
+  // exactly `doctype/name`, unchanged from before namespacing existed.
+  private namespace: string | null
 
   constructor() {
     this.docs = new Map<DocKey, Ref<Doc | null>>()
     this.lastFetched = new Map()
     this.revisions = new Map()
     this.inflight = new Map()
+    this.namespace = this.readCookieNamespace()
+    // Fire-and-forget: `this.namespace` above is set synchronously, so every
+    // key computed this tick or later already reflects it. Only the IDB
+    // reconciliation against the previous page load's namespace — and the
+    // purge it may trigger — trails behind.
+    this.reconcileNamespace().catch((error) => {
+      console.error('Failed to reconcile doc cache namespace:', error)
+    })
+  }
+
+  /**
+   * Reads the standard Frappe session cookie `user_id`, the same cookie every
+   * logged-in Frappe app already sets — nothing for an app to configure.
+   * `undefined` (SSR, or a test environment with no DOM), a missing cookie,
+   * and an explicit `Guest` value all resolve to `null`, matching today's
+   * unnamespaced behavior for a signed-out visitor.
+   */
+  private readCookieNamespace(): string | null {
+    if (typeof document === 'undefined' || !document.cookie) return null
+    for (const pair of document.cookie.split(';')) {
+      const eq = pair.indexOf('=')
+      if (eq === -1) continue
+      if (pair.slice(0, eq).trim() !== 'user_id') continue
+      const raw = pair.slice(eq + 1).trim()
+      let value: string
+      try {
+        value = decodeURIComponent(raw)
+      } catch {
+        value = raw
+      }
+      value = value.trim()
+      return value && value !== 'Guest' ? value : null
+    }
+    return null
+  }
+
+  /**
+   * Namespace changes are only ever detected here, at construction — there is
+   * no live cookie watcher. In practice that's fine: a Frappe login/logout
+   * flow reloads the document, which re-runs this module and constructs a
+   * fresh store. An app that somehow swaps the session user without a reload
+   * would not see the new namespace take effect until the next load.
+   *
+   * Compares the freshly-read namespace against the one recorded in IDB from
+   * the last time this ran. Purging only fires when both are non-null and
+   * differ — a real account handoff. Guest/no-cookie loads (`current` is
+   * null) never touch the record at all, so an intervening logged-out page
+   * load can't erase the trail: the next real login is still compared
+   * against the last account that was actually signed in, not against
+   * whatever happened in between.
+   */
+  private async reconcileNamespace() {
+    const current = this.namespace
+    if (!current) return
+    const stored = (await idbStore.get(NAMESPACE_META_KEY)) as string | null
+    if (stored === current) return
+    if (stored) {
+      // A different account was signed in as of the last page load. Purge it
+      // now rather than let it sit in IDB indefinitely — a shared browser
+      // should not keep accumulating every past account's cached docs.
+      await this.purgeStoredNamespace(stored)
+    }
+    await idbStore.set(NAMESPACE_META_KEY, current)
+  }
+
+  private async purgeStoredNamespace(namespace: string) {
+    // The in-memory `docs` map is always empty this early — this runs from
+    // the constructor, before any getDoc/setDoc call populates it — so the
+    // outgoing namespace's keys can only be found by scanning IDB directly,
+    // the same way clearAll() does.
+    const prefix = this.storePrefix + this.namespacePrefix(namespace)
+    const allKeys = await idbStore.keys()
+    const matching = allKeys.filter((key: string) => key.startsWith(prefix))
+    await Promise.all(matching.map((key: string) => idbStore.delete(key)))
+  }
+
+  private namespacePrefix(namespace: string | null): string {
+    return namespace ? `${namespace}::` : ''
   }
 
   /**
@@ -187,7 +275,7 @@ class DocStore {
   }
 
   private getKey(doctype: string, name: string): DocKey {
-    return `${doctype.trim()}/${name.trim()}` as DocKey
+    return `${this.namespacePrefix(this.namespace)}${doctype.trim()}/${name.trim()}` as DocKey
   }
 
   private isStale(key: DocKey): boolean {
@@ -214,6 +302,7 @@ class DocStore {
         key.startsWith(this.storePrefix),
       )
       await Promise.all(docKeys.map((key: string) => idbStore.delete(key)))
+      await idbStore.delete(NAMESPACE_META_KEY)
       this.docs.clear()
       this.lastFetched.clear()
       this.revisions.clear()
@@ -225,4 +314,10 @@ class DocStore {
   }
 }
 
+// The package's one DocStore instance. Not part of the public surface — there
+// is no app-facing API for this store at all. useDoc, useNewDoc, useDoctype
+// and useList reach it with a relative import; every doc it caches is
+// automatically scoped to whichever `user_id` cookie was present when this
+// module first ran (see the constructor / readCookieNamespace above), so
+// there is nothing for an app to call or configure.
 export const docStore = new DocStore()


### PR DESCRIPTION
## Problem

`useDoc` caches every fetched document unconditionally in `docStore`, keyed only by `` `${doctype}/${name}` ``, both in memory and in IndexedDB. On a shared browser, user B signing in can be served user A's cached document — offline, or even briefly before B's own fetch resolves. This is a cross-account data leak.

`useList` and `useCall` already avoid this via a per-call `cacheKey` (frappe/gameplan#516 uses it to scope Gameplan's list/call caches to the session user), but that pattern doesn't transfer to `useDoc`: those two only persist to IDB when a caller opts in with `cacheKey`, so namespacing the key is something the opted-in call site can do. `useDoc` persists on every fetch with no opt-in point at all.

## Design: automatic, zero adoption code

This PR went through two earlier shapes before landing here — a per-call `useDoc({ cacheKey })` option, then a global `setCacheNamespace(namespace)` function apps would call once at session start. Both were opt-in, and opt-in is the wrong shape for this specific problem: **any call an app has to remember to make is a call it can forget**, and a forgotten one leaks silently by default — which is the exact failure mode this PR exists to close. There's nothing to forget if there's nothing to call.

So `docStore` now derives its namespace itself, automatically, from the standard Frappe session cookie `user_id` — a cookie every logged-in Frappe app already sets, with nothing for the app to configure. It's read once when the store is constructed and prefixes every doc cache key for the lifetime of that page load. There is **no public API change in this PR at all** — `docStore` was never exported from the package, still isn't, and `src/data-fetching/index.ts` has a zero-line diff against `main`.

Cookie handling:
- The value is `decodeURIComponent`-ed (Frappe URL-encodes it, e.g. for an email address).
- A missing cookie, an empty value, or an explicit `Guest` all resolve to `null` — the unnamespaced default, identical to today's behavior for a signed-out visitor.
- `typeof document === 'undefined'` (SSR, or a non-browser test environment) also resolves to `null`.

## Purge-on-switch, adapted to being automatic

There's no explicit "switch" event anymore, so detection moves to construction time: the store records the last-seen namespace in IDB (a reserved meta key, not a `doc:`-prefixed one, so it can never collide with a real doctype/name). Each time the store is constructed it compares the freshly-read cookie namespace against that record:
- **Both non-null and different** → a real account handoff. The outgoing namespace's docs are purged from IDB (scanned by key prefix, the same way `clearAll()` already scans) rather than just left fenced off behind their own prefix indefinitely — a shared browser shouldn't keep accumulating every past account's cached docs forever.
- **No stored record yet** (first time this browser has ever recorded a namespace) → nothing is purged. There's no prior namespace to distrust, and wiping IDB here would throw away a *returning* user's own offline cache — the entire point of this caching layer (see the offline-support work in frappe/gameplan).
- A Guest/no-cookie load never touches the record at all, so an intervening logged-out page load can't erase the trail — the next real login is still compared against the last account that was actually signed in.

**Limitation, called out explicitly**: namespace changes are only ever detected at construction (page load) — there's no live cookie watcher. In practice this is fine, because a Frappe login/logout flow reloads the document, which re-runs this module and constructs a fresh store. An app that somehow swapped the session user without a full reload would not see the new namespace take effect (or the purge fire) until the next load.

## Tests

Reworked `src/data-fetching/docStore.test.ts`'s `cache namespacing` group to drive `document.cookie` directly (this file runs under `@vitest-environment node`, so `document` doesn't exist unless a test stubs it) and construct fresh `DocStore` instances to stand in for separate page loads:
- no cookie, and an explicit `Guest` cookie, behave byte-identically to before this feature (bare `doctype/name` keys)
- a signed-in user gets keys prefixed with their (decoded) cookie value
- the same user across two inits keeps their cache
- a different user across inits purges the outgoing account's docs and can't read them
- the first namespaced init doesn't purge data cached before any user was known

`yarn test`: 54 files / 473 tests, all green. No pre-existing failures encountered.

## Adoption

None needed. Gameplan (frappe/gameplan#516) already scopes its own `useList`/`useCall` caches to the session user with an explicit `cacheKey`; `useDoc` now gets the same protection automatically, with no code change on the Gameplan side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1006/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 64.27% (+0.05% vs `main`)
<!-- coverage-report:end -->
