### PR TITLE
fix(Toast): render ToastProvider before the slot so early toasts land

### DIFF
--- a/skills/frappe-ui/SETUP.md
+++ b/skills/frappe-ui/SETUP.md
@@ -60,7 +60,6 @@ export default defineConfig({
     // prebundles them.
     include: [
       'tippy.js',
-      'showdown',
       'engine.io-client',
       'socket.io-client',
       'debug',

--- a/skills/frappe-ui/SETUP.md
+++ b/skills/frappe-ui/SETUP.md
@@ -59,7 +59,6 @@ export default defineConfig({
     // converted to ESM for the browser — list them explicitly so Vite
     // prebundles them.
     include: [
-      'feather-icons',
       'tippy.js',
       'showdown',
       'engine.io-client',

--- a/spec/toast.md
+++ b/spec/toast.md
@@ -60,12 +60,14 @@ Wrap the app once with `<FrappeUIProvider>`:
 
 The provider renders sonner's `<Toaster>` with our baked-in defaults. No other setup required.
 
-Apps that don't use the provider can mount the viewport themselves:
+Apps that don't use the provider can mount the viewport themselves. Put it
+before the app content: it only shows toasts published after it subscribes, so
+anything the app toasts from `setup()` is lost if it mounts later.
 
 ```vue
 <template>
-  <RouterView />
   <ToastProvider />
+  <RouterView />
 </template>
 ```
 

--- a/src/components/FrappeUIProvider/FrappeUIProvider.md
+++ b/src/components/FrappeUIProvider/FrappeUIProvider.md
@@ -24,8 +24,10 @@ Only if the app uses the imperative `dialog.*` / `toast.*` helpers (or
 `Dialog`'s `dialog.confirm` / `alert` / `prompt` family). An app that mounts
 neither doesn't need it. An app that wants the portals without the wrapper can
 mount `<Dialogs />` and `<ToastProvider />` directly instead — both stay
-exported for that case. Mount `<ToastProvider />` once: it has no dedup
-guard, so a second one renders every toast twice. `<Dialogs />` dedups
+exported for that case. Mount `<ToastProvider />` ahead of the app content:
+it only shows toasts published after it subscribes, so anything the app
+toasts from `setup()` is dropped if it mounts later. Mount it once too: it
+has no dedup guard, so a second one renders every toast twice. `<Dialogs />` dedups
 itself — only one host renders the stack, nested or sibling, and an extra
 mount warns in dev.
 

--- a/src/components/FrappeUIProvider/FrappeUIProvider.vue
+++ b/src/components/FrappeUIProvider/FrappeUIProvider.vue
@@ -1,7 +1,22 @@
 <template>
+  <!--
+    ToastProvider comes first, before the slot. vue-sonner's <Toaster> is a pure
+    subscriber: it calls ToastState.subscribe() and only ever sees toasts
+    published *after* that call — it never seeds from ToastState.toasts. With
+    the slot rendered first, anything the app tree toasts from setup() or
+    onMounted() is published to zero subscribers and silently dropped.
+
+    Rendering the Toaster ahead of the slot establishes the subscription while
+    the app subtree is still being set up, so those toasts land. DOM order costs
+    nothing here: the toaster is position:fixed at z-index 999999999, so it
+    still paints above app content.
+
+    <Dialogs /> needs no such treatment — it reads the `dialogs` ref at render
+    time, so a dialog opened before it mounts still shows on the first render.
+  -->
+  <ToastProvider />
   <slot />
   <Dialogs />
-  <ToastProvider />
 </template>
 
 <script setup lang="ts">

--- a/src/components/Toast/Toast.cy.ts
+++ b/src/components/Toast/Toast.cy.ts
@@ -1,3 +1,4 @@
+import { defineComponent, h } from 'vue'
 import { toast, ToastProvider } from '../../index'
 import FrappeUIProvider from '../FrappeUIProvider/FrappeUIProvider.vue'
 
@@ -77,5 +78,22 @@ describe('Toast v1 — vue-sonner integration', () => {
       toast.message('Plain message')
     })
     cy.contains('Plain message').should('exist')
+  })
+
+  // ---- toasts fired while the app subtree is still mounting ------------------
+
+  // <Toaster> only receives toasts published after it subscribes, so a toast
+  // fired from a slot child's setup() is dropped unless ToastProvider renders
+  // ahead of the slot. Regression test for frappe/frappe-ui#963.
+  it('keeps a toast fired from slot content during setup', () => {
+    const Child = defineComponent({
+      setup() {
+        toast.success('Toasted from setup')
+        return () => h('div', 'child')
+      },
+    })
+
+    cy.mount(FrappeUIProvider, { slots: { default: () => h(Child) } })
+    cy.contains('Toasted from setup').should('exist')
   })
 })

--- a/vite/index.js
+++ b/vite/index.js
@@ -53,8 +53,11 @@ function frappeuiPlugin(options = {}) {
       return {
         optimizeDeps: {
           include: [
+            // Every entry here must be a frappe-ui dependency. A name that no
+            // installed package resolves makes Vite log "Failed to resolve
+            // dependency ... present in 'optimizeDeps.include'" on each dev
+            // start of every consuming app.
             'highlight.js/lib/core',
-            'interactjs',
             // Deps behind the imperative `toast()` / `dialog.*` surfaces.
             //
             // Both are backed by module-level state — the `dialogs` ref in
@@ -72,7 +75,6 @@ function frappeuiPlugin(options = {}) {
             'reka-ui',
             'vue-sonner',
             'dompurify',
-            'feather-icons',
           ],
         },
       }

--- a/vite/index.js
+++ b/vite/index.js
@@ -52,7 +52,28 @@ function frappeuiPlugin(options = {}) {
     config() {
       return {
         optimizeDeps: {
-          include: ['highlight.js/lib/core', 'interactjs'],
+          include: [
+            'highlight.js/lib/core',
+            'interactjs',
+            // Deps behind the imperative `toast()` / `dialog.*` surfaces.
+            //
+            // Both are backed by module-level state — the `dialogs` ref in
+            // src/utils/dialog.ts and vue-sonner's ToastState — which a full
+            // page reload wipes. So when one of these is discovered late (the
+            // dep optimizer only crawls what the scanner reached, and it misses
+            // dynamic imports inside template expressions among other things),
+            // Vite logs "optimized dependencies changed. reloading" and the
+            // toast or dialog the user just triggered never paints. It works on
+            // the next click, which is what makes it read as flaky.
+            //
+            // Pre-declaring them keeps that discovery at server start. The cost
+            // is an esbuild pre-bundle the browser only downloads if something
+            // actually imports it, and every frappe-ui app pulls these anyway.
+            'reka-ui',
+            'vue-sonner',
+            'dompurify',
+            'feather-icons',
+          ],
         },
       }
     },


### PR DESCRIPTION
Refs #963 — "toast/imperative dialogs don't show up sometimes (flaky)".

I reproduced #963 in a throwaway Vite app with frappe-ui symlinked in, driven by headless Chromium. There are two separate causes. This PR fixes one and mitigates the other.

## 1. Toasts fired before `<ToastProvider>` mounts are dropped

`FrappeUIProvider` rendered `<slot />` first. vue-sonner's `<Toaster>` only receives toasts published *after* it subscribes, so anything the app toasted from `setup()` went nowhere.

`<Dialogs />` reads its ref at render time, so it was never affected — the same call site showed the dialog but not the toast:

```
pre-mount call results: {"toasts":0,"dialogs":1}
```

**Fix:** render `<ToastProvider />` before `<slot />`. Safe — the toaster is `position: fixed` at `z-index: 999999999`, so DOM order doesn't change what paints on top.

New Cypress test covers it. Confirmed it fails on the old order.

*Still open:* a toast fired before `createApp().mount()` is also lost. That needs seeding the Toaster from `toast.getToasts()`, which vue-sonner gives no clean hook for — separate issue.

## 2. Vite full reload wipes the state (this is the flaky part)

Both surfaces are module-level state — the `dialogs` ref and vue-sonner's `ToastState` — and a Vite reload wipes both. So the call succeeds and nothing paints.

Cold dep cache, first time a code path pulls an un-optimized dep:

```
[vite] ✨ new dependencies optimized: canvas-confetti
[vite] ✨ optimized dependencies changed. reloading
→ dialogs: 0
```

Warm cache, same click:

```
→ dialogs: 1
```

Deterministic per code path per dev session, which is why it reads as random — it fires the first time you delete a page, then works on retry. `vite/barrelImports.js:13` already documents this trigger.

**Mitigation:** pre-declare `reka-ui`, `vue-sonner` and `dompurify` in `optimizeDeps.include`. These are what a cold run actually discovered late on the toast/dialog path, and every frappe-ui app pulls them anyway.

The same pass drops `interactjs` and `feather-icons` from that list. Neither is a frappe-ui dependency, so each made Vite log "Failed to resolve dependency" on every dev start of an app that does not install it. `feather-icons` is gone from the setup skill's list too, with `showdown`, for the same reason. An app that installs `interactjs` itself loses only the pre-declaration, not the dep.

This makes the reload rarer on the core paths. It does not eliminate late discovery in general — the dep scanner has blind spots nothing here can close. **If anyone can catch `[vite] optimized dependencies changed. reloading` in the console when it happens in Studio, that tells us which dep to add next.**

## Testing

- `yarn test` — 211 passed
- Cypress `Toast.cy.ts`, `utils/dialog.cy.ts`, `Dialog.cy.ts` — 69 passed
- `yarn type-check` — 171 errors, same count on `main`; none from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1026/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 70.53% (±0.00% vs `main`)
<!-- coverage-report:end -->




