### PR TITLE
refactor(tokens)!: remove deprecated radius aliases and text-*-black

### DIFF
--- a/docs/components/foundations/TypographyPage.vue
+++ b/docs/components/foundations/TypographyPage.vue
@@ -9,7 +9,7 @@ type SizeMeta = {
   fontWeight?: string
 }
 type SizeEntry = [string, SizeMeta]
-type Weight = 'regular' | 'medium' | 'semibold' | 'bold' | 'black'
+type Weight = 'regular' | 'medium' | 'semibold' | 'bold'
 type TrackGroup = 'text' | 'paragraph'
 
 // Group sizes for the page. Order matters: it drives display order.
@@ -35,7 +35,6 @@ const weightButtons = [
   { label: 'Medium (500)', value: 'medium' },
   { label: 'Semibold (600)', value: 'semibold' },
   { label: 'Bold (700)', value: 'bold' },
-  { label: 'Black (800)', value: 'black' },
 ]
 
 const fontWeight = computed(
@@ -44,8 +43,8 @@ const fontWeight = computed(
 
 // Resolve the real token class for the current weight, so the sample carries
 // the exact `text-<size>-<weight>` utility (inspectable, not inline styles).
-// A few weight pairings aren't exported (e.g. base+black), so fall back to the
-// bare regular token, which is the only style that ships for them.
+// If a (size, weight) pairing is ever missing from the export, fall back to
+// the bare regular token, which is the only style that ships for it.
 function tokenClass(prefix: string, group: TrackGroup, size: string): string {
   if (weight.value === 'regular') return `${prefix}${size}`
   const byWeight = (

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -1318,6 +1318,13 @@ plain English, so the codemod only rewrites it inside quoted strings and
 `@apply` rules. A class list inside a multi-line template literal can be
 missed — grep for bare `rounded` after running it.
 
+The alias CSS variables go away with the aliases. Hand-written CSS that
+reads `var(--radius-sm)` / `var(--radius-md)` / `var(--radius-lg)` /
+`var(--radius-xl)` / `var(--radius-2xl)` resolves to nothing — the same
+silent break. The codemod only rewrites `rounded-*` classes, so grep for
+`--radius-(sm|md|lg|xl|2xl)` and switch to the numbered variables
+(`var(--radius-5)` for the old `--radius-md`, same map as above).
+
 ### `text-*-black` styles removed
 
 The `text-<size>-black` / `text-p-<size>-black` style classes are removed —

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -1249,15 +1249,22 @@ npx --package frappe-ui@beta tokens-v2 .
 ```
 
 The codemod renames espresso color tokens like `bg-surface-white` to
-`bg-surface-base` and merges static text size + weight class pairs, for example
-`text-base font-medium` to `text-base-medium`. Run it once per codebase; the
-token migration is not idempotent because some v2 names overlap with v0 names.
+`bg-surface-base`, merges static text size + weight class pairs (for example
+`text-base font-medium` to `text-base-medium`), and renames the removed
+radius aliases (`rounded-md` → `rounded-5`, see below). Run it once per
+codebase; the token migration is not idempotent because some v2 names overlap
+with v0 names. The radius renames are idempotent and also run on
+already-migrated codebases.
 
 After upgrading to `frappe-ui@1.0.0-beta.11`, run the codemod again. Apps that
 already ran it will only get the typography correction (`text-lg` → `text-md`,
-`text-xl` → `text-lg`, ...). Apps that still have pre-v2 color tokens can pass
-`--force`, but review the output carefully because color tokens may
-double-shift.
+`text-xl` → `text-lg`, ...) and the radius renames. Apps that still have
+pre-v2 color tokens can pass `--force`, but review the output carefully
+because color tokens may double-shift.
+
+Already ran the typography correction too? Pass `--radius-only`. It performs
+only the radius renames (safe to repeat) and reports removed tokens — it
+never touches color or text-size names, so nothing can double-shift.
 
 ### Unused tokens and utilities removed
 
@@ -1280,6 +1287,47 @@ If your build used any of these, replace them with the nearest step on the
 regular scale — e.g. `text-16xl` → `text-12xl`, `shadow-status` →
 `shadow-sm`, `surface-alert-button-error` → `surface-red-2` (or whichever
 `variant`+`theme` pairing the design calls for).
+
+### Radius aliases removed
+
+The named radius aliases are removed in `1.0.0`. Numbered tokens are the only
+radius vocabulary now ([ADR-0006](https://github.com/frappe/frappe-ui/blob/main/spec/adr/0006-numbered-radius-tokens.md)).
+`rounded-none` and `rounded-full` are kept.
+
+This is a **silent** break. The preset replaces Tailwind's `borderRadius`
+scale, so an unmigrated `rounded-md` emits no CSS at all — no build error, no
+type error, just square corners. Run the codemod, then grep for leftover
+aliases.
+
+| Before | After | px |
+|---|---|---|
+| `rounded` | `rounded-4` | 8 |
+| `rounded-sm` | `rounded-1` | 4 |
+| `rounded-md` | `rounded-5` | 10 |
+| `rounded-lg` | `rounded-6` | 12 |
+| `rounded-xl` | `rounded-7` | 16 |
+| `rounded-2xl` | `rounded-8` | 20 |
+
+The same map applies to directional and corner forms (`rounded-t-lg` →
+`rounded-t-6`, `rounded-tl-sm` → `rounded-tl-1`) and to variant prefixes
+(`hover:rounded-2xl` → `hover:rounded-8`). Pixel values are identical — the
+migration changes vocabulary, not rendering.
+
+The codemod handles all of these. One caveat: the bare word `rounded` is
+plain English, so the codemod only rewrites it inside quoted strings and
+`@apply` rules. A class list inside a multi-line template literal can be
+missed — grep for bare `rounded` after running it.
+
+### `text-*-black` styles removed
+
+The `text-<size>-black` / `text-p-<size>-black` style classes are removed —
+zero usage anywhere, and the Figma weights behind them were corrupt export
+data. This is also a **silent** break: the class stops emitting CSS.
+
+The codemod no longer merges `font-extrabold` (or `font-black`) onto a
+`text-*-black` class. It flags the pair under "needs manual attention"
+instead. If you need weight 800, keep `font-extrabold`; there is no
+letter-spacing-corrected style class for it.
 
 ## Editor
 

--- a/spec/adr/0006-numbered-radius-tokens.md
+++ b/spec/adr/0006-numbered-radius-tokens.md
@@ -1,6 +1,6 @@
 # Numbered radius tokens are canonical
 
-**Status**: accepted
+**Status**: accepted (amended — see [Amendment](#amendment-2026-08-09-aliases-removed-in-100))
 
 ## Context
 
@@ -36,6 +36,16 @@ The canonical mapping:
 | `rounded-full` | 9999 | — (kept; semantically meaningful, not part of the scale) |
 
 `rounded-none` and `rounded-full` are retained — they're semantic, not size-named, and have no numbered ambiguity.
+
+## Amendment (2026-08-09): aliases removed in 1.0.0
+
+The "next breaking release" arrived: `1.0.0` removes the deprecated aliases (#998, decided in #993; ADR-0008 forbids shipping deprecated members at the tag). This supersedes the "remain as deprecated migration aliases" language above:
+
+- `tailwind/generated/radius.json` now ships only the numbered scale plus `none` and `full`. The alias keys (`sm`, `DEFAULT`, `md`, `lg`, `xl`, `2xl`) are gone; an unmigrated alias emits no CSS (silent break — the preset replaces Tailwind's `borderRadius` scale). The alias `--radius-sm/md/lg/xl/2xl` CSS variables go with them.
+- The codemod exists now: `tailwind/migrate-tokens-v2.js` (`tokens-v2`) performs the renames from the table above, directional and variant-prefixed forms included, and has a `--radius-only` mode for already-migrated codebases.
+- The internal migration is complete (#997 swept `src/`, docs, and stories).
+
+`rounded-none` and `rounded-full` remain kept, as decided above. See the [migration guide](../../docs/content/docs/migration.md) for the consumer-facing before/after.
 
 ## Rationale
 

--- a/spec/foundations.md
+++ b/spec/foundations.md
@@ -26,7 +26,7 @@ Anything in this repo that diverges from Figma is either (a) drift to be fixed, 
 | Typography model | Atomic size/weight/line-height tokens from Figma export, plus named-style utilities for composite styles |
 | Named typography utilities | `text-{size}-medium` for sizes whose medium-variant tracking is confirmed in Figma. See [ADR-0007](./adr/0007-typography-style-utilities.md) |
 | Focus indicator | `focus-visible:ring-2` + themed `ring-<color>`. No offset, no blur. See [ADR-0005](./adr/0005-focus-ring-2px.md) |
-| Radius scale | Numbered tokens `rounded-0`…`rounded-9` are canonical. Named aliases (`rounded`, `rounded-md`, …) are deprecated. See [ADR-0006](./adr/0006-numbered-radius-tokens.md) |
+| Radius scale | Numbered tokens `rounded-0`…`rounded-9` are canonical. Named aliases (`rounded`, `rounded-md`, …) are removed. See [ADR-0006](./adr/0006-numbered-radius-tokens.md) |
 | Color themes | Figma defines `default` (gray) and `red`. `blue` and `green` are code-only extensions (see below) |
 | Component size scale | Figma defines `sm` / `md` / `lg`. `xs`, `xl`, and `2xl` are code-only extensions |
 
@@ -109,11 +109,11 @@ Generated from Figma `radius.*` tokens into [`tailwind/generated/radius.json`](.
 | `rounded-none` | 0 | — (semantic alias for `rounded-0`) |
 | `rounded-full` | 9999 | — (semantic, not on the scale) |
 
-### Deprecated — flagged for migration
+### Removed aliases
 
-These aliases remain in `tailwind/generated/radius.json` so consumer apps keep working, but they are **not** to be used in new code. Migrate existing usages in `src/` to the numbered equivalent:
+The named size aliases were removed in `1.0.0` (#998, per ADR-0006/ADR-0008). They emit no CSS anymore — a leftover alias is a silent no-op:
 
-| Deprecated alias | Migrate to | px |
+| Removed alias | Replacement | px |
 |---|---|---|
 | `rounded` / `rounded-DEFAULT` | `rounded-4` | 8 |
 | `rounded-sm` | `rounded-1` | 4 |
@@ -122,9 +122,9 @@ These aliases remain in `tailwind/generated/radius.json` so consumer apps keep w
 | `rounded-xl` | `rounded-7` | 16 |
 | `rounded-2xl` | `rounded-8` | 20 |
 
-Migration is purely vocabulary — pixel values are identical. The aliases will be removed in the next breaking release.
+Replacement is purely vocabulary — pixel values are identical. The `tokens-v2` codemod ([`tailwind/migrate-tokens-v2.js`](../tailwind/migrate-tokens-v2.js)) performs these renames, directional forms included.
 
-To find usages: `grep -rE "rounded(-md|-lg|-xl|-2xl|-sm|-DEFAULT)?\\b" src/`. A bare `rounded` (not `rounded-N`) is the most common occurrence.
+To find leftovers: `grep -rE "rounded(-md|-lg|-xl|-2xl|-sm|-DEFAULT)?\\b" src/`. A bare `rounded` (not `rounded-N`) is the most common occurrence.
 
 ## Themes & colors
 

--- a/spec/foundations.md
+++ b/spec/foundations.md
@@ -124,7 +124,7 @@ The named size aliases were removed in `1.0.0` (#998, per ADR-0006/ADR-0008). Th
 
 Replacement is purely vocabulary — pixel values are identical. The `tokens-v2` codemod ([`tailwind/migrate-tokens-v2.js`](../tailwind/migrate-tokens-v2.js)) performs these renames, directional forms included.
 
-To find leftovers: `grep -rE "rounded(-md|-lg|-xl|-2xl|-sm|-DEFAULT)?\\b" src/`. A bare `rounded` (not `rounded-N`) is the most common occurrence.
+To find leftovers: `grep -rPn 'rounded(-(sm|md|lg|xl|2xl|DEFAULT))?(?![-\w])' src/`. The lookahead keeps migrated tokens (`rounded-4`) out of the results; a bare `rounded` (not `rounded-N`) is the most common leftover.
 
 ## Themes & colors
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,7 @@ import typography from './tailwind/generated/typography.json'
 // switcher, so the JIT scanner never sees the literal names. Build the exact
 // set the plugin emits (WEIGHT_VARIANTS, only pairings present in the tracking
 // export) and safelist it. Mirrors buildTextStyleUtilities() in plugin.js.
-const WEIGHT_VARIANTS = ['medium', 'semibold', 'bold', 'black']
+const WEIGHT_VARIANTS = ['medium', 'semibold', 'bold']
 const typeSafelist = []
 for (const [group, prefix] of [
   ['text', 'text-'],

--- a/tailwind/figma-tokens-to-theme.js
+++ b/tailwind/figma-tokens-to-theme.js
@@ -42,15 +42,12 @@ const ALPHA_FAMILIES = ['gray-alpha']
 const SEMANTIC_CATEGORIES = ['surface', 'surface-alpha', 'ink', 'outline', 'outline-alpha']
 
 // Named aliases layered on top of Figma's numeric radius keys.
-// Each name is matched by px value, so the alias stays correct if Figma shifts.
+// Matched by px value, so the alias stays correct if Figma shifts.
+// Only `none` survives — the deprecated size aliases (`sm`, `DEFAULT`, `md`,
+// `lg`, `xl`, `2xl`) were removed in 1.0.0 per ADR-0006 (#998). Migrate old
+// code with tailwind/migrate-tokens-v2.js.
 const RADIUS_NAME_BY_PX = {
   '0px': 'none',
-  '4px': 'sm',
-  '8px': 'DEFAULT',
-  '10px': 'md',
-  '12px': 'lg',
-  '16px': 'xl',
-  '20px': '2xl',
 }
 // Preserved from current plugin.js — Figma doesn't model `full`.
 const RADIUS_EXTRA = { full: '9999px' }

--- a/tailwind/generated/radius.json
+++ b/tailwind/generated/radius.json
@@ -10,11 +10,5 @@
   "8": "20px",
   "9": "999px",
   "full": "9999px",
-  "none": "0px",
-  "sm": "4px",
-  "DEFAULT": "8px",
-  "md": "10px",
-  "lg": "12px",
-  "xl": "16px",
-  "2xl": "20px"
+  "none": "0px"
 }

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -239,6 +239,12 @@ const BARE_ROUNDED_REGEX = /(?<![a-zA-Z0-9])rounded(?![a-zA-Z0-9-])/g
 // an `@apply` rule. Prose in markdown and comments has neither. Known gap: a
 // class list inside a multi-line template literal has no quote on its own
 // line and is skipped — grep for bare `rounded` after running the codemod.
+
+// An apostrophe inside a word (`row's`, `it's`) is not a string delimiter —
+// without this, `// the row's corners are rounded when it's hovered` would
+// count as "inside quotes" and get rewritten.
+const stripContractions = (s) => s.replace(/(?<=\w)'(?=\w)/g, '')
+
 function isClassContext(content, offset) {
   const lineStart = content.lastIndexOf('\n', offset - 1) + 1
   const lineEndIdx = content.indexOf('\n', offset)
@@ -247,8 +253,10 @@ function isClassContext(content, offset) {
   const after = content.slice(offset, lineEnd)
   if (/@apply[^;]*$/.test(before)) return true
   for (const quote of ['"', "'", '`']) {
-    const opensBefore = (before.split(quote).length - 1) % 2 === 1
-    if (opensBefore && after.includes(quote)) return true
+    const b = quote === "'" ? stripContractions(before) : before
+    const a = quote === "'" ? stripContractions(after) : after
+    const opensBefore = (b.split(quote).length - 1) % 2 === 1
+    if (opensBefore && a.includes(quote)) return true
   }
   return false
 }

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -29,13 +29,31 @@
  * audit (#940) — no utility ships for them anymore. A class that would have
  * shifted onto one of them is left untouched and reported under "needs
  * manual attention" instead of being rewritten to a dead class.
+ *
+ * Radius aliases (`rounded`, `rounded-sm/md/lg/xl/2xl`, and their directional
+ * forms) were removed in 1.0.0 per ADR-0006. The codemod renames them to the
+ * numbered tokens (`rounded-4`, `rounded-1/5/6/7/8`). These renames are
+ * idempotent and run in every mode. `rounded-none` and `rounded-full` are
+ * kept tokens and stay untouched. The bare word `rounded` is also plain
+ * English, so it is only rewritten in class-like contexts (inside a quoted
+ * string or an `@apply` rule) — prose and comments keep their words.
+ *
+ * A codebase that already ran BOTH the color migration and the typography
+ * correction must not run either again (both shift names). Pass
+ * --radius-only there: it runs only the (idempotent) radius renames and the
+ * removed-token report.
+ *
+ * The `text-<size>-black` style classes were removed in 1.0.0 (#998, zero
+ * usage; the Figma weights behind them were corrupt export data). Existing
+ * `text-*-black` usage is flagged, never renamed, and a `font-extrabold` /
+ * `font-black` next to a text size is flagged instead of merged.
  */
 
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
-const USAGE = 'Usage: tokens-v2 [--dry-run] [--force] <dir-or-file...>'
+const USAGE = 'Usage: tokens-v2 [--dry-run] [--force] [--radius-only] <dir-or-file...>'
 
 // ---------- MAPPING ----------
 
@@ -165,7 +183,9 @@ const MIGRATED_TEXT_SIZE_SHIFT = MIGRATED_TEXT_SIZE_SHIFT_ALL.filter(
 )
 
 // Each size surfaces as a bare size utility, a paragraph variant, and weighted
-// component classes. All forms shift together.
+// component classes. All forms shift together. `-black` is absent on purpose:
+// the black style classes were removed in #998, so a `text-*-black` is never
+// renamed — it's flagged (see BLACK_STYLE_TOKENS below).
 const textSizeRenames = (shift) => Object.fromEntries(
   shift.flatMap(([from, to]) => [
     [`text-${from}`, `text-${to}`],
@@ -176,13 +196,62 @@ const textSizeRenames = (shift) => Object.fromEntries(
     [`text-p-${from}-semibold`, `text-p-${to}-semibold`],
     [`text-${from}-bold`, `text-${to}-bold`],
     [`text-p-${from}-bold`, `text-p-${to}-bold`],
-    [`text-${from}-black`, `text-${to}-black`],
-    [`text-p-${from}-black`, `text-p-${to}-black`],
   ]),
 )
 
 const UNMIGRATED_TEXT_SIZE_RENAMES = textSizeRenames(UNMIGRATED_TEXT_SIZE_SHIFT)
 const MIGRATED_TEXT_SIZE_RENAMES = textSizeRenames(MIGRATED_TEXT_SIZE_SHIFT)
+
+// ---------- RADIUS RENAMES ----------
+
+// ADR-0006 / #998: the named radius aliases are removed in 1.0.0 in favor of
+// the numbered scale. The map is deterministic (bare `rounded` = 8px =
+// `rounded-4`; sm→1, md→5, lg→6, xl→7, 2xl→8). `rounded-none` and
+// `rounded-full` are kept tokens, never touched. Unlike the color renames,
+// these are idempotent (no numbered token appears on the left), so they run in
+// every mode.
+const RADIUS_STEP_BY_ALIAS = { sm: '1', md: '5', lg: '6', xl: '7', '2xl': '8' }
+const RADIUS_BARE_STEP = '4'
+// Every side prefix Tailwind derives from the borderRadius scale, including
+// the 3.3+ logical sides. Numbered directional utilities (`rounded-t-6`,
+// `rounded-ss-1`, …) exist for all of them.
+const RADIUS_SIDES = ['t', 'r', 'b', 'l', 'tl', 'tr', 'br', 'bl', 's', 'e', 'ss', 'se', 'es', 'ee']
+
+export const RADIUS_RENAMES = {}
+for (const side of RADIUS_SIDES.map((s) => `-${s}`)) {
+  // Bare directional alias: `rounded-t` = `rounded-t-4`. (The side-less bare
+  // `rounded` is also plain English — see BARE_ROUNDED_REGEX below.)
+  RADIUS_RENAMES[`rounded${side}`] = `rounded${side}-${RADIUS_BARE_STEP}`
+}
+for (const side of ['', ...RADIUS_SIDES.map((s) => `-${s}`)]) {
+  for (const [alias, step] of Object.entries(RADIUS_STEP_BY_ALIAS)) {
+    RADIUS_RENAMES[`rounded${side}-${alias}`] = `rounded${side}-${step}`
+  }
+}
+
+// The bare `rounded` utility is an ordinary English word ("values are rounded
+// to px"), so a global text rename would corrupt prose and comments. It is
+// rewritten only in class-like contexts — see isClassContext().
+const BARE_ROUNDED_REGEX = /(?<![a-zA-Z0-9])rounded(?![a-zA-Z0-9-])/g
+
+// A bare `rounded` at `offset` counts as a class when its line puts it inside
+// a quoted string (class attributes, JS class lists, template literals) or in
+// an `@apply` rule. Prose in markdown and comments has neither. Known gap: a
+// class list inside a multi-line template literal has no quote on its own
+// line and is skipped — grep for bare `rounded` after running the codemod.
+function isClassContext(content, offset) {
+  const lineStart = content.lastIndexOf('\n', offset - 1) + 1
+  const lineEndIdx = content.indexOf('\n', offset)
+  const lineEnd = lineEndIdx === -1 ? content.length : lineEndIdx
+  const before = content.slice(lineStart, offset)
+  const after = content.slice(offset, lineEnd)
+  if (/@apply[^;]*$/.test(before)) return true
+  for (const quote of ['"', "'", '`']) {
+    const opensBefore = (before.split(quote).length - 1) % 2 === 1
+    if (opensBefore && after.includes(quote)) return true
+  }
+  return false
+}
 
 // Full old token name → full new token name. NOTE: alpha categories must come
 // before their base category when building the alternation so that e.g.
@@ -199,13 +268,36 @@ export const COLOR_TOKEN_RENAMES = {
 export const TOKEN_RENAMES = {
   ...COLOR_TOKEN_RENAMES,
   ...UNMIGRATED_TEXT_SIZE_RENAMES,
+  ...RADIUS_RENAMES,
 }
+
+// Radius renames are idempotent, so they also run when the color/typography
+// migration is already done.
+const MIGRATED_MODE_RENAMES = {
+  ...MIGRATED_TEXT_SIZE_RENAMES,
+  ...RADIUS_RENAMES,
+}
+
+// The full text-size vocabulary ever seen by the codemod (live, dead, and
+// temp-scale names). Used for weight merging and the black-style flag list.
+const TEXT_SIZES = [
+  'tiny', '2xs', 'xs', 'sm', 'base', 'md', 'lg', 'xl', '2xl', '3xl', '4xl',
+  '5xl', '6xl', '7xl', '8xl', '9xl', '10xl', '11xl', '12xl', '13xl', '14xl',
+  '15xl', '16xl', '17xl',
+]
 
 // A dead size surfaces as a bare size utility and weighted component classes
 // (no `text-p-*` form — paragraph styles only ever went up to `4xl` and never
 // had a `tiny`, so those combinations never existed).
 const deadSizeTokens = (sizes) => sizes.flatMap((s) => [
   `text-${s}`, `text-${s}-medium`, `text-${s}-semibold`, `text-${s}-bold`, `text-${s}-black`,
+])
+
+// #998: the black weight styles were removed with zero usage. Any literal
+// `text-*-black` is dead in every mode — flagged, never renamed.
+const BLACK_STYLE_TOKENS = TEXT_SIZES.flatMap((s) => [
+  `text-${s}-black`,
+  `text-p-${s}-black`,
 ])
 
 // Tokens dropped in v2 with no replacement — usage is reported, never rewritten.
@@ -215,6 +307,7 @@ export const REMOVED_TOKENS = [
   // #940: dead in every mode — either the v2 name directly, or (for `tiny`,
   // which never shifted) the only name it ever had.
   ...deadSizeTokens(DEAD_SIZES),
+  ...BLACK_STYLE_TOKENS,
 ]
 
 // Old-scale `12xl` is only dead in *unmigrated* content: there it's the size
@@ -257,10 +350,11 @@ const buildFlagRegex = (tokens) => new RegExp(
   'g',
 )
 // Which "no replacement" tokens to flag depends on mode — see the `12xl` /
-// `17xl` note above.
+// `17xl` note above. Radius-only content is presumed migrated (a literal
+// `text-12xl` there is the healthy v2 name), so it shares the migrated list.
 const FULL_FLAG_REGEX = buildFlagRegex(UNMIGRATED_REMOVED_TOKENS)
 const MIGRATED_FLAG_REGEX = buildFlagRegex(MIGRATED_REMOVED_TOKENS)
-const flagRegexFor = (mode) => (mode === 'migrated-typography' ? MIGRATED_FLAG_REGEX : FULL_FLAG_REGEX)
+const flagRegexFor = (mode) => (mode === 'full' ? FULL_FLAG_REGEX : MIGRATED_FLAG_REGEX)
 
 // ---------- WEIGHT-CLASS MERGE ----------
 
@@ -281,15 +375,15 @@ const WEIGHT_SUFFIX = {
   'font-medium': 'medium',
   'font-semibold': 'semibold',
   'font-bold': 'bold',
-  'font-extrabold': 'black',
   'font-normal': '', // regular — drop the weight; the bare `text-<size>` is regular
 }
 
-const TEXT_SIZES = [
-  'tiny', '2xs', 'xs', 'sm', 'base', 'md', 'lg', 'xl', '2xl', '3xl', '4xl',
-  '5xl', '6xl', '7xl', '8xl', '9xl', '10xl', '11xl', '12xl', '13xl', '14xl',
-  '15xl', '16xl', '17xl',
-]
+// #998 removed the `text-*-black` styles, so the black-ish weight utilities
+// have no style class to merge onto. A size + one of these is flagged for
+// manual attention instead of merged (`font-extrabold` was the old merge
+// source for `-black`; `font-black` is Tailwind's 900, which never had an
+// espresso style).
+const BLACK_WEIGHT_CLASSES = ['font-extrabold', 'font-black']
 const SIZE_CLASS = new RegExp(`^text-(?:p-)?(?:${TEXT_SIZES.join('|')})$`)
 
 // Static class/className attribute value — not `:class` / `v-bind:class` (the
@@ -303,10 +397,20 @@ const tokenRe = (tok) => new RegExp(`(?:^|\\s)${escapeRe(tok)}(?=\\s|$)`)
 
 export function mergeWeightClasses(content) {
   const merges = []
+  const flagged = []
   const migrated = content.replace(CLASS_ATTR, (full, name, eq, quote, value, offset) => {
     const words = value.split(/\s+/).filter(Boolean)
     const sizes = words.filter((w) => SIZE_CLASS.test(w))
     const weights = words.filter((w) => w in WEIGHT_SUFFIX)
+    const blacks = words.filter((w) => BLACK_WEIGHT_CLASSES.includes(w))
+    if (sizes.length === 1 && blacks.length > 0) {
+      // Would have merged onto a removed `text-*-black` class — flag instead.
+      flagged.push({
+        token: `${sizes[0]} + ${blacks[0]}`,
+        line: lineAt(content, offset),
+      })
+      return full
+    }
     if (sizes.length !== 1 || weights.length !== 1) return full
 
     const size = sizes[0]
@@ -320,7 +424,7 @@ export function mergeWeightClasses(content) {
     merges.push({ from: `${size} + ${weight}`, to: merged, line: lineAt(content, offset) })
     return `${name}${eq}${quote}${newValue}${quote}`
   })
-  return { migrated, merges }
+  return { migrated, merges, flagged }
 }
 
 // ---------- ALREADY-MIGRATED DETECTION ----------
@@ -355,14 +459,19 @@ export function detectMigrationState(files) {
   return { pre, post, likelyMigrated: post > 0 }
 }
 
-export function getMigrationMode({ likelyMigrated }, { force = false } = {}) {
+export function getMigrationMode({ likelyMigrated }, { force = false, radiusOnly = false } = {}) {
+  if (radiusOnly) return 'radius-only'
   return likelyMigrated && !force ? 'migrated-typography' : 'full'
 }
 
+const RENAMES_BY_MODE = {
+  full: TOKEN_RENAMES,
+  'migrated-typography': MIGRATED_MODE_RENAMES,
+  'radius-only': RADIUS_RENAMES,
+}
+
 export function migrateTokens(content, { mode = 'full' } = {}) {
-  const tokenRenames = mode === 'migrated-typography'
-    ? MIGRATED_TEXT_SIZE_RENAMES
-    : TOKEN_RENAMES
+  const tokenRenames = RENAMES_BY_MODE[mode]
   const renameRegex = renameRegexFor(tokenRenames)
   const replacements = []
   let migrated = content.replace(renameRegex, (match, _token, offset) => {
@@ -371,16 +480,25 @@ export function migrateTokens(content, { mode = 'full' } = {}) {
     return to
   })
 
+  // Bare `rounded` → `rounded-4`, class contexts only (see isClassContext).
+  migrated = migrated.replace(BARE_ROUNDED_REGEX, (match, offset) => {
+    if (!isClassContext(migrated, offset)) return match
+    const to = `rounded-${RADIUS_BARE_STEP}`
+    replacements.push({ from: match, to, line: lineAt(migrated, offset) })
+    return to
+  })
+
   let merges = []
+  const flagged = []
   if (mode === 'full') {
     // Merge weight classes on the post-rename text so `text-xl font-medium`
     // becomes `text-2xl-medium` (size shift first, then merge).
     const result = mergeWeightClasses(migrated)
     migrated = result.migrated
     merges = result.merges
+    flagged.push(...result.flagged)
   }
 
-  const flagged = []
   for (const m of content.matchAll(flagRegexFor(mode))) {
     flagged.push({ token: m[0], line: lineAt(content, m.index) })
   }
@@ -424,6 +542,7 @@ function main() {
   const help = args.includes('--help') || args.includes('-h')
   const dryRun = args.includes('--dry-run')
   const force = args.includes('--force')
+  const radiusOnly = args.includes('--radius-only')
   const targets = args.filter((a) => !a.startsWith('--'))
 
   if (help) {
@@ -441,8 +560,8 @@ function main() {
 
   // Guard against a destructive second full pass (the color renames reuse names).
   const { pre, post, likelyMigrated } = detectMigrationState(files)
-  const mode = getMigrationMode({ likelyMigrated }, { force })
-  if (likelyMigrated) {
+  const mode = getMigrationMode({ likelyMigrated }, { force, radiusOnly })
+  if (likelyMigrated && !radiusOnly) {
     console.warn('\n⚠  This codebase looks already or partially migrated to espresso v2.')
     console.warn(`   Found ${post} v2-only token(s) and ${pre} pre-v2 token(s).`)
     if (force) {
@@ -452,7 +571,8 @@ function main() {
         console.warn(`   ${pre} pre-v2 color token(s) will be left untouched.`)
         console.warn('   Pass --force to run the color migration too. Review carefully: color tokens may double-shift.')
       }
-      console.warn('   Running only the typography correction (`text-lg` → `text-md`, ...).\n')
+      console.warn('   Running only the typography correction (`text-lg` → `text-md`, ...) and the radius renames.')
+      console.warn('   Already ran the typography correction too? Use --radius-only instead.\n')
     }
   }
 
@@ -485,7 +605,8 @@ function main() {
   console.log(
     `\n${dryRun ? '[dry-run] would update' : 'Updated'} ${filesChanged} files, ` +
       `${totalReplacements} token renames, ${totalMerges} weight-class merges` +
-      (mode === 'migrated-typography' ? ' (typography correction only)' : ''),
+      (mode === 'migrated-typography' ? ' (typography correction + radius renames)' : '') +
+      (mode === 'radius-only' ? ' (radius renames only)' : ''),
   )
 
   if (allFlagged.length > 0) {

--- a/tailwind/migrate-tokens-v2.test.js
+++ b/tailwind/migrate-tokens-v2.test.js
@@ -134,6 +134,22 @@ describe('tokens v2 migration', () => {
     )
   })
 
+  it('does not treat apostrophes in prose as string delimiters', () => {
+    const input = [
+      "// the row's corners are rounded when it's hovered",
+      "const cls = 'rounded' // it's the default",
+    ].join('\n')
+
+    const result = migrateTokens(input)
+
+    expect(result.migrated).toBe(
+      [
+        "// the row's corners are rounded when it's hovered",
+        "const cls = 'rounded-4' // it's the default",
+      ].join('\n'),
+    )
+  })
+
   it('flags text-*-black instead of renaming it (#998)', () => {
     const result = migrateTokens('<div class="text-base-black text-p-xl-black"></div>')
 

--- a/tailwind/migrate-tokens-v2.test.js
+++ b/tailwind/migrate-tokens-v2.test.js
@@ -76,6 +76,88 @@ describe('tokens v2 migration', () => {
     expect(result.flagged).toEqual([])
   })
 
+  it('renames radius aliases to numbered tokens (ADR-0006)', () => {
+    const result = migrateTokens(
+      '<div class="rounded rounded-sm rounded-md rounded-lg rounded-xl rounded-2xl"></div>',
+    )
+
+    expect(result.migrated).toBe(
+      '<div class="rounded-4 rounded-1 rounded-5 rounded-6 rounded-7 rounded-8"></div>',
+    )
+    expect(result.flagged).toEqual([])
+  })
+
+  it('renames directional and variant-prefixed radius aliases', () => {
+    const result = migrateTokens(
+      '<div class="rounded-t rounded-t-lg rounded-tl-sm hover:rounded-2xl rounded-ss-md"></div>',
+    )
+
+    expect(result.migrated).toBe(
+      '<div class="rounded-t-4 rounded-t-6 rounded-tl-1 hover:rounded-8 rounded-ss-5"></div>',
+    )
+  })
+
+  it('keeps rounded-none, rounded-full, numbered tokens, and arbitrary radii', () => {
+    const input = '<div class="rounded-none rounded-full rounded-5 rounded-[3px]"></div>'
+    const result = migrateTokens(input)
+
+    expect(result.migrated).toBe(input)
+  })
+
+  it('renames radius aliases in migrated-typography mode too', () => {
+    const result = migrateTokens('<div class="rounded rounded-md text-lg"></div>', {
+      mode: 'migrated-typography',
+    })
+
+    expect(result.migrated).toBe('<div class="rounded-4 rounded-5 text-md"></div>')
+  })
+
+  it('rewrites bare `rounded` in class contexts and @apply, not in prose', () => {
+    const input = [
+      "const cls = 'px-2 rounded border'",
+      '// line-heights are rounded to px',
+      'The shell (rounded/bg/shadow) is owned by the parent.',
+      '.btn { @apply rounded border; }',
+      'Values are rounded up, per the `rounded` utility docs.',
+    ].join('\n')
+
+    const result = migrateTokens(input)
+
+    expect(result.migrated).toBe(
+      [
+        "const cls = 'px-2 rounded-4 border'",
+        '// line-heights are rounded to px',
+        'The shell (rounded/bg/shadow) is owned by the parent.',
+        '.btn { @apply rounded-4 border; }',
+        'Values are rounded up, per the `rounded-4` utility docs.',
+      ].join('\n'),
+    )
+  })
+
+  it('flags text-*-black instead of renaming it (#998)', () => {
+    const result = migrateTokens('<div class="text-base-black text-p-xl-black"></div>')
+
+    expect(result.migrated).toBe('<div class="text-base-black text-p-xl-black"></div>')
+    expect(result.flagged.map((f) => f.token)).toEqual([
+      'text-base-black',
+      'text-p-xl-black',
+    ])
+  })
+
+  it('flags a size + font-extrabold/font-black pair instead of merging (#998)', () => {
+    const result = migrateTokens('<div class="text-xl font-extrabold"></div>')
+
+    // The size still shifts (xl → 2xl); the weight is not merged onto the
+    // removed black style.
+    expect(result.migrated).toBe('<div class="text-2xl font-extrabold"></div>')
+    expect(result.merges).toEqual([])
+    expect(result.flagged.map((f) => f.token)).toEqual(['text-2xl + font-extrabold'])
+
+    const black = migrateTokens('<div class="text-sm font-black"></div>')
+    expect(black.migrated).toBe('<div class="text-sm font-black"></div>')
+    expect(black.flagged.map((f) => f.token)).toEqual(['text-sm + font-black'])
+  })
+
   it('selects typography-only mode when v2 sentinels are present', () => {
     const file = writeTempFile(
       '<div class="bg-surface-base bg-surface-white text-xl"></div>',
@@ -85,6 +167,19 @@ describe('tokens v2 migration', () => {
     expect(state).toEqual({ pre: 1, post: 1, likelyMigrated: true })
     expect(getMigrationMode(state)).toBe('migrated-typography')
     expect(getMigrationMode(state, { force: true })).toBe('full')
+    expect(getMigrationMode(state, { radiusOnly: true })).toBe('radius-only')
+  })
+
+  it('radius-only mode renames radii and touches nothing else', () => {
+    const result = migrateTokens(
+      '<div class="rounded rounded-md text-lg bg-surface-white text-base-black"></div>',
+      { mode: 'radius-only' },
+    )
+
+    expect(result.migrated).toBe(
+      '<div class="rounded-4 rounded-5 text-lg bg-surface-white text-base-black"></div>',
+    )
+    expect(result.flagged.map((f) => f.token)).toEqual(['text-base-black'])
   })
 })
 

--- a/tailwind/plugin.js
+++ b/tailwind/plugin.js
@@ -17,36 +17,27 @@ let cssVariables = mergeVariableLayers(
   generateRadiusVariables(),
 )
 
-// Emit `--radius-{key}` for every radius token (numeric scale + aliases) so
-// the values are inspectable as real CSS variables. `borderRadius` is rewired
-// below to consume these vars, so `rounded-4` and `--radius-4` stay in sync.
+// Emit `--radius-{key}` for every radius token (the numbered scale plus the
+// kept `none` / `full` names — the deprecated size aliases were removed in
+// 1.0.0 per ADR-0006, #998) so the values are inspectable as real CSS
+// variables. `borderRadius` is rewired below to consume these vars, so
+// `rounded-4` and `--radius-4` stay in sync.
 function generateRadiusVariables() {
   const vars = {}
   for (const [key, value] of Object.entries(radiusTokens)) {
-    if (key === 'DEFAULT') continue
     vars[`--radius-${key}`] = value
   }
   return { ':root': vars }
 }
 
-// Map `DEFAULT` (Tailwind's `rounded` class) onto the numeric var that
-// shares its value, so we don't emit a `--radius-DEFAULT` (awkward name).
 // Each value carries a trailing `/* {px} */` comment so editor tooling
 // (Tailwind IntelliSense) surfaces the resolved px on hover, instead of
-// the opaque `var(--radius-*)` reference.
+// the opaque `var(--radius-*)` reference. No `DEFAULT` key: the bare
+// `rounded` utility no longer exists — use `rounded-4`.
 function buildRadiusConfig() {
-  const numericByValue = {}
-  for (const [key, value] of Object.entries(radiusTokens)) {
-    if (/^\d+$/.test(key)) numericByValue[value] = key
-  }
   const out = {}
   for (const [key, value] of Object.entries(radiusTokens)) {
-    if (key === 'DEFAULT') {
-      const numeric = numericByValue[value]
-      out[key] = numeric ? `var(--radius-${numeric}) /* ${value} */` : value
-    } else {
-      out[key] = `var(--radius-${key}) /* ${value} */`
-    }
+    out[key] = `var(--radius-${key}) /* ${value} */`
   }
   return out
 }

--- a/tailwind/plugin.js
+++ b/tailwind/plugin.js
@@ -60,7 +60,9 @@ function mergeVariableLayers(...layers) {
 // can't follow font-weight, so each (size, weight) must ship as a self-contained
 // class. `regular` stays the bare `text-<size>` / `text-p-<size>` utility.
 // (Component classes are JIT-purged, so only the ones used in content emit.)
-const WEIGHT_VARIANTS = ['medium', 'semibold', 'bold', 'black']
+// `black` was dropped in #998 — zero usage, and the Figma weights behind it
+// were corrupt export data.
+const WEIGHT_VARIANTS = ['medium', 'semibold', 'bold']
 
 function buildFontSize() {
   const out = {}

--- a/v1-release/changelog.md
+++ b/v1-release/changelog.md
@@ -9,6 +9,24 @@ one-time dev-mode warning (unless noted). Removal is post-v1.
 
 ## Unreleased
 
+### Radius aliases and `text-*-black` styles removed (breaking, silent)
+
+Per ADR-0006 and ADR-0008 (#998, decided in #993):
+
+- The named radius aliases (`rounded`, `rounded-sm`, `rounded-md`,
+  `rounded-lg`, `rounded-xl`, `rounded-2xl`, and their directional forms) are
+  removed. Numbered tokens are the only radius vocabulary
+  (`rounded` → `rounded-4`, sm→1, md→5, lg→6, xl→7, 2xl→8; identical px).
+  `rounded-none` and `rounded-full` stay. **Silent break:** the preset
+  replaces Tailwind's scale, so an unmigrated alias emits no CSS — square
+  corners, no build error. The `tokens-v2` codemod now performs these renames
+  (idempotent, runs in every mode); it rewrites bare `rounded` only inside
+  quoted strings and `@apply` rules, so grep for leftovers.
+- The `text-<size>-black` / `text-p-<size>-black` style classes are removed
+  (zero usage; the Figma black weights were corrupt export data). Also a
+  silent break. The codemod flags `font-extrabold` / `font-black` next to a
+  text size instead of merging onto the removed class.
+
 ### ListFilter — removed (breaking)
 
 - **Breaking, loud:** `ListFilter` is no longer exported — the import fails.


### PR DESCRIPTION
Removes the deprecated radius aliases and the black weight styles, and teaches the `tokens-v2` codemod the radius renames. Per ADR-0006/ADR-0008, decided in #993.

Refs #998

**Base branch:** targets `v1/997-radius-token-sweep` (#1013) because removing the aliases on top of main's unmigrated tree would strip radii from our own components. Retarget to `main` once #1013 merges.

## Removed

- Radius aliases `rounded`, `rounded-sm/md/lg/xl/2xl` (and directional forms). Numbered tokens are the only radius vocabulary. `rounded-none` / `rounded-full` stay. `radius.json` diff is only the alias removal.
- `text-<size>-black` / `text-p-<size>-black` styles: dropped from `WEIGHT_VARIANTS`, the docs safelist, and the typography page weight switcher. `text-10xl`–`12xl` stay (decided).

**Silent break.** The preset replaces Tailwind's scales, so an unmigrated `rounded-md` or `text-base-black` emits no CSS — no build error, just missing styles. Migration guide has the before/after map.

## Codemod coverage

- `rounded`→`rounded-4`, sm→1, md→5, lg→6, xl→7, 2xl→8; directional, logical (`rounded-ss-*`), and variant-prefixed forms included. Idempotent, runs in every mode.
- Bare `rounded` is plain English — rewritten only inside quoted strings and `@apply` rules; prose and comments stay untouched.
- `font-extrabold` / `font-black` next to a size is flagged for manual attention instead of merged onto a removed `-black` class; literal `text-*-black` is flagged as removed.
- New `--radius-only` flag: an app that already ran the color migration **and** the typography correction must not re-run either (both shift names); this runs just the radius renames. Documented in the migration guide.

## Dogfood diff (codemod vs #1013's manual sweep)

Ran the codemod (`--radius-only`) over a copy of pre-sweep `main` and diffed against `v1/997-radius-token-sweep`: 445 codemod renames vs 409 manual, **8 files differ**.

- **Codemod bugs: 0.** Every real class list matches the sweep exactly.
- **Manual-sweep misses: 0.** No spot where #1013 renamed and the codemod did not.
- **Expected divergence: 8 files**, all deliberate keeps or editorial work — ADR-0006, `spec/foundations.md`, `spec/popover.md` (historical quote), `docs/content/docs/migration.md` + `src/components/Tooltip/Tooltip.md` ("before" samples), `skills/frappe-ui/TOKENS.md` (sweep added prose/reformatting; renames identical), `ListFilter.vue` (kept by #1013 pending its deletion — #1011 has since merged and deleted it, so this PR carries no ListFilter edit), and one backtick-quoted `rounded` in a `plugin.js` comment.

## Tests

- vitest: 54 files, 478 tests pass (15 codemod tests, 8 new).
- Theme probe build (tailwind CLI): aliases and `text-base-black` emit nothing; numbered, directional, logical, `none`/`full`, `text-base-bold` all emit.
- Cypress: Button, Badge, Dialog — 48 tests pass.
- `yarn type-check`: same pre-existing vitepress/ and VNodeChild errors as base; no new errors.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1014/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 64.23% (±0.00% vs `main`)
<!-- coverage-report:end -->






