### PR TITLE
fix(data-fetching): normalize useNewDoc name and gate useAction store writes itself

### DIFF
--- a/src/data-fetching/useAction.ts
+++ b/src/data-fetching/useAction.ts
@@ -15,6 +15,13 @@ export interface UseActionOptions<TResponse, TParams> {
   key?: (params: TParams) => string
   /** Return a message to reject the submit before any request is sent. */
   validate?: (params: TParams) => string | void
+  /**
+   * Store write callback, firing for every successful submit — NOT gated by
+   * the per-target freshness check. Like `useIsolatedCall`'s `onStoreWrite`,
+   * this lets the store gate itself via dispatch version (#1017) instead of
+   * being silently dropped by the per-target skip.
+   */
+  onStoreWrite?: (data: TResponse, params: TParams) => void
   onSuccess?: (data: TResponse, params: TParams) => void
   onError?: (error: Error, params: TParams) => void
 }
@@ -156,12 +163,14 @@ export function useAction<TResponse, TParams extends Record<string, any>>(
           baseUrl,
           immediate: false,
           refetch: false,
-          // Gated: this is where `useDoctype` and `useList` write the shared
-          // stores, and a stale same-target submit must not hand them its
-          // response.
+          // Store writes fire for every successful submit — the store gates
+          // itself via dispatch version (#1017). Consumer hooks remain gated
+          // per target: a stale same-target submit must not hand them its
+          // response or re-run their side effects (refetch, etc.).
           // Always wrapped, even without a consumer hook: a success must be
           // recorded either way, or it could not make older answers stale.
           onSuccess: (response) => {
+            options.onStoreWrite?.(response, params)
             if (!isFreshForTarget()) return
             if (target != null) lastWrittenByTarget.set(target, sequence)
             options.onSuccess?.(response, params)

--- a/src/data-fetching/useDoctype/useDoctype.ts
+++ b/src/data-fetching/useDoctype/useDoctype.ts
@@ -61,7 +61,7 @@ function useDelete(doctype: string, options: UseDoctypeOptions = {}) {
     method: 'DELETE',
     baseUrl,
     key: ({ name }) => name,
-    onSuccess(_data, { name }) {
+    onStoreWrite(_data, { name }) {
       docStore.removeDoc(doctype, name)
       listStore.removeRow(doctype, name)
     },
@@ -150,7 +150,7 @@ function useSetValue<T extends Record<string, any>>(
     method: 'PUT',
     baseUrl,
     key: ({ name }) => name,
-    onSuccess(data) {
+    onStoreWrite(data) {
       docStore.setDoc({ doctype, ...data })
       listStore.updateRow(doctype, data)
     },

--- a/src/data-fetching/useList/useList.ts
+++ b/src/data-fetching/useList/useList.ts
@@ -200,9 +200,11 @@ export function useList<T extends { name: string }>(
     method: 'PUT',
     baseUrl,
     key: ({ name }) => name,
-    onSuccess(data) {
+    onStoreWrite(data) {
       docStore.setDoc({ doctype, ...data })
       listStore.updateRow(doctype, data)
+    },
+    onSuccess() {
       if (refetch) execute()
     },
   })
@@ -224,10 +226,12 @@ export function useList<T extends { name: string }>(
     method: 'DELETE',
     baseUrl,
     key: ({ name }) => name,
-    onSuccess(_data, { name }) {
-      if (refetch) execute()
+    onStoreWrite(_data, { name }) {
       docStore.removeDoc(doctype, name)
       listStore.removeRow(doctype, name)
+    },
+    onSuccess() {
+      if (refetch) execute()
     },
   })
 

--- a/src/data-fetching/useNewDoc/useNewDoc.ts
+++ b/src/data-fetching/useNewDoc/useNewDoc.ts
@@ -72,7 +72,10 @@ export function useNewDoc<T extends object>(
       // winning write; each caller resolves with the doc it created.
       // `doctype` is merged the same way `onSuccess` merges it for the
       // store, so the resolved doc keeps the shape callers had before.
-      return { doctype, ...response } as T
+      // `name` is cast to String because an autoincrement doctype answers
+      // with a JSON number, and the type says `name: string` — feed it
+      // back into `useDoc` and `toValue(name)?.trim()` would throw.
+      return { doctype, ...response, name: String(response.name) } as T
     })
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1018 (merged as 4c1f142). Two non-blocking nits from the last review round.

### 1. `useNewDoc.submit()` resolves an unnormalized `name`

`submit()` resolves `{ doctype, ...response }` — the raw response. An `autoincrement` doctype answers with a JSON number, but `T` types `name` as `string`, so nothing catches it. Feeding the resolved doc straight back into `useDoc` hits `toValue(name)?.trim()` (`useDoc.ts:170`) and throws a TypeError on a number.

**Fix:** `{ doctype, ...response, name: String(response.name) }`.

### 2. `useAction`'s skip was deciding store writes

`useList` and `useDoctype` wrote the shared stores (`docStore.setDoc`/`listStore.updateRow`, `removeDoc`/`removeRow`) inside `onSuccess`, which is gated by the per-target freshness check. That was safe only because `key` is the document name today — a skipped write is one the store gate would reject anyway. Key `setValue` by anything finer later (e.g. `name/fieldname` for per-field `isLoading`) and two saves to one document stop sharing a target; the skip then silently decides store writes again.

**Fix:** give `useAction` the same `onStoreWrite` seam `useIsolatedCall` has. Store writes fire for every successful submit, and `docStore`/`listStore` gate themselves via dispatch version (#1017). Consumer hooks (and the refetch) stay per-target gated.

## Changes
- `useNewDoc.ts`: `String(response.name)` in the resolved doc
- `useAction.ts`: add `onStoreWrite` option, fired before the per-target gate
- `useList.ts`: move setValue/delete store writes to `onStoreWrite`
- `useDoctype.ts`: move setValue/delete store writes to `onStoreWrite`

## Testing
All data-fetching test suites pass: useNewDoc (8), useAction (5), useList (16), useDoctype (24), useDoc (16), staleWrites (19), useCall (18), docStore (8).

<!-- coverage-report:start -->
Coverage: 71.26% (±0.00% vs `main`)
<!-- coverage-report:end -->
