### PR TITLE
fix(Tree): let the browser keep modified arrow keys (Closes #1037)

### DIFF
--- a/src/components/Tree/tree.cy.ts
+++ b/src/components/Tree/tree.cy.ts
@@ -132,6 +132,20 @@ describe('Tree', () => {
     cy.contains('Node A').should('exist')
   })
 
+  it('lets the browser keep modified arrow keys', () => {
+    cy.mount(Tree, { props: { nodes: makeNodes(), nodeKey: 'id' } })
+    cy.get('[role="treeitem"]').first().focus()
+    cy.focused().should('contain', 'Root')
+    // A modified key must not preventDefault — the tree focus must not move
+    // (the browser would handle Alt/Cmd+Arrow, Ctrl+Home/End itself).
+    cy.focused().trigger('keydown', { key: 'ArrowDown', altKey: true })
+    cy.focused().should('contain', 'Root')
+    cy.focused().trigger('keydown', { key: 'ArrowDown', metaKey: true })
+    cy.focused().should('contain', 'Root')
+    cy.focused().trigger('keydown', { key: 'Home', ctrlKey: true })
+    cy.focused().should('contain', 'Root')
+  })
+
   it('renders custom item-label and item-prefix/item-suffix slots', () => {
     cy.mount(Tree, {
       props: { nodes: makeNodes(), nodeKey: 'id', expanded: true },

--- a/src/components/Tree/tree.cy.ts
+++ b/src/components/Tree/tree.cy.ts
@@ -142,7 +142,9 @@ describe('Tree', () => {
     cy.focused().should('contain', 'Root')
     cy.focused().trigger('keydown', { key: 'ArrowDown', metaKey: true })
     cy.focused().should('contain', 'Root')
-    cy.focused().trigger('keydown', { key: 'Home', ctrlKey: true })
+    // Ctrl+End, not Ctrl+Home: focus starts on the first row, so an unguarded
+    // Home would land back on Root and the assertion could never fail.
+    cy.focused().trigger('keydown', { key: 'End', ctrlKey: true })
     cy.focused().should('contain', 'Root')
   })
 

--- a/src/components/Tree/useTreeKeyboard.ts
+++ b/src/components/Tree/useTreeKeyboard.ts
@@ -102,7 +102,7 @@ export function useTreeKeyboard(options: KeyboardOptions) {
         toggle(current.node)
         break
       default:
-        if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        if (e.key.length === 1) {
           typeaheadSearch(e.key)
         }
     }

--- a/src/components/Tree/useTreeKeyboard.ts
+++ b/src/components/Tree/useTreeKeyboard.ts
@@ -62,6 +62,9 @@ export function useTreeKeyboard(options: KeyboardOptions) {
   }
 
   function onKeydown(e: KeyboardEvent): void {
+    // Let the browser handle modified keys (Alt/Cmd/Ctrl+Arrow, Ctrl+Home/End, etc.)
+    if (e.altKey || e.metaKey || e.ctrlKey) return
+
     const index = indexOfFocused()
     const current = flat.value[index]
     if (!current && !['Home', 'End'].includes(e.key)) return


### PR DESCRIPTION
## Summary

`Tree/useTreeKeyboard.ts` was calling `preventDefault()` before testing for modifier keys, so **Alt/Cmd+Arrow** and **Ctrl+Home/End** were swallowed by the tree's keyboard handler instead of reaching the browser.

This matches the gap the charts fixed in `729f7d5` — the shape to copy is to return before the switch when a modifier is held.

## Changes

- `src/components/Tree/useTreeKeyboard.ts`: early-return from `onKeydown` when `altKey`, `metaKey`, or `ctrlKey` is held.
- `src/components/Tree/tree.cy.ts`: added a test asserting modified keys do not move tree focus (browser keeps them).

Closes #1037

<!-- coverage-report:start -->
Coverage: 71.88% (±0.00% vs `main`)
<!-- coverage-report:end -->

