### PR TITLE
fix(editor): keep adjacent lists merged so numbering continues

### DIFF
--- a/docs/content/docs/molecules/editor.md
+++ b/docs/content/docs/molecules/editor.md
@@ -145,7 +145,7 @@ Individual TipTap extensions with frappe-ui defaults already applied. Use these 
 | Blocks      | `CodeBlock`, `Table`, `TableRow`, `TableCell`, `TableHeader`, `TaskList`, `TaskItem` |
 | Media       | `Image`, `ImageGroup`, `ImageViewer`, `Video`, `Iframe`             |
 | Suggestions | `Mention`, `Tag`, `Emoji`, `SlashCommands`, `SuggestionExtension`   |
-| Behavior    | `Typography`, `TextAlign`, `Toc`, `ContentPaste`, `StyleClipboard`  |
+| Behavior    | `Typography`, `TextAlign`, `Toc`, `ContentPaste`, `StyleClipboard`, `ListJoin` |
 
 ### Menu items
 

--- a/src/molecules/editor/extensions.ts
+++ b/src/molecules/editor/extensions.ts
@@ -156,10 +156,10 @@ export const StarterKit = Extension.create<StarterKitOptions>({
     pushConfigured(list, ListItem, this.options.listItem)
     pushConfigured(list, ListKeymap, this.options.listKeymap)
     pushConfigured(list, OrderedList, this.options.orderedList)
-    // Re-merges lists that an edit split apart; harmless when no list node
-    // is in the schema, so it rides along with any list at all.
-    if (this.options.bulletList !== false || this.options.orderedList !== false)
-      list.push(ListJoin)
+    // Re-merges lists that an edit split apart. Unconditional: it covers task
+    // lists too (added by RichTextKit, not here) and no-ops when the schema
+    // has no list node at all.
+    list.push(ListJoin)
     pushConfigured(list, Paragraph, this.options.paragraph)
     pushConfigured(list, Strike, this.options.strike)
     if (this.options.text !== false) list.push(Text)
@@ -222,6 +222,12 @@ export const Heading = HeadingExtension
  * Registered alongside `Heading` in the kits; `collectHeadings` reads its ids.
  */
 export const HeadingIds = HeadingIdsExtension
+/**
+ * Re-merges adjacent same-kind lists (bullet, ordered, task) that an edit split
+ * apart, so ordered-list numbering never restarts mid-list. In `StarterKit`;
+ * exported for anyone assembling extensions by hand.
+ */
+export { ListJoin }
 // frappe-ui's link: inline edit popup, Mod-k shortcut, smart paste handling, and
 // boundary clearing. Already defaults openOnClick:false / autolink:true.
 export const Link = LinkExtension

--- a/src/molecules/editor/extensions.ts
+++ b/src/molecules/editor/extensions.ts
@@ -21,6 +21,7 @@ import {
   OrderedList,
   type OrderedListOptions,
 } from '@tiptap/extension-list'
+import { ListJoin } from './extensions/list/list-join'
 import { Paragraph, type ParagraphOptions } from '@tiptap/extension-paragraph'
 import { Strike, type StrikeOptions } from '@tiptap/extension-strike'
 import { Text } from '@tiptap/extension-text'
@@ -155,6 +156,10 @@ export const StarterKit = Extension.create<StarterKitOptions>({
     pushConfigured(list, ListItem, this.options.listItem)
     pushConfigured(list, ListKeymap, this.options.listKeymap)
     pushConfigured(list, OrderedList, this.options.orderedList)
+    // Re-merges lists that an edit split apart; harmless when no list node
+    // is in the schema, so it rides along with any list at all.
+    if (this.options.bulletList !== false || this.options.orderedList !== false)
+      list.push(ListJoin)
     pushConfigured(list, Paragraph, this.options.paragraph)
     pushConfigured(list, Strike, this.options.strike)
     if (this.options.text !== false) list.push(Text)
@@ -244,7 +249,9 @@ export const Table = TiptapTable.configure({ resizable: true }).extend({
             }),
           ]
         : []),
-      tableEditing({ allowTableNodeSelection: this.options.allowTableNodeSelection }),
+      tableEditing({
+        allowTableNodeSelection: this.options.allowTableNodeSelection,
+      }),
     ]
   },
 })

