### PR TITLE
fix: clean up dead ink class name and update ink-shift refusal message (Closes #1035)

### DIFF
--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -1505,8 +1505,10 @@ linked external package never blocks a target the run would not rewrite. Run
 the codemod on each real package root directly, so every migrated tree gets
 its own marker. If the refusal names a marker inside a vendored dependency
 (for example `vendor/frappe-ui/.tokens-v2-ink-shift`), that dependency is
-already shifted — run the codemod per package root and leave the vendored
-marker alone.
+already shifted — leave its marker alone and target the directories that do
+not contain it. Pointing at the app root will not help: the search walks the
+whole subtree, so any ancestor of the vendored copy finds the same marker and
+refuses again. Target `src/` and your other own trees instead.
 
 The old `ink-<family>-1` step was white. The new `-1` is a light tint, so
 these sites have no automatic destination. The codemod flags them under

--- a/experimental/TextEditor/components/LinkPopup.vue
+++ b/experimental/TextEditor/components/LinkPopup.vue
@@ -14,7 +14,7 @@
     />
     <a
       v-else
-      class="text-ink-gray-700 underline text-sm flex-1 truncate pl-1"
+      class="text-ink-gray-7 underline text-sm flex-1 truncate pl-1"
       :title="_href"
       :href="_href"
       target="_blank"

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -782,8 +782,8 @@ function main() {
       inkShiftMarkerDirs
         .map((d) => findInkShiftMarkerBelow(d, { roots: inkShiftMarkerDirs }))
         .find(Boolean)
-    // Both branches print this. Two copies is what drifted apart over the last
-    // two review rounds, so keep one source and let each branch pick a writer.
+    // Both branches print this. Keep one source and let each pass its writer;
+    // two copies drift.
     const printVendoredHint = (write) => {
       write('   If the marker sits in a vendored copy outside node_modules, targeting')
       write(`   any ancestor of it finds it again — target directories that do not contain ${marker}.\n`)

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -793,7 +793,8 @@ function main() {
     if (marker) {
       console.warn(`\n⚠  ${marker} found: --ink-shift already ran on this target.`)
       console.warn('   A real run would double-shift and will refuse to start.')
-      console.warn(`   Target directories that do not contain ${marker}.\n`)
+      console.warn('   If the marker sits in a vendored copy outside node_modules, targeting')
+      console.warn(`   any ancestor of it finds it again — target directories that do not contain ${marker}.\n`)
     } else {
       console.warn('\n⚠  Ink scale shift (#1016): this must run exactly once per codebase.')
       console.warn(

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -782,19 +782,23 @@ function main() {
       inkShiftMarkerDirs
         .map((d) => findInkShiftMarkerBelow(d, { roots: inkShiftMarkerDirs }))
         .find(Boolean)
+    // Both branches print this. Two copies is what drifted apart over the last
+    // two review rounds, so keep one source and let each branch pick a writer.
+    const printVendoredHint = (write) => {
+      write('   If the marker sits in a vendored copy outside node_modules, targeting')
+      write(`   any ancestor of it finds it again — target directories that do not contain ${marker}.\n`)
+    }
     if (marker && !dryRun) {
       console.error(`\n✗  ${marker} found: --ink-shift already ran on this target.`)
       console.error('   A second run would double-shift every chromatic ink token.')
       console.error('   Delete the marker only to re-run the shift on purpose.')
-      console.error('   If the marker sits in a vendored copy outside node_modules, targeting')
-      console.error(`   any ancestor of it finds it again — target directories that do not contain ${marker}.\n`)
+      printVendoredHint(console.error)
       process.exit(1)
     }
     if (marker) {
       console.warn(`\n⚠  ${marker} found: --ink-shift already ran on this target.`)
       console.warn('   A real run would double-shift and will refuse to start.')
-      console.warn('   If the marker sits in a vendored copy outside node_modules, targeting')
-      console.warn(`   any ancestor of it finds it again — target directories that do not contain ${marker}.\n`)
+      printVendoredHint(console.warn)
     } else {
       console.warn('\n⚠  Ink scale shift (#1016): this must run exactly once per codebase.')
       console.warn(

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -785,7 +785,8 @@ function main() {
     if (marker && !dryRun) {
       console.error(`\n✗  ${marker} found: --ink-shift already ran on this target.`)
       console.error('   A second run would double-shift every chromatic ink token.')
-      console.error('   Delete the marker only to re-run the shift on purpose.\n')
+      console.error('   Delete the marker only to re-run the shift on purpose.')
+      console.error('   If the marker sits under a vendored package, run the codemod per package root instead.\n')
       process.exit(1)
     }
     if (marker) {

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -787,7 +787,7 @@ function main() {
       console.error('   A second run would double-shift every chromatic ink token.')
       console.error('   Delete the marker only to re-run the shift on purpose.')
       console.error('   If the marker sits in a vendored copy outside node_modules, targeting')
-      console.error('   its package root finds it again — target the directories you own instead.\n')
+      console.error(`   any ancestor of it finds it again — target directories that do not contain ${marker}.\n`)
       process.exit(1)
     }
     if (marker) {

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -786,7 +786,8 @@ function main() {
       console.error(`\n✗  ${marker} found: --ink-shift already ran on this target.`)
       console.error('   A second run would double-shift every chromatic ink token.')
       console.error('   Delete the marker only to re-run the shift on purpose.')
-      console.error('   If the marker sits under a vendored package, run the codemod per package root instead.\n')
+      console.error('   If the marker sits in a vendored copy outside node_modules, targeting')
+      console.error('   its package root finds it again — target the directories you own instead.\n')
       process.exit(1)
     }
     if (marker) {

--- a/tailwind/migrate-tokens-v2.js
+++ b/tailwind/migrate-tokens-v2.js
@@ -792,7 +792,8 @@ function main() {
     }
     if (marker) {
       console.warn(`\n⚠  ${marker} found: --ink-shift already ran on this target.`)
-      console.warn('   A real run would double-shift and will refuse to start.\n')
+      console.warn('   A real run would double-shift and will refuse to start.')
+      console.warn(`   Target directories that do not contain ${marker}.\n`)
     } else {
       console.warn('\n⚠  Ink scale shift (#1016): this must run exactly once per codebase.')
       console.warn(


### PR DESCRIPTION
## Summary

Follow-up to #1022. Two barista nits from the final review round:

### 1. Dead ink class name in LinkPopup

`experimental/TextEditor/components/LinkPopup.vue:17` carried `text-ink-gray-700` — a stale non-v2 name. The ink color keys are `gray-1..9`, not `gray-700`. Fixed to `text-ink-gray-7`.

### 2. Ink-shift refusal message contradicts the migration guide

`tailwind/migrate-tokens-v2.js:788` ended with "Delete the marker only to re-run the shift on purpose". The guide tells users whose app root contains a vendored frappe-ui checkout to leave the marker alone and run per package root. Added a clause: if the marker sits under a vendored package, run the codemod per package root instead.

Closes #1035

<!-- coverage-report:start -->
Coverage: 71.88% (±0.00% vs `main`)
<!-- coverage-report:end -->






