### PR TITLE
refactor(tokens): migrate internal rounded-* aliases to numbered radius (#997)

### DIFF
--- a/docs/components/Home/ComponentGroups.vue
+++ b/docs/components/Home/ComponentGroups.vue
@@ -69,14 +69,14 @@ const componentGroups = {
     <div
       v-for="(components, group) in componentGroups"
       :key="group"
-      class="rounded border border-outline-gray-2 dark:border-0 grid"
+      class="rounded-4 border border-outline-gray-2 dark:border-0 grid"
     >
       <component
         :is="components.component"
-        class="min-h-[130px] bg-surface-gray-2 dark:bg-surface-gray-1 rounded-t"
+        class="min-h-[130px] bg-surface-gray-2 dark:bg-surface-gray-1 rounded-t-4"
       />
 
-      <div class="grid gap-2 p-4 bg-surface-elevation-1 rounded-b">
+      <div class="grid gap-2 p-4 bg-surface-elevation-1 rounded-b-4">
         <h3 class="text-md font-semibold text-ink-gray-9">
           {{ group }}
         </h3>

--- a/docs/components/Home/Hero.vue
+++ b/docs/components/Home/Hero.vue
@@ -20,7 +20,7 @@ import { withBase } from 'vitepress'
       <div class="flex gap-3 mt-6 mx-auto">
         <a
           :href="withBase('/docs/getting-started')"
-          class="inline-flex items-center gap-2 h-8 px-2.5 rounded text-base font-medium text-ink-base bg-surface-gray-10 hover:bg-surface-gray-9 active:bg-surface-gray-8 transition-colors focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3"
+          class="inline-flex items-center gap-2 h-8 px-2.5 rounded-4 text-base font-medium text-ink-base bg-surface-gray-10 hover:bg-surface-gray-9 active:bg-surface-gray-8 transition-colors focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3"
         >
           Get Started
           <LucideRight class="h-4 w-4" />

--- a/docs/components/Home/Showcase/col1.vue
+++ b/docs/components/Home/Showcase/col1.vue
@@ -44,7 +44,7 @@ const selOpts = ["Admin", "Editor", "Viewer", "Guest"]
 
 <template>
   <section
-    class="grid gap-5 *:rounded *:border [&_label]:text-ink-gray-9 [&_label]:mb-2 [&_label]:text-base h-fit"
+    class="grid gap-5 *:rounded-4 *:border [&_label]:text-ink-gray-9 [&_label]:mb-2 [&_label]:text-base h-fit"
   >
     <div class="grid p-5 grid-cols-2 gap-y-5 gap-x-4 h-fit">
       <FormControl
@@ -130,7 +130,7 @@ const selOpts = ["Admin", "Editor", "Viewer", "Guest"]
       />
 
       <div class="flex gap-3">
-        <div class="my-auto bg-surface-gray-2 p-2 rounded">
+        <div class="my-auto bg-surface-gray-2 p-2 rounded-4">
           <LucideGlobe class="size-6" />
         </div>
         <div class="grid gap-1 mr-auto">

--- a/docs/components/Home/Showcase/col2.vue
+++ b/docs/components/Home/Showcase/col2.vue
@@ -44,7 +44,7 @@ const resetState = () => {
 
 <template>
   <section
-    class="grid gap-5 *:rounded *:border [&_label]:text-ink-gray-9 [&_label]:mb-2 [&_label]:text-base h-fit"
+    class="grid gap-5 *:rounded-4 *:border [&_label]:text-ink-gray-9 [&_label]:mb-2 [&_label]:text-base h-fit"
   >
     <div class="h-fit">
       <Tabs :tabs v-model="val" class='[&>[role=tablist]]:px-4'>
@@ -114,7 +114,7 @@ const resetState = () => {
       <Progress :value="20" label="Daily Progress" size="lg" :hint="true" />
 
       <div class="flex gap-3">
-        <span class="p-3 px-4 rounded bg-surface-gray-2 flex items-center">
+        <span class="p-3 px-4 rounded-4 bg-surface-gray-2 flex items-center">
           <LucideTag class="size-5" />
         </span>
 
@@ -147,12 +147,12 @@ const resetState = () => {
       <div class="!col-span-1 flex flex-wrap gap-x-1">
         <label class="w-full">Status</label>
 
-        <Badge theme="blue" class="rounded-sm"> Stable</Badge>
-        <Badge theme="orange" class="rounded-sm"> Moderate</Badge>
+        <Badge theme="blue" class="rounded-1"> Stable</Badge>
+        <Badge theme="orange" class="rounded-1"> Moderate</Badge>
       </div>
     </div>
 
-    <div class="p-2 grid h-full [&_label]:!m-0 *:rounded *:cursor-pointer">
+    <div class="p-2 grid h-full [&_label]:!m-0 *:rounded-4 *:cursor-pointer">
       <div class="flex items-center gap-2 boder-b p-2 px-2 pb-3 !rounded-none">
         <span class="text-ink-gray-5"> Settings </span>
         <LucideRight class="size-4 text-ink-gray-5" />

--- a/docs/components/Home/Showcase/col3.vue
+++ b/docs/components/Home/Showcase/col3.vue
@@ -71,7 +71,7 @@ const toggledDiv = ref(false)
 
 <template>
   <section
-    class="grid gap-5 *:rounded *:border [&_label]:text-ink-gray-9 [&_label]:mb-2 [&_label]:text-base h-fit"
+    class="grid gap-5 *:rounded-4 *:border [&_label]:text-ink-gray-9 [&_label]:mb-2 [&_label]:text-base h-fit"
   >
     <div class="p-5 h-fit prose prose-sm">
       <Progress
@@ -96,7 +96,7 @@ const toggledDiv = ref(false)
           :key="tag"
           :theme="themes[tagIndex] || 'gray'"
           size="lg"
-          class="rounded-sm"
+          class="rounded-1"
         >
           {{ tag }}
         </Badge>
@@ -114,7 +114,7 @@ const toggledDiv = ref(false)
         <span class="ml-3 text-sm !text-ink-gray-9"> + 5 more </span>
       </div>
 
-      <div class="grid grid-cols-2 mt-3 gap-3 *:py-4 border-t rounded pt-3">
+      <div class="grid grid-cols-2 mt-3 gap-3 *:py-4 border-t rounded-4 pt-3">
         <Button @click="decProgress">Back</Button>
         <Button @click="incProgress" variant="solid">Next</Button>
       </div>
@@ -126,7 +126,7 @@ const toggledDiv = ref(false)
           <LucideCoins class="size-4" />
           Price range
         </span>
-        <Badge size="lg" class="rounded-sm">
+        <Badge size="lg" class="rounded-1">
           ${{ slider2Val[0] * 10 }} - ${{ slider2Val[1] * 10 }}
         </Badge>
       </div>

--- a/docs/components/Home/Showcase/col4.vue
+++ b/docs/components/Home/Showcase/col4.vue
@@ -109,7 +109,7 @@ const notifs = [
 
 <template>
   <section
-    class="grid gap-5 *:rounded *:border [&_label]:text-ink-gray-9 [&_label]:mb-2 [&_label]:text-base h-fit"
+    class="grid gap-5 *:rounded-4 *:border [&_label]:text-ink-gray-9 [&_label]:mb-2 [&_label]:text-base h-fit"
   >
     <div class="p-5 bg-urface-cards h-fit">
       <Tree
@@ -178,7 +178,7 @@ const notifs = [
         </template>
       </Progress>
 
-      <div class="px-8 !py-3 rounded bg-surface-gray-1 text-sm text-ink-gray-5">
+      <div class="px-8 !py-3 rounded-4 bg-surface-gray-1 text-sm text-ink-gray-5">
         <li :class='{ "line-through opacity-60": hasValidLength }'>
           Includes 9-16 characters
         </li>

--- a/docs/components/Home/dummies/Charts.vue
+++ b/docs/components/Home/dummies/Charts.vue
@@ -7,11 +7,11 @@ let bars = [22, 36, 28, 44, 30, 52, 34, 40, 26, 48, 32, 44, 28];
   <div
     class="p-3 flex items-end gap-6 overflow-hidden"
   >
-    <div class="flex items-end gap-2 w-full bg-surface-elevation-1 p-4 pt-8 rounded overflow-hidden shadow-lg dark:shadow-none ">
+    <div class="flex items-end gap-2 w-full bg-surface-elevation-1 p-4 pt-8 rounded-4 overflow-hidden shadow-lg dark:shadow-none ">
       <div
         v-for="(h, i) in bars"
         :key="i"
-        class="min-w-[10px] rounded-sm bg-surface-gray-4"
+        class="min-w-[10px] rounded-1 bg-surface-gray-4"
         :style="{ height: `${h * 2}px` }"
       />
     </div>

--- a/docs/components/Home/dummies/DataDisplay.vue
+++ b/docs/components/Home/dummies/DataDisplay.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="p-3 grid grid-cols-3 gap-2">
     <div
-      class="rounded bg-surface-elevation-1 dark:bg-surface-elevation-1 p-2 flex flex-col gap-2 shadow-lg dark:shadow-none "
+      class="rounded-4 bg-surface-elevation-1 dark:bg-surface-elevation-1 p-2 flex flex-col gap-2 shadow-lg dark:shadow-none "
       v-for="_ in 3"
     >
-      <div class="h-2 w-8 rounded bg-surface-gray-2" />
-      <div class="h-2 w-full rounded bg-surface-gray-2" />
-      <div class="h-3 w-full rounded bg-surface-gray-2" />
-      <div class="h-3 w-full rounded bg-surface-gray-2" />
+      <div class="h-2 w-8 rounded-4 bg-surface-gray-2" />
+      <div class="h-2 w-full rounded-4 bg-surface-gray-2" />
+      <div class="h-3 w-full rounded-4 bg-surface-gray-2" />
+      <div class="h-3 w-full rounded-4 bg-surface-gray-2" />
     </div>
   </div>
 </template>

--- a/docs/components/Home/dummies/Datetime.vue
+++ b/docs/components/Home/dummies/Datetime.vue
@@ -1,17 +1,17 @@
 <template>
   <div class="p-5 grid gap-3">
     <div
-      class="bg-surface-elevation-1 rounded-sm p-2 flex items-center justify-between shadow-lg dark:shadow-none"
+      class="bg-surface-elevation-1 rounded-1 p-2 flex items-center justify-between shadow-lg dark:shadow-none"
     >
-      <div class="h-3 w-1/2 bg-surface-gray-3 rounded" />
-      <div class="h-4 w-4 bg-surface-gray-4 rounded" />
+      <div class="h-3 w-1/2 bg-surface-gray-3 rounded-4" />
+      <div class="h-4 w-4 bg-surface-gray-4 rounded-4" />
     </div>
 
-    <div class="bg-surface-elevation-1 rounded p-3 grid grid-cols-7 gap-2 shadow-lg dark:shadow-none">
+    <div class="bg-surface-elevation-1 rounded-4 p-3 grid grid-cols-7 gap-2 shadow-lg dark:shadow-none">
       <div
         v-for="i in 14"
         :key="i"
-        class="h-4 rounded-sm bg-surface-gray-3"
+        class="h-4 rounded-1 bg-surface-gray-3"
       />
     </div>
   </div>

--- a/docs/components/Home/dummies/Feedback.vue
+++ b/docs/components/Home/dummies/Feedback.vue
@@ -4,31 +4,31 @@
   >
     <div class="flex flex-col gap-3">
       <div
-        class="shadow-lg dark:shadow-none bg-surface-elevation-1 border border-outline-gray-3 rounded p-2 w-32 flex items-center gap-2"
+        class="shadow-lg dark:shadow-none bg-surface-elevation-1 border border-outline-gray-3 rounded-4 p-2 w-32 flex items-center gap-2"
       >
         <div class="flex w-full">
-          <span class="h-1.5 w-1/2 bg-gray-500 rounded-l mb-1" />
-          <span class="h-1.5 w-full bg-surface-gray-4 rounded-r mb-1" />
+          <span class="h-1.5 w-1/2 bg-gray-500 rounded-l-4 mb-1" />
+          <span class="h-1.5 w-full bg-surface-gray-4 rounded-r-4 mb-1" />
         </div>
       </div>
 
       <div
-        class="shadow-lg dark:shadow-none bg-surface-elevation-1 border border-surface-gray-3 rounded p-2 w-32 flex items-center gap-2"
+        class="shadow-lg dark:shadow-none bg-surface-elevation-1 border border-surface-gray-3 rounded-4 p-2 w-32 flex items-center gap-2"
       >
         <div class="h-2 w-2 bg-green-400/40 rounded-full flex-shrink-0" />
         <div class="flex-1">
-          <div class="h-1.5 w-full bg-surface-gray-3 rounded mb-1" />
-          <div class="h-1.5 w-3/4 bg-surface-gray-3 rounded" />
+          <div class="h-1.5 w-full bg-surface-gray-3 rounded-4 mb-1" />
+          <div class="h-1.5 w-3/4 bg-surface-gray-3 rounded-4" />
         </div>
       </div>
 
       <div
-        class="shadow-lg dark:shadow-none  bg-surface-elevation-1 border border-surface-gray-3 rounded p-2 w-32 flex items-center gap-2"
+        class="shadow-lg dark:shadow-none  bg-surface-elevation-1 border border-surface-gray-3 rounded-4 p-2 w-32 flex items-center gap-2"
       >
         <div class="h-2 w-2 bg-red-400/40 rounded-full flex-shrink-0" />
         <div class="flex-1">
-          <div class="h-1.5 w-full bg-surface-gray-3 rounded mb-1" />
-          <div class="h-1.5 w-2/3 bg-surface-gray-3 rounded" />
+          <div class="h-1.5 w-full bg-surface-gray-3 rounded-4 mb-1" />
+          <div class="h-1.5 w-2/3 bg-surface-gray-3 rounded-4" />
         </div>
       </div>
     </div>

--- a/docs/components/Home/dummies/Forms.vue
+++ b/docs/components/Home/dummies/Forms.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="p-5">
     <div
-      class="bg-surface-elevation-1 rounded p-3 grid grid-cols-2 gap-x-3 w-full shadow-lg dark:shadow-none"
+      class="bg-surface-elevation-1 rounded-4 p-3 grid grid-cols-2 gap-x-3 w-full shadow-lg dark:shadow-none"
     >
       <span class="text-ink-gray-4">****</span>
       <span class="text-ink-gray-4">******</span>
-      <span class="h-3 bg-surface-gray-2 rounded-sm -mt-1" />
-      <span class="h-3 bg-surface-gray-2 rounded-sm -mt-1" />
+      <span class="h-3 bg-surface-gray-2 rounded-1 -mt-1" />
+      <span class="h-3 bg-surface-gray-2 rounded-1 -mt-1" />
       <span class="text-ink-gray-4">****</span>
       <span class="text-ink-gray-4">******</span>
-      <span class="h-3 bg-surface-gray-2 rounded-sm -mt-1" />
-      <span class="h-3 bg-surface-gray-2 rounded-sm -mt-1" />
+      <span class="h-3 bg-surface-gray-2 rounded-1 -mt-1" />
+      <span class="h-3 bg-surface-gray-2 rounded-1 -mt-1" />
 
       <span
-        class="bg-surface-gray-10 p-1 mt-3 w-8 rounded-sm col-span-2 ml-auto"
+        class="bg-surface-gray-10 p-1 mt-3 w-8 rounded-1 col-span-2 ml-auto"
       />
     </div>
   </div>

--- a/docs/components/Home/dummies/Navigation.vue
+++ b/docs/components/Home/dummies/Navigation.vue
@@ -18,18 +18,18 @@ onUnmounted(() => {
 <template>
   <div class="p-6 px-20 grid">
     <div
-      class="flex items-center gap-1 bg-surface-gray-4 rounded-sm p-1 m-auto w-full"
+      class="flex items-center gap-1 bg-surface-gray-4 rounded-1 p-1 m-auto w-full"
     >
       <div
         v-for="(_, i) in 3"
         :key="i"
-        class="h-3 w-full rounded-sm transition-all duration-500 ease-in-out"
+        class="h-3 w-full rounded-1 transition-all duration-500 ease-in-out"
         :class="active === i ? 'bg-surface-base' : 'bg-surface-gray-2'"
       />
     </div>
 
     <div
-      class="mt-2 p-5 animate-pulse rounded flex items-center w-full bg-surface-gray-4 dark:bg-surface-gray-3"
+      class="mt-2 p-5 animate-pulse rounded-4 flex items-center w-full bg-surface-gray-4 dark:bg-surface-gray-3"
     />
   </div>
 </template>

--- a/docs/components/Home/dummies/Overlays.vue
+++ b/docs/components/Home/dummies/Overlays.vue
@@ -4,27 +4,27 @@
   >
     <div class="mx-auto grid gap-2 relative w-1/2">
       <div
-        class="absolute bottom-3 -left-6 bg-surface-elevation-1 rounded shadow-md border border-outline-gray-2 p-1.5 w-20"
+        class="absolute bottom-3 -left-6 bg-surface-elevation-1 rounded-4 shadow-md border border-outline-gray-2 p-1.5 w-20"
       >
-        <div class="h-2 w-full bg-surface-gray-2 rounded mb-1.5" />
-        <div class="h-2 w-3/4 bg-surface-gray-2 rounded mb-1.5" />
-        <div class="h-2 w-full bg-ink-blue-link/10 rounded" />
+        <div class="h-2 w-full bg-surface-gray-2 rounded-4 mb-1.5" />
+        <div class="h-2 w-3/4 bg-surface-gray-2 rounded-4 mb-1.5" />
+        <div class="h-2 w-full bg-ink-blue-link/10 rounded-4" />
       </div>
 
-      <span class="h-2 bg-surface-gray-3 w-6 mr-auto p-2 rounded-sm"> </span>
+      <span class="h-2 bg-surface-gray-3 w-6 mr-auto p-2 rounded-1"> </span>
 
       <div
-        class="bg-surface-elevation-1 rounded-lg p-3 shadow-2xl border border-outline-gray-2"
+        class="bg-surface-elevation-1 rounded-6 p-3 shadow-2xl border border-outline-gray-2"
       >
         <div class="flex items-center justify-between mb-2">
-          <div class="h-2 w-12 bg-surface-gray-3 rounded" />
+          <div class="h-2 w-12 bg-surface-gray-3 rounded-4" />
           <div class="h-2 w-2 bg-surface-gray-4 rounded-full" />
         </div>
-        <div class="h-2 w-full bg-surface-gray-2 rounded mb-1.5" />
-        <div class="h-2 w-3/4 bg-surface-gray-2 rounded mb-3" />
+        <div class="h-2 w-full bg-surface-gray-2 rounded-4 mb-1.5" />
+        <div class="h-2 w-3/4 bg-surface-gray-2 rounded-4 mb-3" />
         <div class="flex gap-1.5 justify-end">
-          <div class="h-4 w-10 bg-surface-gray-3 rounded text-[6px]" />
-          <div class="h-4 w-10 bg-ink-blue-link rounded" />
+          <div class="h-4 w-10 bg-surface-gray-3 rounded-4 text-[6px]" />
+          <div class="h-4 w-10 bg-ink-blue-link rounded-4" />
         </div>
       </div>
     </div>

--- a/docs/components/LucideGallery.vue
+++ b/docs/components/LucideGallery.vue
@@ -79,7 +79,7 @@ const filteredIcons = computed(() => {
             :text="icon.name"
           >
             <div
-              class="flex size-14 cursor-pointer items-center justify-center rounded text-ink-gray-7 hover:bg-surface-gray-2"
+              class="flex size-14 cursor-pointer items-center justify-center rounded-4 text-ink-gray-7 hover:bg-surface-gray-2"
               @click="copyName(icon.name)"
             >
               <span class="size-6 [&>svg]:size-full" v-html="icon.svg" />

--- a/docs/components/Story.vue
+++ b/docs/components/Story.vue
@@ -22,7 +22,7 @@ const props = withDefaults(defineProps<Props>(), {
     </Button>
 
     <div
-      class="border border-outline-gray-2 p-5 rounded overflow-auto scrollbar"
+      class="border border-outline-gray-2 p-5 rounded-4 overflow-auto scrollbar"
       :class="props.previewCss"
     >
       <slot />

--- a/docs/components/foundations/ElevationPreview.vue
+++ b/docs/components/foundations/ElevationPreview.vue
@@ -44,7 +44,7 @@ const modeButtons = [
         class="flex w-full items-center gap-4 py-4 text-left"
       >
         <div
-          class="size-16 shrink-0 rounded-lg bg-surface-elevation-2"
+          class="size-16 shrink-0 rounded-6 bg-surface-elevation-2"
           :class="`shadow-${row.name}`"
         ></div>
         <div class="grid gap-0.5 min-w-0 flex-1">

--- a/docs/components/foundations/FocusRingPreview.vue
+++ b/docs/components/foundations/FocusRingPreview.vue
@@ -64,7 +64,7 @@ const RINGS = [
       <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-7">
         <div v-for="ring in RINGS" :key="ring.label" class="grid gap-3">
           <div
-            class="h-16 rounded-md bg-surface-base"
+            class="h-16 rounded-5 bg-surface-base"
             :class="ring.ringClass"
           ></div>
           <div class="grid gap-0.5">

--- a/docs/components/foundations/PalettePage.vue
+++ b/docs/components/foundations/PalettePage.vue
@@ -91,7 +91,7 @@ const overlayBlack = computed(
         >
           <Tooltip :hover-delay="0">
             <div
-              class="aspect-square rounded"
+              class="aspect-square rounded-4"
               :style="{ background: value as string }"
             ></div>
             <template #content>
@@ -115,7 +115,7 @@ const overlayBlack = computed(
         {{ family.label }}
       </h2>
       <div
-        class="grid gap-1.5 p-2 -mx-2 rounded"
+        class="grid gap-1.5 p-2 -mx-2 rounded-4"
         :style="{
           gridTemplateColumns: `repeat(${family.shades.length}, minmax(0, 1fr))`,
           background:
@@ -131,7 +131,7 @@ const overlayBlack = computed(
         >
           <Tooltip :hover-delay="0">
             <div
-              class="aspect-square rounded"
+              class="aspect-square rounded-4"
               :style="{ background: value as string }"
             ></div>
             <template #content>
@@ -139,7 +139,7 @@ const overlayBlack = computed(
             </template>
           </Tooltip>
           <span
-            class="text-xs font-medium text-ink-gray-7 bg-surface-base/80 dark:bg-surface-gray-1/80 rounded px-1 w-fit"
+            class="text-xs font-medium text-ink-gray-7 bg-surface-base/80 dark:bg-surface-gray-1/80 rounded-4 px-1 w-fit"
           >
             {{ shade }}
           </span>
@@ -166,7 +166,7 @@ const overlayBlack = computed(
             >
               <Tooltip :hover-delay="0">
                 <div
-                  class="aspect-square rounded"
+                  class="aspect-square rounded-4"
                   :style="{
                     background: `linear-gradient(${value}, ${value}), #0f0f0f`,
                   }"
@@ -196,7 +196,7 @@ const overlayBlack = computed(
             >
               <Tooltip :hover-delay="0">
                 <div
-                  class="aspect-square rounded"
+                  class="aspect-square rounded-4"
                   :style="{
                     background: `linear-gradient(${value}, ${value}), #ffffff`,
                   }"
@@ -223,7 +223,7 @@ const overlayBlack = computed(
         <div v-for="n in NEUTRALS" :key="n.key" class="grid gap-1 text-left">
           <Tooltip :hover-delay="0">
             <div
-              class="aspect-square rounded border border-outline-gray-2"
+              class="aspect-square rounded-4 border border-outline-gray-2"
               :style="{ background: n.value }"
             ></div>
             <template #content>

--- a/docs/components/foundations/RadiusPage.vue
+++ b/docs/components/foundations/RadiusPage.vue
@@ -6,7 +6,7 @@ const NUMERIC_KEYS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 // Display order for the unified scale: numerics in order, then `full`.
 const SCALE_KEYS = [...NUMERIC_KEYS, 'full']
 
-// Map each alias (`rounded-sm`, `rounded-md`, `rounded`, …) to the numeric
+// Map each alias (`rounded-1`, `rounded-5`, `rounded-4`, …) to the numeric
 // scale entry that shares its value. The page renders one row per scale
 // step; aliases land alongside their numeric twin.
 const ALIASES_BY_NUMERIC = computed(() => {
@@ -19,7 +19,7 @@ const ALIASES_BY_NUMERIC = computed(() => {
     const value = table[aliasKey]
     const numeric = NUMERIC_KEYS.find((n) => table[n] === value)
     if (!numeric) continue
-    const cls = aliasKey === 'DEFAULT' ? 'rounded' : `rounded-${aliasKey}`
+    const cls = aliasKey === 'DEFAULT' ? 'rounded-4' : `rounded-${aliasKey}`
     ;(aliases[numeric] ||= []).push(cls)
   }
   return aliases
@@ -62,7 +62,7 @@ const rows = computed(() =>
             <span
               v-for="alias in r.aliases"
               :key="alias"
-              class="text-2xs font-mono text-ink-gray-6 bg-surface-gray-2 rounded px-1.5 py-0.5"
+              class="text-2xs font-mono text-ink-gray-6 bg-surface-gray-2 rounded-4 px-1.5 py-0.5"
             >
               {{ alias }}
             </span>

--- a/docs/components/foundations/SemanticPage.vue
+++ b/docs/components/foundations/SemanticPage.vue
@@ -122,7 +122,7 @@ const sections = computed(() =>
         >
           <Tooltip :hover-delay="0">
             <div
-              class="size-8 rounded-md shrink-0"
+              class="size-8 rounded-5 shrink-0"
               :style="{ background: entry.value }"
             ></div>
             <template #content>

--- a/docs/components/foundations/TypographyPage.vue
+++ b/docs/components/foundations/TypographyPage.vue
@@ -127,7 +127,7 @@ const paragraphSample =
   <div class="grid gap-14">
     <header class="grid gap-6">
       <div
-        class="rounded-xl border border-outline-gray-2 bg-surface-gray-1 px-6 py-5 grid gap-3"
+        class="rounded-7 border border-outline-gray-2 bg-surface-gray-1 px-6 py-5 grid gap-3"
       >
         <div class="flex items-baseline justify-between gap-4">
           <span class="text-xl font-semibold text-ink-gray-8">{{

--- a/docs/components/recipes/AccountingMobile.vue
+++ b/docs/components/recipes/AccountingMobile.vue
@@ -153,7 +153,7 @@ const pnlColumns = ['8rem', ...months.map(() => '4.5rem')]
     <PageHeaderMobile :title="title">
       <template #prefix>
         <div
-          class="flex size-8 items-center justify-center rounded bg-surface-gray-7 text-ink-white"
+          class="flex size-8 items-center justify-center rounded-4 bg-surface-gray-7 text-ink-white"
         >
           <span class="lucide-landmark size-4" aria-hidden="true" />
         </div>
@@ -178,7 +178,7 @@ const pnlColumns = ['8rem', ...months.map(() => '4.5rem')]
 
     <!-- Cashflow ------------------------------------------------------------>
     <div v-if="section === 'cashflow'" class="space-y-4 px-4 pb-6 pt-3">
-      <div class="h-52 overflow-hidden rounded-lg border bg-surface-base p-3">
+      <div class="h-52 overflow-hidden rounded-6 border bg-surface-base p-3">
         <AxisChart :config="cashflow" />
       </div>
 
@@ -186,7 +186,7 @@ const pnlColumns = ['8rem', ...months.map(() => '4.5rem')]
         <div
           v-for="stat in cashflowStats"
           :key="stat.label"
-          class="rounded-lg border bg-surface-base p-3"
+          class="rounded-6 border bg-surface-base p-3"
         >
           <div class="text-sm text-ink-gray-6">{{ stat.label }}</div>
           <div
@@ -305,7 +305,7 @@ const pnlColumns = ['8rem', ...months.map(() => '4.5rem')]
     <div v-else class="px-4 pb-6 pt-3">
       <ScrollArea
         orientation="horizontal"
-        class="rounded-lg border bg-surface-base"
+        class="rounded-6 border bg-surface-base"
         viewport-class="p-3"
       >
         <List class="w-max" :columns="pnlColumns" :row-height="40">

--- a/docs/components/recipes/DealsDesktop.vue
+++ b/docs/components/recipes/DealsDesktop.vue
@@ -521,7 +521,7 @@ onBeforeUnmount(() => {
           <div
             v-for="(column, ci) in columns"
             :key="column.status"
-            class="flex min-h-0 w-72 shrink-0 flex-col rounded-lg bg-surface-gray-1 dark:bg-transparent dark:border"
+            class="flex min-h-0 w-72 shrink-0 flex-col rounded-6 bg-surface-gray-1 dark:bg-transparent dark:border"
           >
             <div class="flex items-center justify-between pl-3 pr-1 pt-1">
               <div class="flex items-center gap-2">
@@ -565,12 +565,12 @@ onBeforeUnmount(() => {
                        carries its content while it's lifted. -->
                   <div
                     v-if="deal === drag.deal"
-                    class="rounded-lg border-2 border-dashed border-outline-gray-2 bg-surface-gray-2"
+                    class="rounded-6 border-2 border-dashed border-outline-gray-2 bg-surface-gray-2"
                     :style="{ height: drag.height + 'px' }"
                   />
                   <div
                     v-else
-                    class="group cursor-grab rounded-lg border bg-surface-elevation-1 p-3 transition hover:shadow-sm"
+                    class="group cursor-grab rounded-6 border bg-surface-elevation-1 p-3 transition hover:shadow-sm"
                   >
                     <DealCard :deal="deal" :owners="owners" :logo="logo" />
                   </div>
@@ -597,7 +597,7 @@ onBeforeUnmount(() => {
         }"
       >
         <div
-          class="drag-ghost rounded-lg border bg-surface-elevation-1 p-3 transition-[transform,box-shadow] duration-150 ease-out"
+          class="drag-ghost rounded-6 border bg-surface-elevation-1 p-3 transition-[transform,box-shadow] duration-150 ease-out"
           :class="drag.settling ? '' : 'rotate-2 scale-[1.02] shadow-xl'"
         >
           <DealCard :deal="drag.deal" :owners="owners" :logo="logo" ghost />

--- a/docs/components/recipes/DealsMobile.vue
+++ b/docs/components/recipes/DealsMobile.vue
@@ -104,7 +104,7 @@ const columns = ref([
         <div
           v-for="column in columns"
           :key="column.status"
-          class="flex min-h-0 w-72 shrink-0 snap-start flex-col rounded-lg bg-surface-gray-1"
+          class="flex min-h-0 w-72 shrink-0 snap-start flex-col rounded-6 bg-surface-gray-1"
         >
           <div class="flex items-center justify-between pl-3 pr-1 pt-1">
             <div class="flex items-center gap-2">
@@ -130,7 +130,7 @@ const columns = ref([
               <div
                 v-for="deal in column.deals"
                 :key="deal.org"
-                class="rounded-lg border bg-surface-base p-3 shadow-sm"
+                class="rounded-6 border bg-surface-base p-3 shadow-sm"
               >
                 <div class="flex items-center gap-2">
                   <Avatar

--- a/docs/components/recipes/DiscussionsDesktop.vue
+++ b/docs/components/recipes/DiscussionsDesktop.vue
@@ -1056,7 +1056,7 @@ const spaceActions = [
               <div
                 v-for="emoji in customEmojis"
                 :key="emoji"
-                class="grid size-10 place-content-center rounded-lg border text-xl"
+                class="grid size-10 place-content-center rounded-6 border text-xl"
               >
                 {{ emoji }}
               </div>

--- a/docs/components/recipes/DiscussionsMobile.vue
+++ b/docs/components/recipes/DiscussionsMobile.vue
@@ -235,7 +235,7 @@ const discussions = [
           v-for="space in spaces"
           :key="space.name"
           :value="space.name"
-          class="h-11 rounded-md"
+          class="h-11 rounded-5"
           @click="selectSpace(space.name)"
         >
           <ListCell>

--- a/docs/components/recipes/FilesMobile.vue
+++ b/docs/components/recipes/FilesMobile.vue
@@ -666,7 +666,7 @@ function goHome() {
         <button
           v-for="item in nav"
           :key="item.label"
-          class="flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left transition"
+          class="flex w-full items-center gap-2 rounded-6 px-3 py-2.5 text-left transition"
           :class="
             item.label === activeNav
               ? 'bg-surface-gray-3'
@@ -698,7 +698,7 @@ function goHome() {
         <button
           v-for="action in activeItemActions"
           :key="action.label"
-          class="flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left transition hover:bg-surface-gray-2"
+          class="flex w-full items-center gap-2 rounded-6 px-3 py-2.5 text-left transition hover:bg-surface-gray-2"
           @click="runAction(action)"
         >
           <span

--- a/docs/components/recipes/MailMobile.vue
+++ b/docs/components/recipes/MailMobile.vue
@@ -628,7 +628,7 @@ function goToMail() {
         <button
           v-for="box in mailboxes"
           :key="box.label"
-          class="flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left transition"
+          class="flex w-full items-center gap-2 rounded-6 px-3 py-2.5 text-left transition"
           :class="
             box.label === activeMailbox
               ? 'bg-surface-gray-3'
@@ -653,7 +653,7 @@ function goToMail() {
         <button
           v-for="label in labels"
           :key="label"
-          class="flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left transition"
+          class="flex w-full items-center gap-2 rounded-6 px-3 py-2.5 text-left transition"
           :class="
             label === activeMailbox
               ? 'bg-surface-gray-3'

--- a/docs/components/recipes/RecipeExample.vue
+++ b/docs/components/recipes/RecipeExample.vue
@@ -145,7 +145,7 @@ onBeforeUnmount(() => observer?.disconnect())
     <div v-show="tab === 'preview'">
       <div
         v-if="isMobile"
-        class="flex justify-center rounded border bg-surface-gray-1 py-8"
+        class="flex justify-center rounded-4 border bg-surface-gray-1 py-8"
         :style="{ minHeight: frameHeight }"
       >
         <iframe
@@ -153,7 +153,7 @@ onBeforeUnmount(() => observer?.disconnect())
           :src="src"
           :title="heading"
           loading="lazy"
-          class="w-[390px] rounded border bg-surface-base shadow-lg"
+          class="w-[390px] rounded-4 border bg-surface-base shadow-lg"
           :style="{ height: frameHeight }"
         />
       </div>
@@ -163,12 +163,12 @@ onBeforeUnmount(() => observer?.disconnect())
           :src="src"
           :title="heading"
           loading="lazy"
-          class="w-full rounded border bg-surface-base"
+          class="w-full rounded-4 border bg-surface-base"
           :style="{ height: frameHeight }"
         />
         <div
           v-else
-          class="w-full rounded border bg-surface-gray-1"
+          class="w-full rounded-4 border bg-surface-gray-1"
           :style="{ height: frameHeight }"
         />
       </template>
@@ -179,7 +179,7 @@ onBeforeUnmount(() => observer?.disconnect())
          the height and let it scroll. -->
     <div
       v-show="tab === 'code'"
-      class="recipe-code overflow-hidden rounded border [&_div[class*=language-]]:my-0 [&_div[class*=language-]]:rounded-none [&_div[class*=language-]]:border-0"
+      class="recipe-code overflow-hidden rounded-4 border [&_div[class*=language-]]:my-0 [&_div[class*=language-]]:rounded-none [&_div[class*=language-]]:border-0"
       :style="{ maxHeight: frameHeight }"
     >
       <div class="h-full overflow-auto" :style="{ maxHeight: frameHeight }">

--- a/docs/components/recipes/TasksDesktop.vue
+++ b/docs/components/recipes/TasksDesktop.vue
@@ -1009,7 +1009,7 @@ function addComment() {
           <div class="mt-4 space-y-4">
             <div v-for="group in groupedTasks" :key="group.key">
               <button
-                class="group flex w-full items-baseline rounded-sm bg-surface-sidebar px-2.5 py-2 text-base transition hover:bg-surface-gray-2"
+                class="group flex w-full items-baseline rounded-1 bg-surface-sidebar px-2.5 py-2 text-base transition hover:bg-surface-gray-2"
                 @click="toggleGroup(group.key)"
               >
                 <span class="font-medium text-ink-gray-8">

--- a/docs/components/tokens/BgColor.vue
+++ b/docs/components/tokens/BgColor.vue
@@ -36,7 +36,7 @@ const copyToClipboard = (txt: string) => {
       <div class="grid gap-3" v-else>
         <div
           v-if="color.value"
-          class="rounded size-20"
+          class="rounded-4 size-20"
           :style="{ backgroundColor: color.value }"
         ></div>
 

--- a/docs/components/tokens/BorderColor.vue
+++ b/docs/components/tokens/BorderColor.vue
@@ -18,7 +18,7 @@ const _data = props.data.slice(0, props.data.length - 2)
 
       <div v-else class="grid gap-2">
         <div
-          class="rounded border-2 flex items-end p-5"
+          class="rounded-4 border-2 flex items-end p-5"
           :style="{ borderColor: color.value }"
         ></div>
         <span>{{ color.name }}</span>

--- a/docs/components/tokens/BorderRadius.vue
+++ b/docs/components/tokens/BorderRadius.vue
@@ -49,8 +49,8 @@ const data = props.data.slice(0, props.data.length - 1);
         </div>
 
         <div class="text-sm text-ink-gray-5 grid gap-2">
-          <span class="h-3 rounded-sm bg-surface-gray-2 w-1/2"> </span>
-          <span class="h-5 rounded-sm bg-surface-gray-3 w-full"> </span>
+          <span class="h-3 rounded-1 bg-surface-gray-2 w-1/2"> </span>
+          <span class="h-5 rounded-1 bg-surface-gray-3 w-full"> </span>
         </div>
 
         <div class="flex items-center justify-between">

--- a/docs/components/tokens/Text.vue
+++ b/docs/components/tokens/Text.vue
@@ -29,7 +29,7 @@ const para =
 
 <template>
   <div class="grid gap-3">
-    <Tabs :tabs v-model="activeTab" class="[&>div]:!px-1 rounded" />
+    <Tabs :tabs v-model="activeTab" class="[&>div]:!px-1 rounded-4" />
 
     <template v-if='activeTabLabel === "Text Color"'>
       <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-x-4 gap-y-10">
@@ -56,7 +56,7 @@ const para =
       <div
         v-for="item in data.fontSize"
         :key="item.name"
-        class="rounded border border-outline-gray-3 p-4"
+        class="rounded-4 border border-outline-gray-3 p-4"
       >
         <div class="text-xs opacity-60 mb-1">
           {{ item.name }}
@@ -88,7 +88,7 @@ const para =
       <div
         v-for="item in data.fontWeight"
         :key="item.name"
-        class="rounded border border-outline-gray-2 p-4"
+        class="rounded-4 border border-outline-gray-2 p-4"
       >
         <div class="text-sm text-gray-500 mb-1">
           {{ item.name }} ({{ item.value }})
@@ -107,7 +107,7 @@ const para =
       <div
         v-for="item in data.letterSpacing"
         :key="item.name"
-        class="rounded border p-4"
+        class="rounded-4 border p-4"
         :style='
           {
             letterSpacing: item.value,
@@ -128,7 +128,7 @@ const para =
       <div
         v-for="item in data.lineHeight"
         :key="item.name"
-        class="rounded border border-outline-gray-2 p-3"
+        class="rounded-4 border border-outline-gray-2 p-3"
       >
         <div class="text-xs opacity-60 mb-1">
           leading-{{ item.name }}

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -584,7 +584,7 @@ it and add `bare`:
 ```vue
 <Tooltip bare>
   <template #content>
-    <img :src="url" class="max-h-40 rounded shadow-xl" />
+    <img :src="url" class="max-h-40 rounded-4 shadow-xl" />
   </template>
   <span class="truncate">{{ filename }}</span>
 </Tooltip>
@@ -1185,7 +1185,7 @@ markup, using [`LoadingText`](./components/loadingtext) or
 </Card>
 
 <!-- After -->
-<div class="flex flex-col rounded-lg border px-6 py-5">
+<div class="flex flex-col rounded-6 border px-6 py-5">
   <div class="flex items-baseline justify-between">
     <h2 class="text-lg font-semibold">Title</h2>
     <Button label="Edit" />

--- a/docs/content/docs/other/directives.md
+++ b/docs/content/docs/other/directives.md
@@ -57,7 +57,7 @@ const setInactive = () => (active.value = false)
 </script>
 
 <template>
-  <div class="rounded-lg border p-8" v-on-outside-click="setInactive">
+  <div class="rounded-6 border p-8" v-on-outside-click="setInactive">
     <Button @click="active = true">
       {{ active ? 'Click outside' : 'Click me' }}
     </Button>

--- a/experimental/Accordion/Accordion.vue
+++ b/experimental/Accordion/Accordion.vue
@@ -70,7 +70,7 @@ defineSlots<{
     >
       <AccordionHeader :as="props.headingTag" class="m-0 flex">
         <AccordionTrigger
-          class="group flex flex-1 select-none items-center gap-2 rounded px-2 py-3 text-left text-base font-medium text-ink-gray-8 outline-none transition-colors duration-150 hover:text-ink-gray-9 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3 disabled:cursor-not-allowed disabled:text-ink-gray-4 disabled:hover:text-ink-gray-4"
+          class="group flex flex-1 select-none items-center gap-2 rounded-4 px-2 py-3 text-left text-base font-medium text-ink-gray-8 outline-none transition-colors duration-150 hover:text-ink-gray-9 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-3 disabled:cursor-not-allowed disabled:text-ink-gray-4 disabled:hover:text-ink-gray-4"
           data-slot="trigger"
         >
           <span class="flex min-w-0 flex-1 items-center gap-2">

--- a/experimental/CodeEditor/CodeEditor.playground.vue
+++ b/experimental/CodeEditor/CodeEditor.playground.vue
@@ -94,7 +94,7 @@ function buildCode(v: Record<string, any>) {
           v-if="hasPreview"
           :model-value="code"
           :language="language"
-          class="min-h-[4.5rem] rounded-md border border-surface-gray-2 p-3"
+          class="min-h-[4.5rem] rounded-5 border border-surface-gray-2 p-3"
         />
       </div>
     </template>

--- a/experimental/CodeEditor/stories/Preview.vue
+++ b/experimental/CodeEditor/stories/Preview.vue
@@ -30,7 +30,7 @@ const markdown = ref(
       v-if="mode === 'preview'"
       :model-value="markdown"
       language="markdown"
-      class="min-h-[4.5rem] rounded-md border border-surface-gray-2 p-3 mt-3"
+      class="min-h-[4.5rem] rounded-5 border border-surface-gray-2 p-3 mt-3"
     />
   </div>
 </template>

--- a/experimental/FloatingWindow/FloatingWindow.vue
+++ b/experimental/FloatingWindow/FloatingWindow.vue
@@ -10,7 +10,7 @@
       ref="panel"
       v-bind="$attrs"
       :data-state="mode"
-      class="floating-window relative flex flex-col rounded-lg border border-outline-gray-2 bg-surface-elevation-1"
+      class="floating-window relative flex flex-col rounded-6 border border-outline-gray-2 bg-surface-elevation-1"
       :class="isDocked ? '' : 'shadow-2xl'"
       :style="style"
     >
@@ -114,7 +114,7 @@
           type="button"
           data-resize="se"
           aria-label="Resize window"
-          class="absolute -bottom-1 -right-1 z-10 size-4 cursor-nwse-resize rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+          class="absolute -bottom-1 -right-1 z-10 size-4 cursor-nwse-resize rounded-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
           @pointerdown.prevent="startResize($event, { x: 1, y: 1 })"
           @keydown="onResizeKey"
         />

--- a/experimental/ListView/ListGroupHeader.vue
+++ b/experimental/ListView/ListGroupHeader.vue
@@ -2,7 +2,7 @@
   <div class="flex items-center">
     <button
       @click="toggleGroup"
-      class="ms-[3px] me-[11px] rounded p-1 hover:bg-surface-gray-2"
+      class="ms-[3px] me-[11px] rounded-4 p-1 hover:bg-surface-gray-2"
     >
       <DownSolid
         class="h-4 w-4 text-ink-gray-6 transition-transform duration-200"

--- a/experimental/ListView/ListHeader.vue
+++ b/experimental/ListView/ListHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="mb-2 grid items-center gap-4 rounded bg-surface-gray-2 p-2"
+    class="mb-2 grid items-center gap-4 rounded-4 bg-surface-gray-2 p-2"
     :style="{
       gridTemplateColumns: getGridTemplateColumns(
         list.columns,

--- a/experimental/ListView/ListRow.vue
+++ b/experimental/ListView/ListRow.vue
@@ -96,7 +96,7 @@
         v-if="!isLastRow"
         class="h-px border-t"
         :class="
-          roundedClass === 'rounded' || roundedClass?.includes?.('rounded-b')
+          roundedClass === 'rounded-4' || roundedClass?.includes?.('rounded-b-4')
             ? 'mx-2 border-outline-gray-1'
             : 'border-t-[--surface-gray-2]'
         "
@@ -174,7 +174,7 @@ const rowHeight = computed(() => {
 })
 
 const roundedClass = computed(() => {
-  if (!isSelected.value) return 'rounded'
+  if (!isSelected.value) return 'rounded-4'
 
   const selections = [...list.value.selections]
   let groups = list.value.rows[0]?.group
@@ -188,7 +188,7 @@ const roundedClass = computed(() => {
     let atBottom = !selections.includes(rows[currentIndex + 1]?.name)
     let atTop = !selections.includes(rows[currentIndex - 1]?.name)
 
-    return (atBottom ? 'rounded-b ' : '') + (atTop ? 'rounded-t' : '')
+    return (atBottom ? 'rounded-b-4 ' : '') + (atTop ? 'rounded-t-4' : '')
   }
 })
 

--- a/experimental/ListView/ListSelectBanner.vue
+++ b/experimental/ListView/ListSelectBanner.vue
@@ -12,7 +12,7 @@
       class="absolute inset-x-0 bottom-6 mx-auto w-max text-base"
     >
       <div
-        class="flex min-w-[596px] items-center gap-3 rounded-lg bg-surface-base px-4 py-2 shadow-2xl"
+        class="flex min-w-[596px] items-center gap-3 rounded-6 bg-surface-base px-4 py-2 shadow-2xl"
         :class="$attrs.class"
       >
         <slot

--- a/experimental/MultiEmailInput/MultiEmailInput.vue
+++ b/experimental/MultiEmailInput/MultiEmailInput.vue
@@ -170,13 +170,13 @@ const showEmpty = computed(
 const rowAvatarSize = computed(() => (props.size === 'sm' ? 'sm' : 'md'))
 
 const boxClasses = computed(() => [
-  'flex flex-wrap items-center gap-1.5 rounded bg-surface-gray-2 px-1.5 py-1 transition-colors focus-within:ring-2 focus-within:ring-outline-gray-3',
+  'flex flex-wrap items-center gap-1.5 rounded-4 bg-surface-gray-2 px-1.5 py-1 transition-colors focus-within:ring-2 focus-within:ring-outline-gray-3',
   inputFontSizeClasses(props.size),
   props.disabled && 'cursor-not-allowed bg-surface-gray-1',
 ])
 
 const chipClasses =
-  'inline-flex items-center gap-1 rounded border border-outline-gray-1 bg-surface-base px-1.5 py-0.5 text-sm text-ink-gray-7 transition-colors data-[disabled]:opacity-60 aria-[current=true]:ring-2 aria-[current=true]:ring-outline-gray-3'
+  'inline-flex items-center gap-1 rounded-4 border border-outline-gray-1 bg-surface-base px-1.5 py-0.5 text-sm text-ink-gray-7 transition-colors data-[disabled]:opacity-60 aria-[current=true]:ring-2 aria-[current=true]:ring-outline-gray-3'
 
 const inputClasses = computed(() => [
   'min-w-[6rem] flex-1 border-0 bg-transparent p-0.5 text-ink-gray-8 outline-none ring-0 placeholder:text-ink-gray-4 focus:ring-0 disabled:cursor-not-allowed',
@@ -328,7 +328,7 @@ defineSlots<MultiEmailInputSlots>()
               <span class="truncate">{{ chip.label }}</span>
               <TagsInputItemDelete
                 :aria-label="`Remove ${chip.value}`"
-                class="-mr-0.5 inline-flex items-center justify-center rounded-sm p-0.5 text-ink-gray-5 opacity-70 transition hover:text-ink-gray-7 hover:opacity-100"
+                class="-mr-0.5 inline-flex items-center justify-center rounded-1 p-0.5 text-ink-gray-5 opacity-70 transition hover:text-ink-gray-7 hover:opacity-100"
               >
                 <span class="lucide-x size-3" />
               </TagsInputItemDelete>
@@ -361,7 +361,7 @@ defineSlots<MultiEmailInputSlots>()
           :side="side"
           :align="align"
           :side-offset="offset"
-          class="z-[100] min-w-[--reka-combobox-trigger-width] overflow-hidden rounded-lg bg-surface-elevation-2 shadow-2xl"
+          class="z-[100] min-w-[--reka-combobox-trigger-width] overflow-hidden rounded-6 bg-surface-elevation-2 shadow-2xl"
           @open-auto-focus.prevent
         >
           <ComboboxViewport class="max-h-60 overflow-auto p-1">

--- a/experimental/MultiEmailInput/stories/CustomChip.vue
+++ b/experimental/MultiEmailInput/stories/CustomChip.vue
@@ -28,7 +28,7 @@ const options = [
         <button
           type="button"
           :aria-label="`Remove ${value}`"
-          class="-mr-0.5 grid size-4 place-items-center rounded-sm text-ink-gray-5 hover:text-ink-gray-7"
+          class="-mr-0.5 grid size-4 place-items-center rounded-1 text-ink-gray-5 hover:text-ink-gray-7"
           @click="removeTag"
         >
           <span class="lucide-x size-3" />

--- a/experimental/SpriteIcons/IconPicker.vue
+++ b/experimental/SpriteIcons/IconPicker.vue
@@ -153,7 +153,7 @@ defineExpose({
       :open="isOpen"
     >
       <ComboboxAnchor
-        class="flex h-7 w-full items-center justify-between gap-2 rounded px-2 py-1 transition-colors"
+        class="flex h-7 w-full items-center justify-between gap-2 rounded-4 px-2 py-1 transition-colors"
         :class="{
           'opacity-50 pointer-events-none': disabled,
           [variantClasses]: true,
@@ -182,7 +182,7 @@ defineExpose({
       </ComboboxAnchor>
       <ComboboxPortal>
         <ComboboxContent
-          class="z-10 w-60 mt-1 bg-surface-elevation-2 overflow-hidden rounded-lg shadow-2xl"
+          class="z-10 w-60 mt-1 bg-surface-elevation-2 overflow-hidden rounded-6 shadow-2xl"
           position="popper"
           @openAutoFocus.prevent
           @closeAutoFocus.prevent
@@ -204,7 +204,7 @@ defineExpose({
                 :key="iconName"
                 @click="handleIconClick(iconName)"
                 type="button"
-                class="w-8 h-8 flex items-center justify-center rounded hover:bg-surface-gray-3 transition-colors"
+                class="w-8 h-8 flex items-center justify-center rounded-4 hover:bg-surface-gray-3 transition-colors"
                 :class="{
                   'bg-surface-gray-3': internalModelValue === iconName,
                 }"

--- a/experimental/TextEditor/TextEditor.cy.ts
+++ b/experimental/TextEditor/TextEditor.cy.ts
@@ -81,7 +81,7 @@ describe('<TextEditor />', () => {
     })
 
     // The fixed menu component in TextEditor.vue has these specific classes
-    cy.get('.rounded-t-lg.border.border-outline-elevation-2').should('exist')
+    cy.get('.rounded-t-6.border.border-outline-elevation-2').should('exist')
     // Should contain some default buttons like Bold
     cy.get('button[title="Bold"]').should('exist')
   })

--- a/experimental/TextEditor/TextEditor.vue
+++ b/experimental/TextEditor/TextEditor.vue
@@ -9,7 +9,7 @@
   >
     <TextEditorBubbleMenu :buttons="bubbleMenu" :options="bubbleMenuOptions" />
     <TextEditorFixedMenu
-      class="w-full overflow-x-auto rounded-t-lg border border-outline-elevation-2"
+      class="w-full overflow-x-auto rounded-t-6 border border-outline-elevation-2"
       :buttons="fixedMenu"
     />
     <TextEditorFloatingMenu :buttons="floatingMenu" />

--- a/experimental/TextEditor/components/FontColor.vue
+++ b/experimental/TextEditor/components/FontColor.vue
@@ -22,7 +22,7 @@
           >
             <button
               :aria-label="color.name"
-              class="flex h-5 w-5 items-center justify-center rounded border text-base"
+              class="flex h-5 w-5 items-center justify-center rounded-4 border text-base"
               :class="color.class"
               @click="setForegroundColor(color)"
             >
@@ -40,7 +40,7 @@
           >
             <button
               :aria-label="color.name"
-              class="flex h-5 w-5 items-center justify-center rounded border text-base text-ink-gray-9"
+              class="flex h-5 w-5 items-center justify-center rounded-4 border text-base text-ink-gray-9"
               :class="color.class"
               @click="setBackgroundColor(color)"
             >

--- a/experimental/TextEditor/components/ImageViewerModal.vue
+++ b/experimental/TextEditor/components/ImageViewerModal.vue
@@ -49,7 +49,7 @@
         <!-- Caption -->
         <div
           v-if="currentImage.alt"
-          class="absolute bottom-4 p-2 text-center rounded-sm text-white text-sm bg-black/65 z-10 transition-opacity duration-300 ease-in-out"
+          class="absolute bottom-4 p-2 text-center rounded-1 text-white text-sm bg-black/65 z-10 transition-opacity duration-300 ease-in-out"
           :class="{ 'opacity-0 pointer-events-none': !isControlsVisible }"
         >
           {{ currentImage.alt }}
@@ -67,10 +67,10 @@
           @wheel.stop
         >
           <!-- Navigation controls -->
-          <div class="bg-black/65 rounded flex items-center">
+          <div class="bg-black/65 rounded-4 flex items-center">
             <Tooltip text="Previous image">
               <button
-                class="p-2 hover:bg-gray-900 rounded-l focus:outline-none"
+                class="p-2 hover:bg-gray-900 rounded-l-4 focus:outline-none"
                 @click.stop="previousImage"
               >
                 <LucideChevronLeft class="size-4" />
@@ -83,7 +83,7 @@
 
             <Tooltip text="Next image">
               <button
-                class="p-2 hover:bg-gray-900 rounded-r focus:outline-none"
+                class="p-2 hover:bg-gray-900 rounded-r-4 focus:outline-none"
                 @click.stop="nextImage"
               >
                 <LucideChevronRight class="size-4" />
@@ -92,10 +92,10 @@
           </div>
 
           <!-- Zoom controls -->
-          <div class="bg-black/65 rounded flex items-center">
+          <div class="bg-black/65 rounded-4 flex items-center">
             <Tooltip text="Zoom out">
               <button
-                class="p-2 hover:bg-gray-900 rounded-l focus:outline-none"
+                class="p-2 hover:bg-gray-900 rounded-l-4 focus:outline-none"
                 @click.stop="zoomOut"
               >
                 <LucideMinus class="size-4" />
@@ -113,7 +113,7 @@
 
             <Tooltip text="Zoom in">
               <button
-                class="p-2 hover:bg-gray-900 rounded-r focus:outline-none"
+                class="p-2 hover:bg-gray-900 rounded-r-4 focus:outline-none"
                 @click.stop="zoomIn"
               >
                 <LucidePlus class="size-4" />
@@ -122,10 +122,10 @@
           </div>
 
           <!-- Action controls -->
-          <div class="bg-black/65 rounded flex items-center">
+          <div class="bg-black/65 rounded-4 flex items-center">
             <Tooltip text="Download image">
               <button
-                class="p-2 hover:bg-gray-900 rounded-l focus:outline-none"
+                class="p-2 hover:bg-gray-900 rounded-l-4 focus:outline-none"
                 @click.stop="downloadImage"
               >
                 <LucideDownload class="size-4" />
@@ -136,7 +136,7 @@
               :text="isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'"
             >
               <button
-                class="p-2 hover:bg-gray-900 rounded-r focus:outline-none hidden sm:block"
+                class="p-2 hover:bg-gray-900 rounded-r-4 focus:outline-none hidden sm:block"
                 @click.stop="toggleFullscreen"
               >
                 <LucideMaximize v-if="!isFullscreen" class="size-4" />
@@ -146,10 +146,10 @@
           </div>
 
           <!-- Close button -->
-          <div class="bg-black/65 rounded flex items-center">
+          <div class="bg-black/65 rounded-4 flex items-center">
             <Tooltip text="Close">
               <button
-                class="p-2 hover:bg-gray-900 rounded focus:outline-none"
+                class="p-2 hover:bg-gray-900 rounded-4 focus:outline-none"
                 @click.stop="close"
               >
                 <LucideX class="size-4" />

--- a/experimental/TextEditor/components/LinkPopup.vue
+++ b/experimental/TextEditor/components/LinkPopup.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="p-2 w-72 flex items-center gap-2 bg-surface-base shadow-xl rounded"
+    class="p-2 w-72 flex items-center gap-2 bg-surface-base shadow-xl rounded-4"
   >
     <TextInput
       v-if="edit"

--- a/experimental/TextEditor/components/MediaNodeView.vue
+++ b/experimental/TextEditor/components/MediaNodeView.vue
@@ -288,7 +288,7 @@ const wrapperClasses = (float: string) => [
           :loop="node.attrs.loop" :muted="node.attrs.muted" :controls="isUploaded" @click.stop="selectMedia"
           @loadedmetadata="handleMediaLoaded" />
 
-        <div v-if="isUploaded" class="absolute top-2 right-2 items-center bg-black/65 px-1.5 py-1 gap-2 rounded"
+        <div v-if="isUploaded" class="absolute top-2 right-2 items-center bg-black/65 px-1.5 py-1 gap-2 rounded-4"
           :class="selected && isEditable ? 'flex' : 'hidden'">
           <button>
             <LucideCaptions @click="toggleCaptions" class="size-4"
@@ -305,7 +305,7 @@ const wrapperClasses = (float: string) => [
           </button> -->
 
           <div ref="alignButtonRef" v-if="showAlignPopper && !isVideo"
-            class="absolute top-full mt-1 right-6 bg-black/65 rounded shadow-lg px-1.5 py-1 z-50 gap-2.5 flex items-center">
+            class="absolute top-full mt-1 right-6 bg-black/65 rounded-4 shadow-lg px-1.5 py-1 z-50 gap-2.5 flex items-center">
             <Tooltip text="Align left" class="h-5">
               <button @click="setAlignment('left')" class="text-ink-gray-4 hover:text-ink-base" :class="node.attrs.align === 'left'
                 ? 'text-ink-base'
@@ -333,7 +333,7 @@ const wrapperClasses = (float: string) => [
           </div>
 
           <div v-if="showFloatPopper" ref="floatButtonRef"
-            class="absolute top-full mt-1 right-0 bg-black/65 rounded shadow-lg px-1.5 py-1 z-50 gap-2.5 flex items-center">
+            class="absolute top-full mt-1 right-0 bg-black/65 rounded-4 shadow-lg px-1.5 py-1 z-50 gap-2.5 flex items-center">
             <Tooltip text="Float left" class="h-5">
               <button @click="setFloat('left')" class="text-ink-gray-4 hover:text-ink-base" :class="node.attrs.float === 'left'
                 ? 'text-ink-base'
@@ -367,13 +367,13 @@ const wrapperClasses = (float: string) => [
           @click="isVideo ? editor.commands.reuploadVideo(node.attrs.uploadId) : editor.commands.reuploadImage(node.attrs.uploadId)"
         />
 
-        <button v-if="selected && isEditable && isUploaded" class="absolute bottom-2 right-2 cursor-nw-resize bg-black/65 rounded p-1"
+        <button v-if="selected && isEditable && isUploaded" class="absolute bottom-2 right-2 cursor-nw-resize bg-black/65 rounded-4 p-1"
           @mousedown.prevent="startResize">
           <LucideMoveDiagonal2 class="text-white size-4" />
         </button>
         <div v-if="node.attrs.loading" class="inset-0 absolute flex items-center justify-center z-10">
           <div
-            class="bg-gray-900/80 p-2 inset-0 leading-none rounded-sm flex flex-col items-center justify-center gap-2">
+            class="bg-gray-900/80 p-2 inset-0 leading-none rounded-1 flex flex-col items-center justify-center gap-2">
             <div class="flex items-center gap-2">
               <LoadingIndicator class="text-gray-100 size-4" />
               <span class="text-gray-100">Uploading {{ isVideo ? 'video' : 'image' }}...</span>
@@ -381,7 +381,7 @@ const wrapperClasses = (float: string) => [
           </div>
         </div>
       </div>
-      <div v-else class="flex flex-col items-center justify-center gap-2 border rounded text-ink-gray-6 text-sm py-5 max-w-full" :class="{ 'border-none': selected }" :style="{ width: node.attrs.width + 'px', aspectRatio: node.attrs.width && node.attrs.height ? `${node.attrs.width} / ${node.attrs.height}` : undefined,}">
+      <div v-else class="flex flex-col items-center justify-center gap-2 border rounded-4 text-ink-gray-6 text-sm py-5 max-w-full" :class="{ 'border-none': selected }" :style="{ width: node.attrs.width + 'px', aspectRatio: node.attrs.width && node.attrs.height ? `${node.attrs.width} / ${node.attrs.height}` : undefined,}">
         <div class="text-ink-gray-8 text-base">This {{ isVideo ? 'video' : 'image' }} hasn't yet been uploaded.</div>
         <div v-if="node.attrs.error" class="text-sm text-ink-red-8">{{ node.attrs.error }}</div>
       </div>

--- a/experimental/TextEditor/components/MentionList.vue
+++ b/experimental/TextEditor/components/MentionList.vue
@@ -2,12 +2,12 @@
   <div>
     <div
       v-if="items.length"
-      class="min-w-40 rounded-lg border bg-surface-base p-1 text-base shadow-lg"
+      class="min-w-40 rounded-6 border bg-surface-base p-1 text-base shadow-lg"
     >
       <button
         :class="[
           index === selectedIndex ? 'bg-surface-gray-2' : '',
-          'flex w-full items-center whitespace-nowrap rounded-md px-2 py-2 text-sm text-ink-gray-9',
+          'flex w-full items-center whitespace-nowrap rounded-5 px-2 py-2 text-sm text-ink-gray-9',
         ]"
         v-for="(item, index) in items"
         :key="index"

--- a/experimental/TextEditor/components/TextEditorBubbleMenu.vue
+++ b/experimental/TextEditor/components/TextEditorBubbleMenu.vue
@@ -1,13 +1,13 @@
 <template>
   <BubbleMenu
     v-if="bubbleMenuButtons"
-    class="bubble-menu rounded-md z-[100]"
+    class="bubble-menu rounded-5 z-[100]"
     :class="bubbleMenuButtons.length > 1 && 'shadow-sm'"
     :editor="editor"
     v-bind="options"
   >
     <TextEditorMenu
-      class="rounded"
+      class="rounded-4"
       :class="bubbleMenuButtons.length > 1 && 'shadow-lg'"
       :buttons="bubbleMenuButtons"
     />

--- a/experimental/TextEditor/components/TextEditorFloatingMenu.vue
+++ b/experimental/TextEditor/components/TextEditorFloatingMenu.vue
@@ -8,7 +8,7 @@
     <button
       v-for="button in floatingMenuButtons"
       :key="button.label"
-      class="flex rounded p-1 text-ink-gray-8 transition-colors"
+      class="flex rounded-4 p-1 text-ink-gray-8 transition-colors"
       :class="
         button.isActive(editor)
           ? 'bg-surface-gray-2'

--- a/experimental/TextEditor/components/TextEditorMenu.vue
+++ b/experimental/TextEditor/components/TextEditorMenu.vue
@@ -16,7 +16,7 @@
             <Popover>
               <template #trigger>
                 <button
-                  class="rounded p-1 text-base-medium text-ink-gray-8 transition-colors"
+                  class="rounded-4 p-1 text-base-medium text-ink-gray-8 transition-colors"
                   :class="
                     getActiveButton(button)
                       ? 'bg-surface-gray-3'
@@ -46,7 +46,7 @@
                     >
                       <template v-slot="componentSlotProps">
                         <button
-                          class="w-full h-7 rounded px-2 text-base flex items-center gap-2 hover:bg-surface-gray-3"
+                          class="w-full h-7 rounded-4 px-2 text-base flex items-center gap-2 hover:bg-surface-gray-3"
                           :class="
                             option.isDisabled?.(editor) &&
                             'opacity-50 pointer-events-none'
@@ -78,7 +78,7 @@
                     </component>
                     <button
                       v-else
-                      class="w-full h-7 rounded px-2 text-base flex items-center gap-2 hover:bg-surface-gray-3"
+                      class="w-full h-7 rounded-4 px-2 text-base flex items-center gap-2 hover:bg-surface-gray-3"
                       :class="
                         option.isDisabled?.(editor) &&
                         'opacity-50 pointer-events-none'
@@ -109,7 +109,7 @@
           </div>
           <button
             v-else-if="!button.component"
-            class="flex rounded text-ink-gray-8 transition-colors focus-within:ring-0"
+            class="flex rounded-4 text-ink-gray-8 transition-colors focus-within:ring-0"
             :class="[
               buttons.length > 1 ? 'p-1' : 'p-1.5 border',
               button.isDisabled?.(editor) && 'opacity-50 pointer-events-none',
@@ -139,7 +139,7 @@
             <component :is="button.component || 'div'" v-bind="{ editor }">
               <template v-slot="componentSlotProps">
                 <button
-                  class="flex rounded p-1 text-ink-gray-8 transition-colors"
+                  class="flex rounded-4 p-1 text-ink-gray-8 transition-colors"
                   :class="[
                     button.isDisabled?.(editor) &&
                       'opacity-50 pointer-events-none',
@@ -171,7 +171,7 @@
             </component>
             <template #fallback>
               <button
-                class="flex rounded p-1 text-ink-gray-8 transition-colors"
+                class="flex rounded-4 p-1 text-ink-gray-8 transition-colors"
                 :class="[
                   button.isDisabled?.(editor) &&
                     'opacity-50 pointer-events-none',

--- a/experimental/TextEditor/extensions/iframe/IframeNodeView.vue
+++ b/experimental/TextEditor/extensions/iframe/IframeNodeView.vue
@@ -186,7 +186,7 @@ function setCursorBeforeIframe() {
   <NodeViewWrapper>
     <div
       ref="containerRef"
-      class="relative overflow-hidden not-prose my-6 rounded-lg block max-w-full focus:outline-none"
+      class="relative overflow-hidden not-prose my-6 rounded-6 block max-w-full focus:outline-none"
       :class="[
         { 'ring-2 ring-outline-gray-3 ring-offset-2': selected },
         node.attrs.align === 'center' ? 'mx-auto' : '',
@@ -204,7 +204,7 @@ function setCursorBeforeIframe() {
         <iframe
           v-if="node.attrs.src"
           ref="iframeRef"
-          class="rounded-lg border-0 block max-w-full h-auto"
+          class="rounded-6 border-0 block max-w-full h-auto"
           :class="{
             'pointer-events-none': isEditable && !props.node.attrs.interactive,
           }"
@@ -231,7 +231,7 @@ function setCursorBeforeIframe() {
           <!-- Alignment Controls -->
           <div
             v-if="selected && isEditable"
-            class="flex divide-x divide-ink-gray-6 rounded-md bg-black/65"
+            class="flex divide-x divide-ink-gray-6 rounded-5 bg-black/65"
           >
             <button
               @click.stop="setAlignment('left')"
@@ -268,7 +268,7 @@ function setCursorBeforeIframe() {
           <!-- Resize Handle -->
           <button
             v-if="selected && isEditable"
-            class="cursor-nw-resize bg-black/65 rounded-md p-1"
+            class="cursor-nw-resize bg-black/65 rounded-5 p-1"
             @mousedown.prevent="startResize"
             title="Resize"
           >
@@ -280,7 +280,7 @@ function setCursorBeforeIframe() {
         <!-- Loading state for new embeds -->
         <div
           v-if="!node.attrs.src"
-          class="flex items-center justify-center bg-surface-gray-1 rounded-lg w-[640px] h-[360px]"
+          class="flex items-center justify-center bg-surface-gray-1 rounded-6 w-[640px] h-[360px]"
         >
           <div class="text-ink-gray-5 text-center">
             <div class="text-lg mb-1">🔗</div>

--- a/experimental/TextEditor/extensions/image-group/ImageGroupUploadDialog.vue
+++ b/experimental/TextEditor/extensions/image-group/ImageGroupUploadDialog.vue
@@ -93,7 +93,7 @@
                       saveCaption(`${item.type}-${idx}`, idx)
                     "
                     @keydown.escape="cancelEditingCaption"
-                    class="w-full text-xs bg-white/90 text-gray-900 px-1 py-0.5 rounded-sm border-none outline-none"
+                    class="w-full text-xs bg-white/90 text-gray-900 px-1 py-0.5 rounded-1 border-none outline-none"
                     placeholder="Add caption..."
                     maxlength="200"
                   />
@@ -153,7 +153,7 @@
                         saveCaption(`${item.type}-${idx}`, idx)
                       "
                       @keydown.escape="cancelEditingCaption"
-                      class="w-full text-xs bg-white/90 text-gray-900 px-1 py-0.5 rounded border-none outline-none"
+                      class="w-full text-xs bg-white/90 text-gray-900 px-1 py-0.5 rounded-4 border-none outline-none"
                       placeholder="Add caption..."
                       maxlength="200"
                     />
@@ -172,7 +172,7 @@
           class="flex flex-col items-center justify-center min-h-[200px]"
         >
           <div
-            class="w-full flex flex-1 flex-col items-center justify-center border border-outline-gray-2 rounded-lg bg-surface-gray-1 h-full cursor-pointer transition hover:border-primary-400 hover:bg-primary-50 text-center"
+            class="w-full flex flex-1 flex-col items-center justify-center border border-outline-gray-2 rounded-6 bg-surface-gray-1 h-full cursor-pointer transition hover:border-primary-400 hover:bg-primary-50 text-center"
             @click="triggerFileInput"
             @dragover.prevent
             @drop.prevent="onDrop"
@@ -189,7 +189,7 @@
           <div class="mb-2 text-sm">
             Uploading: {{ uploadedCount }}/{{ totalCount }}
           </div>
-          <div class="w-full bg-gray-200 rounded h-2 overflow-hidden">
+          <div class="w-full bg-gray-200 rounded-4 h-2 overflow-hidden">
             <div
               class="bg-surface-gray-8 h-2 transition-all"
               :style="{ width: uploadProgress + '%' }"

--- a/experimental/TextEditor/extensions/suggestion/SuggestionList.vue
+++ b/experimental/TextEditor/extensions/suggestion/SuggestionList.vue
@@ -3,7 +3,7 @@
     <div
       v-if="items.length || showNoResults"
       ref="container"
-      class="relative max-h-[300px] min-w-40 overflow-y-auto rounded-lg bg-surface-base p-1 text-base shadow-lg"
+      class="relative max-h-[300px] min-w-40 overflow-y-auto rounded-6 bg-surface-base p-1 text-base shadow-lg"
       :class="containerClass"
     >
       <button
@@ -15,7 +15,7 @@
           }
         "
         :class="[
-          'flex w-full items-center whitespace-nowrap rounded-md px-2 py-1.5 text-sm text-ink-gray-9',
+          'flex w-full items-center whitespace-nowrap rounded-5 px-2 py-1.5 text-sm text-ink-gray-9',
           index === selectedIndex ? 'bg-surface-gray-2' : '',
           itemClass,
         ]"

--- a/experimental/TextEditor/extensions/toc-node/TocNodeView.vue
+++ b/experimental/TextEditor/extensions/toc-node/TocNodeView.vue
@@ -21,7 +21,7 @@
     <button
       v-if="isEditable"
       @click="removeNode"
-      class="absolute top-2 right-2 bg-black/65 hover:bg-black/80 text-ink-gray-4 hover:text-ink-base p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity"
+      class="absolute top-2 right-2 bg-black/65 hover:bg-black/80 text-ink-gray-4 hover:text-ink-base p-1 rounded-4 opacity-0 group-hover:opacity-100 transition-opacity"
       title="Remove table of contents"
     >
       <span class="lucide-x size-4" />

--- a/skills/frappe-ui/COMPONENTS.md
+++ b/skills/frappe-ui/COMPONENTS.md
@@ -153,7 +153,7 @@ For every app-owned scroll region (sidebar nav, panes; `orientation="horizontal"
 
 ### `Divider` — see Display.
 
-> Don't use `Card` — compose surfaces directly with `bg-surface-base rounded border border-outline-gray-1 p-4`.
+> Don't use `Card` — compose surfaces directly with `bg-surface-base rounded-4 border border-outline-gray-1 p-4`.
 
 ## Provider
 

--- a/skills/frappe-ui/TOKENS.md
+++ b/skills/frappe-ui/TOKENS.md
@@ -80,6 +80,9 @@ All have tuned letter-spacing — don't override unless you know why.
 | `rounded-8`      | 20    | Marketing surfaces             |
 | `rounded-full`   | pill  | Avatars, status dots, pill badges |
 
+The full scale is `rounded-0` through `rounded-9` (see `spec/foundations.md`).
+The table lists the steps you will actually reach for.
+
 ## Shadow
 
 | Class         | Use                                  |

--- a/skills/frappe-ui/TOKENS.md
+++ b/skills/frappe-ui/TOKENS.md
@@ -72,12 +72,12 @@ All have tuned letter-spacing — don't override unless you know why.
 | Class            | px    | Use                            |
 |------------------|-------|--------------------------------|
 | `rounded-none`   | 0     | Flush edges                    |
-| `rounded-sm`     | 4     | Tags, small chips              |
-| `rounded` (default) | 8  | Inputs, buttons, list items    |
-| `rounded-md`     | 10    | Cards                          |
-| `rounded-lg`     | 12    | Dialogs, larger surfaces       |
-| `rounded-xl`     | 16    | Hero panels                    |
-| `rounded-2xl`    | 20    | Marketing surfaces             |
+| `rounded-1`      | 4     | Tags, small chips              |
+| `rounded-4`      | 8     | Inputs, buttons, list items (default) |
+| `rounded-5`      | 10    | Cards                          |
+| `rounded-6`      | 12    | Dialogs, larger surfaces       |
+| `rounded-7`      | 16    | Hero panels                    |
+| `rounded-8`      | 20    | Marketing surfaces             |
 | `rounded-full`   | pill  | Avatars, status dots, pill badges |
 
 ## Shadow

--- a/spec/hover-card.md
+++ b/spec/hover-card.md
@@ -187,7 +187,7 @@ entrance only puts motion between the press and the content. `HoverCard` was the
 last holdout, on the argument that a hover open is not on a latency path. That
 is true, but it is not worth being the only surface with its own rhythm.
 
-`PopoverPanel` owns the **shell only** (rounded-lg, `bg-surface-elevation-2`,
+`PopoverPanel` owns the **shell only** (rounded-6, `bg-surface-elevation-2`,
 shadow, ring + the `data-slot`/`data-state`/`data-motion` wiring). `HoverCard`
 renders its own `HoverCardContent` and its own contents inside `PopoverPanel`.
 It does not delegate behavior to the panel. This is the same DRY split applied

--- a/spec/popover.md
+++ b/spec/popover.md
@@ -35,7 +35,7 @@ component (`Popover`, `Select`, `Combobox`, `DatePicker`, `TimePicker`).
 
 `PopoverPanel` owns:
 
-- the visual shell: `rounded-lg bg-surface-elevation-2 shadow-2xl ring-1
+- the visual shell: `rounded-6 bg-surface-elevation-2 shadow-2xl ring-1
   ring-black ring-opacity-5`
 - `data-slot="content"`
 - the motion-target wiring: `data-state="open|closed"` and
@@ -251,7 +251,7 @@ Stable hooks instead:
 - `data-state="open" | "closed"` — driven by the reka popover primitive
 - `data-motion="instant"` — on the content-body
 
-The shell visual is owned by `PopoverPanel`: `rounded-lg
+The shell visual is owned by `PopoverPanel`: `rounded-6
 bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5`. (This is a
 deliberate restyle from the legacy `rounded-lg border bg-surface-elevation-2
 shadow-xl` shell.)

--- a/src/components/Badge/stories/EventStatus.vue
+++ b/src/components/Badge/stories/EventStatus.vue
@@ -3,7 +3,7 @@ import { Badge } from 'frappe-ui'
 </script>
 
 <template>
-  <div class="w-96 rounded-r-md border-l-2 border-outline-gray-3 px-3 py-2 transition-colors hover:bg-surface-gray-1">
+  <div class="w-96 rounded-r-5 border-l-2 border-outline-gray-3 px-3 py-2 transition-colors hover:bg-surface-gray-1">
     <Badge theme="red" size="md">
       <template #prefix>
         <span class="lucide-mail" aria-hidden="true" />

--- a/src/components/Badge/stories/ListStatus.vue
+++ b/src/components/Badge/stories/ListStatus.vue
@@ -47,7 +47,7 @@ const leads = [
 
 <template>
   <div
-    class="w-full max-w-[640px] overflow-hidden rounded-lg border border-outline-gray-1 bg-surface-base shadow-sm"
+    class="w-full max-w-[640px] overflow-hidden rounded-6 border border-outline-gray-1 bg-surface-base shadow-sm"
   >
     <div class="flex items-center justify-between border-b border-outline-gray-1 px-3 py-2.5">
       <h3 class="m-0 text-base-medium text-ink-gray-8">Lead pipeline</h3>
@@ -71,7 +71,7 @@ const leads = [
       >
         <div class="flex min-w-0 items-center gap-2">
           <div
-            class="flex size-6 shrink-0 items-center justify-center rounded bg-surface-gray-2 text-xs-medium text-ink-gray-6"
+            class="flex size-6 shrink-0 items-center justify-center rounded-4 bg-surface-gray-2 text-xs-medium text-ink-gray-6"
           >
             {{ lead.name.slice(0, 1) }}
           </div>

--- a/src/components/BottomSheet/stories/Title.vue
+++ b/src/components/BottomSheet/stories/Title.vue
@@ -14,7 +14,7 @@ const options = ['Rename', 'Duplicate', 'Move to folder', 'Delete']
       <button
         v-for="option in options"
         :key="option"
-        class="rounded px-3 py-2.5 text-start text-p-base text-ink-gray-8 hover:bg-surface-gray-2"
+        class="rounded-4 px-3 py-2.5 text-start text-p-base text-ink-gray-8 hover:bg-surface-gray-2"
         @click="open = false"
       >
         {{ option }}

--- a/src/components/Breadcrumbs/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs/Breadcrumbs.vue
@@ -19,7 +19,7 @@
           v-if="item.route"
           :to="item.route"
           @click="item.onClick?.($event)"
-          class="flex items-center rounded px-0.5 py-1 text-lg-medium"
+          class="flex items-center rounded-4 px-0.5 py-1 text-lg-medium"
           :class="[
             i == crumbs.length - 1
               ? 'min-w-0 text-ink-gray-9'
@@ -39,7 +39,7 @@
           v-else-if="item.href"
           :href="item.href"
           @click="onLinkClick(item, $event)"
-          class="flex items-center rounded px-0.5 py-1 text-lg-medium"
+          class="flex items-center rounded-4 px-0.5 py-1 text-lg-medium"
           :class="[
             i == crumbs.length - 1
               ? 'min-w-0 text-ink-gray-9'
@@ -58,7 +58,7 @@
         <button
           v-else
           @click="item.onClick?.($event)"
-          class="flex items-center rounded px-0.5 py-1 text-lg-medium"
+          class="flex items-center rounded-4 px-0.5 py-1 text-lg-medium"
           :class="[
             i == crumbs.length - 1
               ? 'min-w-0 text-ink-gray-9'

--- a/src/components/Calendar/CalendarMonthEvent.vue
+++ b/src/components/Calendar/CalendarMonthEvent.vue
@@ -16,7 +16,7 @@
     <template #trigger>
       <div
         v-bind="$attrs"
-        class="event flex gap-1.5 min-h-6 mx-px rounded p-[5px] transition-all duration-75 w-full overflow-hidden"
+        class="event flex gap-1.5 min-h-6 mx-px rounded-4 p-[5px] transition-all duration-75 w-full overflow-hidden"
         :class="{
           active: activeEvent == (props.event?.id || props.event?.name),
         }"
@@ -32,7 +32,7 @@
       >
         <div
           v-if="props.event.fromTime"
-          class="event-border w-[2px] rounded shrink-0"
+          class="event-border w-[2px] rounded-4 shrink-0"
           :style="eventBorderStyle"
         />
         <div

--- a/src/components/Calendar/CalendarMonthly.vue
+++ b/src/components/Calendar/CalendarMonthly.vue
@@ -46,7 +46,7 @@
                   !isCurrentMonth(date)
                     ? 'bg-surface-base text-ink-gray-4'
                     : isToday(date)
-                      ? 'flex items-center justify-center bg-surface-gray-10 text-ink-gray-2 rounded size-[25px]'
+                      ? 'flex items-center justify-center bg-surface-gray-10 text-ink-gray-2 rounded-4 size-[25px]'
                       : 'bg-surface-base text-ink-gray-8',
                 ]"
                 @click.stop="

--- a/src/components/Calendar/CalendarTimeMarker.vue
+++ b/src/components/Calendar/CalendarTimeMarker.vue
@@ -5,7 +5,7 @@
     v-if="parseDate(date) === parseDate(now)"
   >
     <Tooltip :text="dayjs(now).format('ddd, MMM D, YYYY h:mm a')">
-      <div class="current-time relative h-0.5 bg-[#E03636] rounded" />
+      <div class="current-time relative h-0.5 bg-[#E03636] rounded-4" />
     </Tooltip>
   </div>
 </template>

--- a/src/components/Calendar/CalendarWeekDayEvent.vue
+++ b/src/components/Calendar/CalendarWeekDayEvent.vue
@@ -23,7 +23,7 @@
       <div class="flex" :style="containerStyle">
       <div
         ref="eventRef"
-        class="event min-h-6 mx-px shadow rounded transition-all duration-75 shrink-0"
+        class="event min-h-6 mx-px shadow rounded-4 transition-all duration-75 shrink-0"
         :class="{
           active: activeEvent == (props.event?.id || props.event?.name),
         }"
@@ -43,7 +43,7 @@
         <div class="flex gap-1.5 h-full p-[5px]">
           <div
             v-if="props.event.fromTime"
-            class="event-border h-full w-[2px] rounded shrink-0"
+            class="event-border h-full w-[2px] rounded-4 shrink-0"
             :style="eventBorderStyle"
           />
           <div

--- a/src/components/Calendar/CalendarWeekly.vue
+++ b/src/components/Calendar/CalendarWeekly.vue
@@ -12,7 +12,7 @@
           {{ isToday(date) ? daysList[date.getDay()] : parseDateWithDay(date) }}
           <span
             v-if="isToday(date)"
-            class="inline-flex items-center justify-center bg-surface-gray-10 text-ink-gray-1 rounded size-[25px]"
+            class="inline-flex items-center justify-center bg-surface-gray-10 text-ink-gray-1 rounded-4 size-[25px]"
           >
             {{ date.getDate() }}
           </span>

--- a/src/components/Calendar/EventModalContent.vue
+++ b/src/components/Calendar/EventModalContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-80 rounded-lg bg-surface-elevation-2 text-ink-gray-8 p-4">
+  <div class="w-80 rounded-6 bg-surface-elevation-2 text-ink-gray-8 p-4">
     <div class="flex flex-row-reverse gap-2">
       <span class="cursor-pointer" @click.stop="$emit('close')">
         <span class="lucide-x size-4" aria-hidden="true" />

--- a/src/components/Calendar/ShowMoreCalendarEvent.vue
+++ b/src/components/Calendar/ShowMoreCalendarEvent.vue
@@ -13,7 +13,7 @@
   </CalendarMonthEvent>
   <button
     v-if="totalEventsCount > 2"
-    class="w-fit rounded-sm p-px px-2 mx-px text-base-medium text-ink-gray-6 hover:bg-surface-gray-1"
+    class="w-fit rounded-1 p-px px-2 mx-px text-base-medium text-ink-gray-6 hover:bg-surface-gray-1"
     @click.stop="emit('showMoreEvents')"
   >
     {{ totalEventsCount - 2 }} more

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -4,10 +4,10 @@
     :class="[props.padded ? 'flex' : 'inline-flex', containerClasses]"
     @click="onContainerClick"
   >
-    <div class="inline-flex items-center gap-2 rounded transition">
+    <div class="inline-flex items-center gap-2 rounded-4 transition">
       <input
         ref="inputRef"
-        class="rounded-sm mt-[1px]"
+        class="rounded-1 mt-[1px]"
         :class="inputClasses"
         type="checkbox"
         :disabled="disabled"
@@ -135,7 +135,7 @@ const containerClasses = computed(() => {
       : props.size === 'sm'
         ? 'h-7 px-1.5'
         : 'h-6 px-1.5'
-  const classes = ['group rounded transition-colors', sizeClass]
+  const classes = ['group rounded-4 transition-colors', sizeClass]
   if (!hasDetail) classes.push('justify-center')
   classes.push(
     props.disabled

--- a/src/components/Combobox/stories/Clearable.vue
+++ b/src/components/Combobox/stories/Clearable.vue
@@ -86,7 +86,7 @@ function clear(key: string, event: Event) {
             <span
               v-if="field.key === 'colour'"
               :class="[
-                'inline-block size-3 rounded-sm',
+                'inline-block size-3 rounded-1',
                 colourSwatch[getOptionValue(item)] ?? 'bg-surface-gray-3',
               ]"
             />
@@ -129,7 +129,7 @@ function clear(key: string, event: Event) {
             type="button"
             aria-label="Clear"
             tabindex="-1"
-            class="grid size-4 place-items-center rounded-sm text-ink-gray-5 opacity-0 hover:bg-surface-gray-3 hover:text-ink-gray-7 group-hover:opacity-100 focus:opacity-100"
+            class="grid size-4 place-items-center rounded-1 text-ink-gray-5 opacity-0 hover:bg-surface-gray-3 hover:text-ink-gray-7 group-hover:opacity-100 focus:opacity-100"
             @click="clear(field.key, $event)"
             @pointerdown.stop
           >

--- a/src/components/Combobox/stories/CreateNew.vue
+++ b/src/components/Combobox/stories/CreateNew.vue
@@ -63,11 +63,11 @@ function getBgClass(item: { label: string }) {
         <span
           v-if="item.key !== 'create'"
           :class="getBgClass(item)"
-          class="size-3 rounded-sm"
+          class="size-3 rounded-1"
         />
         <span
           v-if="item.key === 'create'"
-          class="rounded-sm bg-surface-gray-8 lucide-tag"
+          class="rounded-1 bg-surface-gray-8 lucide-tag"
         />
       </template>
       <template #item-create="{ query }">

--- a/src/components/Combobox/stories/InDialog.vue
+++ b/src/components/Combobox/stories/InDialog.vue
@@ -74,7 +74,7 @@ const emojis = [
           </Combobox>
         </div>
 
-        <div class="rounded bg-surface-gray-1 p-3 text-sm text-ink-gray-7">
+        <div class="rounded-4 bg-surface-gray-1 p-3 text-sm text-ink-gray-7">
           <div>
             Repo: <code>{{ repo || 'None' }}</code>
           </div>

--- a/src/components/Combobox/stories/SearchSlots.vue
+++ b/src/components/Combobox/stories/SearchSlots.vue
@@ -36,7 +36,7 @@ function clearSearch(setQuery: (value: string) => void, focus: () => void) {
         v-if="query"
         type="button"
         aria-label="Clear search"
-        class="grid size-5 shrink-0 place-items-center rounded text-ink-gray-5 hover:bg-surface-gray-2 hover:text-ink-gray-8"
+        class="grid size-5 shrink-0 place-items-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-2 hover:text-ink-gray-8"
         @pointerdown.prevent
         @click="clearSearch(setQuery, focus)"
       >
@@ -44,7 +44,7 @@ function clearSearch(setQuery: (value: string) => void, focus: () => void) {
       </button>
       <kbd
         v-else
-        class="shrink-0 rounded border border-outline-gray-2 bg-surface-gray-1 px-1.5 py-0.5 text-p-xs text-ink-gray-5"
+        class="shrink-0 rounded-4 border border-outline-gray-2 bg-surface-gray-1 px-1.5 py-0.5 text-p-xs text-ink-gray-5"
       >
         ⌘ K
       </kbd>

--- a/src/components/CommandPalette/CommandPaletteItem.vue
+++ b/src/components/CommandPalette/CommandPaletteItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex w-full min-w-0 items-center rounded px-2 py-2 text-base-medium text-ink-gray-8"
+    class="flex w-full min-w-0 items-center rounded-4 px-2 py-2 text-base-medium text-ink-gray-8"
     :class="{ 'bg-surface-gray-2': active }"
   >
     <OptionIcon v-if="item.icon" :icon="item.icon" class="mr-3" />

--- a/src/components/ContextMenu/stories/FileList.vue
+++ b/src/components/ContextMenu/stories/FileList.vue
@@ -75,7 +75,7 @@ const activeOptions = ref<ContextMenuOptions>([])
 
 <template>
   <div
-    class="w-80 overflow-hidden rounded-xl border border-outline-gray-2 bg-surface-base shadow-sm"
+    class="w-80 overflow-hidden rounded-7 border border-outline-gray-2 bg-surface-base shadow-sm"
   >
     <div class="border-b border-outline-gray-1 px-3 py-2">
       <p class="text-p-sm-medium text-ink-gray-5">Recents</p>

--- a/src/components/ContextMenu/stories/Groups.vue
+++ b/src/components/ContextMenu/stories/Groups.vue
@@ -71,7 +71,7 @@ const actions: ContextMenuOptions = [
 <template>
   <ContextMenu :options="actions">
     <div
-      class="w-72 cursor-default select-none rounded-xl border border-outline-gray-2 bg-surface-base p-4 shadow-sm"
+      class="w-72 cursor-default select-none rounded-7 border border-outline-gray-2 bg-surface-base p-4 shadow-sm"
     >
       <div class="mb-3 flex items-start justify-between gap-2">
         <Badge theme="orange" label="In Progress" />

--- a/src/components/ContextMenu/stories/Simple.vue
+++ b/src/components/ContextMenu/stories/Simple.vue
@@ -49,7 +49,7 @@ function restore() {
         </div>
         <div
           v-if="!deleted"
-          class="w-fit cursor-default select-none rounded-2xl rounded-tl-sm bg-surface-gray-3 px-3.5 py-2 text-sm text-ink-gray-8"
+          class="w-fit cursor-default select-none rounded-8 rounded-tl-1 bg-surface-gray-3 px-3.5 py-2 text-sm text-ink-gray-8"
         >
           {{ text }}
         </div>

--- a/src/components/DatePicker/CalendarPanel.vue
+++ b/src/components/DatePicker/CalendarPanel.vue
@@ -158,7 +158,7 @@
             v-for="y in years"
             type="button"
             :key="y"
-            class="w-full text-ink-gray-8 h-7 shrink-0 rounded py-1 text-sm text-center cursor-pointer transition-colors duration-100"
+            class="w-full text-ink-gray-8 h-7 shrink-0 rounded-4 py-1 text-sm text-center cursor-pointer transition-colors duration-100"
             :class="
               y === currentYear
                 ? 'bg-surface-gray-2 hover:bg-surface-gray-3'
@@ -181,7 +181,7 @@
             v-for="(m, i) in months"
             type="button"
             :key="m"
-            class="w-full text-ink-gray-8 shrink-0 h-7 rounded py-1 text-sm text-center cursor-pointer transition-colors duration-100"
+            class="w-full text-ink-gray-8 shrink-0 h-7 rounded-4 py-1 text-sm text-center cursor-pointer transition-colors duration-100"
             :class="
               i === currentMonth
                 ? 'bg-surface-gray-2 hover:bg-surface-gray-3'
@@ -461,7 +461,7 @@ function cellClass(cell: CalendarPanelCell): Array<string | false> {
 
   if (cell.isUnavailable) {
     return [
-      'rounded',
+      'rounded-4',
       ...restingText,
       todayFont,
       'opacity-30 cursor-not-allowed',
@@ -470,7 +470,7 @@ function cellClass(cell: CalendarPanelCell): Array<string | false> {
 
   if (cell.isRangeStart || cell.isRangeEnd || cell.isSelected) {
     return [
-      'rounded',
+      'rounded-4',
       todayFont,
       'bg-surface-gray-9 text-ink-base hover:bg-surface-gray-9 cursor-pointer',
     ]
@@ -478,7 +478,7 @@ function cellClass(cell: CalendarPanelCell): Array<string | false> {
 
   if (cell.inRange) {
     return [
-      'rounded',
+      'rounded-4',
       ...restingText,
       todayFont,
       'bg-surface-gray-3 hover:bg-surface-gray-3 cursor-pointer',
@@ -486,7 +486,7 @@ function cellClass(cell: CalendarPanelCell): Array<string | false> {
   }
 
   return [
-    'rounded',
+    'rounded-4',
     ...restingText,
     todayFont,
     'hover:bg-surface-gray-2 cursor-pointer',

--- a/src/components/DatePicker/stories/DateTime.vue
+++ b/src/components/DatePicker/stories/DateTime.vue
@@ -33,7 +33,7 @@ function nextFridayMidnight() {
 }
 
 const rowCls =
-  'w-full rounded px-2 py-1.5 text-left text-base hover:bg-surface-gray-2'
+  'w-full rounded-4 px-2 py-1.5 text-left text-base hover:bg-surface-gray-2'
 </script>
 
 <template>

--- a/src/components/DatePicker/stories/Examples.vue
+++ b/src/components/DatePicker/stories/Examples.vue
@@ -41,7 +41,7 @@ const stardateCeil = dayjs('2300-12-31').format('YYYY-MM-DD')
 const dueDate = ref('')
 
 const rowCls =
-  'w-full rounded px-2 py-1.5 text-left text-base hover:bg-surface-gray-2'
+  'w-full rounded-4 px-2 py-1.5 text-left text-base hover:bg-surface-gray-2'
 </script>
 
 <template>

--- a/src/components/DatePicker/stories/Range.vue
+++ b/src/components/DatePicker/stories/Range.vue
@@ -41,7 +41,7 @@ function lastNDays(days: number): [Dayjs, Dayjs] {
 
 // Canonical sidebar row styling.
 const rowCls =
-  'w-full rounded px-2 py-1.5 text-left text-base hover:bg-surface-gray-2'
+  'w-full rounded-4 px-2 py-1.5 text-left text-base hover:bg-surface-gray-2'
 
 // 4. Project sprint — weekdays only, span limited to ~2 weeks via `max`
 const sprint = ref<string[]>([])
@@ -232,7 +232,7 @@ const ret = computed(() =>
     <DateRangePicker v-model="flight" dual-pane :min="today">
       <template #trigger="{ togglePopover, isOpen }">
         <div
-          class="grid grid-cols-2 divide-x divide-outline-gray-2 rounded border bg-surface-base text-sm transition-colors"
+          class="grid grid-cols-2 divide-x divide-outline-gray-2 rounded-4 border bg-surface-base text-sm transition-colors"
           :class="
             isOpen
               ? 'border-outline-gray-4 ring-2 ring-outline-gray-2'
@@ -241,7 +241,7 @@ const ret = computed(() =>
         >
           <button
             type="button"
-            class="flex items-center gap-2 rounded-l px-3 py-2 text-left hover:bg-surface-gray-1"
+            class="flex items-center gap-2 rounded-l-4 px-3 py-2 text-left hover:bg-surface-gray-1"
             @click="togglePopover"
           >
             <span
@@ -257,7 +257,7 @@ const ret = computed(() =>
           </button>
           <button
             type="button"
-            class="flex items-center gap-2 rounded-r px-3 py-2 text-left hover:bg-surface-gray-1"
+            class="flex items-center gap-2 rounded-r-4 px-3 py-2 text-left hover:bg-surface-gray-1"
             @click="togglePopover"
           >
             <span

--- a/src/components/DesktopShell/DesktopShell.cy.ts
+++ b/src/components/DesktopShell/DesktopShell.cy.ts
@@ -26,7 +26,7 @@ describe('<DesktopShell />', () => {
       .should('have.class', 'flex')
       .and('have.class', 'min-w-0')
       .and('have.class', 'flex-1')
-      .and('not.have.class', 'rounded-lg')
+      .and('not.have.class', 'rounded-6')
   })
 
   it('registers its scroll region so shellScrollContainer resolves', () => {

--- a/src/components/DesktopShell/stories/Default.vue
+++ b/src/components/DesktopShell/stories/Default.vue
@@ -53,7 +53,7 @@ const posts = [
 <template>
   <!-- Bounded height so the shell's `h-full` has something to fill in the preview. -->
   <div
-    class="h-[560px] overflow-hidden rounded-md border w-full bg-surface-white"
+    class="h-[560px] overflow-hidden rounded-5 border w-full bg-surface-white"
   >
     <DesktopShell>
       <template #rail>

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -29,7 +29,7 @@
         >
           <DialogContent
             ref="contentRef"
-            class="my-8 inline-block w-full transform overflow-hidden rounded-xl bg-surface-elevation-1 text-start align-middle shadow-xl dialog-content focus-visible:outline-none"
+            class="my-8 inline-block w-full transform overflow-hidden rounded-7 bg-surface-elevation-1 text-start align-middle shadow-xl dialog-content focus-visible:outline-none"
             :class="sizeClass"
             @open-auto-focus="handleOpenAutoFocus"
             @escape-key-down="

--- a/src/components/Dialog/stories/CommandPalette.vue
+++ b/src/components/Dialog/stories/CommandPalette.vue
@@ -111,7 +111,7 @@ function onEnter() {
         <li
           v-for="(cmd, i) in filtered"
           :key="cmd.label"
-          class="flex cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-base"
+          class="flex cursor-pointer items-center gap-3 rounded-5 px-3 py-2 text-base"
           :class="
             i === activeIndex
               ? 'bg-surface-gray-2 text-ink-gray-9'

--- a/src/components/Dropdown/stories/KebabMenu.vue
+++ b/src/components/Dropdown/stories/KebabMenu.vue
@@ -53,7 +53,7 @@ function rowActions(task: Task): DropdownOptions {
 
 <template>
   <div
-    class="w-80 divide-y divide-outline-gray-1 rounded-lg border border-outline-gray-1 bg-surface-base"
+    class="w-80 divide-y divide-outline-gray-1 rounded-6 border border-outline-gray-1 bg-surface-base"
   >
     <div
       v-for="task in tasks"

--- a/src/components/Dropdown/stories/UserMenu.vue
+++ b/src/components/Dropdown/stories/UserMenu.vue
@@ -89,12 +89,12 @@ const userMenuItems = computed(() => [
     <Dropdown :options="userMenuItems">
       <template #default="{ open }">
         <button
-          class="flex w-56 items-center rounded-md px-2 py-2 text-left transition-colors"
+          class="flex w-56 items-center rounded-5 px-2 py-2 text-left transition-colors"
           :class="open ? 'bg-surface-gray-3' : 'hover:bg-surface-gray-2'"
         >
           <!-- Gameplan logo -->
           <svg
-            class="size-8 rounded"
+            class="size-8 rounded-4"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 44 44"

--- a/src/components/ItemListRow/ItemListRow.vue
+++ b/src/components/ItemListRow/ItemListRow.vue
@@ -50,7 +50,7 @@ defineSlots<{
     :data-state="isEmphasized ? 'active' : 'inactive'"
     :data-disabled="disabled ? '' : undefined"
     :class="[
-      'flex w-full items-center gap-2 rounded transition-colors',
+      'flex w-full items-center gap-2 rounded-4 transition-colors',
       sizeClasses,
       stateClasses,
     ]"

--- a/src/components/ItemListRow/stories/RowStates.vue
+++ b/src/components/ItemListRow/stories/RowStates.vue
@@ -3,7 +3,7 @@ import { ItemListRow } from 'frappe-ui'
 </script>
 
 <template>
-  <div class="flex w-[320px] flex-col gap-2 rounded-lg border border-outline-gray-2 bg-surface-elevation-2 p-2">
+  <div class="flex w-[320px] flex-col gap-2 rounded-6 border border-outline-gray-2 bg-surface-elevation-2 p-2">
     <ItemListRow>
       Simple row with no prefix or suffix
     </ItemListRow>

--- a/src/components/KeyboardShortcut/KeyboardShortcut.vue
+++ b/src/components/KeyboardShortcut/KeyboardShortcut.vue
@@ -10,7 +10,7 @@
       <kbd
         v-for="(part, idx) in parsedParts"
         :key="idx + '-' + part.raw"
-        class="inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded bg-surface-gray-2 px-1.5 text-xs-medium text-ink-gray-7"
+        class="inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-4 bg-surface-gray-2 px-1.5 text-xs-medium text-ink-gray-7"
       >
         <span
           v-if="bgIconFor(part)"

--- a/src/components/KeyboardShortcutsModal/KeyboardShortcutsModal.vue
+++ b/src/components/KeyboardShortcutsModal/KeyboardShortcutsModal.vue
@@ -49,7 +49,7 @@
           <div
             v-for="shortcut in shortcuts"
             :key="shortcut.id.toString()"
-            class="grid grid-cols-[1fr_auto] items-start gap-3 rounded py-0.5"
+            class="grid grid-cols-[1fr_auto] items-start gap-3 rounded-4 py-0.5"
           >
             <span class="text-p-base text-ink-gray-6">
               {{ shortcut.description }}

--- a/src/components/Menu/Menu.vue
+++ b/src/components/Menu/Menu.vue
@@ -112,7 +112,7 @@ async function handleItemSelect(item: MenuOption, event: Event) {
           v-else-if="isMenuSwitchOption(item)"
           data-slot="item"
           :data-disabled="item.disabled ? '' : undefined"
-          class="rounded"
+          class="rounded-4"
         >
           <MenuItemContent
             :item="item"

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -16,14 +16,14 @@ export type NormalizedMenuGroup = MenuGroupOption & {
 
 export const menuClasses = {
   content:
-    'menu-content min-w-40 divide-y divide-outline-elevation-2 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none',
+    'menu-content min-w-40 divide-y divide-outline-elevation-2 rounded-6 bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none',
   group: 'p-1.5',
   groupLabel: 'flex h-7 items-center px-2 text-sm font-medium text-ink-gray-4',
   itemIcon: 'size-4 shrink-0',
   itemIconPlaceholder: 'size-4 shrink-0',
   chevronIcon: 'size-4 shrink-0',
   menuItem:
-    'cursor-pointer rounded outline-none data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed',
+    'cursor-pointer rounded-4 outline-none data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed',
 } as const
 
 export function isMenuGroupOption(item: MenuItem): item is MenuGroupOption {

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -487,7 +487,7 @@ defineSlots<MultiSelectSlots>()
             <div
               data-slot="content-body"
               data-motion="instant"
-              class="overflow-hidden rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5"
+              class="overflow-hidden rounded-6 bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5"
             >
               <div
                 v-if="!hideSearch"

--- a/src/components/MultiSelect/stories/SearchSlots.vue
+++ b/src/components/MultiSelect/stories/SearchSlots.vue
@@ -35,7 +35,7 @@ function clearSearch(setQuery: (value: string) => void, focus: () => void) {
         v-if="query"
         type="button"
         aria-label="Clear search"
-        class="grid size-5 shrink-0 place-items-center rounded text-ink-gray-5 hover:bg-surface-gray-2 hover:text-ink-gray-8"
+        class="grid size-5 shrink-0 place-items-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-2 hover:text-ink-gray-8"
         @pointerdown.prevent
         @click="clearSearch(setQuery, focus)"
       >
@@ -43,7 +43,7 @@ function clearSearch(setQuery: (value: string) => void, focus: () => void) {
       </button>
       <kbd
         v-else
-        class="shrink-0 flex items-center justify-center rounded-sm size-5 border border-outline-gray-2 bg-surface-gray-1 text-p-xs text-ink-gray-5"
+        class="shrink-0 flex items-center justify-center rounded-1 size-5 border border-outline-gray-2 bg-surface-gray-1 text-p-xs text-ink-gray-5"
       >
         F
       </kbd>

--- a/src/components/MultiSelect/stories/TagsTrigger.vue
+++ b/src/components/MultiSelect/stories/TagsTrigger.vue
@@ -33,7 +33,7 @@ function removeTag(value: string | number) {
       <button
         type="button"
         :data-state="open ? 'open' : 'closed'"
-        class="flex w-96 min-h-8 cursor-pointer items-center gap-1.5 rounded border border-[--surface-gray-2] px-1.5 py-1 text-left transition-colors hover:border-outline-elevation-2 data-[state=open]:focus-ring"
+        class="flex w-96 min-h-8 cursor-pointer items-center gap-1.5 rounded-4 border border-[--surface-gray-2] px-1.5 py-1 text-left transition-colors hover:border-outline-elevation-2 data-[state=open]:focus-ring"
         @click="setOpen(!open)"
       >
         <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1">
@@ -48,7 +48,7 @@ function removeTag(value: string | number) {
               <span
                 role="button"
                 tabindex="-1"
-                class="-mr-0.5 inline-flex cursor-pointer items-center justify-center rounded-sm p-0.5 opacity-70 hover:opacity-100"
+                class="-mr-0.5 inline-flex cursor-pointer items-center justify-center rounded-1 p-0.5 opacity-70 hover:opacity-100"
                 @click.stop="removeTag(option.value)"
                 @pointerdown.stop
               >

--- a/src/components/Popover/Popover.md
+++ b/src/components/Popover/Popover.md
@@ -63,7 +63,7 @@ to match the panel surface.
 ## Styling
 
 The popover ships with its panel shell baked in
-(`rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5`)
+(`rounded-6 bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5`)
 — there are no class-injection props. Style it through the stable `data-slot`
 hooks instead:
 

--- a/src/components/Popover/stories/Bare.vue
+++ b/src/components/Popover/stories/Bare.vue
@@ -10,7 +10,7 @@ import { Button, Popover } from 'frappe-ui'
     <template #default>
       <!-- bare: no panel shell, the content brings its own surface -->
       <div
-        class="max-h-72 w-64 overflow-y-auto rounded-2xl bg-surface-gray-7 p-4 text-p-sm text-ink-white shadow-2xl"
+        class="max-h-72 w-64 overflow-y-auto rounded-8 bg-surface-gray-7 p-4 text-p-sm text-ink-white shadow-2xl"
       >
         This panel has no default chrome — the popover renders the content
         directly so it can use its own background, radius, and shadow.

--- a/src/components/Progress/Progress.vue
+++ b/src/components/Progress/Progress.vue
@@ -26,7 +26,7 @@
       :model-value="clampedValue"
       :max="MAX_VALUE"
       :get-value-label="() => valueLabel"
-      class="transform-gpu overflow-hidden rounded-xl"
+      class="transform-gpu overflow-hidden rounded-7"
       :class="indicatorContainerClasses"
     >
       <!-- Continuous Progress Bar -->

--- a/src/components/Progress/stories/MultiStepForm.vue
+++ b/src/components/Progress/stories/MultiStepForm.vue
@@ -20,7 +20,7 @@ function continueForm() {
 </script>
 
 <template>
-  <div class="w-full max-w-[400px] rounded-xl border border-outline-gray-1 p-4">
+  <div class="w-full max-w-[400px] rounded-7 border border-outline-gray-1 p-4">
     <Progress
       :value="percent"
       :label="steps[step]"

--- a/src/components/Progress/stories/Onboarding.vue
+++ b/src/components/Progress/stories/Onboarding.vue
@@ -52,7 +52,7 @@ function completeStep(index: number) {
 </script>
 
 <template>
-  <div class="w-full max-w-[320px] rounded-xl bg-surface-base p-2.5 shadow-lg">
+  <div class="w-full max-w-[320px] rounded-7 bg-surface-base p-2.5 shadow-lg">
     <Progress
       :value="percent"
       label="Get Started with Frappe Drive"
@@ -63,7 +63,7 @@ function completeStep(index: number) {
       <div
         v-for="(step, index) in steps"
         :key="step.title"
-        class="rounded-lg p-2"
+        class="rounded-6 p-2"
         :class="{ 'bg-surface-gray-1': expanded === index }"
       >
         <button

--- a/src/components/Radio/Radio.vue
+++ b/src/components/Radio/Radio.vue
@@ -78,7 +78,7 @@ const hasDescription = computed(() =>
 // any click forwarding. Padding just adds the surface.
 const rowClasses = computed(() => {
   const classes = [
-    'group flex items-start gap-2 rounded text-start transition-colors',
+    'group flex items-start gap-2 rounded-4 text-start transition-colors',
     'focus:outline-none focus-visible:focus-ring',
     isDisabled.value ? 'cursor-not-allowed' : 'cursor-pointer',
   ]

--- a/src/components/Rail/RailItem.vue
+++ b/src/components/Rail/RailItem.vue
@@ -27,7 +27,7 @@
         v-if="showIndicator"
         data-slot="rail-item-indicator"
         aria-hidden="true"
-        class="absolute -left-[11px] top-1/2 h-7 w-1 -translate-y-1/2 rounded-r bg-surface-gray-8"
+        class="absolute -left-[11px] top-1/2 h-7 w-1 -translate-y-1/2 rounded-r-4 bg-surface-gray-8"
       />
       <slot>
         <span
@@ -60,7 +60,7 @@
         v-if="showIndicator"
         data-slot="rail-item-indicator"
         aria-hidden="true"
-        class="absolute -left-[11px] top-1/2 h-7 w-1 -translate-y-1/2 rounded-r bg-surface-gray-8"
+        class="absolute -left-[11px] top-1/2 h-7 w-1 -translate-y-1/2 rounded-r-4 bg-surface-gray-8"
       />
       <slot>
         <span

--- a/src/components/Rail/stories/Default.vue
+++ b/src/components/Rail/stories/Default.vue
@@ -11,7 +11,7 @@ const communities = [
 </script>
 
 <template>
-  <div class="flex h-[420px] overflow-hidden rounded-md border bg-surface-base">
+  <div class="flex h-[420px] overflow-hidden rounded-5 border bg-surface-base">
     <Rail>
       <RailItem label="Home" variant="ghost" icon="lucide-house" @click="active = ''" />
 

--- a/src/components/Rating/Rating.vue
+++ b/src/components/Rating/Rating.vue
@@ -17,7 +17,7 @@
     <div
       :id="inputId"
       ref="rootRef"
-      class="rating-stars inline-flex shrink-0 gap-0.5 leading-none rounded-sm"
+      class="rating-stars inline-flex shrink-0 gap-0.5 leading-none rounded-1"
       :class="hasLabeling ? null : (attrs.class as any)"
       :style="hasLabeling ? null : (attrs.style as any)"
       :role="isSliderMode ? 'slider' : 'radiogroup'"
@@ -42,7 +42,7 @@
         v-for="index in starCount"
         :key="index"
         type="button"
-        class="rating-star relative inline-flex shrink-0 rounded-sm"
+        class="rating-star relative inline-flex shrink-0 rounded-1"
         :class="[sizeClass, isDisabled ? 'cursor-default' : 'cursor-pointer']"
         data-slot="star"
         :data-index="index"

--- a/src/components/ScrollArea/ScrollBar.vue
+++ b/src/components/ScrollArea/ScrollBar.vue
@@ -6,7 +6,7 @@
   >
     <ScrollAreaThumb
       data-slot="scroll-area-thumb"
-      class="relative flex-1 rounded-lg bg-gray-400 transition-opacity duration-150 ease-out before:absolute before:left-1/2 before:top-1/2 before:h-full before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] dark:bg-gray-700"
+      class="relative flex-1 rounded-6 bg-gray-400 transition-opacity duration-150 ease-out before:absolute before:left-1/2 before:top-1/2 before:h-full before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] dark:bg-gray-700"
       :class="[
         isThumbVisible
           ? 'opacity-100 pointer-events-auto'

--- a/src/components/ScrollArea/stories/Default.vue
+++ b/src/components/ScrollArea/stories/Default.vue
@@ -5,12 +5,12 @@ const items = Array.from({ length: 30 }, (_, i) => `Item ${i + 1}`)
 </script>
 
 <template>
-  <ScrollArea class="h-64 w-64 rounded-md border bg-surface-base">
+  <ScrollArea class="h-64 w-64 rounded-5 border bg-surface-base">
     <div class="space-y-1 p-3">
       <div
         v-for="item in items"
         :key="item"
-        class="rounded px-2 py-1.5 text-base text-ink-gray-8 hover:bg-surface-gray-2"
+        class="rounded-4 px-2 py-1.5 text-base text-ink-gray-8 hover:bg-surface-gray-2"
       >
         {{ item }}
       </div>

--- a/src/components/Select/stories/CustomTrigger.vue
+++ b/src/components/Select/stories/CustomTrigger.vue
@@ -30,7 +30,7 @@ const options = [
       <template #trigger="{ selectedOption, open }">
         <span
           :class="[
-            'rounded px-1 -mx-1 font-medium text-ink-gray-8 decoration-outline-gray-3 underline-offset-4 transition-colors duration-150',
+            'rounded-4 px-1 -mx-1 font-medium text-ink-gray-8 decoration-outline-gray-3 underline-offset-4 transition-colors duration-150',
             open ? 'bg-surface-gray-3' : 'underline hover:bg-surface-gray-3',
           ]"
         >

--- a/src/components/SettingsDialog/SettingsNavItem.vue
+++ b/src/components/SettingsDialog/SettingsNavItem.vue
@@ -6,7 +6,7 @@
   -->
   <TabsTrigger
     :value="value"
-    class="flex h-7 w-full items-center gap-2 rounded px-2 text-left text-base text-ink-gray-7 data-[state=active]:bg-surface-elevation-3 data-[state=active]:shadow-sm data-[state=inactive]:hover:bg-surface-gray-2"
+    class="flex h-7 w-full items-center gap-2 rounded-4 px-2 text-left text-base text-ink-gray-7 data-[state=active]:bg-surface-elevation-3 data-[state=active]:shadow-sm data-[state=inactive]:hover:bg-surface-gray-2"
   >
     <slot name="prefix" />
     <span class="min-w-0 flex-1 truncate"><slot /></span>

--- a/src/components/SettingsDialog/stories/PanelBasic.vue
+++ b/src/components/SettingsDialog/stories/PanelBasic.vue
@@ -25,7 +25,7 @@ const frequencyOptions = [
     full dialog SettingsDialog provides it; here we add a minimal one to show a
     single panel in isolation.
   -->
-  <div class="h-96 w-full overflow-hidden rounded border border-outline-gray-2">
+  <div class="h-96 w-full overflow-hidden rounded-4 border border-outline-gray-2">
     <TabsRoot default-value="notifications" class="flex h-full">
       <SettingsPanel value="notifications">
         <SettingsHeader title="Notifications" />

--- a/src/components/Sidebar/SidebarHeader.vue
+++ b/src/components/Sidebar/SidebarHeader.vue
@@ -7,7 +7,7 @@
     <Dropdown :options="props.menuItems" match-trigger-width>
       <template v-slot="{ open }">
         <button
-          class="flex h-10 items-center rounded px-1.5 duration-300 ease-in-out"
+          class="flex h-10 items-center rounded-4 px-1.5 duration-300 ease-in-out"
           :class="
             isCollapsed
               ? 'w-auto'

--- a/src/components/Sidebar/SidebarItem.vue
+++ b/src/components/Sidebar/SidebarItem.vue
@@ -2,7 +2,7 @@
   <div
     data-slot="sidebar-item"
     :data-state="resolvedActive ? 'active' : 'inactive'"
-    class="group/sidebar-item flex h-7 items-center rounded transition"
+    class="group/sidebar-item flex h-7 items-center rounded-4 transition"
     :class="
       resolvedActive
         ? 'bg-surface-elevation-3 text-ink-gray-8 shadow-sm'
@@ -24,7 +24,7 @@
       :accesskey="accessKey"
       :aria-label="tooltipText || undefined"
       :aria-current="resolvedActive ? 'page' : undefined"
-      class="flex h-full min-w-0 flex-1 items-center rounded pl-2 focus-visible:ring-0 focus-visible:focus-ring"
+      class="flex h-full min-w-0 flex-1 items-center rounded-4 pl-2 focus-visible:ring-0 focus-visible:focus-ring"
       @click="handleClick"
     >
       <Tooltip
@@ -63,7 +63,7 @@
       type="button"
       :accesskey="accessKey"
       :aria-label="tooltipText || undefined"
-      class="flex h-full text-left min-w-0 flex-1 items-center rounded pl-2 focus-visible:ring-0 focus-visible:focus-ring"
+      class="flex h-full text-left min-w-0 flex-1 items-center rounded-4 pl-2 focus-visible:ring-0 focus-visible:focus-ring"
       @click="handleClick"
     >
       <Tooltip

--- a/src/components/Sidebar/SidebarSection.vue
+++ b/src/components/Sidebar/SidebarSection.vue
@@ -27,7 +27,7 @@
           v-if="collapsible"
           :id="triggerId"
           type="button"
-          class="flex items-center gap-1 rounded focus-visible:ring-0 focus-visible:focus-ring"
+          class="flex items-center gap-1 rounded-4 focus-visible:ring-0 focus-visible:focus-ring"
           :aria-expanded="!isSectionCollapsed"
           :aria-controls="bodyId"
           :aria-hidden="isSidebarCollapsed || undefined"

--- a/src/components/Sidebar/stories/Card.vue
+++ b/src/components/Sidebar/stories/Card.vue
@@ -11,7 +11,7 @@ const status = ref('')
 
 <template>
   <div class="grid w-full max-w-lg grid-cols-2 items-start gap-4">
-    <div class="rounded-md bg-surface-gray-1 p-3">
+    <div class="rounded-5 bg-surface-gray-1 p-3">
       <SidebarCard
         title="Your trial ends soon!"
         description="Upgrade to keep enjoying features."
@@ -22,7 +22,7 @@ const status = ref('')
       />
     </div>
 
-    <div class="rounded-md bg-surface-gray-1 p-3">
+    <div class="rounded-5 bg-surface-gray-1 p-3">
       <SidebarCard
         v-if="showFeatureCard"
         theme="blue"
@@ -44,7 +44,7 @@ const status = ref('')
       </button>
     </div>
 
-    <div class="rounded-md bg-surface-gray-1 p-3">
+    <div class="rounded-5 bg-surface-gray-1 p-3">
       <SidebarCard
         theme="amber"
         title="Storage is almost full"
@@ -56,7 +56,7 @@ const status = ref('')
       />
     </div>
 
-    <div class="rounded-md bg-surface-gray-1 p-3">
+    <div class="rounded-5 bg-surface-gray-1 p-3">
       <SidebarCard
         theme="red"
         title="Payment failed"

--- a/src/components/Sidebar/stories/Collapsed.vue
+++ b/src/components/Sidebar/stories/Collapsed.vue
@@ -17,7 +17,7 @@ const items = [
 </script>
 
 <template>
-  <div class="flex h-[360px] w-fit overflow-hidden rounded-md border">
+  <div class="flex h-[360px] w-fit overflow-hidden rounded-5 border">
     <!-- v-model:collapsed is app state; SidebarCollapseToggle flips it. -->
     <Sidebar v-model:collapsed="collapsed">
       <div class="flex-1 overflow-y-auto px-2 pt-2">

--- a/src/components/Sidebar/stories/Default.vue
+++ b/src/components/Sidebar/stories/Default.vue
@@ -51,15 +51,15 @@ const sortOptions = [
 </script>
 
 <template>
-  <div class="flex h-[560px] w-fit overflow-hidden rounded-md border">
+  <div class="flex h-[560px] w-fit overflow-hidden rounded-5 border">
     <Sidebar disable-collapse width="14rem">
       <!-- App switcher — the app owns the header. -->
       <div class="flex shrink-0 items-center p-2">
         <button
-          class="flex h-8 w-full items-center gap-2 rounded px-1 transition hover:bg-surface-gray-2"
+          class="flex h-8 w-full items-center gap-2 rounded-4 px-1 transition hover:bg-surface-gray-2"
         >
           <div
-            class="grid size-6 shrink-0 place-items-center rounded bg-surface-gray-7 text-xs font-medium text-ink-white"
+            class="grid size-6 shrink-0 place-items-center rounded-4 bg-surface-gray-7 text-xs font-medium text-ink-white"
           >
             F
           </div>

--- a/src/components/Sidebar/stories/Section.vue
+++ b/src/components/Sidebar/stories/Section.vue
@@ -11,7 +11,7 @@ const viewsCollapsed = ref(false)
 </script>
 
 <template>
-  <div class="flex h-[360px] w-fit overflow-hidden rounded-md border">
+  <div class="flex h-[360px] w-fit overflow-hidden rounded-5 border">
     <Sidebar disable-collapse width="14rem">
       <div class="flex-1 overflow-y-auto px-2 pt-2">
         <SidebarLabel>Pipeline</SidebarLabel>

--- a/src/components/Skeleton/stories/Card.vue
+++ b/src/components/Skeleton/stories/Card.vue
@@ -4,7 +4,7 @@ import { Skeleton } from 'frappe-ui'
 
 <template>
   <div class="w-64 space-y-4">
-    <Skeleton class="h-40 w-full rounded-lg" />
+    <Skeleton class="h-40 w-full rounded-6" />
     <Skeleton class="h-5 w-3/5" />
     <Skeleton class="h-4 w-full" />
     <Skeleton class="h-4 w-4/5" />

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -70,7 +70,7 @@ const bidirectionalRangeStyles = computed(() => {
 
 const trackClasses = computed(() => {
   return [
-    'relative grow rounded',
+    'relative grow rounded-4',
     props.size === 'md' ? 'h-1.5' : 'h-1',
     props.disabled ? 'bg-surface-gray-2' : 'bg-surface-gray-3',
   ]
@@ -78,7 +78,7 @@ const trackClasses = computed(() => {
 
 const rangeClasses = computed(() => {
   return [
-    'absolute h-full rounded',
+    'absolute h-full rounded-4',
     props.disabled ? 'bg-surface-gray-4' : 'bg-surface-gray-10',
   ]
 })

--- a/src/components/Slider/stories/Range.vue
+++ b/src/components/Slider/stories/Range.vue
@@ -8,6 +8,6 @@ const value = ref([20, 80])
 <template>
   <div class="flex flex-col gap-3 w-full max-w-md">
     <Slider v-model="value" label="Price range" />
-    <Badge class="w-fit !rounded-sm">{{ value.join(' – ') }}</Badge>
+    <Badge class="w-fit !rounded-1">{{ value.join(' – ') }}</Badge>
   </div>
 </template>

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -186,7 +186,7 @@ const switchGroupClasses = computed(() => {
       : 'justify-between gap-x-3',
   ]
   if (!props.padded) {
-    classes.push('py-1.5 cursor-pointer rounded')
+    classes.push('py-1.5 cursor-pointer rounded-4')
     if (props.disabled) classes.push('cursor-not-allowed')
   }
   return classes
@@ -238,7 +238,7 @@ const containerClasses = computed(() => {
       : props.size === 'sm'
         ? 'h-7 px-2'
         : 'h-6 px-1.5'
-  const classes = ['group rounded transition-colors', sizeClass]
+  const classes = ['group rounded-4 transition-colors', sizeClass]
   if (!hasDetail) classes.push('justify-center')
   // With the switch at the start the row hugs its content; at the end it spans
   // the full width so `justify-between` can push the switch to the right edge.

--- a/src/components/TabButtons/TabButtons.vue
+++ b/src/components/TabButtons/TabButtons.vue
@@ -130,7 +130,7 @@ function horizontalClasses() {
     case 'ghost': {
       const surface =
         props.type === 'subtle' ? 'bg-surface-gray-2' : 'bg-surface-base'
-      const shape = isSm ? 'gap-1 rounded' : 'gap-1.5 rounded-[10px]'
+      const shape = isSm ? 'gap-1 rounded-4' : 'gap-1.5 rounded-[10px]'
       return [...base, 'p-px', surface, shape]
     }
     case 'underline':
@@ -154,7 +154,7 @@ function verticalClasses() {
     case 'ghost': {
       const surface =
         props.type === 'subtle' ? 'bg-surface-gray-2' : 'bg-surface-base'
-      const shape = isSm ? 'gap-1 rounded' : 'gap-1.5 rounded-[10px]'
+      const shape = isSm ? 'gap-1 rounded-4' : 'gap-1.5 rounded-[10px]'
       return [...base, 'p-px', surface, shape, 'items-center']
     }
     case 'underline':

--- a/src/components/Tabs/Tabs.playground.vue
+++ b/src/components/Tabs/Tabs.playground.vue
@@ -44,7 +44,7 @@ function tabsFor(icons: boolean) {
   <PlaygroundFrame :knobs="knobs" :code="buildCode" preview-min-height="220px">
     <template #preview="{ values }">
       <div
-        class="w-full max-w-md overflow-hidden rounded-lg border border-outline-gray-1"
+        class="w-full max-w-md overflow-hidden rounded-6 border border-outline-gray-1"
         :class="values.vertical ? 'h-[200px]' : 'h-[160px]'"
       >
         <Tabs :tabs="tabsFor(values.icons)" :vertical="values.vertical">

--- a/src/components/Tabs/stories/Icons.vue
+++ b/src/components/Tabs/stories/Icons.vue
@@ -29,7 +29,7 @@ const state = reactive({
 </script>
 
 <template>
-  <Tabs class="border rounded" v-model="state.index" :tabs="state.tabs">
+  <Tabs class="border rounded-4" v-model="state.index" :tabs="state.tabs">
     <template #tab-panel="{ tab }">
       <div class="p-5">{{ tab.content }}</div>
     </template>

--- a/src/components/Tabs/stories/Orientation.vue
+++ b/src/components/Tabs/stories/Orientation.vue
@@ -26,14 +26,14 @@ const state = reactive({
 
 <template>
   <div class="w-full items-center grid gap-5">
-    <Tabs class="border rounded" v-model="state.index" :tabs="state.tabs">
+    <Tabs class="border rounded-4" v-model="state.index" :tabs="state.tabs">
       <template #tab-panel="{ tab }">
         <div class="p-5">{{ tab.content }}</div>
       </template>
     </Tabs>
 
     <Tabs
-      class="border rounded"
+      class="border rounded-4"
       v-model="state.index"
       :tabs="state.tabs"
       :vertical="true"

--- a/src/components/TextInput/TextInput.cy.ts
+++ b/src/components/TextInput/TextInput.cy.ts
@@ -15,10 +15,10 @@ const inputTypes = [
 ]
 
 const sizeCLass = {
-  sm: 'text-base rounded h-7',
-  md: 'text-base rounded h-8',
-  lg: 'text-lg rounded-md h-10',
-  xl: 'text-2xl rounded-md h-10',
+  sm: 'text-base rounded-4 h-7',
+  md: 'text-base rounded-4 h-8',
+  lg: 'text-lg rounded-5 h-10',
+  xl: 'text-2xl rounded-5 h-10',
 }
 
 const variantClasses = {

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -166,10 +166,10 @@ const textColor = computed(() => {
 
 const inputClasses = computed(() => {
   let sizeClasses = {
-    sm: 'text-base rounded h-7',
-    md: 'text-base rounded h-8',
-    lg: 'text-lg rounded-md h-10',
-    xl: 'text-2xl rounded-md h-10',
+    sm: 'text-base rounded-4 h-7',
+    md: 'text-base rounded-4 h-8',
+    lg: 'text-lg rounded-5 h-10',
+    xl: 'text-2xl rounded-5 h-10',
   }[props.size]
 
   let paddingClasses = {

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -114,10 +114,10 @@ const attrsWithoutClassStyle = computed(() => {
 
 const inputClasses = computed(() => {
   let sizeClasses = {
-    sm: 'text-base rounded',
-    md: 'text-lg rounded',
-    lg: 'text-2xl rounded-md',
-    xl: 'text-3xl rounded-md',
+    sm: 'text-base rounded-4',
+    md: 'text-lg rounded-4',
+    lg: 'text-2xl rounded-5',
+    xl: 'text-3xl rounded-5',
   }[props.size]
 
   let paddingClasses = {

--- a/src/components/ThemeSwitcher/ThemeSwitcher.vue
+++ b/src/components/ThemeSwitcher/ThemeSwitcher.vue
@@ -38,7 +38,7 @@
         <div
           data-slot="option"
           :data-theme-option="option.value"
-          class="flex-1 max-w-[227px] min-h-[42px] cursor-pointer overflow-hidden rounded-lg border outline-none transition-colors motion-reduce:transition-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+          class="flex-1 max-w-[227px] min-h-[42px] cursor-pointer overflow-hidden rounded-6 border outline-none transition-colors motion-reduce:transition-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
           :class="checked ? 'border-outline-gray-5' : 'border-outline-gray-modals'"
         >
           <ThemePreview

--- a/src/components/ThemeSwitcher/previews/PreviewWindow.vue
+++ b/src/components/ThemeSwitcher/previews/PreviewWindow.vue
@@ -10,7 +10,7 @@
       viewBox="0 0 207 68"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      class="block h-auto rounded-tl-sm"
+      class="block h-auto rounded-tl-1"
       :class="{ 'w-full': fill }"
     >
       <path d="M0 4C0 1.79086 1.79086 0 4 0H207V83H0V4Z" :fill="colors.background" />

--- a/src/components/ThemeSwitcher/stories/Menu.vue
+++ b/src/components/ThemeSwitcher/stories/Menu.vue
@@ -37,7 +37,7 @@ const crmLogo = 'https://raw.githubusercontent.com/frappe/crm/develop/.github/lo
   <Dropdown :options="menuOptions">
     <template #default="{ open }">
       <button
-        class="flex items-center gap-2 rounded-md px-2 py-2"
+        class="flex items-center gap-2 rounded-5 px-2 py-2"
         :class="open ? 'bg-surface-gray-3' : 'hover:bg-surface-gray-2'"
       >
         <Avatar shape='square' :image="crmLogo" label="CRM" />

--- a/src/components/TimePicker/TimePicker.vue
+++ b/src/components/TimePicker/TimePicker.vue
@@ -65,7 +65,7 @@
           ref="panelRef"
           data-slot="content-body"
           data-motion="instant"
-          class="time-picker-panel max-h-48 w-44 overflow-y-auto rounded-lg bg-surface-elevation-2 p-1 text-base shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
+          class="time-picker-panel max-h-48 w-44 overflow-y-auto rounded-6 bg-surface-elevation-2 p-1 text-base shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
           role="listbox"
           :aria-activedescendant="activeDescendantId"
         >
@@ -76,7 +76,7 @@
             :id="optionId(idx)"
             type="button"
             role="option"
-            class="group flex h-7 w-full items-center rounded px-2 text-left tabular-nums"
+            class="group flex h-7 w-full items-center rounded-4 px-2 text-left tabular-nums"
             :class="rowClass(opt, idx)"
             :aria-selected="canonicalValue === opt.value || undefined"
             @click="selectOption(opt.value)"

--- a/src/components/Toast/ToastProvider.vue
+++ b/src/components/Toast/ToastProvider.vue
@@ -9,14 +9,14 @@
       unstyled: true,
       classes: {
         toast:
-          'group py-2.5 flex items-center px-4 bg-surface-gray-9 rounded-md shadow-xl w-[360px] after:bg-transparent',
+          'group py-2.5 flex items-center px-4 bg-surface-gray-9 rounded-5 shadow-xl w-[360px] after:bg-transparent',
         title: 'text-p-base font-medium text-ink-base',
         description: 'text-p-base text-ink-base',
         icon: 'mr-2 text-ink-base [&_svg]:size-4',
         closeButton:
-          'order-1 ml-auto group-has-[[data-action]]:ml-0 grid place-items-center rounded-sm text-ink-base hover:bg-surface-gray-8 size-5 !transition-colors [&_svg]:size-4',
+          'order-1 ml-auto group-has-[[data-action]]:ml-0 grid place-items-center rounded-1 text-ink-base hover:bg-surface-gray-8 size-5 !transition-colors [&_svg]:size-4',
         actionButton:
-          'flex shrink-0 text-ink-blue-link font-medium py-1.5 px-2 h-7 text-base mr-2 ml-auto bg-transparent hover:bg-surface-gray-8 rounded !transition-colors',
+          'flex shrink-0 text-ink-blue-link font-medium py-1.5 px-2 h-7 text-base mr-2 ml-auto bg-transparent hover:bg-surface-gray-8 rounded-4 !transition-colors',
         cancelButton:
           'flex text-ink-blue-link font-medium py-1.5 px-2 text-base hover:bg-surface-gray-8 transition-colors',
         error: '[&_[data-icon]]:text-ink-red-5',

--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -81,7 +81,7 @@ means deleting that wrapper:
 <!-- before -->
 <Tooltip>
   <template #body>
-    <div class="rounded-4 bg-surface-gray-10 px-2 py-1 text-xs text-ink-base shadow-xl">
+    <div class="rounded bg-surface-gray-10 px-2 py-1 text-xs text-ink-base shadow-xl">
       <span>Hide password</span>
     </div>
   </template>

--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -81,7 +81,7 @@ means deleting that wrapper:
 <!-- before -->
 <Tooltip>
   <template #body>
-    <div class="rounded bg-surface-gray-10 px-2 py-1 text-xs text-ink-base shadow-xl">
+    <div class="rounded-4 bg-surface-gray-10 px-2 py-1 text-xs text-ink-base shadow-xl">
       <span>Hide password</span>
     </div>
   </template>

--- a/src/components/Tooltip/TooltipBubble.vue
+++ b/src/components/Tooltip/TooltipBubble.vue
@@ -51,7 +51,7 @@ defineSlots<{
       <div
         v-else
         data-slot="bubble"
-        class="rounded bg-surface-gray-10 px-2 py-1 text-xs text-ink-base shadow-xl"
+        class="rounded-4 bg-surface-gray-10 px-2 py-1 text-xs text-ink-base shadow-xl"
       >
         <slot name="content">{{ text }}</slot>
       </div>

--- a/src/components/Tooltip/stories/Slots.vue
+++ b/src/components/Tooltip/stories/Slots.vue
@@ -19,7 +19,7 @@ import { Button, KeyboardShortcut, Tooltip } from 'frappe-ui'
         <img
           src="https://frappeui.com/frappe-ui-logo.svg"
           alt="frappe-ui"
-          class="size-20 rounded bg-surface-white p-2 shadow-xl"
+          class="size-20 rounded-4 bg-surface-white p-2 shadow-xl"
         />
       </template>
       <Button>Preview</Button>

--- a/src/components/Tree/Tree.vue
+++ b/src/components/Tree/Tree.vue
@@ -40,7 +40,7 @@
   <Teleport :to="portalTarget ?? 'body'">
     <div
       v-if="dragLabel"
-      class="frappe-tree-drag-label pointer-events-none fixed z-[1000] rounded-md bg-surface-gray-7 px-2 py-1 text-xs text-ink-white shadow-lg"
+      class="frappe-tree-drag-label pointer-events-none fixed z-[1000] rounded-5 bg-surface-gray-7 px-2 py-1 text-xs text-ink-white shadow-lg"
       :style="{
         top: `${dragDrop.state.y + 18}px`,
         left: `${dragDrop.state.x + 12}px`,

--- a/src/components/Tree/TreeItem.vue
+++ b/src/components/Tree/TreeItem.vue
@@ -18,7 +18,7 @@
   >
     <div
       data-slot="row"
-      class="frappe-tree-row group/row relative flex items-center gap-1.5 rounded-md px-1.5"
+      class="frappe-tree-row group/row relative flex items-center gap-1.5 rounded-5 px-1.5"
       :class="[
         ctx.draggable.value && !ctx.disabled.value ? 'cursor-grab' : '',
         // When the row is fully overridden via #item, the consumer owns its hover/selected surface
@@ -42,7 +42,7 @@
           type="button"
           data-slot="toggle"
           :data-state="expanded ? 'expanded' : 'collapsed'"
-          class="flex size-5 shrink-0 items-center justify-center rounded text-ink-gray-5 hover:bg-surface-gray-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-outline-gray-3"
+          class="flex size-5 shrink-0 items-center justify-center rounded-4 text-ink-gray-5 hover:bg-surface-gray-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-outline-gray-3"
           :aria-label="expanded ? 'Collapse' : 'Expand'"
           tabindex="-1"
           @click.stop="ctx.toggle(node)"

--- a/src/components/shared/popover/PopoverPanel.vue
+++ b/src/components/shared/popover/PopoverPanel.vue
@@ -16,7 +16,7 @@
  * Combobox, HoverCard, DatePicker, TimePicker, …).
  *
  * It owns ONLY two things:
- *   1. the visual shell — `rounded-lg bg-surface-elevation-2 shadow-2xl
+ *   1. the visual shell — `rounded-6 bg-surface-elevation-2 shadow-2xl
  *      ring-1 ring-black ring-opacity-5` — matching what the selection family
  *      renders today, plus the `data-slot="content-body"` hook, and
  *   2. the open/close motion wiring (`data-motion` + the co-located
@@ -57,5 +57,5 @@ defineSlots<{ default?: () => any }>()
 // selection family's `content-body` so every popover surface shares one look.
 // Consumer `class` (layout) auto-merges after this.
 const shellClass =
-  'overflow-hidden rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 will-change-[opacity]'
+  'overflow-hidden rounded-6 bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 will-change-[opacity]'
 </script>

--- a/src/components/shared/selection/utils.ts
+++ b/src/components/shared/selection/utils.ts
@@ -13,10 +13,10 @@ export type SelectionVariant = 'subtle' | 'outline' | 'ghost'
 
 export function triggerSizeClasses(size: SelectionSize) {
   return {
-    sm: 'min-h-7 rounded px-2',
-    md: 'min-h-8 rounded px-2.5',
-    lg: 'min-h-10 rounded-md px-3',
-    xl: 'min-h-10 rounded-md px-3',
+    sm: 'min-h-7 rounded-4 px-2',
+    md: 'min-h-8 rounded-4 px-2.5',
+    lg: 'min-h-10 rounded-5 px-3',
+    xl: 'min-h-10 rounded-5 px-3',
   }[size]
 }
 
@@ -76,7 +76,7 @@ export const triggerBaseClassesFocusWithin =
   'relative inline-flex items-center gap-2 text-left text-ink-gray-7 outline-none transition-[background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-within:focus-ring data-[state=open]:focus-ring'
 
 export const itemClasses =
-  'select-none rounded border-0 text-base text-ink-gray-9 transition-colors duration-100 ease-out data-[disabled]:text-ink-gray-4 data-[highlighted]:bg-surface-alpha-gray-2 data-[state=checked]:bg-surface-gray-3 data-[highlighted]:data-[state=checked]:bg-surface-gray-4'
+  'select-none rounded-4 border-0 text-base text-ink-gray-9 transition-colors duration-100 ease-out data-[disabled]:text-ink-gray-4 data-[highlighted]:bg-surface-alpha-gray-2 data-[state=checked]:bg-surface-gray-3 data-[highlighted]:data-[state=checked]:bg-surface-gray-4'
 
 /**
  * Case-insensitive substring match against an option's label and value.

--- a/src/molecules/editor/Editor.cy.ts
+++ b/src/molecules/editor/Editor.cy.ts
@@ -40,7 +40,7 @@ function mountEditor(
                   h(EditorContent, {
                     editor,
                     class:
-                      'min-h-24 w-[520px] rounded border border-outline-gray-2 p-3',
+                      'min-h-24 w-[520px] rounded-4 border border-outline-gray-2 p-3',
                   }),
                 ],
               },

--- a/src/molecules/editor/EditorBubbleMenu.vue
+++ b/src/molecules/editor/EditorBubbleMenu.vue
@@ -37,7 +37,7 @@ const floatingOptions = computed(() => {
   >
     <div
       data-slot="bubble-menu"
-      class="flex items-center gap-1 rounded border border-outline-gray-2 bg-surface-elevation-2 p-1 shadow-sm"
+      class="flex items-center gap-1 rounded-4 border border-outline-gray-2 bg-surface-elevation-2 p-1 shadow-sm"
     >
       <MenuItems :editor="editor" :items="items" />
     </div>

--- a/src/molecules/editor/EditorFloatingMenu.vue
+++ b/src/molecules/editor/EditorFloatingMenu.vue
@@ -37,7 +37,7 @@ const floatingOptions = computed(() => {
   >
     <div
       data-slot="floating-menu"
-      class="flex items-center gap-1 rounded border border-outline-gray-2 bg-surface-elevation-2 p-1 shadow-sm"
+      class="flex items-center gap-1 rounded-4 border border-outline-gray-2 bg-surface-elevation-2 p-1 shadow-sm"
     >
       <MenuItems :editor="editor" :items="items" />
     </div>

--- a/src/molecules/editor/EditorTableMenu.vue
+++ b/src/molecules/editor/EditorTableMenu.vue
@@ -275,7 +275,7 @@ onBeforeUnmount(closeContextMenu)
         v-show="visible && editor"
         ref="floating"
         data-slot="table-menu"
-        class="fixed left-0 top-0 z-[100] flex items-center gap-1 rounded-lg border border-outline-gray-2 bg-surface-elevation-2 p-1 shadow-sm"
+        class="fixed left-0 top-0 z-[100] flex items-center gap-1 rounded-6 border border-outline-gray-2 bg-surface-elevation-2 p-1 shadow-sm"
       >
         <MenuItems v-if="editor" :editor="editor" :items="tableToolbar" />
       </div>

--- a/src/molecules/editor/components/AttachmentNodeView.vue
+++ b/src/molecules/editor/components/AttachmentNodeView.vue
@@ -53,7 +53,7 @@ const isLink = computed(() => isUploaded.value && !isLoading.value)
   >
     <component
       :is="isLink ? 'a' : 'span'"
-      class="inline-flex h-6 max-w-full items-center gap-1.5 rounded-lg border bg-surface-gray-2 px-2 text-sm no-underline"
+      class="inline-flex h-6 max-w-full items-center gap-1.5 rounded-6 border bg-surface-gray-2 px-2 text-sm no-underline"
       :class="[
         error
           ? 'border-dashed border-outline-gray-2 text-ink-gray-6'
@@ -94,7 +94,7 @@ const isLink = computed(() => isUploaded.value && !isLoading.value)
     <button
       v-if="isLoading && isEditable"
       type="button"
-      class="inline-flex items-center justify-center rounded p-0.5 text-ink-gray-6 hover:bg-surface-gray-3"
+      class="inline-flex items-center justify-center rounded-4 p-0.5 text-ink-gray-6 hover:bg-surface-gray-3"
       title="Cancel upload"
       contenteditable="false"
       @click="cancel"
@@ -104,7 +104,7 @@ const isLink = computed(() => isUploaded.value && !isLoading.value)
     <button
       v-else-if="error && isEditable"
       type="button"
-      class="inline-flex items-center justify-center rounded p-0.5 text-ink-gray-6 hover:bg-surface-gray-3"
+      class="inline-flex items-center justify-center rounded-4 p-0.5 text-ink-gray-6 hover:bg-surface-gray-3"
       title="Try again"
       contenteditable="false"
       @click="retry"

--- a/src/molecules/editor/components/EditorPopover.vue
+++ b/src/molecules/editor/components/EditorPopover.vue
@@ -23,7 +23,7 @@ import { FocusScope } from 'reka-ui'
  * floating panel needs — border/background/shadow, `role="dialog"` + label, an
  * enter animation, and a looping focus trap (reka-ui `FocusScope`) — so each
  * feature only renders its own contents. The corner radius is intentionally NOT
- * owned here: each popup sets its own via `content-class` (e.g. `rounded-md`).
+ * owned here: each popup sets its own via `content-class` (e.g. `rounded-5`).
  *
  * It deliberately does NOT handle Escape or scroll-locking: dismissal and
  * scroll policy vary per popup and are owned by the opener (see the link

--- a/src/molecules/editor/components/ImageViewerModal.vue
+++ b/src/molecules/editor/components/ImageViewerModal.vue
@@ -41,7 +41,7 @@
         <!-- Caption -->
         <div
           v-if="currentImage.alt"
-          class="absolute bottom-4 p-2 text-center rounded-sm text-white text-sm bg-black/65 z-10 transition-opacity duration-300 ease-in-out"
+          class="absolute bottom-4 p-2 text-center rounded-1 text-white text-sm bg-black/65 z-10 transition-opacity duration-300 ease-in-out"
           :class="{ 'opacity-0 pointer-events-none': !isControlsVisible }"
         >
           {{ currentImage.alt }}

--- a/src/molecules/editor/components/MediaNodeView.vue
+++ b/src/molecules/editor/components/MediaNodeView.vue
@@ -269,7 +269,7 @@ function setVideoOptions(options: {
   >
     <div
       ref="containerRef"
-      class="group relative isolate overflow-hidden not-prose rounded"
+      class="group relative isolate overflow-hidden not-prose rounded-4"
       :class="containerClasses(node.attrs, selected)"
       :style="{ width: node.attrs.width ? `${node.attrs.width}px` : 'auto' }"
       data-video-fullscreen-root
@@ -281,7 +281,7 @@ function setVideoOptions(options: {
         <img
           v-if="!isVideo"
           ref="mediaRef"
-          class="rounded"
+          class="rounded-4"
           :class="!isUploaded && 'opacity-40'"
           :src="node.attrs.src || fileContent"
           :alt="node.attrs.alt || ''"
@@ -292,7 +292,7 @@ function setVideoOptions(options: {
         <img
           v-else-if="isVideo && !isUploaded && videoPoster"
           ref="mediaRef"
-          class="rounded"
+          class="rounded-4"
           :src="videoPoster"
           :alt="node.attrs.alt || 'Video preview'"
           :width="node.attrs.width"
@@ -302,7 +302,7 @@ function setVideoOptions(options: {
         <video
           v-else-if="isVideo"
           ref="mediaRef"
-          class="rounded"
+          class="rounded-4"
           :class="!isUploaded && 'opacity-40'"
           :src="node.attrs.src || fileContent"
           :width="node.attrs.width"
@@ -370,7 +370,7 @@ function setVideoOptions(options: {
 
       <div
         v-else
-        class="flex flex-col items-center justify-center gap-3 border rounded text-ink-gray-6 text-sm px-4 py-5 max-w-full"
+        class="flex flex-col items-center justify-center gap-3 border rounded-4 text-ink-gray-6 text-sm px-4 py-5 max-w-full"
         :class="{ 'border-none': selected }"
         :style="{
           width: node.attrs.width ? `${node.attrs.width}px` : undefined,

--- a/src/molecules/editor/components/MediaToolbar.vue
+++ b/src/molecules/editor/components/MediaToolbar.vue
@@ -79,7 +79,7 @@ onUnmounted(() => {
 
 <template>
   <div
-    class="absolute top-2 right-2 z-20 max-w-[calc(100%-1rem)] flex-wrap justify-end items-center bg-black/65 px-1.5 py-1 gap-2 rounded"
+    class="absolute top-2 right-2 z-20 max-w-[calc(100%-1rem)] flex-wrap justify-end items-center bg-black/65 px-1.5 py-1 gap-2 rounded-4"
     :class="isVisible ? 'flex' : 'hidden'"
   >
     <!-- The caption toggle carries a visible word, not just an icon: it is the
@@ -145,13 +145,13 @@ onUnmounted(() => {
     <div
       v-if="showVideoOptions && isVideo"
       ref="videoOptionsRef"
-      class="absolute top-full right-0 z-50 mt-1 w-40 rounded bg-black/80 p-1 shadow-lg"
+      class="absolute top-full right-0 z-50 mt-1 w-40 rounded-4 bg-black/80 p-1 shadow-lg"
     >
       <button
         v-for="option in videoOptionKeys"
         :key="option"
         type="button"
-        class="flex w-full items-center justify-between rounded px-2 py-1 text-left text-xs text-white/80 hover:bg-white/10 hover:text-white"
+        class="flex w-full items-center justify-between rounded-4 px-2 py-1 text-left text-xs text-white/80 hover:bg-white/10 hover:text-white"
         :aria-pressed="Boolean(node.attrs[option])"
         @click.stop="toggleVideoOption(option)"
       >

--- a/src/molecules/editor/components/TableContextMenu.vue
+++ b/src/molecules/editor/components/TableContextMenu.vue
@@ -109,7 +109,7 @@ function onKeydown(event: KeyboardEvent) {
   <div
     ref="menu"
     role="menu"
-    class="min-w-[208px] rounded-lg border border-outline-gray-1 bg-surface-elevation-2 p-1 text-base shadow-xl outline-none"
+    class="min-w-[208px] rounded-6 border border-outline-gray-1 bg-surface-elevation-2 p-1 text-base shadow-xl outline-none"
     @keydown="onKeydown"
   >
     <template v-for="(item, index) in visible" :key="index">
@@ -123,7 +123,7 @@ function onKeydown(event: KeyboardEvent) {
         type="button"
         :role="item.isActive ? 'menuitemcheckbox' : 'menuitem'"
         :aria-checked="item.isActive ? isChecked(item) : undefined"
-        class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-ink-gray-8 hover:bg-surface-gray-3 focus-visible:bg-surface-gray-3 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        class="flex w-full items-center gap-2 rounded-4 px-2 py-1.5 text-left text-ink-gray-8 hover:bg-surface-gray-3 focus-visible:bg-surface-gray-3 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         :disabled="disabled(item)"
         @click="run(item, $event)"
       >

--- a/src/molecules/editor/components/UploadProgressIndicator.vue
+++ b/src/molecules/editor/components/UploadProgressIndicator.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{ (e: 'cancel'): void }>()
     aria-live="polite"
   >
     <div
-      class="pointer-events-auto flex items-center gap-2 rounded bg-black/65 px-1.5 py-1"
+      class="pointer-events-auto flex items-center gap-2 rounded-4 bg-black/65 px-1.5 py-1"
     >
       <span class="tabular-nums text-sm text-white">{{ percent }}%</span>
       <button

--- a/src/molecules/editor/components/VideoControls.vue
+++ b/src/molecules/editor/components/VideoControls.vue
@@ -136,7 +136,7 @@ function onTrackPointerUp() {
 <template>
   <div
     v-if="videoEl && !hidden"
-    class="absolute inset-x-2 bottom-2 flex items-center gap-2 rounded bg-black/65 px-2 py-1.5 transition-opacity"
+    class="absolute inset-x-2 bottom-2 flex items-center gap-2 rounded-4 bg-black/65 px-2 py-1.5 transition-opacity"
     :class="
       playing && !scrubbing
         ? 'opacity-0 group-hover:opacity-100 focus-within:opacity-100'

--- a/src/molecules/editor/components/font-color/ColorSwatchGrid.vue
+++ b/src/molecules/editor/components/font-color/ColorSwatchGrid.vue
@@ -10,7 +10,7 @@
         type="button"
         :aria-label="swatch.label"
         :aria-pressed="swatch.value === active"
-        class="flex h-6 w-6 items-center justify-center rounded-sm border text-base focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3"
+        class="flex h-6 w-6 items-center justify-center rounded-1 border text-base focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3"
         :class="[
           swatch.class,
           variant === 'highlight' ? 'text-ink-gray-9' : '',

--- a/src/molecules/editor/components/font-color/fontColorController.ts
+++ b/src/molecules/editor/components/font-color/fontColorController.ts
@@ -32,7 +32,7 @@ const FontColorPanel = defineComponent({
         EditorPopover,
         {
           dialogLabel: 'Text and background color',
-          contentClass: 'rounded-md p-2.5',
+          contentClass: 'rounded-5 p-2.5',
         },
         {
           default: () => [

--- a/src/molecules/editor/components/image-viewer/ImageViewerControlsBar.vue
+++ b/src/molecules/editor/components/image-viewer/ImageViewerControlsBar.vue
@@ -9,10 +9,10 @@
     @wheel.stop
   >
     <!-- Navigation controls -->
-    <div class="bg-black/65 rounded flex items-center">
+    <div class="bg-black/65 rounded-4 flex items-center">
       <Tooltip text="Previous image">
         <button
-          class="p-2 hover:bg-gray-900 rounded-l focus:outline-none"
+          class="p-2 hover:bg-gray-900 rounded-l-4 focus:outline-none"
           @click.stop="emit('previous')"
         >
           <span class="lucide-chevron-left size-4" />
@@ -25,7 +25,7 @@
 
       <Tooltip text="Next image">
         <button
-          class="p-2 hover:bg-gray-900 rounded-r focus:outline-none"
+          class="p-2 hover:bg-gray-900 rounded-r-4 focus:outline-none"
           @click.stop="emit('next')"
         >
           <span class="lucide-chevron-right size-4" />
@@ -34,10 +34,10 @@
     </div>
 
     <!-- Zoom controls -->
-    <div class="bg-black/65 rounded flex items-center">
+    <div class="bg-black/65 rounded-4 flex items-center">
       <Tooltip text="Zoom out">
         <button
-          class="p-2 hover:bg-gray-900 rounded-l focus:outline-none"
+          class="p-2 hover:bg-gray-900 rounded-l-4 focus:outline-none"
           @click.stop="emit('zoom-out')"
         >
           <span class="lucide-minus size-4" />
@@ -55,7 +55,7 @@
 
       <Tooltip text="Zoom in">
         <button
-          class="p-2 hover:bg-gray-900 rounded-r focus:outline-none"
+          class="p-2 hover:bg-gray-900 rounded-r-4 focus:outline-none"
           @click.stop="emit('zoom-in')"
         >
           <span class="lucide-plus size-4" />
@@ -64,10 +64,10 @@
     </div>
 
     <!-- Action controls -->
-    <div class="bg-black/65 rounded flex items-center">
+    <div class="bg-black/65 rounded-4 flex items-center">
       <Tooltip text="Download image">
         <button
-          class="p-2 hover:bg-gray-900 rounded-l focus:outline-none"
+          class="p-2 hover:bg-gray-900 rounded-l-4 focus:outline-none"
           @click.stop="emit('download')"
         >
           <span class="lucide-download size-4" />
@@ -76,7 +76,7 @@
 
       <Tooltip :text="isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'">
         <button
-          class="p-2 hover:bg-gray-900 rounded-r focus:outline-none hidden sm:block"
+          class="p-2 hover:bg-gray-900 rounded-r-4 focus:outline-none hidden sm:block"
           @click.stop="emit('toggle-fullscreen')"
         >
           <span v-if="!isFullscreen" class="lucide-maximize size-4" />
@@ -86,10 +86,10 @@
     </div>
 
     <!-- Close button -->
-    <div class="bg-black/65 rounded flex items-center">
+    <div class="bg-black/65 rounded-4 flex items-center">
       <Tooltip text="Close">
         <button
-          class="p-2 hover:bg-gray-900 rounded focus:outline-none"
+          class="p-2 hover:bg-gray-900 rounded-4 focus:outline-none"
           @click.stop="emit('close')"
         >
           <span class="lucide-x size-4" />

--- a/src/molecules/editor/components/table-color/tableCellColorController.ts
+++ b/src/molecules/editor/components/table-color/tableCellColorController.ts
@@ -29,7 +29,7 @@ const TableCellColorPanel = defineComponent({
     return () =>
       h(
         EditorPopover,
-        { dialogLabel: 'Cell color', contentClass: 'rounded-md p-2.5' },
+        { dialogLabel: 'Cell color', contentClass: 'rounded-5 p-2.5' },
         {
           default: () => [
             h('div', { 'data-slot': 'table-cell-color-panel' }, [

--- a/src/molecules/editor/components/table-size-picker/TableSizePicker.vue
+++ b/src/molecules/editor/components/table-size-picker/TableSizePicker.vue
@@ -52,7 +52,7 @@ function onKeydown(event: KeyboardEvent) {
 <template>
   <EditorPopover
     dialog-label="Insert table"
-    content-class="rounded-md p-2.5"
+    content-class="rounded-5 p-2.5"
     :autofocus="false"
   >
     <div data-slot="table-size-picker">
@@ -71,7 +71,7 @@ function onKeydown(event: KeyboardEvent) {
             :key="c"
             type="button"
             tabindex="-1"
-            class="size-4 rounded-sm border"
+            class="size-4 rounded-1 border"
             :class="
               r <= rows && c <= cols
                 ? 'border-outline-gray-3 bg-surface-gray-4'

--- a/src/molecules/editor/extensions/iframe/IframeNodeView.vue
+++ b/src/molecules/editor/extensions/iframe/IframeNodeView.vue
@@ -140,7 +140,7 @@ function commitCaption(event: Event): void {
   <NodeViewWrapper>
     <div
       ref="containerRef"
-      class="relative isolate my-6 block max-w-full overflow-hidden rounded not-prose focus:outline-none"
+      class="relative isolate my-6 block max-w-full overflow-hidden rounded-4 not-prose focus:outline-none"
       :class="[
         { 'ring-2 ring-outline-gray-3 ring-offset-2': selected },
         node.attrs.align === 'center' ? 'mx-auto' : '',
@@ -158,7 +158,7 @@ function commitCaption(event: Event): void {
         <iframe
           v-if="node.attrs.src"
           ref="iframeRef"
-          class="block h-auto max-w-full rounded border-0"
+          class="block h-auto max-w-full rounded-4 border-0"
           :class="{ 'pointer-events-none': overlayActive }"
           :src="node.attrs.src"
           :style="frameStyle"
@@ -200,7 +200,7 @@ function commitCaption(event: Event): void {
         <!-- Placeholder while no src is set -->
         <div
           v-if="!node.attrs.src"
-          class="flex h-[360px] w-[640px] items-center justify-center rounded bg-surface-gray-1"
+          class="flex h-[360px] w-[640px] items-center justify-center rounded-4 bg-surface-gray-1"
         >
           <div class="text-center text-ink-gray-5">
             <div class="mb-1 text-lg">🔗</div>

--- a/src/molecules/editor/extensions/image-group/ImageGroupGrid.vue
+++ b/src/molecules/editor/extensions/image-group/ImageGroupGrid.vue
@@ -12,7 +12,7 @@
       @drop="onDrop(idx)"
       @dragend="onDragEnd"
       @dragleave="onDragLeave(idx)"
-      class="group cursor-grab rounded transition-opacity active:cursor-grabbing"
+      class="group cursor-grab rounded-4 transition-opacity active:cursor-grabbing"
       :class="{
         'ring-2 ring-outline-gray-4 ring-offset-1 z-10': isDropTarget(idx),
         'opacity-50': draggedIndex === idx,
@@ -20,7 +20,7 @@
     >
       <div class="relative">
         <div
-          class="absolute left-1 top-1 z-10 rounded bg-white/80 p-1 text-ink-gray-6 opacity-100 shadow-sm sm:opacity-0 sm:group-hover:opacity-100"
+          class="absolute left-1 top-1 z-10 rounded-4 bg-white/80 p-1 text-ink-gray-6 opacity-100 shadow-sm sm:opacity-0 sm:group-hover:opacity-100"
           aria-hidden="true"
         >
           <span class="lucide-grip size-3" />

--- a/src/molecules/editor/extensions/image-group/ImageGroupGridCell.vue
+++ b/src/molecules/editor/extensions/image-group/ImageGroupGridCell.vue
@@ -1,11 +1,11 @@
 <template>
   <div
-    class="relative aspect-square w-full h-full overflow-hidden group rounded bg-surface-gray-1"
+    class="relative aspect-square w-full h-full overflow-hidden group rounded-4 bg-surface-gray-1"
   >
     <button
       v-if="item.status !== 'uploading'"
       type="button"
-      class="absolute top-1 right-1 z-10 rounded bg-black/65 p-1 transition-opacity opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100"
+      class="absolute top-1 right-1 z-10 rounded-4 bg-black/65 p-1 transition-opacity opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100"
       aria-label="Remove image"
       @click.stop="$emit('remove')"
     >
@@ -15,7 +15,7 @@
     <!-- Unsupported preview (HEIC/HEIF): filename placeholder -->
     <div
       v-if="!previewable"
-      class="flex flex-col items-center justify-center w-full h-full text-ink-gray-4 bg-surface-gray-1 rounded"
+      class="flex flex-col items-center justify-center w-full h-full text-ink-gray-4 bg-surface-gray-1 rounded-4"
     >
       <span
         class="text-p-xs text-ink-gray-4 w-full text-center px-2 mt-1"
@@ -40,7 +40,7 @@
          what they typed); hover-revealed "Add caption…" affordance when empty. -->
     <div
       v-if="previewable"
-      class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent rounded-b transition-opacity"
+      class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent rounded-b-4 transition-opacity"
       :class="
         editing || caption
           ? 'opacity-100'
@@ -66,7 +66,7 @@
           @blur="commit"
           @keydown.enter.prevent="commit"
           @keydown.escape="cancel"
-          class="w-full text-xs bg-white/90 text-gray-900 px-1 py-0.5 rounded-sm border-none outline-none"
+          class="w-full text-xs bg-white/90 text-gray-900 px-1 py-0.5 rounded-1 border-none outline-none"
           placeholder="Add caption..."
           maxlength="200"
           aria-label="Image caption"

--- a/src/molecules/editor/extensions/image-group/ImageGroupNodeView.vue
+++ b/src/molecules/editor/extensions/image-group/ImageGroupNodeView.vue
@@ -3,7 +3,7 @@
     <!-- Selectable like every other media node: click selects, controls live
          in the on-selection dark toolbar (same pattern as MediaToolbar). -->
     <div
-      class="group/gallery relative isolate w-full not-prose my-2 rounded"
+      class="group/gallery relative isolate w-full not-prose my-2 rounded-4"
       :class="{
         'ring-2 ring-outline-gray-3 ring-offset-2': selected && isEditable,
         'cursor-pointer': isEditable && !selected,
@@ -12,7 +12,7 @@
     >
       <div
         v-if="selected && isEditable"
-        class="absolute top-2 right-2 z-20 flex items-center gap-2 rounded bg-black/65 px-1.5 py-1"
+        class="absolute top-2 right-2 z-20 flex items-center gap-2 rounded-4 bg-black/65 px-1.5 py-1"
         @pointerdown.prevent.stop
       >
         <Tooltip text="Edit gallery" class="h-5">
@@ -46,12 +46,12 @@
         <div
           v-for="(img, idx) in images"
           :key="(img.attrs.uploadId ?? img.attrs.src) + '-' + idx"
-          class="relative aspect-square w-full h-full overflow-hidden rounded bg-surface-gray-1 group"
+          class="relative aspect-square w-full h-full overflow-hidden rounded-4 bg-surface-gray-1 group"
         >
           <button
             v-if="isEditable && selected"
             type="button"
-            class="absolute top-1 right-1 z-10 rounded bg-black/65 p-1 transition-opacity opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100"
+            class="absolute top-1 right-1 z-10 rounded-4 bg-black/65 p-1 transition-opacity opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100"
             aria-label="Remove image"
             @click.stop="removeImage(idx)"
           >
@@ -75,7 +75,7 @@
 
           <div
             v-if="img.attrs.alt"
-            class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent rounded-b opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
+            class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent rounded-b-4 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
           >
             <div class="p-2">
               <div class="text-white text-xs truncate" :title="img.attrs.alt">

--- a/src/molecules/editor/extensions/image-group/ImageGroupUploadDialog.vue
+++ b/src/molecules/editor/extensions/image-group/ImageGroupUploadDialog.vue
@@ -55,7 +55,7 @@
           class="flex flex-col items-center justify-center min-h-[200px]"
         >
           <div
-            class="w-full flex flex-1 flex-col items-center justify-center border border-outline-gray-2 rounded-lg bg-surface-gray-1 h-full cursor-pointer transition hover:border-outline-gray-3 hover:bg-surface-gray-2 text-center"
+            class="w-full flex flex-1 flex-col items-center justify-center border border-outline-gray-2 rounded-6 bg-surface-gray-1 h-full cursor-pointer transition hover:border-outline-gray-3 hover:bg-surface-gray-2 text-center"
             @click="triggerFileInput"
           >
             <div class="text-ink-gray-4 mb-2">
@@ -72,7 +72,7 @@
             Uploading {{ dialog.uploadedCount.value }} of
             {{ dialog.totalCount.value }}…
           </div>
-          <div class="w-full bg-surface-gray-2 rounded h-2 overflow-hidden">
+          <div class="w-full bg-surface-gray-2 rounded-4 h-2 overflow-hidden">
             <div
               class="bg-surface-gray-8 h-2 transition-all"
               :style="{ width: dialog.uploadProgress.value + '%' }"

--- a/src/molecules/editor/extensions/link/LinkEditorPopup.vue
+++ b/src/molecules/editor/extensions/link/LinkEditorPopup.vue
@@ -1,7 +1,7 @@
 <template>
   <EditorPopover
     dialog-label="Edit link"
-    content-class="flex min-w-60 max-w-80 items-center gap-1 rounded-md p-1"
+    content-class="flex min-w-60 max-w-80 items-center gap-1 rounded-5 p-1"
     :autofocus="false"
   >
     <template v-if="edit">

--- a/src/molecules/editor/extensions/suggestion/SuggestionList.vue
+++ b/src/molecules/editor/extensions/suggestion/SuggestionList.vue
@@ -7,7 +7,7 @@
       :trapped="false"
       :loop="false"
       :content-class="[
-        'relative max-h-[300px] min-w-40 overflow-y-auto rounded-lg p-1 text-base',
+        'relative max-h-[300px] min-w-40 overflow-y-auto rounded-6 p-1 text-base',
         containerClass,
       ]"
     >

--- a/src/molecules/editor/extensions/suggestion/SuggestionListItem.vue
+++ b/src/molecules/editor/extensions/suggestion/SuggestionListItem.vue
@@ -2,7 +2,7 @@
   <button
     type="button"
     :class="[
-      'flex w-full items-center whitespace-nowrap rounded px-2 py-1.5 text-sm text-ink-gray-9',
+      'flex w-full items-center whitespace-nowrap rounded-4 px-2 py-1.5 text-sm text-ink-gray-9',
       selected ? 'bg-surface-gray-2' : '',
       itemClass,
     ]"

--- a/src/molecules/editor/extensions/toc-node/TocNodeView.vue
+++ b/src/molecules/editor/extensions/toc-node/TocNodeView.vue
@@ -20,7 +20,7 @@
     <button
       v-if="isEditable"
       @click="removeNode"
-      class="absolute top-2 right-2 bg-black/65 hover:bg-black/80 text-ink-gray-4 hover:text-ink-base p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity"
+      class="absolute top-2 right-2 bg-black/65 hover:bg-black/80 text-ink-gray-4 hover:text-ink-base p-1 rounded-4 opacity-0 group-hover:opacity-100 transition-opacity"
       title="Remove table of contents"
     >
       <span class="lucide-x size-4" />

--- a/src/molecules/editor/stories/Comment.vue
+++ b/src/molecules/editor/stories/Comment.vue
@@ -52,7 +52,7 @@ function submit() {
       >
         <template #default="{ isEmpty }">
           <div
-            class="min-w-0 flex-1 rounded-lg border border-outline-gray-2 bg-surface-base focus-within:border-outline-gray-3"
+            class="min-w-0 flex-1 rounded-6 border border-outline-gray-2 bg-surface-base focus-within:border-outline-gray-3"
           >
             <EditorBubbleMenu :items="commentToolbar" />
             <EditorContent
@@ -92,7 +92,7 @@ function submit() {
       >
         FA
       </div>
-      <div class="min-w-0 flex-1 rounded-lg bg-surface-gray-1 px-3 py-2">
+      <div class="min-w-0 flex-1 rounded-6 bg-surface-gray-1 px-3 py-2">
         <div class="mb-0.5 text-sm-medium text-ink-gray-8">Faris Ansari</div>
         <Editor v-model="submitted" :extensions="extensions" :editable="false">
           <template #default>

--- a/src/molecules/editor/stories/Inline.vue
+++ b/src/molecules/editor/stories/Inline.vue
@@ -18,7 +18,7 @@ const title = ref('<p>Q3 launch plan</p>')
     <Editor v-model="title" :extensions="extensions" placeholder="Untitled">
       <EditorBubbleMenu :items="minimalToolbar" />
       <EditorContent
-        class="rounded-md border border-outline-gray-2 bg-surface-base px-3 py-2 text-3xl-semibold text-ink-gray-9 focus-within:border-outline-gray-3 focus-within:ring-2 focus-within:ring-outline-gray-2"
+        class="rounded-5 border border-outline-gray-2 bg-surface-base px-3 py-2 text-3xl-semibold text-ink-gray-9 focus-within:border-outline-gray-3 focus-within:ring-2 focus-within:ring-outline-gray-2"
       />
     </Editor>
     <p class="mt-2 text-sm text-ink-gray-5">

--- a/src/molecules/editor/stories/Primitives.vue
+++ b/src/molecules/editor/stories/Primitives.vue
@@ -53,7 +53,7 @@ const wordCount = computed(() => {
 
 <template>
   <div class="w-full max-w-2xl">
-    <div class="overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-base">
+    <div class="overflow-hidden rounded-6 border border-outline-gray-2 bg-surface-base">
       <EditorBubbleMenu :editor="editor" :items="toolbar" />
       <EditorFloatingMenu :editor="editor" :items="toolbar" />
       <div class="border-b border-outline-gray-1 px-2 py-1.5">

--- a/src/molecules/editor/stories/RichText.vue
+++ b/src/molecules/editor/stories/RichText.vue
@@ -114,7 +114,7 @@ const uploadFunction = async (file) => ({
         <!-- Inside <Editor>, the building blocks read the editor from
              context — no :editor prop needed. -->
         <div
-          class="overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-base"
+          class="overflow-hidden rounded-6 border border-outline-gray-2 bg-surface-base"
         >
           <EditorBubbleMenu :items="bubbleToolbar" />
           <EditorFloatingMenu :items="toolbar" />

--- a/src/molecules/list/ListHeaderCellSort.vue
+++ b/src/molecules/list/ListHeaderCellSort.vue
@@ -16,7 +16,7 @@
       <button
         ref="button"
         type="button"
-        class="group inline-flex h-7 min-w-0 items-center gap-1 rounded text-sm-medium text-ink-gray-5 transition-colors"
+        class="group inline-flex h-7 min-w-0 items-center gap-1 rounded-4 text-sm-medium text-ink-gray-5 transition-colors"
         @click="emit('click', $event)"
       >
         <!-- End-aligned: the glyph leads so the label stays flush with the

--- a/src/molecules/list/stories/Virtual.vue
+++ b/src/molecules/list/stories/Virtual.vue
@@ -11,7 +11,7 @@ const items = Array.from({ length: 1000 }, (_, i) => ({
 <template>
   <!-- The scroll container is app-owned: ListRows finds the nearest
        scrollable ancestor and windows against it. -->
-  <div class="h-72 w-full overflow-y-auto rounded border">
+  <div class="h-72 w-full overflow-y-auto rounded-4 border">
     <List :columns="['3rem', 'minmax(0,1fr)', '6rem']" :row-height="44" class="px-2">
       <ListRows :items="items" virtual v-slot="{ item }">
         <ListRow>

--- a/tailwind/plugin.js
+++ b/tailwind/plugin.js
@@ -192,11 +192,11 @@ let globalStyles = (theme) => ({
 
 let componentStyles = {
   '.form-input, .form-textarea, .form-select': {
-    '@apply h-7 rounded border border-[--surface-gray-2] bg-surface-gray-2 py-1.5 pl-2 pr-2 text-base text-ink-gray-8 placeholder-ink-gray-4 transition-colors hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:bg-surface-base focus:shadow-sm focus:ring-0':
+    '@apply h-7 rounded-4 border border-[--surface-gray-2] bg-surface-gray-2 py-1.5 pl-2 pr-2 text-base text-ink-gray-8 placeholder-ink-gray-4 transition-colors hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:bg-surface-base focus:shadow-sm focus:ring-0':
       {},
   },
   '.form-checkbox': {
-    '@apply rounded-md bg-surface-gray-2 text-ink-blue-5 focus:ring-0': {},
+    '@apply rounded-5 bg-surface-gray-2 text-ink-blue-5 focus:ring-0': {},
   },
   "[data-theme='dark'] [type='checkbox']:checked": {
     'background-image': `url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%230F0F0F' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e")`,

--- a/vitepress/components/Docs/CommandPalette.vue
+++ b/vitepress/components/Docs/CommandPalette.vue
@@ -135,7 +135,7 @@ const onFilterKeydown = (e: KeyboardEvent) => {
                 as="a"
                 :value="item.link"
                 :href="withBase(item.link)"
-                class="flex w-full min-w-0 items-center rounded px-2 py-2 text-base font-medium text-ink-gray-7 outline-none data-[highlighted]:bg-surface-gray-3"
+                class="flex w-full min-w-0 items-center rounded-4 px-2 py-2 text-base font-medium text-ink-gray-7 outline-none data-[highlighted]:bg-surface-gray-3"
                 @click="onItemClick($event, item)"
               >
                 <span class="overflow-hidden text-ellipsis whitespace-nowrap">
@@ -161,12 +161,12 @@ const onFilterKeydown = (e: KeyboardEvent) => {
           <div class="flex items-center gap-4">
             <div class="flex items-center gap-1">
               <kbd
-                class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-sm bg-surface-gray-2 p-0.5 font-[inherit] text-[11px] font-medium leading-normal tracking-[0.02em] text-ink-gray-5"
+                class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-1 bg-surface-gray-2 p-0.5 font-[inherit] text-[11px] font-medium leading-normal tracking-[0.02em] text-ink-gray-5"
               >
                 <span class="lucide-arrow-down size-4" />
               </kbd>
               <kbd
-                class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-sm bg-surface-gray-2 p-0.5 font-[inherit] text-[11px] font-medium leading-normal tracking-[0.02em] text-ink-gray-5"
+                class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-1 bg-surface-gray-2 p-0.5 font-[inherit] text-[11px] font-medium leading-normal tracking-[0.02em] text-ink-gray-5"
               >
                 <span class="lucide-arrow-up size-4" />
               </kbd>
@@ -174,7 +174,7 @@ const onFilterKeydown = (e: KeyboardEvent) => {
             </div>
             <div class="flex items-center gap-1">
               <kbd
-                class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-sm bg-surface-gray-2 p-0.5 font-[inherit] text-[11px] font-medium leading-normal tracking-[0.02em] text-ink-gray-5"
+                class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-1 bg-surface-gray-2 p-0.5 font-[inherit] text-[11px] font-medium leading-normal tracking-[0.02em] text-ink-gray-5"
               >
                 <span class="lucide-corner-down-left size-4" />
               </kbd>
@@ -182,7 +182,7 @@ const onFilterKeydown = (e: KeyboardEvent) => {
             </div>
             <div class="flex items-center gap-1">
               <kbd
-                class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-sm bg-surface-gray-2 p-0.5 font-[inherit] text-[11px] font-medium leading-normal tracking-[0.02em] text-ink-gray-5"
+                class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-1 bg-surface-gray-2 p-0.5 font-[inherit] text-[11px] font-medium leading-normal tracking-[0.02em] text-ink-gray-5"
               >
                 <span class="lucide-command w-3 h-3" />
                 <span class="lucide-corner-down-left size-4" />
@@ -191,7 +191,7 @@ const onFilterKeydown = (e: KeyboardEvent) => {
             </div>
             <div class="flex items-center gap-1">
               <kbd
-                class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-sm bg-surface-gray-2 p-0.5 px-1 font-[inherit] font-medium leading-normal tracking-[0.02em] text-sm text-ink-gray-5"
+                class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-1 bg-surface-gray-2 p-0.5 px-1 font-[inherit] font-medium leading-normal tracking-[0.02em] text-sm text-ink-gray-5"
               >
                 esc
               </kbd>
@@ -200,7 +200,7 @@ const onFilterKeydown = (e: KeyboardEvent) => {
           </div>
           <div class="flex items-center gap-1">
             <kbd
-              class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-sm bg-surface-gray-2 p-0.5 font-[inherit] text-[11px] font-medium leading-normal tracking-[0.02em] text-ink-gray-5"
+              class="inline-flex items-center gap-0.5 whitespace-nowrap rounded-1 bg-surface-gray-2 p-0.5 font-[inherit] text-[11px] font-medium leading-normal tracking-[0.02em] text-ink-gray-5"
             >
               <span class="lucide-command w-3 h-3" />
               <span class="text-sm">K</span>

--- a/vitepress/components/Docs/Demo.vue
+++ b/vitepress/components/Docs/Demo.vue
@@ -21,7 +21,7 @@ const isEditorDemo = computed(() => props.name?.startsWith('Editor'))
 <template>
   <div>
     <div
-      class="rounded-xl overflow-hidden border border-outline-gray-1 divide-y divide-outline-gray-1"
+      class="rounded-7 overflow-hidden border border-outline-gray-1 divide-y divide-outline-gray-1"
     >
       <div
         :class="[

--- a/vitepress/components/Docs/MobileNavSheet.vue
+++ b/vitepress/components/Docs/MobileNavSheet.vue
@@ -91,7 +91,7 @@ onUnmounted(() => {
   >
     <div
       v-if="state.mobsidebar"
-      class="lg:hidden fixed inset-x-0 bottom-0 z-50 h-[80dvh] bg-surface-base rounded-t-2xl shadow-2xl flex flex-col"
+      class="lg:hidden fixed inset-x-0 bottom-0 z-50 h-[80dvh] bg-surface-base rounded-t-8 shadow-2xl flex flex-col"
       role="dialog"
       aria-modal="true"
       aria-label="Navigation"
@@ -131,7 +131,7 @@ onUnmounted(() => {
               v-for="item in section.items"
               :key="item.text"
               :href="withBase(item.link)"
-              class="pl-2 flex h-11 items-center rounded-md text-md transition-colors"
+              class="pl-2 flex h-11 items-center rounded-5 text-md transition-colors"
               :class="
                 isActive(item.link)
                   ? 'bg-surface-gray-2 text-ink-gray-8'

--- a/vitepress/components/Docs/PlaygroundFrame.vue
+++ b/vitepress/components/Docs/PlaygroundFrame.vue
@@ -104,7 +104,7 @@ function onCopy() {
 <template>
   <div class="not-prose">
     <div
-      class="overflow-hidden rounded-xl border border-outline-gray-1 divide-y divide-outline-gray-1"
+      class="overflow-hidden rounded-7 border border-outline-gray-1 divide-y divide-outline-gray-1"
     >
       <div
         class="flex items-center justify-center bg-surface-base p-8 dot-grid"

--- a/vitepress/components/Docs/PrevNextBtns.vue
+++ b/vitepress/components/Docs/PrevNextBtns.vue
@@ -35,7 +35,7 @@ const nextLink = computed(() => {
 
 const subtleMdLink =
   'inline-flex items-center gap-2 ' +
-  'h-8 px-2.5 rounded ' +
+  'h-8 px-2.5 rounded-4 ' +
   'text-base font-medium ' +
   'text-ink-gray-8 bg-surface-gray-2 ' +
   'hover:bg-surface-gray-3 active:bg-surface-gray-4 ' +

--- a/vitepress/components/Docs/PropsTable.vue
+++ b/vitepress/components/Docs/PropsTable.vue
@@ -43,7 +43,7 @@ const typeDefinition = computed(() => {
   <div class="not-prose mt-2">
     <details class="group">
       <summary
-        class="flex rounded cursor-pointer list-none items-center gap-2 py-2 text-sm font-medium text-ink-gray-6 transition-colors hover:text-ink-gray-9"
+        class="flex rounded-4 cursor-pointer list-none items-center gap-2 py-2 text-sm font-medium text-ink-gray-6 transition-colors hover:text-ink-gray-9"
       >
         <LucideChevronRight
           class="size-4 shrink-0 transition-transform group-open:rotate-90"
@@ -51,7 +51,7 @@ const typeDefinition = computed(() => {
         Show types
       </summary>
 
-      <div class="mt-1 overflow-hidden rounded-xl border bg-surface-gray-1">
+      <div class="mt-1 overflow-hidden rounded-7 border bg-surface-gray-1">
         <slot v-if="hasCustomCodeSlot" name="code" />
         <pre
           v-else

--- a/vitepress/components/Docs/Search.vue
+++ b/vitepress/components/Docs/Search.vue
@@ -24,7 +24,7 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown))
   <button
     v-bind="$attrs"
     aria-label="Open search"
-    class="relative h-8 items-center rounded border border-[--surface-gray-2] bg-surface-gray-2 ps-9 pe-9 text-base text-ink-gray-4 transition-colors hover:border-outline-elevation-2 hover:bg-surface-gray-3"
+    class="relative h-8 items-center rounded-4 border border-[--surface-gray-2] bg-surface-gray-2 ps-9 pe-9 text-base text-ink-gray-4 transition-colors hover:border-outline-elevation-2 hover:bg-surface-gray-3"
     @click="state.searchDialog = true"
   >
     <span

--- a/vitepress/components/Docs/Sidebar.vue
+++ b/vitepress/components/Docs/Sidebar.vue
@@ -44,7 +44,7 @@ const isActive = (link: string) =>
                 v-for="item in section.items"
                 :key="item.text"
                 :href="withBase(item.link)"
-                class="pl-2 flex h-7 items-center rounded text-sm transition-colors"
+                class="pl-2 flex h-7 items-center rounded-4 text-sm transition-colors"
                 :class="
                   isActive(item.link)
                     ? 'bg-surface-gray-2 text-ink-gray-8'

--- a/vitepress/css/style.css
+++ b/vitepress/css/style.css
@@ -71,7 +71,7 @@ code {
 }
 
 .shiki {
-  @apply max-h-[500px] w-full overflow-auto leading-relaxed rounded;
+  @apply max-h-[500px] w-full overflow-auto leading-relaxed rounded-4;
   @apply !p-3 !py-3 sm:!p-5 sm:!py-4 !bg-surface-gray-1 dark:!bg-transparent dark:border;
 
   font-family: monospace;
@@ -164,7 +164,7 @@ code {
 /* doc typography */
 .docs {
   code:not(pre code) {
-    @apply text-sm rounded-sm bg-surface-gray-3 dark:bg-surface-gray-2 p-0.5 px-1;
+    @apply text-sm rounded-1 bg-surface-gray-3 dark:bg-surface-gray-2 p-0.5 px-1;
   }
 }
 


### PR DESCRIPTION
Mechanical vocabulary sweep per ADR-0006. Pixel values are identical — no visual change. Unblocks the alias removal in #998.

Refs #997

## Mapping

| Old alias | New token | px | Replaced |
|---|---|---|---|
| `rounded` | `rounded-4` | 8 | 240 (incl. 25 directional: `-t/-r/-b/-l`) |
| `rounded-sm` | `rounded-1` | 4 | 51 (incl. 2 `rounded-tl-sm`) |
| `rounded-md` | `rounded-5` | 10 | 45 (incl. 1 `rounded-r-md`) |
| `rounded-lg` | `rounded-6` | 12 | 58 (incl. 2 `rounded-t-lg`) |
| `rounded-xl` | `rounded-7` | 16 | 11 |
| `rounded-2xl` | `rounded-8` | 20 | 4 (incl. 1 `rounded-t-2xl`) |

Total: 409 replacements across 189 files (`src/`, `docs/`, `icons/`, `experimental/`, `vitepress/`, `spec/`, `skills/`, `tailwind/plugin.js` componentStyles, `App.vue`).

## Deliberate keeps

- `rounded-none` and `rounded-full` — retained per ADR-0006.
- `tailwind/generated/radius.json` alias definitions — #998 removes them.
- `spec/adr/0006-numbered-radius-tokens.md` and the deprecation table in `spec/foundations.md` — they document the aliases.
- `docs/content/docs/migration.md` and `v1-release/changelog.md` — historical migration docs.
- One historical quote in `spec/popover.md` ("legacy `rounded-lg border ...` shell").
- Prose uses of the word "rounded" ("rounded corners", "rounded hover surface") in comments and specs.
- `src/components/ListFilter/` — #999 deletes the directory.

## Tests

- vitest: 54 files, 470 tests passed.
- Cypress component suite: full component suite green — 68 specs, 860 tests passed (one earlier run had 5 flaky failures while a type-check ran concurrently; clean on rerun).
- `yarn type-check`: same pre-existing errors as main (vitepress/ and VNodeChild typing); no new errors.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1013/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 64.23% (±0.00% vs `main`)
<!-- coverage-report:end -->