--- a/src/molecules/editor/extensions.ts
+++ b/src/molecules/editor/extensions.ts
@@ -106,6 +106,7 @@ export interface StarterKitOptions {
   italic?: StarterKitMember<ItalicOptions>
   link?: false
   listItem?: StarterKitMember<ListItemOptions>
+  listJoin?: false
   listKeymap?: StarterKitMember<ListKeymapOptions>
   orderedList?: StarterKitMember<OrderedListOptions>
   paragraph?: StarterKitMember<ParagraphOptions>
@@ -156,10 +157,10 @@ export const StarterKit = Extension.create<StarterKitOptions>({
     pushConfigured(list, ListItem, this.options.listItem)
     pushConfigured(list, ListKeymap, this.options.listKeymap)
     pushConfigured(list, OrderedList, this.options.orderedList)
-    // Re-merges lists that an edit split apart. Unconditional: it covers task
-    // lists too (added by RichTextKit, not here) and no-ops when the schema
-    // has no list node at all.
-    list.push(ListJoin)
+    // Re-merges lists that an edit split apart. Its own key rather than a
+    // bulletList/orderedList guard: it also covers task lists, which come from
+    // RichTextKit. Opt out to keep parsed HTML structurally untouched.
+    if (this.options.listJoin !== false) list.push(ListJoin)
     pushConfigured(list, Paragraph, this.options.paragraph)
     pushConfigured(list, Strike, this.options.strike)
     if (this.options.text !== false) list.push(Text)

--- a/src/molecules/editor/extensions/list/list-join.test.ts
+++ b/src/molecules/editor/extensions/list/list-join.test.ts
@@ -228,6 +228,34 @@ describe('ListJoin', () => {
     ).toHaveLength(2)
   })
 
+  it('sets no metadata of its own, so it composes in a chain', () => {
+    const editor = editorWith(
+      '<p>keep</p><ol><li><p>a</p></li></ol><p>gone</p><ol><li><p>b</p></li></ol>',
+    )
+    // Settle TrailingNode first: it appends its paragraph on the first
+    // transaction, and undo does not take that back out.
+    editor.view.dispatch(editor.state.tr)
+    const before = editor.getJSON()
+    const onUpdate = vi.fn()
+    editor.on('update', onUpdate)
+
+    // Delete the paragraph between the lists and join, in one chain.
+    let from = -1
+    editor.state.doc.descendants((node, pos) => {
+      if (node.isText && node.text === 'gone') from = pos
+    })
+    editor
+      .chain()
+      .deleteRange({ from: from - 1, to: from + 5 })
+      .joinAdjacentLists()
+      .run()
+
+    // The chain is the user's edit: it reports an update and takes one undo.
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    editor.commands.undo()
+    expect(editor.getJSON()).toEqual(before)
+  })
+
   it('merges list nodes whose attributes are deep-equal objects', () => {
     const ListWithObjectAttr = OrderedList.extend({
       addAttributes() {

--- a/src/molecules/editor/extensions/list/list-join.test.ts
+++ b/src/molecules/editor/extensions/list/list-join.test.ts
@@ -1,8 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { Editor } from '@tiptap/core'
+import { RichTextKit } from '../../kits'
 import { StarterKit } from '../../extensions'
 
 function editorWith(content: string) {
@@ -127,6 +128,59 @@ describe('ListJoin', () => {
     expect(lists).toHaveLength(1)
     expect(lists[0].attrs!.start).toBe(5)
     expect(lists[0].content).toHaveLength(2)
+  })
+
+  it('repairs a document that arrives already split', () => {
+    // Initial content is parsed without a transaction, so only the view-init
+    // pass can fix a document saved back when the bug was live.
+    const editor = editorWith(
+      '<ol><li><p>a</p></li></ol><ol><li><p>b</p></li></ol>',
+    )
+    const lists = editor
+      .getJSON()
+      .content!.filter((n) => n.type === 'orderedList')
+    expect(lists).toHaveLength(1)
+    expect(lists[0].content).toHaveLength(2)
+  })
+
+  it('does not mark a document dirty when repairing it on load', () => {
+    const onUpdate = vi.fn()
+    new Editor({
+      extensions: [StarterKit],
+      content: '<ol><li><p>a</p></li></ol><ol><li><p>b</p></li></ol>',
+      onUpdate,
+    })
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('merges adjacent task lists, which only RichTextKit enables', () => {
+    const taskList = (text: string) =>
+      `<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><p>${text}</p></li></ul>`
+    const editor = new Editor({
+      extensions: [RichTextKit],
+      content: taskList('a') + taskList('b'),
+    })
+    const lists = editor.getJSON().content!.filter((n) => n.type === 'taskList')
+    expect(lists).toHaveLength(1)
+    expect(lists[0].content).toHaveLength(2)
+  })
+
+  it('reverts the join and the edit together on a single undo', () => {
+    const editor = editorWith(
+      '<ol><li><p>a</p></li></ol><p></p><ol><li><p>b</p></li></ol>',
+    )
+    const pos = emptyParagraphPos(editor)
+    editor.commands.deleteRange({ from: pos - 1, to: pos + 1 })
+    expect(
+      editor.getJSON().content!.filter((n) => n.type === 'orderedList'),
+    ).toHaveLength(1)
+
+    // One undo, not two: the join rides on the user's own history entry.
+    editor.commands.undo()
+    const lists = editor
+      .getJSON()
+      .content!.filter((n) => n.type === 'orderedList')
+    expect(lists).toHaveLength(2)
   })
 
   it('merges nested lists split inside a list item', () => {

--- a/src/molecules/editor/extensions/list/list-join.test.ts
+++ b/src/molecules/editor/extensions/list/list-join.test.ts
@@ -79,6 +79,56 @@ describe('ListJoin', () => {
     expect(lists[1].attrs!.start).toBe(7)
   })
 
+  it('keeps a list with its own marker style separate', () => {
+    const editor = editorWith(
+      '<ol><li><p>a</p></li></ol><p></p><ol type="a"><li><p>b</p></li></ol>',
+    )
+    const pos = emptyParagraphPos(editor)
+    editor.commands.deleteRange({ from: pos - 1, to: pos + 1 })
+
+    const lists = editor
+      .getJSON()
+      .content!.filter((n) => n.type === 'orderedList')
+    expect(lists).toHaveLength(2)
+    expect(lists[1].attrs!.type).toBe('a')
+  })
+
+  it('merges a chain of three adjacent lists in one pass', () => {
+    const editor = editorWith(
+      '<ol><li><p>a</p></li></ol><ol><li><p>b</p></li></ol><ol><li><p>c</p></li></ol><p>x</p>',
+    )
+    editor.commands.insertContentAt(editor.state.doc.content.size - 1, 'y')
+
+    const lists = editor
+      .getJSON()
+      .content!.filter((n) => n.type === 'orderedList')
+    expect(lists).toHaveLength(1)
+    expect(lists[0].content).toHaveLength(3)
+  })
+
+  it('carries a non-default start across a split', () => {
+    const editor = editorWith(
+      '<ol start="5"><li><p>a</p></li><li><p>b</p></li><li><p>c</p></li></ol>',
+    )
+    let bPos = -1
+    editor.state.doc.descendants((node, pos) => {
+      if (node.isText && node.text === 'b') bPos = pos
+    })
+    editor.commands.setTextSelection(bPos + 1)
+    editor.commands.deleteRange({ from: bPos, to: bPos + 1 })
+    editor.commands.liftListItem('listItem')
+    // Remove the paragraph the lifted item left behind.
+    const pos = emptyParagraphPos(editor)
+    editor.commands.deleteRange({ from: pos - 1, to: pos + 1 })
+
+    const lists = editor
+      .getJSON()
+      .content!.filter((n) => n.type === 'orderedList')
+    expect(lists).toHaveLength(1)
+    expect(lists[0].attrs!.start).toBe(5)
+    expect(lists[0].content).toHaveLength(2)
+  })
+
   it('merges nested lists split inside a list item', () => {
     const editor = editorWith(
       '<ul><li><p>parent</p><ol><li><p>a</p></li></ol><ol><li><p>b</p></li></ol></li></ul>',

--- a/src/molecules/editor/extensions/list/list-join.test.ts
+++ b/src/molecules/editor/extensions/list/list-join.test.ts
@@ -3,8 +3,25 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import { Editor } from '@tiptap/core'
+import { OrderedList } from '@tiptap/extension-list'
+import { ref, nextTick, createApp, defineComponent } from 'vue'
 import { RichTextKit } from '../../kits'
 import { StarterKit } from '../../extensions'
+import { useEditor } from '../../useEditor'
+
+/** Mount `useEditor` the way a consumer does, without rendering EditorContent. */
+function mountUseEditor(content: ReturnType<typeof ref<string>>) {
+  let editor: ReturnType<typeof useEditor> | null = null
+  createApp(
+    defineComponent({
+      setup() {
+        editor = useEditor({ content, extensions: [StarterKit] })
+        return () => null
+      },
+    }),
+  ).mount(document.createElement('div'))
+  return editor!
+}
 
 function editorWith(content: string) {
   return new Editor({ extensions: [StarterKit], content })
@@ -179,6 +196,73 @@ describe('ListJoin', () => {
       content: '<ol><li><p>a</p></li></ol>',
     })
     expect(editor.commands.joinAdjacentLists()).toBe(false)
+  })
+
+  it('repairs content written through the useEditor ref, still unmounted', async () => {
+    const split = '<ol><li><p>a</p></li></ol><ol><li><p>b</p></li></ol>'
+    const content = ref('<p>start</p>')
+    const editor = mountUseEditor(content)
+    expect(editor.value!.state.plugins).toHaveLength(0)
+
+    content.value = split
+    await nextTick()
+
+    const lists = editor
+      .value!.getJSON()
+      .content!.filter((n) => n.type === 'orderedList')
+    expect(lists).toHaveLength(1)
+    expect(lists[0].content).toHaveLength(2)
+  })
+
+  it('leaves the document alone when the command is only probed', () => {
+    const editor = new Editor({
+      extensions: [StarterKit],
+      element: null,
+      content: '<ol><li><p>a</p></li></ol><ol><li><p>b</p></li></ol>',
+    })
+    expect(editor.can().joinAdjacentLists()).toBe(true)
+    // A probe shares its transaction with the rest of a can().chain(), so it
+    // must not join: later commands would be tested against the merged doc.
+    expect(
+      editor.getJSON().content!.filter((n) => n.type === 'orderedList'),
+    ).toHaveLength(2)
+  })
+
+  it('merges list nodes whose attributes are deep-equal objects', () => {
+    const ListWithObjectAttr = OrderedList.extend({
+      addAttributes() {
+        return {
+          ...this.parent?.(),
+          meta: {
+            default: null,
+            parseHTML: (element: HTMLElement) => {
+              const raw = element.getAttribute('data-meta')
+              return raw ? JSON.parse(raw) : null
+            },
+            renderHTML: (attributes: { meta?: unknown }) =>
+              attributes.meta
+                ? { 'data-meta': JSON.stringify(attributes.meta) }
+                : {},
+          },
+        }
+      },
+    })
+    const list = '<ol data-meta=\'{"a":1}\'><li><p>x</p></li></ol>'
+    const editor = new Editor({
+      extensions: [
+        StarterKit.configure({ orderedList: false }),
+        ListWithObjectAttr,
+      ],
+      element: null,
+      content: list + list,
+    })
+    editor.commands.joinAdjacentLists()
+
+    const lists = editor
+      .getJSON()
+      .content!.filter((n) => n.type === 'orderedList')
+    expect(lists).toHaveLength(1)
+    expect(lists[0].attrs!.meta).toEqual({ a: 1 })
   })
 
   it('finds list nodes by their schema group, not by name', () => {

--- a/src/molecules/editor/extensions/list/list-join.test.ts
+++ b/src/molecules/editor/extensions/list/list-join.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest'
+import { Editor } from '@tiptap/core'
+import { StarterKit } from '../../extensions'
+
+function editorWith(content: string) {
+  return new Editor({ extensions: [StarterKit], content })
+}
+
+/** Position just inside the first empty top-level paragraph. */
+function emptyParagraphPos(editor: Editor): number {
+  let found = -1
+  editor.state.doc.forEach((node, offset) => {
+    if (
+      found === -1 &&
+      node.type.name === 'paragraph' &&
+      node.content.size === 0
+    )
+      found = offset
+  })
+  return found + 1
+}
+
+describe('ListJoin', () => {
+  it('merges two adjacent ordered lists so numbering continues', () => {
+    const editor = editorWith(
+      '<ol><li><p>hello</p></li></ol><p></p><ol><li><p>world</p></li></ol>',
+    )
+    // Deleting the paragraph between the lists leaves them touching.
+    const pos = emptyParagraphPos(editor)
+    editor.commands.deleteRange({ from: pos - 1, to: pos + 1 })
+
+    const lists = editor
+      .getJSON()
+      .content!.filter((n) => n.type === 'orderedList')
+    expect(lists).toHaveLength(1)
+    expect(lists[0].content).toHaveLength(2)
+  })
+
+  it('merges adjacent bullet lists', () => {
+    const editor = editorWith(
+      '<ul><li><p>a</p></li></ul><p></p><ul><li><p>b</p></li></ul>',
+    )
+    const pos = emptyParagraphPos(editor)
+    editor.commands.deleteRange({ from: pos - 1, to: pos + 1 })
+
+    const lists = editor
+      .getJSON()
+      .content!.filter((n) => n.type === 'bulletList')
+    expect(lists).toHaveLength(1)
+    expect(lists[0].content).toHaveLength(2)
+  })
+
+  it('leaves lists of different kinds alone', () => {
+    const editor = editorWith(
+      '<ol><li><p>a</p></li></ol><p></p><ul><li><p>b</p></li></ul>',
+    )
+    const pos = emptyParagraphPos(editor)
+    editor.commands.deleteRange({ from: pos - 1, to: pos + 1 })
+
+    const types = editor.getJSON().content!.map((n) => n.type)
+    expect(types).toContain('orderedList')
+    expect(types).toContain('bulletList')
+  })
+
+  it('keeps a list that was deliberately renumbered separate', () => {
+    const editor = editorWith(
+      '<ol><li><p>a</p></li></ol><p></p><ol start="7"><li><p>b</p></li></ol>',
+    )
+    const pos = emptyParagraphPos(editor)
+    editor.commands.deleteRange({ from: pos - 1, to: pos + 1 })
+
+    const lists = editor
+      .getJSON()
+      .content!.filter((n) => n.type === 'orderedList')
+    expect(lists).toHaveLength(2)
+    expect(lists[1].attrs!.start).toBe(7)
+  })
+
+  it('merges nested lists split inside a list item', () => {
+    const editor = editorWith(
+      '<ul><li><p>parent</p><ol><li><p>a</p></li></ol><ol><li><p>b</p></li></ol></li></ul>',
+    )
+    // A no-op edit is enough to trigger the append transaction.
+    editor.commands.insertContentAt(editor.state.doc.content.size - 1, ' ')
+
+    let nested = 0
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'orderedList') nested++
+    })
+    expect(nested).toBe(1)
+  })
+})

--- a/src/molecules/editor/extensions/list/list-join.test.ts
+++ b/src/molecules/editor/extensions/list/list-join.test.ts
@@ -153,6 +153,43 @@ describe('ListJoin', () => {
     expect(onUpdate).not.toHaveBeenCalled()
   })
 
+  it('repairs an unmounted editor through the command', () => {
+    // `useEditor` builds with `element: null`, so there is no view — and until
+    // it mounts, no ProseMirror plugins either. The command is the only path.
+    const editor = new Editor({
+      extensions: [StarterKit],
+      element: null,
+      content: '<ol><li><p>a</p></li></ol><ol><li><p>b</p></li></ol>',
+    })
+    expect(editor.state.plugins).toHaveLength(0)
+
+    editor.commands.joinAdjacentLists()
+
+    const lists = editor
+      .getJSON()
+      .content!.filter((n) => n.type === 'orderedList')
+    expect(lists).toHaveLength(1)
+    expect(lists[0].content).toHaveLength(2)
+  })
+
+  it('reports nothing to do when the document has no split list', () => {
+    const editor = new Editor({
+      extensions: [StarterKit],
+      element: null,
+      content: '<ol><li><p>a</p></li></ol>',
+    })
+    expect(editor.commands.joinAdjacentLists()).toBe(false)
+  })
+
+  it('finds list nodes by their schema group, not by name', () => {
+    const editor = editorWith('<p>x</p>')
+    const groupOf = (name: string) =>
+      String(editor.schema.nodes[name].spec.group ?? '').split(' ')
+    expect(groupOf('orderedList')).toContain('list')
+    expect(groupOf('bulletList')).toContain('list')
+    expect(groupOf('paragraph')).not.toContain('list')
+  })
+
   it('merges adjacent task lists, which only RichTextKit enables', () => {
     const taskList = (text: string) =>
       `<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><p>${text}</p></li></ul>`

--- a/src/molecules/editor/extensions/list/list-join.test.ts
+++ b/src/molecules/editor/extensions/list/list-join.test.ts
@@ -2,12 +2,19 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi } from 'vitest'
-import { Editor } from '@tiptap/core'
+import { Editor, Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { OrderedList } from '@tiptap/extension-list'
 import { ref, nextTick, createApp, defineComponent } from 'vue'
 import { RichTextKit } from '../../kits'
 import { StarterKit } from '../../extensions'
 import { useEditor } from '../../useEditor'
+import { ListJoin } from './list-join'
+
+const listItemJSON = (text: string) => ({
+  type: 'listItem',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+})
 
 /** Mount `useEditor` the way a consumer does, without rendering EditorContent. */
 function mountUseEditor(
@@ -220,6 +227,46 @@ describe('ListJoin', () => {
     // external content write, would push an empty transaction at consumers.
     mountUseEditor(ref('<ol><li><p>a</p></li></ol>'), { onTransaction })
     expect(onTransaction).not.toHaveBeenCalled()
+  })
+
+  it('leaves a remote collaboration change to the peer that made it', () => {
+    // Stand-in for y-prosemirror's plugin: the real one is pulled in by a
+    // consumer's Collaboration extension, so it cannot be imported here.
+    const ySyncKey = new PluginKey('y-sync')
+    const YSync = Extension.create({
+      name: 'ySyncStandIn',
+      addProseMirrorPlugins: () => [new Plugin({ key: ySyncKey })],
+    })
+    const editor = new Editor({
+      extensions: [StarterKit.configure({ listJoin: false }), ListJoin, YSync],
+      content: '<p>x</p>',
+    })
+
+    // Apply a split-list document the way a remote peer's update arrives.
+    const remote = editor.state.tr
+    remote.replaceWith(
+      0,
+      editor.state.doc.content.size,
+      editor.schema.nodeFromJSON({
+        type: 'doc',
+        content: [
+          { type: 'orderedList', content: [listItemJSON('a')] },
+          { type: 'orderedList', content: [listItemJSON('b')] },
+        ],
+      }).content,
+    )
+    editor.view.dispatch(remote.setMeta(ySyncKey, { isChangeOrigin: true }))
+
+    // Untouched: that peer's own join replicates on its own.
+    expect(
+      editor.getJSON().content!.filter((n) => n.type === 'orderedList'),
+    ).toHaveLength(2)
+
+    // A local edit still joins.
+    editor.commands.insertContentAt(editor.state.doc.content.size - 1, 'z')
+    expect(
+      editor.getJSON().content!.filter((n) => n.type === 'orderedList'),
+    ).toHaveLength(1)
   })
 
   it('can be turned off through the kit', () => {

--- a/src/molecules/editor/extensions/list/list-join.test.ts
+++ b/src/molecules/editor/extensions/list/list-join.test.ts
@@ -10,12 +10,15 @@ import { StarterKit } from '../../extensions'
 import { useEditor } from '../../useEditor'
 
 /** Mount `useEditor` the way a consumer does, without rendering EditorContent. */
-function mountUseEditor(content: ReturnType<typeof ref<string>>) {
+function mountUseEditor(
+  content: ReturnType<typeof ref<string>>,
+  options: Record<string, unknown> = {},
+) {
   let editor: ReturnType<typeof useEditor> | null = null
   createApp(
     defineComponent({
       setup() {
-        editor = useEditor({ content, extensions: [StarterKit] })
+        editor = useEditor({ content, extensions: [StarterKit], ...options })
         return () => null
       },
     }),
@@ -196,6 +199,38 @@ describe('ListJoin', () => {
       content: '<ol><li><p>a</p></li></ol>',
     })
     expect(editor.commands.joinAdjacentLists()).toBe(false)
+  })
+
+  it('repairs content handed to useEditor at construction, still unmounted', () => {
+    // What the comment in useEditor promises: a headless caller reading back
+    // before <EditorContent> mounts gets the repaired document.
+    const editor = mountUseEditor(
+      ref('<ol><li><p>a</p></li></ol><ol><li><p>b</p></li></ol>'),
+    )
+    expect(editor.value!.state.plugins).toHaveLength(0)
+    expect(editor.value!.getHTML()).toBe(
+      '<ol><li><p>a</p></li><li><p>b</p></li></ol>',
+    )
+  })
+
+  it('fires no transaction when useEditor has nothing to join', () => {
+    const onTransaction = vi.fn()
+    // A chain dispatches even when its command returns false, so useEditor
+    // probes with can() first — otherwise every editor built, and every
+    // external content write, would push an empty transaction at consumers.
+    mountUseEditor(ref('<ol><li><p>a</p></li></ol>'), { onTransaction })
+    expect(onTransaction).not.toHaveBeenCalled()
+  })
+
+  it('can be turned off through the kit', () => {
+    const editor = new Editor({
+      extensions: [StarterKit.configure({ listJoin: false })],
+      element: null,
+      content: '<ol><li><p>a</p></li></ol><ol><li><p>b</p></li></ol>',
+    })
+    expect(
+      editor.getJSON().content!.filter((n) => n.type === 'orderedList'),
+    ).toHaveLength(2)
   })
 
   it('repairs content written through the useEditor ref, still unmounted', async () => {

--- a/src/molecules/editor/extensions/list/list-join.ts
+++ b/src/molecules/editor/extensions/list/list-join.ts
@@ -12,13 +12,21 @@ import { canJoin } from '@tiptap/pm/transform'
  * group covers a consumer's own list node too, with no list of names to keep
  * in sync.
  */
+const listTypeCache = new WeakMap<Schema, Set<NodeType>>()
+
 function listTypesIn(schema: Schema): Set<NodeType> {
+  // A schema is fixed for the life of an editor, so resolve it once instead of
+  // on every doc-changing transaction.
+  const cached = listTypeCache.get(schema)
+  if (cached) return cached
+
   const types = new Set<NodeType>()
   for (const name of Object.keys(schema.nodes)) {
     const type = schema.nodes[name]
     const groups = String(type.spec.group ?? '').split(' ')
     if (groups.includes('list')) types.add(type)
   }
+  listTypeCache.set(schema, types)
   return types
 }
 
@@ -87,6 +95,12 @@ declare module '@tiptap/core' {
        * automatically on every edit and when the editor view is created;
        * call it directly to repair a document in an editor that has not been
        * mounted yet (see `useEditor`).
+       *
+       * It sets no transaction metadata, so it composes in a chain without
+       * changing how the caller's own edit is recorded. Repairing a document
+       * on open is not the user's edit — mark that at the call site:
+       * `chain().joinAdjacentLists().setMeta('preventUpdate', true)
+       *   .setMeta('addToHistory', false).run()`
        */
       joinAdjacentLists: () => ReturnType
     }
@@ -117,10 +131,6 @@ export const ListJoin = Extension.create({
           if (!dispatch) return true
 
           for (const pos of positions) tr.join(pos)
-          // Repairing a document on open is not the user's edit: keep it out
-          // of the `update` event and out of the undo stack. The `transaction`
-          // event still fires — dirty-tracking should listen to `update`.
-          tr.setMeta('preventUpdate', true).setMeta('addToHistory', false)
           return true
         },
     }
@@ -144,6 +154,9 @@ export const ListJoin = Extension.create({
         view: (view) => {
           const tr = view.state.tr
           if (joinAdjacentListsIn(tr, view.state.schema)) {
+            // Repairing a document on open is not the user's edit: keep it out
+            // of the `update` event and out of the undo stack. The `transaction`
+            // event still fires — dirty-tracking should listen to `update`.
             view.dispatch(
               tr.setMeta('preventUpdate', true).setMeta('addToHistory', false),
             )

--- a/src/molecules/editor/extensions/list/list-join.ts
+++ b/src/molecules/editor/extensions/list/list-join.ts
@@ -1,0 +1,89 @@
+import { Extension } from '@tiptap/core'
+import type { Node as ProseMirrorNode, NodeType } from '@tiptap/pm/model'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { canJoin } from '@tiptap/pm/transform'
+
+const LIST_NODE_NAMES = ['bulletList', 'orderedList', 'taskList']
+
+/**
+ * Two sibling lists of the same kind are indistinguishable on screen, so they
+ * must be one node. Merge only when the attributes match: a list carrying its
+ * own `start` (or `type`) was numbered deliberately and keeps its identity.
+ */
+function isJoinablePair(
+  before: ProseMirrorNode,
+  after: ProseMirrorNode,
+  listTypes: Set<NodeType>,
+): boolean {
+  if (before.type !== after.type || !listTypes.has(before.type)) return false
+  const keys = new Set([
+    ...Object.keys(before.attrs),
+    ...Object.keys(after.attrs),
+  ])
+  for (const key of keys) {
+    if (before.attrs[key] !== after.attrs[key]) return false
+  }
+  return true
+}
+
+/** Absolute positions of every boundary between two joinable sibling lists. */
+function collectJoinPositions(
+  node: ProseMirrorNode,
+  contentStart: number,
+  listTypes: Set<NodeType>,
+  out: number[],
+): void {
+  let previous: ProseMirrorNode | null = null
+  node.forEach((child, offset) => {
+    const start = contentStart + offset
+    if (previous && isJoinablePair(previous, child, listTypes)) out.push(start)
+    if (child.content.size > 0) {
+      collectJoinPositions(child, start + 1, listTypes, out)
+    }
+    previous = child
+  })
+}
+
+/**
+ * Keeps adjacent lists of the same kind merged into a single list.
+ *
+ * ProseMirror never re-joins siblings on its own, so any edit that splits a
+ * list — lifting an item out, then deleting the paragraph it left behind —
+ * leaves two `orderedList` nodes touching each other. Both render with
+ * `start: 1`, so the tail of the list silently restarts its numbering.
+ */
+export const ListJoin = Extension.create({
+  name: 'listJoin',
+
+  addProseMirrorPlugins() {
+    const listTypes = new Set(
+      LIST_NODE_NAMES.map((name) => this.editor.schema.nodes[name]).filter(
+        (type): type is NodeType => Boolean(type),
+      ),
+    )
+    if (listTypes.size === 0) return []
+
+    return [
+      new Plugin({
+        key: new PluginKey('listJoin'),
+        appendTransaction: (transactions, _oldState, newState) => {
+          if (!transactions.some((transaction) => transaction.docChanged)) {
+            return null
+          }
+          const positions: number[] = []
+          collectJoinPositions(newState.doc, 0, listTypes, positions)
+          if (positions.length === 0) return null
+
+          const tr = newState.tr
+          // Join back-to-front so each join leaves the earlier positions valid.
+          for (const pos of positions.sort((a, b) => b - a)) {
+            if (canJoin(tr.doc, pos)) tr.join(pos)
+          }
+          return tr.docChanged ? tr : null
+        },
+      }),
+    ]
+  },
+})
+
+export default ListJoin

--- a/src/molecules/editor/extensions/list/list-join.ts
+++ b/src/molecules/editor/extensions/list/list-join.ts
@@ -32,15 +32,9 @@ function isJoinablePair(
   after: ProseMirrorNode,
   listTypes: Set<NodeType>,
 ): boolean {
-  if (before.type !== after.type || !listTypes.has(before.type)) return false
-  const keys = new Set([
-    ...Object.keys(before.attrs),
-    ...Object.keys(after.attrs),
-  ])
-  for (const key of keys) {
-    if (before.attrs[key] !== after.attrs[key]) return false
-  }
-  return true
+  // sameMarkup deep-compares attributes, so a list node with an object or
+  // array attribute still merges with its twin.
+  return listTypes.has(before.type) && before.sameMarkup(after)
 }
 
 /** Absolute positions of every boundary between two joinable sibling lists. */
@@ -63,26 +57,26 @@ function collectJoinPositions(
 }
 
 /**
+ * Boundaries in `doc` where two adjacent same-kind lists can be joined,
+ * ordered back-to-front so applying them leaves the earlier ones valid.
+ */
+function joinablePositions(doc: ProseMirrorNode, schema: Schema): number[] {
+  const listTypes = listTypesIn(schema)
+  if (listTypes.size === 0) return []
+
+  const positions: number[] = []
+  collectJoinPositions(doc, 0, listTypes, positions)
+  return positions.sort((a, b) => b - a).filter((pos) => canJoin(doc, pos))
+}
+
+/**
  * Merge every pair of adjacent same-kind lists in `tr.doc`. Returns whether
  * anything was joined.
  */
 function joinAdjacentListsIn(tr: Transaction, schema: Schema): boolean {
-  const listTypes = listTypesIn(schema)
-  if (listTypes.size === 0) return false
-
-  const positions: number[] = []
-  collectJoinPositions(tr.doc, 0, listTypes, positions)
-  if (positions.length === 0) return false
-
-  // Join back-to-front so each join leaves the earlier positions valid.
-  let joined = false
-  for (const pos of positions.sort((a, b) => b - a)) {
-    if (canJoin(tr.doc, pos)) {
-      tr.join(pos)
-      joined = true
-    }
-  }
-  return joined
+  const positions = joinablePositions(tr.doc, schema)
+  for (const pos of positions) tr.join(pos)
+  return positions.length > 0
 }
 
 declare module '@tiptap/core' {
@@ -115,13 +109,18 @@ export const ListJoin = Extension.create({
       joinAdjacentLists:
         () =>
         ({ tr, dispatch }) => {
-          if (!joinAdjacentListsIn(tr, tr.doc.type.schema)) return false
-          if (dispatch) {
-            // Repairing a document on open is not the user's edit: keep it out
-            // of the `update` event and out of the undo stack. The `transaction`
-            // event still fires — dirty-tracking should listen to `update`.
-            tr.setMeta('preventUpdate', true).setMeta('addToHistory', false)
-          }
+          // Answer without touching `tr` when this is only a probe: a
+          // `can().chain()` shares one transaction, so joining here would test
+          // every later command against an already-joined document.
+          const positions = joinablePositions(tr.doc, tr.doc.type.schema)
+          if (positions.length === 0) return false
+          if (!dispatch) return true
+
+          for (const pos of positions) tr.join(pos)
+          // Repairing a document on open is not the user's edit: keep it out
+          // of the `update` event and out of the undo stack. The `transaction`
+          // event still fires — dirty-tracking should listen to `update`.
+          tr.setMeta('preventUpdate', true).setMeta('addToHistory', false)
           return true
         },
     }

--- a/src/molecules/editor/extensions/list/list-join.ts
+++ b/src/molecules/editor/extensions/list/list-join.ts
@@ -4,16 +4,21 @@ import type {
   NodeType,
   Schema,
 } from '@tiptap/pm/model'
-import { Plugin, PluginKey, type Transaction } from '@tiptap/pm/state'
+import {
+  Plugin,
+  PluginKey,
+  type EditorState,
+  type Transaction,
+} from '@tiptap/pm/state'
 import { canJoin } from '@tiptap/pm/transform'
+
+const listTypeCache = new WeakMap<Schema, Set<NodeType>>()
 
 /**
  * Every list node TipTap ships declares `group: 'block list'`, so reading the
  * group covers a consumer's own list node too, with no list of names to keep
  * in sync.
  */
-const listTypeCache = new WeakMap<Schema, Set<NodeType>>()
-
 function listTypesIn(schema: Schema): Set<NodeType> {
   // A schema is fixed for the life of an editor, so resolve it once instead of
   // on every doc-changing transaction.
@@ -85,6 +90,37 @@ function joinAdjacentListsIn(tr: Transaction, schema: Schema): boolean {
   const positions = joinablePositions(tr.doc, schema)
   for (const pos of positions) tr.join(pos)
   return positions.length > 0
+}
+
+/**
+ * Whether these transactions carry a remote collaboration update.
+ *
+ * Collaboration is a consumer-supplied extension (`@tiptap/extension-collaboration`
+ * brings y-prosemirror), so its plugin key cannot be imported here. Find it on
+ * the live state instead: y-prosemirror tags every remote application with the
+ * meta of its `y-sync` plugin.
+ */
+function isRemoteChange(
+  transactions: readonly Transaction[],
+  state: EditorState,
+): boolean {
+  const syncKey = state.plugins.find((plugin) =>
+    ((plugin.spec.key as PluginKey | undefined)?.key ?? '').startsWith(
+      'y-sync',
+    ),
+  )?.spec.key as PluginKey | undefined
+  if (!syncKey) return false
+  return transactions.some((transaction) => {
+    if (transaction.getMeta(syncKey)) return true
+    // Another plugin appending to the same dispatch (TrailingNode does, on any
+    // structural change) produces a transaction that carries no sync meta of
+    // its own. ProseMirror tags it with the root transaction that caused it,
+    // so ask that one — otherwise the guard would depend on plugin order.
+    const root = transaction.getMeta('appendedTransaction') as
+      | Transaction
+      | undefined
+    return Boolean(root?.getMeta(syncKey))
+  })
 }
 
 declare module '@tiptap/core' {
@@ -167,6 +203,12 @@ export const ListJoin = Extension.create({
           if (!transactions.some((transaction) => transaction.docChanged)) {
             return null
           }
+          // A remote peer's edit arrives as a local transaction. That peer runs
+          // this same plugin, and its join replicates on its own — joining here
+          // as well means two peers moving the same nodes concurrently, which
+          // is a duplicate-content shape rather than a converging one.
+          if (isRemoteChange(transactions, newState)) return null
+
           const tr = newState.tr
           return joinAdjacentListsIn(tr, newState.schema) ? tr : null
         },

--- a/src/molecules/editor/extensions/list/list-join.ts
+++ b/src/molecules/editor/extensions/list/list-join.ts
@@ -1,9 +1,22 @@
 import { Extension } from '@tiptap/core'
-import type { Node as ProseMirrorNode, NodeType } from '@tiptap/pm/model'
-import { Plugin, PluginKey } from '@tiptap/pm/state'
+import type {
+  Node as ProseMirrorNode,
+  NodeType,
+  Schema,
+} from '@tiptap/pm/model'
+import { Plugin, PluginKey, type EditorState } from '@tiptap/pm/state'
+import type { Transaction } from '@tiptap/pm/state'
 import { canJoin } from '@tiptap/pm/transform'
 
 const LIST_NODE_NAMES = ['bulletList', 'orderedList', 'taskList']
+
+function listTypesIn(schema: Schema): Set<NodeType> {
+  return new Set(
+    LIST_NODE_NAMES.map((name) => schema.nodes[name]).filter(
+      (type): type is NodeType => Boolean(type),
+    ),
+  )
+}
 
 /**
  * Two sibling lists of the same kind are indistinguishable on screen, so they
@@ -37,11 +50,32 @@ function collectJoinPositions(
   node.forEach((child, offset) => {
     const start = contentStart + offset
     if (previous && isJoinablePair(previous, child, listTypes)) out.push(start)
-    if (child.content.size > 0) {
+    // A list can never live in inline content, so don't walk paragraph text.
+    if (child.content.size > 0 && !child.type.inlineContent) {
       collectJoinPositions(child, start + 1, listTypes, out)
     }
     previous = child
   })
+}
+
+/**
+ * Transaction that merges every pair of adjacent same-kind lists in `state`,
+ * or `null` when the document already has none.
+ */
+function joinAdjacentLists(
+  state: EditorState,
+  listTypes: Set<NodeType>,
+): Transaction | null {
+  const positions: number[] = []
+  collectJoinPositions(state.doc, 0, listTypes, positions)
+  if (positions.length === 0) return null
+
+  const tr = state.tr
+  // Join back-to-front so each join leaves the earlier positions valid.
+  for (const pos of positions.sort((a, b) => b - a)) {
+    if (canJoin(tr.doc, pos)) tr.join(pos)
+  }
+  return tr.docChanged ? tr : null
 }
 
 /**
@@ -56,30 +90,37 @@ export const ListJoin = Extension.create({
   name: 'listJoin',
 
   addProseMirrorPlugins() {
-    const listTypes = new Set(
-      LIST_NODE_NAMES.map((name) => this.editor.schema.nodes[name]).filter(
-        (type): type is NodeType => Boolean(type),
-      ),
-    )
+    const listTypes = listTypesIn(this.editor.schema)
     if (listTypes.size === 0) return []
 
     return [
       new Plugin({
         key: new PluginKey('listJoin'),
+        /**
+         * Initial content is parsed straight into the state, with no
+         * transaction, so `appendTransaction` never sees it. A document saved
+         * back while this bug was live would keep rendering `1.` mid-list —
+         * until the first keystroke, and forever in a read-only editor.
+         * Repair it here: this runs synchronously as the view is created, so
+         * the first paint is already correct.
+         */
+        view: (view) => {
+          const tr = joinAdjacentLists(view.state, listTypes)
+          if (tr) {
+            // `preventUpdate` keeps the repair out of the `update` event:
+            // opening a document must not mark it dirty or fire an autosave
+            // the user never asked for. Any later edit saves the fixed doc.
+            view.dispatch(
+              tr.setMeta('preventUpdate', true).setMeta('addToHistory', false),
+            )
+          }
+          return {}
+        },
         appendTransaction: (transactions, _oldState, newState) => {
           if (!transactions.some((transaction) => transaction.docChanged)) {
             return null
           }
-          const positions: number[] = []
-          collectJoinPositions(newState.doc, 0, listTypes, positions)
-          if (positions.length === 0) return null
-
-          const tr = newState.tr
-          // Join back-to-front so each join leaves the earlier positions valid.
-          for (const pos of positions.sort((a, b) => b - a)) {
-            if (canJoin(tr.doc, pos)) tr.join(pos)
-          }
-          return tr.docChanged ? tr : null
+          return joinAdjacentLists(newState, listTypes)
         },
       }),
     ]

--- a/src/molecules/editor/extensions/list/list-join.ts
+++ b/src/molecules/editor/extensions/list/list-join.ts
@@ -4,18 +4,22 @@ import type {
   NodeType,
   Schema,
 } from '@tiptap/pm/model'
-import { Plugin, PluginKey, type EditorState } from '@tiptap/pm/state'
-import type { Transaction } from '@tiptap/pm/state'
+import { Plugin, PluginKey, type Transaction } from '@tiptap/pm/state'
 import { canJoin } from '@tiptap/pm/transform'
 
-const LIST_NODE_NAMES = ['bulletList', 'orderedList', 'taskList']
-
+/**
+ * Every list node TipTap ships declares `group: 'block list'`, so reading the
+ * group covers a consumer's own list node too, with no list of names to keep
+ * in sync.
+ */
 function listTypesIn(schema: Schema): Set<NodeType> {
-  return new Set(
-    LIST_NODE_NAMES.map((name) => schema.nodes[name]).filter(
-      (type): type is NodeType => Boolean(type),
-    ),
-  )
+  const types = new Set<NodeType>()
+  for (const name of Object.keys(schema.nodes)) {
+    const type = schema.nodes[name]
+    const groups = String(type.spec.group ?? '').split(' ')
+    if (groups.includes('list')) types.add(type)
+  }
+  return types
 }
 
 /**
@@ -59,23 +63,40 @@ function collectJoinPositions(
 }
 
 /**
- * Transaction that merges every pair of adjacent same-kind lists in `state`,
- * or `null` when the document already has none.
+ * Merge every pair of adjacent same-kind lists in `tr.doc`. Returns whether
+ * anything was joined.
  */
-function joinAdjacentLists(
-  state: EditorState,
-  listTypes: Set<NodeType>,
-): Transaction | null {
-  const positions: number[] = []
-  collectJoinPositions(state.doc, 0, listTypes, positions)
-  if (positions.length === 0) return null
+function joinAdjacentListsIn(tr: Transaction, schema: Schema): boolean {
+  const listTypes = listTypesIn(schema)
+  if (listTypes.size === 0) return false
 
-  const tr = state.tr
+  const positions: number[] = []
+  collectJoinPositions(tr.doc, 0, listTypes, positions)
+  if (positions.length === 0) return false
+
   // Join back-to-front so each join leaves the earlier positions valid.
+  let joined = false
   for (const pos of positions.sort((a, b) => b - a)) {
-    if (canJoin(tr.doc, pos)) tr.join(pos)
+    if (canJoin(tr.doc, pos)) {
+      tr.join(pos)
+      joined = true
+    }
   }
-  return tr.docChanged ? tr : null
+  return joined
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    listJoin: {
+      /**
+       * Merge every pair of adjacent same-kind lists in the document. Runs
+       * automatically on every edit and when the editor view is created;
+       * call it directly to repair a document in an editor that has not been
+       * mounted yet (see `useEditor`).
+       */
+      joinAdjacentLists: () => ReturnType
+    }
+  }
 }
 
 /**
@@ -89,10 +110,24 @@ function joinAdjacentLists(
 export const ListJoin = Extension.create({
   name: 'listJoin',
 
-  addProseMirrorPlugins() {
-    const listTypes = listTypesIn(this.editor.schema)
-    if (listTypes.size === 0) return []
+  addCommands() {
+    return {
+      joinAdjacentLists:
+        () =>
+        ({ tr, dispatch }) => {
+          if (!joinAdjacentListsIn(tr, tr.doc.type.schema)) return false
+          if (dispatch) {
+            // Repairing a document on open is not the user's edit: keep it out
+            // of the `update` event and out of the undo stack. The `transaction`
+            // event still fires — dirty-tracking should listen to `update`.
+            tr.setMeta('preventUpdate', true).setMeta('addToHistory', false)
+          }
+          return true
+        },
+    }
+  },
 
+  addProseMirrorPlugins() {
     return [
       new Plugin({
         key: new PluginKey('listJoin'),
@@ -101,15 +136,15 @@ export const ListJoin = Extension.create({
          * transaction, so `appendTransaction` never sees it. A document saved
          * back while this bug was live would keep rendering `1.` mid-list —
          * until the first keystroke, and forever in a read-only editor.
-         * Repair it here: this runs synchronously as the view is created, so
-         * the first paint is already correct.
+         *
+         * This runs synchronously as the view is created, so the first paint
+         * is already correct. It does not cover an editor built with
+         * `element: null`, which has no view and, until it mounts, no plugins
+         * at all — `useEditor` runs the command directly for that.
          */
         view: (view) => {
-          const tr = joinAdjacentLists(view.state, listTypes)
-          if (tr) {
-            // `preventUpdate` keeps the repair out of the `update` event:
-            // opening a document must not mark it dirty or fire an autosave
-            // the user never asked for. Any later edit saves the fixed doc.
+          const tr = view.state.tr
+          if (joinAdjacentListsIn(tr, view.state.schema)) {
             view.dispatch(
               tr.setMeta('preventUpdate', true).setMeta('addToHistory', false),
             )
@@ -120,7 +155,8 @@ export const ListJoin = Extension.create({
           if (!transactions.some((transaction) => transaction.docChanged)) {
             return null
           }
-          return joinAdjacentLists(newState, listTypes)
+          const tr = newState.tr
+          return joinAdjacentListsIn(tr, newState.schema) ? tr : null
         },
       }),
     ]

--- a/src/molecules/editor/useEditor.test.ts
+++ b/src/molecules/editor/useEditor.test.ts
@@ -34,8 +34,13 @@ vi.mock('@tiptap/core', () => {
     }
     content: any
 
-    // `useEditor` normalizes the parsed document through a chain; the real
-    // behaviour is covered against a real editor in list-join.test.ts.
+    // `useEditor` normalizes the parsed document through a chain, guarded by
+    // `can()`; the real behaviour is covered against a real editor in
+    // list-join.test.ts, so nothing to join is the right answer here.
+    can() {
+      return { joinAdjacentLists: () => false }
+    }
+
     chain() {
       const api: any = {
         joinAdjacentLists: () => api,

--- a/src/molecules/editor/useEditor.test.ts
+++ b/src/molecules/editor/useEditor.test.ts
@@ -34,6 +34,17 @@ vi.mock('@tiptap/core', () => {
     }
     content: any
 
+    // `useEditor` normalizes the parsed document through a chain; the real
+    // behaviour is covered against a real editor in list-join.test.ts.
+    chain() {
+      const api: any = {
+        joinAdjacentLists: () => api,
+        setMeta: () => api,
+        run: () => true,
+      }
+      return api
+    }
+
     constructor(options: any) {
       this.options = options
       this.content = options.content ?? ''
@@ -51,7 +62,9 @@ vi.mock('@tiptap/core', () => {
     }
 
     getJSON() {
-      return typeof this.content === 'object' ? this.content : { type: 'doc', content: [] }
+      return typeof this.content === 'object'
+        ? this.content
+        : { type: 'doc', content: [] }
     }
 
     getMarkdown() {
@@ -67,7 +80,15 @@ vi.mock('@tiptap/core', () => {
     }
   }
 
-  return { Editor, Extension, Node, Mark, mergeAttributes, nodeInputRule, markInputRule }
+  return {
+    Editor,
+    Extension,
+    Node,
+    Mark,
+    mergeAttributes,
+    nodeInputRule,
+    markInputRule,
+  }
 })
 
 vi.mock('@tiptap/markdown', () => ({
@@ -192,7 +213,9 @@ describe('frappe-ui/editor minimal primitives', () => {
 
     content.value = '<p>External</p>'
     await nextTick()
-    expect(editor.commands.setContent).toHaveBeenCalledWith('<p>External</p>', { emitUpdate: false })
+    expect(editor.commands.setContent).toHaveBeenCalledWith('<p>External</p>', {
+      emitUpdate: false,
+    })
   })
 
   it('binds JSON content bidirectionally without echoing external writes back', async () => {
@@ -214,10 +237,15 @@ describe('frappe-ui/editor minimal primitives', () => {
     content.value = external
     await nextTick()
 
-    expect(editor.commands.setContent).toHaveBeenCalledWith(external, { emitUpdate: false })
+    expect(editor.commands.setContent).toHaveBeenCalledWith(external, {
+      emitUpdate: false,
+    })
     expect(toRaw(content.value)).toBe(external)
 
-    editor.content = { type: 'doc', content: [{ type: 'paragraph', content: [] }] }
+    editor.content = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [] }],
+    }
     editor.options.onUpdate({ editor })
     expect(toRaw(content.value)).toBe(editor.content)
 
@@ -233,7 +261,11 @@ describe('frappe-ui/editor minimal primitives', () => {
     createApp(
       defineComponent({
         setup() {
-          useEditor({ content: ref('# Hi'), format: 'markdown', extensions: [] })
+          useEditor({
+            content: ref('# Hi'),
+            format: 'markdown',
+            extensions: [],
+          })
           return () => null
         },
       }),
@@ -241,7 +273,9 @@ describe('frappe-ui/editor minimal primitives', () => {
 
     expect(editors[0].options.contentType).toBe('markdown')
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("format: 'markdown' needs the Markdown extension"),
+      expect.stringContaining(
+        "format: 'markdown' needs the Markdown extension",
+      ),
     )
     warn.mockRestore()
   })
@@ -253,7 +287,11 @@ describe('frappe-ui/editor minimal primitives', () => {
     createApp(
       defineComponent({
         setup() {
-          useEditor({ content, format: 'markdown', extensions: [Markdown as any] })
+          useEditor({
+            content,
+            format: 'markdown',
+            extensions: [Markdown as any],
+          })
           return () => null
         },
       }),

--- a/src/molecules/editor/useEditor.ts
+++ b/src/molecules/editor/useEditor.ts
@@ -147,6 +147,10 @@ export function useEditor(
             ? { emitUpdate: false, contentType: 'markdown' }
             : { emitUpdate: false },
         )
+        // Same reason as at construction: while unmounted there are no
+        // plugins, so nothing normalizes what `setContent` just parsed.
+        // No-op when there is nothing to join.
+        editor.value.commands.joinAdjacentLists?.()
       } finally {
         applyingExternalUpdate = false
       }

--- a/src/molecules/editor/useEditor.ts
+++ b/src/molecules/editor/useEditor.ts
@@ -114,6 +114,13 @@ export function useEditor(
 
   editor.value = new TiptapEditor(editorOptions as EditorOptions)
 
+  // We build with `element: null` and let `<EditorContent>` mount later, so an
+  // unmounted editor has no view and no ProseMirror plugins at all. Normalize
+  // the parsed document here instead, or a headless caller — `getHTML()` before
+  // the child mounts, a markdown export that never renders — reads back the
+  // split lists it was handed. No-op once the schema has no list node.
+  editor.value.commands.joinAdjacentLists?.()
+
   const editorStorage = editor.value.storage as typeof editor.value.storage & {
     upload?: { uploadFunction: UseEditorOptions['uploadFunction'] }
   }

--- a/src/molecules/editor/useEditor.ts
+++ b/src/molecules/editor/useEditor.ts
@@ -120,12 +120,16 @@ export function useEditor(
   // the child mounts, a markdown export that never renders — reads back the
   // split lists it was handed. No-op once the schema has no list node.
   // The metas are ours, not the command's: opening a document is not an edit.
-  editor.value
-    .chain()
-    .joinAdjacentLists()
-    .setMeta('preventUpdate', true)
-    .setMeta('addToHistory', false)
-    .run()
+  // Guarded by `can()` because a chain dispatches even when its command
+  // returns false, and an empty transaction still reaches `onTransaction`.
+  if (editor.value.can().joinAdjacentLists?.()) {
+    editor.value
+      .chain()
+      .joinAdjacentLists()
+      .setMeta('preventUpdate', true)
+      .setMeta('addToHistory', false)
+      .run()
+  }
 
   const editorStorage = editor.value.storage as typeof editor.value.storage & {
     upload?: { uploadFunction: UseEditorOptions['uploadFunction'] }
@@ -156,12 +160,14 @@ export function useEditor(
         // Same reason as at construction: while unmounted there are no
         // plugins, so nothing normalizes what `setContent` just parsed.
         // No-op when there is nothing to join.
-        editor.value
-          .chain()
-          .joinAdjacentLists()
-          .setMeta('preventUpdate', true)
-          .setMeta('addToHistory', false)
-          .run()
+        if (editor.value.can().joinAdjacentLists?.()) {
+          editor.value
+            .chain()
+            .joinAdjacentLists()
+            .setMeta('preventUpdate', true)
+            .setMeta('addToHistory', false)
+            .run()
+        }
       } finally {
         applyingExternalUpdate = false
       }

--- a/src/molecules/editor/useEditor.ts
+++ b/src/molecules/editor/useEditor.ts
@@ -119,7 +119,13 @@ export function useEditor(
   // the parsed document here instead, or a headless caller — `getHTML()` before
   // the child mounts, a markdown export that never renders — reads back the
   // split lists it was handed. No-op once the schema has no list node.
-  editor.value.commands.joinAdjacentLists?.()
+  // The metas are ours, not the command's: opening a document is not an edit.
+  editor.value
+    .chain()
+    .joinAdjacentLists()
+    .setMeta('preventUpdate', true)
+    .setMeta('addToHistory', false)
+    .run()
 
   const editorStorage = editor.value.storage as typeof editor.value.storage & {
     upload?: { uploadFunction: UseEditorOptions['uploadFunction'] }
@@ -150,7 +156,12 @@ export function useEditor(
         // Same reason as at construction: while unmounted there are no
         // plugins, so nothing normalizes what `setContent` just parsed.
         // No-op when there is nothing to join.
-        editor.value.commands.joinAdjacentLists?.()
+        editor.value
+          .chain()
+          .joinAdjacentLists()
+          .setMeta('preventUpdate', true)
+          .setMeta('addToHistory', false)
+          .run()
       } finally {
         applyingExternalUpdate = false
       }


### PR DESCRIPTION
## Problem

Numbering restarts at 1 in the tail of an ordered list after an edit splits it.

Type five items, delete the fourth, then delete the empty line it leaves behind:

```
1. hello        1. hello        1. hello
2. world        2. world        2. world
3. this   →     3. this    →    3. this
4. is                           1. a test   ← should be 4.
5. a test       1. a test
```

The numbers in an `<ol>` are not stored per item. A ProseMirror `orderedList`
node holds one `start` attribute and the browser counts from there. Lifting an
item out cuts the list into two `orderedList` nodes. Deleting the paragraph
between them removes the paragraph only: the two list nodes stay siblings,
touching, both with `start: 1`. ProseMirror never re-joins siblings on its own.

## Fix

New `ListJoin` extension. After any change it walks the document and joins
adjacent lists of the same kind, top level and nested.

It joins only when the two nodes' attributes match. A list carrying its own
`start` or `type` was numbered deliberately, so it keeps its identity instead of
being swallowed and silently renumbered. This costs nothing for the bug above: a
split copies attributes to both halves, so `<ol start="5">` splits into two
`start: 5` lists and still merges, keeping the 5.

Registered in `StarterKit` next to `OrderedList`, so `CommentKit` and
`RichTextKit` both pick it up. `bulletList`, `orderedList` and `taskList` are all
covered.

The join is appended to the user's own transaction, so one undo reverts the whole
edit.

## Not changed

While a paragraph still separates the two lists they are genuinely two lists, and
the second restarts at 1. That matches Google Docs and Notion. The merge happens
once the separator is gone.

## Tests

`src/molecules/editor/extensions/list/list-join.test.ts`, 8 cases:

- adjacent ordered lists merge and numbering continues
- adjacent bullet lists merge
- ordered next to bullet stays apart
- `<ol start="7">` stays apart and keeps its start
- `<ol type="a">` stays apart and keeps its marker style
- a chain of three adjacent lists merges in one pass
- a non-default `start` survives a split and re-merge
- nested lists inside a list item merge

Full editor suite passes (155 tests).

<!-- coverage-report:start -->
Coverage: 70.92% (+0.30% vs `main`)
<!-- coverage-report:end -->

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1027/
<!-- docs-preview:end -->





