### PR TITLE
fix(Slider): give the role=slider thumb an accessible name from the label

### DIFF
--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -86,19 +86,18 @@ describe('Slider', () => {
   })
 
   describe('shared labeling contract', () => {
-    it('wires aria-labelledby and aria-describedby', () => {
+    it('wires aria-labelledby and aria-describedby on the slider thumb', () => {
       cy.mount(Slider, {
         props: { label: 'Volume', description: 'Adjust volume.' },
       })
-      cy.get('[role="slider"]')
-        .parents('[aria-labelledby]')
-        .first()
-        .then(($root) => {
-          const labelledBy = $root.attr('aria-labelledby')!
-          const describedBy = $root.attr('aria-describedby')!
-          cy.get(`#${labelledBy}`).should('contain.text', 'Volume')
-          cy.get(`#${describedBy}`).should('contain.text', 'Adjust volume.')
-        })
+      cy.get('[role="slider"]').should(($thumb) => {
+        const labelledBy = $thumb.attr('aria-labelledby')!
+        const describedBy = $thumb.attr('aria-describedby')!
+        expect(labelledBy).to.exist
+        expect(describedBy).to.exist
+        cy.get(`#${labelledBy}`).should('contain.text', 'Volume')
+        cy.get(`#${describedBy}`).should('contain.text', 'Adjust volume.')
+      })
     })
 
     it('renders error state', () => {

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -137,10 +137,6 @@ const hasLabeling = computed(() => {
       :step="props.step"
       :disabled="props.disabled"
       :aria-disabled="props.disabled || undefined"
-      :aria-labelledby="labelledBy"
-      :aria-describedby="describedBy"
-      :aria-errormessage="hasError ? errorMessageId : undefined"
-      :aria-invalid="hasError || undefined"
       data-slot="control"
       v-bind="dataAttrs"
       @value-commit="onValueCommit"
@@ -160,6 +156,10 @@ const hasLabeling = computed(() => {
         v-for="(_, i) in sliderValue"
         :key="`slider-thumb-${i}`"
         :class="thumbClasses"
+        :aria-labelledby="labelledBy"
+        :aria-describedby="describedBy"
+        :aria-errormessage="hasError ? errorMessageId : undefined"
+        :aria-invalid="hasError || undefined"
       />
     </SliderRoot>
     <InputDescription


### PR DESCRIPTION
## Summary

`Slider` puts its accessible name on `SliderRoot`, but reka-ui renders `SliderRoot` as a plain container with no role. The element that actually carries `role="slider"` is `SliderThumb`, which received no `aria-label` and no `aria-labelledby` — so every slider thumb was an unnamed control (failing WCAG 2.1 SC 4.1.2 Name, Role, Value).

This moves the labelling attributes (`aria-labelledby`, `aria-describedby`, `aria-errormessage`, `aria-invalid`) from `SliderRoot` onto each `SliderThumb`, so the `role="slider"` element now has an accessible name.

## Changes

- `src/components/Slider/Slider.vue`: move `aria-labelledby` / `aria-describedby` / `aria-errormessage` / `aria-invalid` from `SliderRoot` to each `SliderThumb`.
- `src/components/Slider/Slider.cy.ts`: update the shared-labeling test to assert the attributes live on `[role="slider"]` directly (not on its parent).

## Test

`npm run test:cypress` — updated `Slider.cy.ts` now asserts `[role="slider"]` carries the label and description IDs, and the label/description text resolves through them.

Fixes #994
