### PR TITLE
fix(Dialogs): dedup host across sibling mounts (#988)

### DIFF
--- a/spec/dialog.md
+++ b/spec/dialog.md
@@ -400,7 +400,7 @@ Every surface in the table below was deleted before 1.0.0, per [ADR-0008](./adr/
 | `confirmDialog()` helper | `dialog.confirm()` |
 | `ConfirmDialog.vue` component | deleted — `dialog.confirm()` renders its own internal dialog, not this component |
 
-`<Dialogs />` is **not** deprecated — it remains exported and is now rendered by `<FrappeUIProvider>` alongside `<Toasts />`. Apps that already mount it in their template continue to work; rendering it twice is safe — only the first mounted host renders the stack, whether the extra host is nested or a sibling; the others render nothing and warn in dev.
+`<Dialogs />` is **not** deprecated — it remains exported and is now rendered by `<FrappeUIProvider>` alongside `<Toasts />`. Apps that already mount it in their template continue to work; rendering it twice is safe — only the first mounted host renders the stack, whether the extra host is nested or a sibling; the others warn in dev. When the rendering host unmounts, the claim hands over to the next mounted host, so the stack never loses its renderer.
 
 ## Migration notes
 

--- a/spec/dialog.md
+++ b/spec/dialog.md
@@ -400,7 +400,7 @@ Every surface in the table below was deleted before 1.0.0, per [ADR-0008](./adr/
 | `confirmDialog()` helper | `dialog.confirm()` |
 | `ConfirmDialog.vue` component | deleted — `dialog.confirm()` renders its own internal dialog, not this component |
 
-`<Dialogs />` is **not** deprecated — it remains exported and is now rendered by `<FrappeUIProvider>` alongside `<Toasts />`. Apps that already mount it in their template continue to work; rendering it twice is safe (the second mount has no extra effect, but the imperative dialog stack lives in a shared module-level ref so the same stack drives both).
+`<Dialogs />` is **not** deprecated — it remains exported and is now rendered by `<FrappeUIProvider>` alongside `<Toasts />`. Apps that already mount it in their template continue to work; rendering it twice is safe — only the first mounted host renders the stack, whether the extra host is nested or a sibling; the others render nothing and warn in dev.
 
 ## Migration notes
 

--- a/src/components/Dialogs.vue
+++ b/src/components/Dialogs.vue
@@ -5,18 +5,51 @@
   </div>
 </template>
 
+<script lang="ts">
+// One claim shared by every `<Dialogs />` in the app, so sibling hosts dedup
+// too — inject only sees ancestors. Client-only: on the server no unmount
+// hook runs to release it, so a claim would leak across requests.
+let activeHost: symbol | null = null
+</script>
+
 <script setup lang="ts">
-import { inject, provide, type InjectionKey } from 'vue'
+import { inject, onUnmounted, provide, type InjectionKey } from 'vue'
 import { dialogs as imperativeDialogs } from '../utils/dialog'
 
-// Only the outermost `<Dialogs />` host renders the stack. Apps that wrap
-// their tree in `<FrappeUIProvider>` (which mounts `<Dialogs />` internally)
-// *and* also mount `<Dialogs />` manually would otherwise see every dialog
-// twice. A nested host yields to its ancestor.
+// Only one `<Dialogs />` host renders the stack. Apps that wrap their tree in
+// `<FrappeUIProvider>` (which mounts `<Dialogs />` internally) *and* also
+// mount `<Dialogs />` manually would otherwise see every dialog twice. A
+// nested host yields to its ancestor via provide/inject; a sibling host (the
+// provider's own mount sits next to the app's slot content, not above it)
+// yields to whichever host mounted first via the module-level claim above.
 const DIALOGS_HOST_KEY = Symbol.for(
   'frappe-ui.dialogs-host',
 ) as InjectionKey<boolean>
 const hasParentHost = inject(DIALOGS_HOST_KEY, false)
-const isPrimaryHost = !hasParentHost
+const hostId = Symbol('dialogs-host')
+const isPrimaryHost = !hasParentHost && claimHost()
 provide(DIALOGS_HOST_KEY, true)
+
+onUnmounted(() => {
+  // Release so the next mounted host (a rerouted app, the next test) wins.
+  if (activeHost === hostId) activeHost = null
+})
+
+function claimHost(): boolean {
+  // SSR renders once and never unmounts; the inject guard above still
+  // dedups nested hosts there.
+  if (typeof window === 'undefined') return true
+  if (activeHost === null) {
+    activeHost = hostId
+    return true
+  }
+  if (import.meta.env.DEV) {
+    console.warn(
+      '[frappe-ui] Multiple <Dialogs /> hosts are mounted; only the first ' +
+        'renders the dialog stack. Remove the extra mount — ' +
+        '<FrappeUIProvider> already includes one.',
+    )
+  }
+  return false
+}
 </script>

--- a/src/components/Dialogs.vue
+++ b/src/components/Dialogs.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- v1 imperative `dialog.*` stack. -->
-    <template v-if="isPrimaryHost">
+    <template v-if="isMounted && isPrimaryHost">
       <component v-for="d in imperativeDialogs" :is="d.component" :key="d.id" />
     </template>
   </div>
@@ -20,7 +20,15 @@ const hosts = shallowRef<symbol[]>([])
 </script>
 
 <script setup lang="ts">
-import { computed, inject, onUnmounted, provide, type InjectionKey } from 'vue'
+import {
+  computed,
+  inject,
+  onMounted,
+  onUnmounted,
+  provide,
+  ref,
+  type InjectionKey,
+} from 'vue'
 import { dialogs as imperativeDialogs } from '../utils/dialog'
 
 // Only one `<Dialogs />` host renders the stack. Apps that wrap their tree in
@@ -36,26 +44,25 @@ const hasParentHost = inject(DIALOGS_HOST_KEY, false)
 provide(DIALOGS_HOST_KEY, true)
 
 const hostId = Symbol('dialogs-host')
-const isClient = typeof window !== 'undefined'
 
-if (!hasParentHost && isClient) {
+if (typeof window !== 'undefined' && !hasParentHost) {
   hosts.value = [...hosts.value, hostId]
   if (hosts.value.length > 1 && import.meta.env.DEV) {
     console.warn(
-      '[frappe-ui] Multiple <Dialogs /> hosts are mounted; only the first ' +
+      '[frappe-ui] Multiple <Dialogs /> hosts are mounted; only one ' +
         'renders the dialog stack. Remove the extra mount — ' +
         '<FrappeUIProvider> already includes one.',
     )
   }
 }
 
-// The wrapper <div> above renders unconditionally so server and client
-// markup match (during SSR the stack is empty, so every host emits the same
-// empty <div>). On the server the claim list stays empty; the inject guard
-// still dedups nested hosts there.
-const isPrimaryHost = computed(() =>
-  isClient ? hosts.value[0] === hostId : !hasParentHost,
-)
+// The stack is empty until after mount, so gating on `isMounted` keeps
+// server and client hydration markup identical — both sides render the
+// false branch — even though the claim list is client-only. The wrapper
+// <div> renders unconditionally for the same reason.
+const isMounted = ref(false)
+onMounted(() => (isMounted.value = true))
+const isPrimaryHost = computed(() => hosts.value[0] === hostId)
 
 onUnmounted(() => {
   // Hand the claim to the next registered host (the provider's own mount,

--- a/src/components/Dialogs.vue
+++ b/src/components/Dialogs.vue
@@ -36,6 +36,8 @@ function warnExtraHost() {
 import {
   computed,
   inject,
+  onActivated,
+  onDeactivated,
   onMounted,
   onUnmounted,
   provide,
@@ -81,6 +83,12 @@ function release() {
 
 onMounted(claim)
 onUnmounted(release)
+// Inside <KeepAlive> a deactivated host never unmounts — it renders into a
+// detached container while still holding the claim. Treat deactivation
+// like unmount and reactivation like mount. `claim` is idempotent because
+// onActivated also fires right after the initial mount.
+onActivated(claim)
+onDeactivated(release)
 
 // The stack is empty until after mount, so gating on `isMounted` keeps
 // server and client hydration markup identical — both sides render the

--- a/src/components/Dialogs.vue
+++ b/src/components/Dialogs.vue
@@ -17,6 +17,19 @@ import { shallowRef } from 'vue'
 // Client-only: on the server no unmount hook runs to release an entry, so
 // it would leak across requests.
 const hosts = shallowRef<symbol[]>([])
+
+// Warn once per session, like `warnDeprecated` — a route swap can hold two
+// hosts for a tick on every navigation, and that mount is one the app needs.
+let warnedExtraHost = false
+function warnExtraHost() {
+  if (!import.meta.env.DEV || warnedExtraHost) return
+  warnedExtraHost = true
+  console.warn(
+    '[frappe-ui] Multiple <Dialogs /> hosts are mounted; only one ' +
+      'renders the dialog stack. Remove the extra mount — ' +
+      '<FrappeUIProvider> already includes one.',
+  )
+}
 </script>
 
 <script setup lang="ts">
@@ -47,13 +60,7 @@ const hostId = Symbol('dialogs-host')
 
 if (typeof window !== 'undefined' && !hasParentHost) {
   hosts.value = [...hosts.value, hostId]
-  if (hosts.value.length > 1 && import.meta.env.DEV) {
-    console.warn(
-      '[frappe-ui] Multiple <Dialogs /> hosts are mounted; only one ' +
-        'renders the dialog stack. Remove the extra mount — ' +
-        '<FrappeUIProvider> already includes one.',
-    )
-  }
+  if (hosts.value.length > 1) warnExtraHost()
 }
 
 // The stack is empty until after mount, so gating on `isMounted` keeps

--- a/src/components/Dialogs.vue
+++ b/src/components/Dialogs.vue
@@ -58,9 +58,11 @@ provide(DIALOGS_HOST_KEY, true)
 
 const hostId = Symbol('dialogs-host')
 
-if (typeof window !== 'undefined' && !hasParentHost) {
-  hosts.value = [...hosts.value, hostId]
-  if (hosts.value.length > 1) warnExtraHost()
+if (typeof window !== 'undefined') {
+  if (!hasParentHost) hosts.value = [...hosts.value, hostId]
+  // Nested extras yield via inject and never register, but they are still
+  // removable mounts — warn for them like for a losing sibling.
+  if (hasParentHost || hosts.value.length > 1) warnExtraHost()
 }
 
 // The stack is empty until after mount, so gating on `isMounted` keeps

--- a/src/components/Dialogs.vue
+++ b/src/components/Dialogs.vue
@@ -6,14 +6,19 @@
 </template>
 
 <script lang="ts">
-// One claim shared by every `<Dialogs />` in the app, so sibling hosts dedup
-// too — inject only sees ancestors. Client-only: on the server no unmount
-// hook runs to release it, so a claim would leak across requests.
-let activeHost: symbol | null = null
+import { shallowRef } from 'vue'
+
+// Every claiming `<Dialogs />` registers here; the first entry renders the
+// stack. Module-level so sibling hosts dedup too — inject only sees
+// ancestors. Reactive so the claim hands over when the current winner
+// unmounts (a rerouted layout, a `v-if`) instead of leaving no renderer.
+// Client-only: on the server no unmount hook runs to release an entry, so
+// it would leak across requests.
+const hosts = shallowRef<symbol[]>([])
 </script>
 
 <script setup lang="ts">
-import { inject, onUnmounted, provide, type InjectionKey } from 'vue'
+import { computed, inject, onUnmounted, provide, type InjectionKey } from 'vue'
 import { dialogs as imperativeDialogs } from '../utils/dialog'
 
 // Only one `<Dialogs />` host renders the stack. Apps that wrap their tree in
@@ -21,35 +26,36 @@ import { dialogs as imperativeDialogs } from '../utils/dialog'
 // mount `<Dialogs />` manually would otherwise see every dialog twice. A
 // nested host yields to its ancestor via provide/inject; a sibling host (the
 // provider's own mount sits next to the app's slot content, not above it)
-// yields to whichever host mounted first via the module-level claim above.
+// yields via the module-level claim list above.
 const DIALOGS_HOST_KEY = Symbol.for(
   'frappe-ui.dialogs-host',
 ) as InjectionKey<boolean>
 const hasParentHost = inject(DIALOGS_HOST_KEY, false)
-const hostId = Symbol('dialogs-host')
-const isPrimaryHost = !hasParentHost && claimHost()
 provide(DIALOGS_HOST_KEY, true)
 
-onUnmounted(() => {
-  // Release so the next mounted host (a rerouted app, the next test) wins.
-  if (activeHost === hostId) activeHost = null
-})
+const hostId = Symbol('dialogs-host')
+const isClient = typeof window !== 'undefined'
 
-function claimHost(): boolean {
-  // SSR renders once and never unmounts; the inject guard above still
-  // dedups nested hosts there.
-  if (typeof window === 'undefined') return true
-  if (activeHost === null) {
-    activeHost = hostId
-    return true
-  }
-  if (import.meta.env.DEV) {
+if (!hasParentHost && isClient) {
+  hosts.value = [...hosts.value, hostId]
+  if (hosts.value.length > 1 && import.meta.env.DEV) {
     console.warn(
       '[frappe-ui] Multiple <Dialogs /> hosts are mounted; only the first ' +
         'renders the dialog stack. Remove the extra mount — ' +
         '<FrappeUIProvider> already includes one.',
     )
   }
-  return false
 }
+
+// On the server the claim list stays empty; the inject guard still dedups
+// nested hosts there.
+const isPrimaryHost = computed(() =>
+  isClient ? hosts.value[0] === hostId : !hasParentHost,
+)
+
+onUnmounted(() => {
+  // Hand the claim to the next registered host (the provider's own mount,
+  // the next test) so the stack keeps rendering.
+  hosts.value = hosts.value.filter((id) => id !== hostId)
+})
 </script>

--- a/src/components/Dialogs.vue
+++ b/src/components/Dialogs.vue
@@ -1,9 +1,7 @@
 <template>
-  <div>
+  <div v-if="isPrimaryHost">
     <!-- v1 imperative `dialog.*` stack. -->
-    <template v-if="isMounted && isPrimaryHost">
-      <component v-for="d in imperativeDialogs" :is="d.component" :key="d.id" />
-    </template>
+    <component v-for="d in imperativeDialogs" :is="d.component" :key="d.id" />
   </div>
 </template>
 
@@ -41,7 +39,6 @@ import {
   onMounted,
   onUnmounted,
   provide,
-  ref,
   type InjectionKey,
 } from 'vue'
 import { dialogs as imperativeDialogs } from '../utils/dialog'
@@ -90,11 +87,8 @@ onUnmounted(release)
 onActivated(claim)
 onDeactivated(release)
 
-// The stack is empty until after mount, so gating on `isMounted` keeps
-// server and client hydration markup identical — both sides render the
-// false branch — even though the claim list is client-only. The wrapper
-// <div> renders unconditionally for the same reason.
-const isMounted = ref(false)
-onMounted(() => (isMounted.value = true))
+// False during SSR and hydration — the claim list only fills on mount —
+// so server and client render the same placeholder and the winner appears
+// after mount. Losing hosts render nothing, not even an empty <div>.
 const isPrimaryHost = computed(() => hosts.value[0] === hostId)
 </script>

--- a/src/components/Dialogs.vue
+++ b/src/components/Dialogs.vue
@@ -10,12 +10,12 @@
 <script lang="ts">
 import { shallowRef } from 'vue'
 
-// Every claiming `<Dialogs />` registers here; the first entry renders the
-// stack. Module-level so sibling hosts dedup too — inject only sees
-// ancestors. Reactive so the claim hands over when the current winner
+// Every claiming `<Dialogs />` registers here on mount; the first entry
+// renders the stack. Module-level so sibling hosts dedup too — inject only
+// sees ancestors. Reactive so the claim hands over when the current winner
 // unmounts (a rerouted layout, a `v-if`) instead of leaving no renderer.
-// Client-only: on the server no unmount hook runs to release an entry, so
-// it would leak across requests.
+// Mount-time only, so it never runs on the server and cannot leak across
+// requests.
 const hosts = shallowRef<symbol[]>([])
 
 // Warn once per session, like `warnDeprecated` — a route swap can hold two
@@ -58,12 +58,29 @@ provide(DIALOGS_HOST_KEY, true)
 
 const hostId = Symbol('dialogs-host')
 
-if (typeof window !== 'undefined') {
-  if (!hasParentHost) hosts.value = [...hosts.value, hostId]
-  // Nested extras yield via inject and never register, but they are still
-  // removable mounts — warn for them like for a losing sibling.
-  if (hasParentHost || hosts.value.length > 1) warnExtraHost()
+// Claim on mount, not in setup — a host whose setup runs but never mounts
+// (a discarded Suspense branch, a sibling render error) must not hold the
+// claim forever. Mounted hooks fire in tree order, so the slot content's
+// host still beats the provider's own mount, same winner as before.
+function claim() {
+  if (hasParentHost) {
+    // Nested extras yield via inject and never register, but they are
+    // still removable mounts — warn for them like for a losing sibling.
+    warnExtraHost()
+    return
+  }
+  if (!hosts.value.includes(hostId)) hosts.value = [...hosts.value, hostId]
+  if (hosts.value.length > 1) warnExtraHost()
 }
+
+function release() {
+  // Hand the claim to the next registered host (the provider's own mount,
+  // the next test) so the stack keeps rendering.
+  hosts.value = hosts.value.filter((id) => id !== hostId)
+}
+
+onMounted(claim)
+onUnmounted(release)
 
 // The stack is empty until after mount, so gating on `isMounted` keeps
 // server and client hydration markup identical — both sides render the
@@ -72,10 +89,4 @@ if (typeof window !== 'undefined') {
 const isMounted = ref(false)
 onMounted(() => (isMounted.value = true))
 const isPrimaryHost = computed(() => hosts.value[0] === hostId)
-
-onUnmounted(() => {
-  // Hand the claim to the next registered host (the provider's own mount,
-  // the next test) so the stack keeps rendering.
-  hosts.value = hosts.value.filter((id) => id !== hostId)
-})
 </script>

--- a/src/components/Dialogs.vue
+++ b/src/components/Dialogs.vue
@@ -1,7 +1,9 @@
 <template>
-  <div v-if="isPrimaryHost">
+  <div>
     <!-- v1 imperative `dialog.*` stack. -->
-    <component v-for="d in imperativeDialogs" :is="d.component" :key="d.id" />
+    <template v-if="isPrimaryHost">
+      <component v-for="d in imperativeDialogs" :is="d.component" :key="d.id" />
+    </template>
   </div>
 </template>
 
@@ -47,8 +49,10 @@ if (!hasParentHost && isClient) {
   }
 }
 
-// On the server the claim list stays empty; the inject guard still dedups
-// nested hosts there.
+// The wrapper <div> above renders unconditionally so server and client
+// markup match (during SSR the stack is empty, so every host emits the same
+// empty <div>). On the server the claim list stays empty; the inject guard
+// still dedups nested hosts there.
 const isPrimaryHost = computed(() =>
   isClient ? hosts.value[0] === hostId : !hasParentHost,
 )

--- a/src/components/FrappeUIProvider/FrappeUIProvider.cy.ts
+++ b/src/components/FrappeUIProvider/FrappeUIProvider.cy.ts
@@ -1,4 +1,4 @@
-import { h, ref } from 'vue'
+import { h, KeepAlive, ref } from 'vue'
 import FrappeUIProvider from './FrappeUIProvider.vue'
 import Dialogs from '../Dialogs.vue'
 import { dialog, dialogs } from '../../utils/dialog'
@@ -52,6 +52,20 @@ describe('<FrappeUIProvider />', () => {
     cy.then(() => dialog.confirm({ title: 'After handover' }))
     cy.get('[role=dialog]').should('have.length', 1)
     cy.get('[role=dialog]').should('contain.text', 'After handover')
+  })
+
+  it('hands the claim over when a keep-alive host deactivates', () => {
+    // A deactivated component never unmounts — without the deactivated
+    // hook it would keep the claim and render into detached DOM.
+    const Other = { template: '<div>Other</div>' }
+    const view = ref<any>(Dialogs)
+    cy.mount(FrappeUIProvider, {
+      slots: { default: () => h(KeepAlive, null, [h(view.value)]) },
+    })
+    cy.then(() => (view.value = Other))
+    cy.then(() => dialog.confirm({ title: 'After deactivate' }))
+    cy.get('[role=dialog]').should('have.length', 1)
+    cy.get('[role=dialog]').should('contain.text', 'After deactivate')
   })
 
   it('releases the host claim on unmount so a new mount renders again', () => {

--- a/src/components/FrappeUIProvider/FrappeUIProvider.cy.ts
+++ b/src/components/FrappeUIProvider/FrappeUIProvider.cy.ts
@@ -1,5 +1,6 @@
 import { h } from 'vue'
 import FrappeUIProvider from './FrappeUIProvider.vue'
+import Dialogs from '../Dialogs.vue'
 import { dialog, dialogs } from '../../utils/dialog'
 
 describe('<FrappeUIProvider />', () => {
@@ -22,6 +23,26 @@ describe('<FrappeUIProvider />', () => {
     })
     cy.then(() => dialog.confirm({ title: 'Delete this?' }))
     cy.get('[role=dialog]').should('contain.text', 'Delete this?')
+  })
+
+  it('dedups a sibling <Dialogs /> mounted in the slot content', () => {
+    // The provider's internal <Dialogs /> and one mounted by the app are
+    // siblings, not ancestor/descendant — inject alone cannot dedup them.
+    cy.mount(FrappeUIProvider, {
+      slots: { default: () => [h('div', 'App'), h(Dialogs)] },
+    })
+    cy.then(() => dialog.confirm({ title: 'Only once' }))
+    cy.get('[role=dialog]').should('have.length', 1)
+  })
+
+  it('releases the host claim on unmount so a new mount renders again', () => {
+    cy.mount(FrappeUIProvider, {
+      slots: { default: () => [h(Dialogs), h(Dialogs)] },
+    }).then(({ wrapper }) => wrapper.unmount())
+    cy.mount(FrappeUIProvider)
+    cy.then(() => dialog.confirm({ title: 'Fresh host' }))
+    cy.get('[role=dialog]').should('have.length', 1)
+    cy.get('[role=dialog]').should('contain.text', 'Fresh host')
   })
 
   it('mounts a Toaster so toast.* has somewhere to render', () => {

--- a/src/components/FrappeUIProvider/FrappeUIProvider.cy.ts
+++ b/src/components/FrappeUIProvider/FrappeUIProvider.cy.ts
@@ -1,4 +1,4 @@
-import { h } from 'vue'
+import { h, ref } from 'vue'
 import FrappeUIProvider from './FrappeUIProvider.vue'
 import Dialogs from '../Dialogs.vue'
 import { dialog, dialogs } from '../../utils/dialog'
@@ -33,6 +33,25 @@ describe('<FrappeUIProvider />', () => {
     })
     cy.then(() => dialog.confirm({ title: 'Only once' }))
     cy.get('[role=dialog]').should('have.length', 1)
+  })
+
+  it('hands the claim to the surviving host when the winner unmounts', () => {
+    // The app's slot-mounted <Dialogs /> registers first and wins. When it
+    // goes away (route change, v-if), the provider's own host must take
+    // over — not leave the stack with no renderer.
+    const show = ref(true)
+    cy.mount(FrappeUIProvider, {
+      slots: {
+        default: () => [h('div', 'App'), show.value ? h(Dialogs) : null],
+      },
+    })
+    cy.then(() => dialog.confirm({ title: 'Before' }))
+    cy.get('[role=dialog]').should('have.length', 1)
+    cy.then(() => (dialogs.value = []))
+    cy.then(() => (show.value = false))
+    cy.then(() => dialog.confirm({ title: 'After handover' }))
+    cy.get('[role=dialog]').should('have.length', 1)
+    cy.get('[role=dialog]').should('contain.text', 'After handover')
   })
 
   it('releases the host claim on unmount so a new mount renders again', () => {

--- a/src/components/FrappeUIProvider/FrappeUIProvider.md
+++ b/src/components/FrappeUIProvider/FrappeUIProvider.md
@@ -24,8 +24,9 @@ Only if the app uses the imperative `dialog.*` / `toast.*` helpers (or
 `Dialog`'s `dialog.confirm` / `alert` / `prompt` family). An app that mounts
 neither doesn't need it. An app that wants the portals without the wrapper can
 mount `<Dialogs />` and `<ToastProvider />` directly instead — both stay
-exported for that case. Mount each once: `<ToastProvider />` has no dedup
-guard, so a second one renders every toast twice, and `<Dialogs />`'s guard
-only catches true ancestor/descendant nesting, not two mounted as siblings.
+exported for that case. Mount `<ToastProvider />` once: it has no dedup
+guard, so a second one renders every toast twice. `<Dialogs />` dedups
+itself — only one host renders the stack, nested or sibling, and an extra
+mount warns in dev.
 
 <!-- @include: ./FrappeUIProvider.api.md -->


### PR DESCRIPTION
The `inject` guard in `Dialogs.vue` only sees ancestor hosts. The provider's internal `<Dialogs />` and one in its slot content are siblings, so both mounted and every dialog rendered twice.

- A module-level claim now makes the first mounted host win.
- Later hosts render nothing and warn in dev; the claim releases on unmount.
- The claim is client-only (no unmount hook on the server); nested hosts still dedup via `inject`.
- New cypress test covers the sibling case; spec/dialog.md wording updated.

Refs #988

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1010/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 64.23% (+0.01% vs `main`)
<!-- coverage-report:end -->



