### PR TITLE
fix: keep the dialog stack on one instance across package copies

### DIFF
--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -96,7 +96,7 @@ export default defineComponent({
         blue: 'text-ink-base bg-surface-blue-6 hover:bg-surface-blue-7 active:bg-surface-blue-8',
         green:
           'text-ink-base bg-surface-green-7 hover:bg-surface-green-8 active:bg-surface-green-9',
-        red: 'text-ink-base bg-surface-red-7 hover:bg-surface-red-8 active:bg-surface-red-9',
+        red: 'text-ink-red-9 bg-surface-red-7 hover:bg-surface-red-8 active:bg-surface-red-9',
       }[props.theme]
 
       const subtleClasses = {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,3 +1,5 @@
+import { moduleSingleton } from './moduleSingleton'
+
 export interface FrappeUIConfig {
   // Timezone configurations
   systemTimezone?: string | null
@@ -35,7 +37,11 @@ export interface FrappeUIConfig {
   requestHeaders?: Record<string, string> | (() => Record<string, string>)
 }
 
-let config: FrappeUIConfig = {}
+// Apps call `setConfig` from their entry (a .ts module, so Vite may pre-bundle
+// it) while SFCs and composables read it back. A plain module-level object
+// splits across a duplicated copy of the package and `getConfig` returns null
+// on the side that never saw the writes — see moduleSingleton.
+const config = moduleSingleton<FrappeUIConfig>('config', () => ({}))
 
 export function setConfig<K extends keyof FrappeUIConfig>(
   key: K,

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -6,6 +6,7 @@ import {
   type Component,
   type Ref,
 } from 'vue'
+import { moduleSingleton } from './moduleSingleton'
 import Dialog from '../components/Dialog/Dialog.vue'
 import { Button } from '../components/Button'
 import FormControl from '../components/FormControl/FormControl.vue'
@@ -188,11 +189,20 @@ interface DialogInstance {
   component: Component
 }
 
-export const dialogs: Ref<DialogInstance[]> = ref([])
-let nextId = 0
+// The stack is written by `dialog.*` (a .ts module, so Vite may pre-bundle it)
+// and read by <Dialogs /> (an SFC, always raw source). A global singleton keeps
+// both sides on one ref even when the package is instantiated twice — see
+// moduleSingleton. The id counter shares the store so ids stay unique across
+// copies; two counters would collide and hand Vue duplicate `:key`s.
+const stack = moduleSingleton('dialog-stack', () => ({
+  dialogs: ref<DialogInstance[]>([]),
+  nextId: 0,
+}))
+
+export const dialogs: Ref<DialogInstance[]> = stack.dialogs
 
 function add(component: Component): number {
-  const id = nextId++
+  const id = stack.nextId++
   dialogs.value = [...dialogs.value, { id, component }]
   return id
 }

--- a/src/utils/moduleSingleton.test.ts
+++ b/src/utils/moduleSingleton.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { moduleSingleton } from './moduleSingleton'
+
+const KEYS = ['test-store', 'test-falsy', 'test-count']
+
+afterEach(() => {
+  for (const key of KEYS) {
+    delete (globalThis as Record<symbol, unknown>)[Symbol.for(`frappe-ui.${key}`)]
+  }
+})
+
+describe('moduleSingleton', () => {
+  // The bug this exists to prevent: Vite's dep pre-bundler cannot parse .vue,
+  // so it inlines frappe-ui's .ts modules and leaves the SFCs as raw source.
+  // A .ts module read from both sides is instantiated twice. Calling the
+  // factory twice with the same key is that second instantiation.
+  it('hands a second module instance the same object', () => {
+    const first = moduleSingleton('test-store', () => ({ items: [1] }))
+    const second = moduleSingleton('test-store', () => ({ items: [] }))
+
+    expect(second).toBe(first)
+
+    first.items.push(2)
+    expect(second.items).toEqual([1, 2])
+  })
+
+  it('runs the factory exactly once, even for a falsy value', () => {
+    let calls = 0
+    const create = () => {
+      calls++
+      return 0
+    }
+
+    expect(moduleSingleton('test-falsy', create)).toBe(0)
+    expect(moduleSingleton('test-falsy', create)).toBe(0)
+    expect(calls).toBe(1)
+  })
+
+  it('keeps separate keys separate', () => {
+    const store = moduleSingleton('test-store', () => ({ items: [] }))
+    const count = moduleSingleton('test-count', () => ({ n: 0 }))
+
+    expect(store).not.toBe(count)
+  })
+})

--- a/src/utils/moduleSingleton.ts
+++ b/src/utils/moduleSingleton.ts
@@ -1,0 +1,31 @@
+/**
+ * Module-level state that survives a duplicated copy of this package.
+ *
+ * esbuild cannot parse `.vue`, so Vite's dep pre-bundler inlines frappe-ui's
+ * `.ts` modules into `node_modules/.vite/deps/frappe-ui.js` while leaving all
+ * ~90 SFCs as external raw-source imports. A `.ts` module imported from both
+ * sides of that boundary is instantiated twice, and any state it holds splits:
+ * `dialog.confirm()` pushes onto the bundled copy's `dialogs` ref while
+ * `<Dialogs />` renders the raw copy's, so no dialog ever appears.
+ *
+ * It fails silently, which is what makes it expensive to find — the call
+ * succeeds, the array grows, and nobody is watching that array. The same split
+ * empties `getConfig` for any SFC that reads it.
+ *
+ * Keying the state off `globalThis` with `Symbol.for` hands every copy the same
+ * object, so the state is correct no matter how many times the module is
+ * instantiated. Rollup keeps one graph, so a production build was never
+ * affected; the cost there is one symbol lookup at module init.
+ *
+ * Only for state that must be process-wide. Anything scoped to a component,
+ * a request, or an app instance belongs in provide/inject instead — a global
+ * would leak across SSR requests.
+ */
+export function moduleSingleton<T>(key: string, create: () => T): T {
+  const symbol = Symbol.for(`frappe-ui.${key}`)
+  const store = globalThis as unknown as Record<symbol, T | undefined>
+  // `in` rather than a truthiness check, so a falsy value still counts as
+  // initialised and `create` runs exactly once.
+  if (!(symbol in store)) store[symbol] = create()
+  return store[symbol] as T
+}


### PR DESCRIPTION
## Problem

`dialog.confirm()` renders nothing in a dev server. The call succeeds, the stack grows, and no dialog appears. There is no error and no warning, which makes it read as an app bug.

Found while migrating Gameplan to beta.43. Every `dialog.confirm` call site in that app was dead.

## Cause

esbuild cannot parse `.vue`, so Vite's dep pre-bundler inlines this package's `.ts` modules into `node_modules/.vite/deps/frappe-ui.js` and leaves all ~90 SFCs as external raw-source imports.

`src/utils/dialog.ts` sits on both sides of that boundary, so it is instantiated twice:

| module | copy |
|---|---|
| `utils/dialog.ts` — writes the stack | inlined into the pre-bundle |
| `components/Dialogs.vue` — renders the stack | raw source |

Verified on a running app:

```js
raw.dialogs === dep.dialogs   // false
```

`barrelImports` hides this whenever the package is symlinked: it rewrites bare specifiers to deep paths, so nothing is pre-bundled and one copy exists. `isWorkingCopy` turns the rewrite off for an installed package, on the reasoning that Vite serves it "as one optimized chunk" — but that chunk externalises every SFC, so the package is served as a chunk *and* as raw source at the same time.

`setConfig` / `getConfig` had the same failure: an SFC reading a key the app's entry had set would get `null` back.

## Fix

`moduleSingleton(key, create)` stores state on `globalThis` under `Symbol.for`, so every copy of the module shares one object. Applied to the dialog stack (plus its id counter, so ids stay unique and Vue never sees duplicate `:key`s) and to the config object.

Rollup keeps a single graph, so production builds were never affected. The cost there is one symbol lookup at module init.

**Toast is not affected.** Its state lives in `vue-sonner`, which the Vite plugin already pins via `optimizeDeps.include`, so it stays a single instance.

## Also in this PR

`fix(button)` — the solid red button's label used `text-ink-base`, which does not carry enough contrast against `bg-surface-red-7`. Now `text-ink-red-9`. Solid blue and green are unchanged.

## Testing

- New unit tests for `moduleSingleton` (shared object, factory runs once even for a falsy value, keys stay separate).
- Full suite: 83 files, 1136 tests, all passing.
- End-to-end against Gameplan on the published beta.43 with the patch applied to the installed package: the pre-bundle/raw split is still present (confirmed in the network log), and the dialog now renders. Reverted Gameplan's local `optimizeDeps` workaround first, so the library fix is what is being tested.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1041/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.26% (±0.00% vs `main`)
<!-- coverage-report:end -->
