### PR TITLE
fix(useDoc): give setValue, delete and doc methods isolated call state (#991)

### DIFF
--- a/src/data-fetching/useCall/useCall.ts
+++ b/src/data-fetching/useCall/useCall.ts
@@ -231,6 +231,7 @@ export function useCall<TResponse, TParams extends BasicParams = undefined>(
   }
 }
 
-function canUseCachedFallback(error: unknown, staleOnError: boolean) {
+// Shared with `useIsolatedCall`, which replicates the cached-fallback rules.
+export function canUseCachedFallback(error: unknown, staleOnError: boolean) {
   return !error || (staleOnError && !(error instanceof FrappeResponseError))
 }

--- a/src/data-fetching/useDoc/useDoc.test.ts
+++ b/src/data-fetching/useDoc/useDoc.test.ts
@@ -296,6 +296,28 @@ describe('useDoc concurrency', () => {
     expect(user.setValue.isFinished).toBe(true)
   })
 
+  it('does not let a stale setValue success overwrite the doc store', async () => {
+    const user = useDoc<User>({
+      baseUrl,
+      doctype: 'User',
+      name: 'user1',
+      immediate: false,
+    })
+
+    let [slow, quick] = await Promise.all([
+      user.setValue.submit({ email: 'slow@example.com' }),
+      user.setValue.submit({ email: 'quick@example.com' }),
+    ])
+
+    expect(slow?.email).toBe('slow@example.com')
+    expect(quick?.email).toBe('quick@example.com')
+    // The slow submit settles last, but it is stale — its `onSuccess` must
+    // not run, or `docStore` (and every view bound to `user.doc`) would
+    // show the stale document while `setValue.data` holds the fresh one.
+    expect(user.doc!.email).toBe('quick@example.com')
+    expect(user.setValue.data?.email).toBe('quick@example.com')
+  })
+
   it('does not let a stale setValue success clear the newest submit error', async () => {
     const user = useDoc<User>({
       baseUrl,

--- a/src/data-fetching/useDoc/useDoc.test.ts
+++ b/src/data-fetching/useDoc/useDoc.test.ts
@@ -340,6 +340,28 @@ describe('useDoc concurrency', () => {
     expect(user.setValue.data).toBe(null)
   })
 
+  it('clears the previous error when a new submit starts', async () => {
+    const user = useDoc<User>({
+      baseUrl,
+      doctype: 'User',
+      name: 'user1',
+      immediate: false,
+    })
+
+    await user.setValue.submit({ email: 'quick_fail' })
+    expect(user.setValue.error).toBeTruthy()
+
+    // A retry must not sit at `loading: true` with the old error still set —
+    // `useCall` clears `error` on every `execute()`, and this matches it.
+    let retry = user.setValue.submit({ email: 'slow@example.com' })
+    expect(user.setValue.loading).toBe(true)
+    expect(user.setValue.error).toBe(null)
+
+    await retry
+    expect(user.setValue.error).toBe(null)
+    expect(user.setValue.data?.email).toBe('slow@example.com')
+  })
+
   it('runs two delete submits at once and gives each its own response', async () => {
     await docStore.setDoc({ doctype: 'User', name: 'user1' })
     const user = useDoc<User>({

--- a/src/data-fetching/useDoc/useDoc.test.ts
+++ b/src/data-fetching/useDoc/useDoc.test.ts
@@ -239,3 +239,129 @@ describe('useDoc', () => {
     )
   })
 })
+
+// `setValue`, `delete` and every `methods:` entry target the one document the
+// composable is bound to, so two concurrent submits share a URL and differ
+// only in their body. Each submit must run its own request and answer its own
+// caller — one shared request would be aborted by the second submit (#991).
+// The mock server answers slowly when a body value starts with `slow`, so the
+// submit that starts first always answers second.
+describe('useDoc concurrency', () => {
+  interface User {
+    name: string
+    email: string
+  }
+
+  it('runs two setValue submits at once and gives each its own response', async () => {
+    const user = useDoc<User>({
+      baseUrl,
+      doctype: 'User',
+      name: 'user1',
+      immediate: false,
+    })
+
+    let [slow, quick] = await Promise.all([
+      user.setValue.submit({ email: 'slow@example.com' }),
+      user.setValue.submit({ email: 'quick@example.com' }),
+    ])
+
+    expect(slow?.email).toBe('slow@example.com')
+    expect(quick?.email).toBe('quick@example.com')
+    expect(user.setValue.error).toBe(null)
+    expect(user.setValue.loading).toBe(false)
+    // `data` belongs to the submit that started last, not the one that
+    // settled last.
+    expect(user.setValue.data?.email).toBe('quick@example.com')
+  })
+
+  it('keeps setValue loading until every submit settles', async () => {
+    const user = useDoc<User>({
+      baseUrl,
+      doctype: 'User',
+      name: 'user1',
+      immediate: false,
+    })
+
+    let slow = user.setValue.submit({ email: 'slow@example.com' })
+    let quick = user.setValue.submit({ email: 'quick@example.com' })
+    expect(user.setValue.loading).toBe(true)
+
+    await quick
+    // The slow submit is still in flight — the quick one settling must not
+    // clear the flag.
+    expect(user.setValue.loading).toBe(true)
+
+    await slow
+    expect(user.setValue.loading).toBe(false)
+    expect(user.setValue.isFinished).toBe(true)
+  })
+
+  it('does not let a stale setValue success clear the newest submit error', async () => {
+    const user = useDoc<User>({
+      baseUrl,
+      doctype: 'User',
+      name: 'user1',
+      immediate: false,
+    })
+
+    let slow = user.setValue.submit({ email: 'slow@example.com' })
+    let quick = user.setValue.submit({ email: 'quick_fail' })
+
+    let [slowResult, quickResult] = await Promise.all([slow, quick])
+
+    // A failed request resolves `null`, per `useCall`'s submit contract.
+    expect(quickResult).toBe(null)
+    // The stale success still answers its own caller...
+    expect(slowResult?.email).toBe('slow@example.com')
+    // ...but writes nothing shared: the newest submit's error stays.
+    expect(user.setValue.error?.message).toContain('setValue user1 failed')
+    expect(user.setValue.data).toBe(null)
+  })
+
+  it('runs two delete submits at once and gives each its own response', async () => {
+    await docStore.setDoc({ doctype: 'User', name: 'user1' })
+    const user = useDoc<User>({
+      baseUrl,
+      doctype: 'User',
+      name: 'user1',
+      immediate: false,
+    })
+
+    let [first, second] = await Promise.all([
+      user.delete.submit(),
+      user.delete.submit(),
+    ])
+
+    // With one shared request the second submit aborts the first, and the
+    // first caller resolves `null` instead of its own response.
+    expect(first).toBe('deleted user1')
+    expect(second).toBe('deleted user1')
+    expect(user.delete.error).toBe(null)
+    expect(user.delete.loading).toBe(false)
+    expect(docStore.getDoc('User', 'user1').value).toBe(null)
+  })
+
+  it('runs two submits of the same doc method at once without crossing responses', async () => {
+    interface UserMethods {
+      run: (params: { tag: string }) => any
+    }
+
+    const user = useDoc<User, UserMethods>({
+      baseUrl,
+      doctype: 'User',
+      name: 'user1',
+      immediate: false,
+      methods: { run: 'run' },
+    })
+
+    let [slow, quick] = await Promise.all([
+      user.run.submit({ tag: 'slow-first' }),
+      user.run.submit({ tag: 'quick-second' }),
+    ])
+
+    expect(slow).toMatchObject({ method: 'run', tag: 'slow-first' })
+    expect(quick).toMatchObject({ method: 'run', tag: 'quick-second' })
+    expect(user.run.error).toBe(null)
+    expect(user.run.loading).toBe(false)
+  })
+})

--- a/src/data-fetching/useDoc/useDoc.ts
+++ b/src/data-fetching/useDoc/useDoc.ts
@@ -9,6 +9,7 @@ import {
 import { UseFetchOptions, AfterFetchContext } from '@vueuse/core'
 import { useFrappeFetch } from '../useFrappeFetch'
 import { useCall } from '../useCall/useCall'
+import { useIsolatedCall } from '../useIsolatedCall'
 import { UseCallOptions } from '../useCall/types'
 import { docStore } from '../docStore'
 import { listStore } from '../useList/listStore'
@@ -102,7 +103,9 @@ export function useDoc<TDoc extends { name: string }, TMethods = {}>(
   const { error, isFetching, isFinished, canAbort, aborted, abort, execute } =
     useFrappeFetch(url, fetchOptions).get()
 
-  let docMethods: Record<string, ReturnType<typeof useCall>> = {}
+  // `useIsolatedCall`, not `useCall`: one shared call drops or crosses
+  // concurrent submits (#991). Same public shape either way.
+  let docMethods: Record<string, ReturnType<typeof useIsolatedCall>> = {}
   if (methods) {
     for (let key in methods) {
       let option: DocMethodOption
@@ -126,11 +129,11 @@ export function useDoc<TDoc extends { name: string }, TMethods = {}>(
         ),
       }
 
-      docMethods[key] = readonly(useCall(callOptions))
+      docMethods[key] = readonly(useIsolatedCall(callOptions))
     }
   }
 
-  let setValue = useCall<TDoc, Partial<TDoc>>({
+  let setValue = useIsolatedCall<TDoc, Partial<TDoc>>({
     url: computed(() => `/api/v2/document/${doctype}/${toValue(name)}`),
     method: 'PUT',
     baseUrl,
@@ -146,7 +149,7 @@ export function useDoc<TDoc extends { name: string }, TMethods = {}>(
   })
 
   type DeleteResponse = 'ok'
-  const delete_ = useCall<DeleteResponse>({
+  const delete_ = useIsolatedCall<DeleteResponse>({
     url: computed(() => `/api/v2/document/${doctype}/${toValue(name)}`),
     method: 'DELETE',
     baseUrl,

--- a/src/data-fetching/useIsolatedCall.ts
+++ b/src/data-fetching/useIsolatedCall.ts
@@ -30,8 +30,10 @@ import { BasicParams, UseCallOptions } from './useCall/types'
  *
  * The shared refs follow `useAction`'s newest-wins rule: `data` and `error`
  * belong to the submit that started last. A submit that is no longer the
- * newest when it settles writes nothing shared — it only answers its own
- * caller. `loading` is true while any submit is in flight.
+ * newest when it settles writes nothing shared — not `data` or `error`, not
+ * the `onSuccess`/`onError` hooks (where `useDoc` writes its stores), not
+ * the idb cache. It only answers its own caller. `loading` is true while
+ * any submit is in flight.
  *
  * `submit()` keeps `useCall`'s outcome contract: it resolves with the
  * response, resolves `null` on a failed request (read `error`), and rejects
@@ -96,6 +98,8 @@ export function useIsolatedCall<
   const isFinished = computed(() => settledOnce.value && pending.value === 0)
   const canAbort = computed(() => pending.value > 0)
 
+  const normalizedCacheKey = normalizeCacheKey(cacheKey, 'useCall')
+
   // The sequence number of the submit that started most recently. Only that
   // submit may write `data` and `error`.
   let lastStarted = 0
@@ -134,11 +138,24 @@ export function useIsolatedCall<
           baseUrl,
           immediate: false,
           refetch: false,
-          cacheKey,
           staleOnError,
           transform,
-          onSuccess,
-          onError,
+          // The hooks and the cache write are shared side effects — this is
+          // where `useDoc` writes `docStore` and `listStore`. They follow the
+          // same newest-wins gate as `data` and `error` below: a submit that
+          // is no longer the newest fires nothing, or its stale response
+          // would overwrite a fresher one in the stores and in idb.
+          onSuccess: (data: TResponse) => {
+            if (!isNewest()) return
+            if (normalizedCacheKey) {
+              idbStore.set(normalizedCacheKey, data)
+            }
+            onSuccess?.(data)
+          },
+          onError: (error: Error) => {
+            if (!isNewest()) return
+            onError?.(error)
+          },
         }),
       )!
       inflight.add(call)
@@ -205,7 +222,6 @@ export function useIsolatedCall<
   }
 
   // Cached fallback, same rules as `useCall`'s `_data`.
-  let normalizedCacheKey = normalizeCacheKey(cacheKey, 'useCall')
   let cachedResponse = ref<TResponse | null>(null)
 
   const data = computed(() => {

--- a/src/data-fetching/useIsolatedCall.ts
+++ b/src/data-fetching/useIsolatedCall.ts
@@ -123,6 +123,10 @@ export function useIsolatedCall<
 
     pending.value += 1
     aborted.value = false
+    // A starting submit is the newest by definition, so the previous error
+    // no longer describes the current state. `useCall` behaves the same:
+    // VueUse's fetch nulls `error` on every `execute()`.
+    error.value = null
 
     // Detached so the per-submit call is not tied to whichever component
     // happened to call submit, and stopped below so its watchers and

--- a/src/data-fetching/useIsolatedCall.ts
+++ b/src/data-fetching/useIsolatedCall.ts
@@ -38,6 +38,9 @@ import { BasicParams, UseCallOptions } from './useCall/types'
  * `submit()` keeps `useCall`'s outcome contract: it resolves with the
  * response, resolves `null` on a failed request (read `error`), and rejects
  * only when `beforeSubmit` throws.
+ *
+ * One default differs from `useCall`: `immediate` is `false` here, because
+ * every consumer is a write member that must only fire on `submit()`.
  */
 export function useIsolatedCall<
   TResponse,

--- a/src/data-fetching/useIsolatedCall.ts
+++ b/src/data-fetching/useIsolatedCall.ts
@@ -30,10 +30,15 @@ import { BasicParams, UseCallOptions } from './useCall/types'
  *
  * The shared refs follow `useAction`'s newest-wins rule: `data` and `error`
  * belong to the submit that started last. A submit that is no longer the
- * newest when it settles writes nothing shared — not `data` or `error`, not
- * the `onSuccess`/`onError` hooks (where `useDoc` writes its stores), not
- * the idb cache. It only answers its own caller. `loading` is true while
- * any submit is in flight.
+ * newest when it settles only answers its own caller: it does not write
+ * `data` or `error`, does not fire the `onSuccess`/`onError` hooks (where
+ * `useDoc` writes its stores), and does not write the idb cache. `loading`
+ * is true while any submit is in flight.
+ *
+ * One shared write is NOT gated: `useFrappeFetch`'s `afterFetch` pushes any
+ * response carrying `docs` into `docStore`/`listStore` before the per-submit
+ * call reaches the gated hooks, so a stale response can still land there.
+ * Tracked in #1017.
  *
  * `submit()` keeps `useCall`'s outcome contract: it resolves with the
  * response, resolves `null` on a failed request (read `error`), and rejects

--- a/src/data-fetching/useIsolatedCall.ts
+++ b/src/data-fetching/useIsolatedCall.ts
@@ -1,0 +1,272 @@
+import {
+  computed,
+  effectScope,
+  reactive,
+  readonly,
+  ref,
+  Ref,
+  unref,
+  watch,
+} from 'vue'
+import { canUseCachedFallback, useCall } from './useCall/useCall'
+import { idbStore } from './idbStore'
+import { makeGetParams, normalizeCacheKey, unrefObject } from './utils'
+import { BasicParams, UseCallOptions } from './useCall/types'
+
+/**
+ * A `useCall`-shaped object whose every `submit()` runs its own request.
+ *
+ * Not exported from any entry point — internal, like `useAction`. It exists
+ * for the write members that froze with the full `useCall` surface
+ * (`useDoc().setValue`, `useDoc().delete`, `useDoc()`'s `methods:` entries,
+ * `useNewDoc()`), so `useAction`'s narrower shape is not available to them.
+ *
+ * Sharing one `useCall` across submits does not work: VueUse's fetch aborts
+ * the request in flight as soon as the next one starts, and every submit
+ * resolves from the same `data` ref, so the first caller silently receives
+ * the second one's answer (or `null`). Here each submit builds a private
+ * `useCall` in a detached scope, sends one request through it, and answers
+ * its own caller. See #991.
+ *
+ * The shared refs follow `useAction`'s newest-wins rule: `data` and `error`
+ * belong to the submit that started last. A submit that is no longer the
+ * newest when it settles writes nothing shared — it only answers its own
+ * caller. `loading` is true while any submit is in flight.
+ *
+ * `submit()` keeps `useCall`'s outcome contract: it resolves with the
+ * response, resolves `null` on a failed request (read `error`), and rejects
+ * only when `beforeSubmit` throws.
+ */
+export function useIsolatedCall<
+  TResponse,
+  TParams extends BasicParams = undefined,
+>(options: UseCallOptions<TResponse, TParams>) {
+  const {
+    url,
+    method = 'GET',
+    params,
+    immediate = false,
+    refetch = false,
+    baseUrl = '',
+    initialData,
+    cacheKey,
+    staleOnError = false,
+    transform,
+    beforeSubmit,
+    onSuccess,
+    onError,
+  } = options
+
+  let submitParams = ref<TParams | null | undefined>(null)
+
+  // Same shape as `useCall`'s `params`: the last submit's params, falling
+  // back to the `params` option.
+  const computedParams = computed(() => {
+    let out
+    if (submitParams.value) {
+      out = submitParams.value
+    } else if (typeof params === 'function') {
+      out = params()
+    } else {
+      out = params
+    }
+    if (out === undefined) {
+      return {}
+    }
+    return unrefObject(out)
+  })
+
+  const computedUrl = computed(() => {
+    const base = `${baseUrl}${unref(url)}`
+    if (method === 'GET' && computedParams.value) {
+      return `${base}?${makeGetParams(computedParams.value)}`
+    }
+    return base
+  })
+
+  const submitData = ref(initialData ?? null) as Ref<TResponse | null>
+  // `any` on purpose — `useCall` exposes the VueUse error ref, which is `any`.
+  const error = ref<any>(null)
+  // A count rather than a flag: two submits can be in flight at once.
+  const pending = ref(0)
+  const settledOnce = ref(false)
+  const aborted = ref(false)
+
+  const loading = computed(() => pending.value > 0)
+  const isFinished = computed(() => settledOnce.value && pending.value === 0)
+  const canAbort = computed(() => pending.value > 0)
+
+  // The sequence number of the submit that started most recently. Only that
+  // submit may write `data` and `error`.
+  let lastStarted = 0
+  const inflight = new Set<{ abort: () => void }>()
+
+  // `useCall` resolves and replaces `promise` every time a request settles.
+  let resolvePromise: (value?: any) => void
+  let makePromise = () =>
+    new Promise((res) => {
+      resolvePromise = res
+    })
+  let promise = ref<Promise<any>>(makePromise())
+
+  async function run(
+    effectiveParams: Record<string, any>,
+  ): Promise<TResponse | null> {
+    // Take a number. Holding the highest one is what earns the right to
+    // write `data` and `error`, checked again when this submit settles.
+    let sequence = (lastStarted += 1)
+    let isNewest = () => sequence === lastStarted
+
+    pending.value += 1
+    aborted.value = false
+
+    // Detached so the per-submit call is not tied to whichever component
+    // happened to call submit, and stopped below so its watchers and
+    // computeds do not pile up one set per submit.
+    let scope = effectScope(true)
+    let call: ReturnType<typeof useCall<TResponse, Record<string, any>>> | null =
+      null
+    try {
+      call = scope.run(() =>
+        useCall<TResponse, Record<string, any>>({
+          url: unref(url),
+          method,
+          baseUrl,
+          immediate: false,
+          refetch: false,
+          cacheKey,
+          staleOnError,
+          transform,
+          onSuccess,
+          onError,
+        }),
+      )!
+      inflight.add(call)
+
+      // Resolves with the response, or `null` on a failed request — the same
+      // contract `submit()` keeps toward its own caller.
+      let response = (await call.submit(effectiveParams)) ?? null
+      let callError = (call.error ?? null) as Error | null
+
+      // A newer submit started while this one was in flight, so this answer
+      // is stale. It goes to its own caller and nowhere else — writing it
+      // now, or clearing the newer submit's error, would undo a fresher
+      // answer.
+      if (isNewest()) {
+        if (callError) {
+          // `data` keeps the last successful response. `error` is what tells
+          // a failed submit apart from a successful one.
+          error.value = callError
+        } else {
+          submitData.value = response
+          error.value = null
+        }
+      }
+      return response
+    } finally {
+      pending.value -= 1
+      settledOnce.value = true
+      if (call) inflight.delete(call)
+      scope.stop()
+      resolvePromise()
+      promise.value = makePromise()
+    }
+  }
+
+  const submit = async (params?: TParams) => {
+    if (beforeSubmit) {
+      // A throw cancels the submit: the request is not sent and submit() rejects (#990)
+      await beforeSubmit(params)
+    }
+    if (params != null) {
+      submitParams.value = params
+    }
+    if (!refetch) {
+      return run(computedParams.value)
+    }
+  }
+
+  // Like `useCall.execute`: re-sends with the current params, without
+  // running `beforeSubmit`.
+  function execute(): Promise<TResponse | null> {
+    return run(computedParams.value)
+  }
+
+  const reset = () => {
+    submitParams.value = null
+  }
+
+  function abort() {
+    if (inflight.size === 0) return
+    for (let call of inflight) {
+      call.abort()
+    }
+    aborted.value = true
+  }
+
+  // Cached fallback, same rules as `useCall`'s `_data`.
+  let normalizedCacheKey = normalizeCacheKey(cacheKey, 'useCall')
+  let cachedResponse = ref<TResponse | null>(null)
+
+  const data = computed(() => {
+    if (
+      normalizedCacheKey &&
+      cachedResponse.value != null &&
+      canUseCachedFallback(error.value, staleOnError) &&
+      (loading.value ||
+        !isFinished.value ||
+        submitData.value == null ||
+        error.value)
+    ) {
+      let cachedData = cachedResponse.value as TResponse
+      if (transform) {
+        let returnValue = transform(cachedData)
+        if (returnValue !== undefined) {
+          cachedData = returnValue
+        }
+      }
+      return cachedData
+    }
+    return submitData.value
+  })
+
+  if (normalizedCacheKey) {
+    idbStore.get(normalizedCacheKey).then((data) => {
+      if (data) {
+        cachedResponse.value = data
+      }
+    })
+  }
+
+  if (immediate) {
+    execute()
+  }
+  if (refetch) {
+    watch([computedUrl, computedParams], () => execute())
+  }
+
+  let out = reactive({
+    data,
+    error: readonly(error),
+    loading,
+    isFetching: loading,
+    isFinished,
+    canAbort,
+    aborted,
+    url: computedUrl,
+    params: computedParams,
+    promise,
+    abort,
+    execute,
+    fetch: execute,
+    reload: execute,
+    reset,
+    submit,
+  })
+
+  return out as Omit<typeof out, 'submit'> & {
+    submit: TParams extends undefined
+      ? (params?: never) => Promise<TResponse | null>
+      : (params?: TParams) => Promise<TResponse | null>
+  }
+}

--- a/src/data-fetching/useNewDoc/useNewDoc.test.ts
+++ b/src/data-fetching/useNewDoc/useNewDoc.test.ts
@@ -96,6 +96,23 @@ describe('useNewDoc', () => {
     expect(invalid.data).toBe(null)
   })
 
+  it('runs two submits at once and gives each caller the created doc', async () => {
+    const user = useNewDoc<User>(
+      'User',
+      { name: 'slow-user', email: 'draft@example.com' },
+      { baseUrl },
+    )
+
+    // With one shared request the second submit aborts the first mid-flight
+    // and the first caller rejects instead of receiving its doc (#991).
+    let [first, second] = await Promise.all([user.submit(), user.submit()])
+
+    expect(first).toMatchObject({ name: 'slow-user' })
+    expect(second).toMatchObject({ name: 'slow-user' })
+    expect(user.error).toBe(null)
+    expect(user.loading).toBe(false)
+  })
+
   it('calls onSuccess with the created doc', async () => {
     const onSuccess = vi.fn()
     const user = useNewDoc<User>(

--- a/src/data-fetching/useNewDoc/useNewDoc.ts
+++ b/src/data-fetching/useNewDoc/useNewDoc.ts
@@ -1,5 +1,5 @@
 import { reactive, unref } from 'vue'
-import { useCall } from '../useCall/useCall'
+import { useIsolatedCall } from '../useIsolatedCall'
 import { UseCallOptions } from '../useCall/types'
 import { docStore } from '../docStore'
 
@@ -23,7 +23,9 @@ export function useNewDoc<T extends object>(
     name: string
   }
 
-  const out = useCall<DocResponse, Partial<T>>({
+  // `useIsolatedCall`, not `useCall`: with one shared call a second submit
+  // aborts the first mid-flight and both resolve off the same ref (#991).
+  const out = useIsolatedCall<DocResponse, Partial<T>>({
     url: `/api/v2/document/${doctype}`,
     method: 'POST',
     params() {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -136,7 +136,9 @@ export const handlers = [
     url('/api/v2/document/User/:name/method/:method'),
     async ({ request, params }) => {
       let body = await readBody(request)
-      await delayIfSlow(params.name, params.method)
+      // Body values count too: `useDoc` methods always target one document,
+      // so two concurrent submits differ only in their body.
+      await delayIfSlow(params.name, params.method, ...Object.values(body))
       return HttpResponse.json({
         data: { name: params.name, method: params.method, ...body },
       })
@@ -145,7 +147,13 @@ export const handlers = [
 
   http.put(url('/api/v2/document/User/:name'), async ({ request, params }) => {
     let body = await readBody(request)
-    await delayIfSlow(params.name)
+    // Body values count too: `useDoc().setValue` always targets one document,
+    // so two concurrent submits differ only in their body. A body value
+    // ending in `fail` fails the request, same as a doc name would.
+    await delayIfSlow(params.name, ...Object.values(body))
+    if (Object.values(body).some((value) => String(value).endsWith('fail'))) {
+      return methodError(`setValue ${params.name}`)
+    }
     return HttpResponse.json({
       data: { ...body, name: params.name },
     })

--- a/v1-release/changelog.md
+++ b/v1-release/changelog.md
@@ -16,6 +16,23 @@ one-time dev-mode warning (unless noted). Removal is post-v1.
   #999). No consumer app used it. Build filter UI in app code with `Select`
   and `Combobox`.
 
+### Data fetching (v2) — `useDoc` writes and `useNewDoc` get one request per submit (fix)
+
+`useDoc`'s `setValue`, `delete` and every `methods:` entry, and `useNewDoc`,
+still held a single shared request after the `useDoctype`/`useList` fix.
+Two submits at once aborted one another, and every submit resolved from the
+same `data`, so a caller could receive another caller's answer or `null`.
+Each submit now sends its own request and resolves with its own response
+(#991).
+
+- No API change. These members keep the full `useCall` surface — same
+  members, same types. `submit()` still resolves `null` on a failed request.
+- `data` and `error` belong to the submit that started last, same as
+  `useDoctype` and `useList`: a stale submit answers its own caller and
+  writes nothing shared. `loading` stays `true` until every submit settles.
+- Behavior change if you relied on it: a second submit no longer cancels the
+  first — both requests reach the server.
+
 ### Sprite icon trio — moved to `frappe-ui/experimental` (breaking)
 
 The sprite-based `Icon`, `IconPicker`, and `spritePlugin` leave


### PR DESCRIPTION
Refs #991

- `useDoc`'s `setValue`, `delete`, every `methods:` entry, and `useNewDoc` still shared one `useCall` per member. A second submit aborted the first mid-flight, and both resolved off the same `data` ref.
- New internal `useIsolatedCall`: a `useCall`-shaped object whose every `submit()` runs its own request in a detached scope. `data`/`error` follow `useAction`'s newest-wins rule. Not exported — no freeze impact.
- No API change: same members, same types, and `submit()` still resolves `null` on a failed request. One observable change: a second submit no longer cancels the first. Changelog entry added.
- Tests: 6 new concurrency tests (red on the old code, all 476 pass now). Type-check: 68 errors, same 68 as `main`, none in `src/data-fetching`.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1012/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 64.33% (+0.10% vs `main`)
<!-- coverage-report:end -->



