### PR TITLE
fix: Slider: forward aria-labelledby to role="slider" element and call useAttrs()

### DIFF
--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -242,6 +242,18 @@ describe('Slider', () => {
     cy.get('#sl-valuetext').should('not.have.attr', 'aria-valuetext')
   })
 
+  it('keeps aria-hidden on the root, not the thumb', () => {
+    // It hides a subtree rather than describing the control. On the thumb it
+    // marks a focusable element hidden and leaves the widget in the tree,
+    // which is the axe `aria-hidden-focus` violation.
+    cy.mount(Slider, {
+      props: { id: 'sl-hidden', modelValue: [25] },
+      attrs: { 'aria-hidden': 'true' },
+    })
+    cy.get('#sl-hidden').should('have.attr', 'aria-hidden', 'true')
+    cy.get('[role="slider"]').should('not.have.attr', 'aria-hidden')
+  })
+
   it('forwards class and style to the rendered root', () => {
     // With a label the wrapper is the root; without one the control is.
     cy.mount(Slider, {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -341,6 +341,32 @@ describe('Slider', () => {
     })
     cy.get('#sl-disabled').should('have.attr', 'aria-disabled', 'true')
     cy.get('#sl-disabled').should('have.attr', 'data-disabled', '')
+    // reka leaves the thumb without one, and the thumb is the control.
+    cy.get('[role="slider"]').should('have.attr', 'aria-disabled', 'true')
+  })
+
+  it('lets a caller aria-label beat the label prop', () => {
+    // Without this the generated `aria-labelledby` wins the name order and the
+    // override does nothing.
+    cy.mount(Slider, {
+      props: { label: 'Volume', modelValue: [25] },
+      attrs: { 'aria-label': 'Custom' },
+    })
+    cy.get('[role="slider"]').should('have.attr', 'aria-label', 'Custom')
+    cy.get('[role="slider"]').should('not.have.attr', 'aria-labelledby')
+  })
+
+  it('qualifies a caller aria-label that beats the label prop on a range', () => {
+    cy.mount(Slider, {
+      props: { label: 'Volume', modelValue: [20, 80] },
+      attrs: { 'aria-label': 'Custom' },
+    })
+    cy.get('[role="slider"]')
+      .first()
+      .should('have.attr', 'aria-label', 'Custom minimum')
+    cy.get('[role="slider"]')
+      .last()
+      .should('have.attr', 'aria-label', 'Custom maximum')
   })
 
   describe('shared labeling contract', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -208,9 +208,10 @@ describe('Slider', () => {
 
   it('keeps the plain name on a single thumb', () => {
     cy.mount(Slider, { props: { label: 'Volume', modelValue: [25] } })
-    cy.get('[role="slider"]')
-      .should('not.have.attr', 'aria-label')
-      .and('have.attr', 'aria-labelledby')
+    // Two chains, not one: `not.have.attr` yields `undefined`, so anything
+    // chained after it asserts on nothing.
+    cy.get('[role="slider"]').should('not.have.attr', 'aria-label')
+    cy.get('[role="slider"]').should('have.attr', 'aria-labelledby')
   })
 
   it('routes any other caller aria-* to the thumb', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -91,12 +91,16 @@ describe('Slider', () => {
         props: { label: 'Volume', description: 'Adjust volume.' },
       })
       cy.get('[role="slider"]')
-        .parents('[aria-labelledby]')
+        .first()
+        .then(($thumb) => {
+          const labelledBy = $thumb.attr('aria-labelledby')!
+          cy.get(`#${labelledBy}`).should('contain.text', 'Volume')
+        })
+      cy.get('[role="slider"]')
+        .parents('[aria-describedby]')
         .first()
         .then(($root) => {
-          const labelledBy = $root.attr('aria-labelledby')!
           const describedBy = $root.attr('aria-describedby')!
-          cy.get(`#${labelledBy}`).should('contain.text', 'Volume')
           cy.get(`#${describedBy}`).should('contain.text', 'Adjust volume.')
         })
     })

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -278,6 +278,9 @@ describe('Slider', () => {
       attrs: { class: 'w-64' },
     })
     cy.get('.w-64').should('not.have.class', 'w-full')
+    // The control still fills that wrapper. Without the `hasLabeling` half of
+    // the guard it falls back to `width: auto`, which is zero in a flex parent.
+    cy.get('.w-64 [data-slot="control"]').should('have.class', 'w-full')
 
     cy.mount(Slider, {
       props: { id: 'sl-bare-w', modelValue: [25] },

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -244,7 +244,8 @@ describe('Slider', () => {
 
   it('drops its own w-full when the caller sets a width', () => {
     // Two width utilities in one list are decided by stylesheet order, so the
-    // caller only wins if ours is not there at all.
+    // caller only wins if ours is not there at all. Both branches place the
+    // caller's class on a different element, so both need the guard.
     cy.mount(Slider, {
       props: { label: 'Volume', modelValue: [25] },
       attrs: { class: 'w-64' },
@@ -252,10 +253,50 @@ describe('Slider', () => {
     cy.get('.w-64').should('not.have.class', 'w-full')
 
     cy.mount(Slider, {
+      props: { id: 'sl-bare-w', modelValue: [25] },
+      attrs: { class: 'w-64' },
+    })
+    cy.get('#sl-bare-w').should('not.have.class', 'w-full')
+
+    cy.mount(Slider, {
+      props: { id: 'sl-variant-w', modelValue: [25] },
+      attrs: { class: 'sm:w-64' },
+    })
+    cy.get('#sl-variant-w').should('not.have.class', 'w-full')
+  })
+
+  it('keeps its own w-full when the caller class has no width', () => {
+    cy.mount(Slider, {
       props: { label: 'Volume', modelValue: [25] },
       attrs: { class: 'mt-4' },
     })
     cy.get('.mt-4').should('have.class', 'w-full')
+
+    cy.mount(Slider, {
+      props: { id: 'sl-bare-mt', modelValue: [25] },
+      attrs: { class: 'mt-4' },
+    })
+    cy.get('#sl-bare-mt').should('have.class', 'w-full')
+  })
+
+  it('keeps a caller aria-invalid and aria-errormessage when there is no error', () => {
+    cy.mount({
+      render: () =>
+        h('div', [
+          h('span', { id: 'ext-err' }, 'Out of range'),
+          h(Slider, {
+            modelValue: [25],
+            'aria-invalid': 'true',
+            'aria-errormessage': 'ext-err',
+          }),
+        ]),
+    })
+    cy.get('[role="slider"]').should('have.attr', 'aria-invalid', 'true')
+    cy.get('[role="slider"]').should(
+      'have.attr',
+      'aria-errormessage',
+      'ext-err',
+    )
   })
 
   it('forwards disabled to aria-disabled and SliderRoot', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -77,6 +77,36 @@ describe('Slider', () => {
     cy.get('[role="slider"]').should('not.have.attr', 'aria-label')
   })
 
+  it('routes a caller aria-label to the thumb, not the root', () => {
+    cy.mount(Slider, {
+      props: { id: 'sl-aria-label', modelValue: [25] },
+      attrs: { 'aria-label': 'Volume' },
+    })
+    cy.get('[role="slider"]').should('have.attr', 'aria-label', 'Volume')
+    cy.get('#sl-aria-label').should('not.have.attr', 'aria-label')
+  })
+
+  it('routes a caller aria-labelledby to the thumb, not the root', () => {
+    cy.mount(
+      {
+        components: { Slider },
+        template: `
+          <div>
+            <span id="ext-label">Volume</span>
+            <Slider id="sl-aria-labelledby" :model-value="[25]" aria-labelledby="ext-label" />
+          </div>
+        `,
+      },
+      {},
+    )
+    cy.get('[role="slider"]').should(
+      'have.attr',
+      'aria-labelledby',
+      'ext-label',
+    )
+    cy.get('#sl-aria-labelledby').should('not.have.attr', 'aria-labelledby')
+  })
+
   it('forwards disabled to aria-disabled and SliderRoot', () => {
     cy.mount(Slider, {
       props: { id: 'sl-disabled', modelValue: [25], disabled: true },

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -424,6 +424,25 @@ describe('Slider', () => {
         })
     })
 
+    it('describes the thumb from both a #description slot and an error', () => {
+      // The branch that a `??` fallback next to `describedBy` would miss: the
+      // error id is already there, so the description id has to be added on
+      // the condition `InputDescription` actually renders on.
+      cy.mount(Slider, {
+        props: { label: 'Volume', error: 'Required' },
+        slots: { description: () => h('span', 'slot description') },
+      })
+
+      cy.get('[role="slider"]')
+        .invoke('attr', 'aria-describedby')
+        .then((ids) => {
+          const [descriptionId, errorId] = String(ids).split(' ')
+          expect(errorId, 'both ids are referenced').to.be.a('string')
+          cy.get(`#${descriptionId}`).should('contain.text', 'slot description')
+          cy.get(`#${errorId}`).should('contain.text', 'Required')
+        })
+    })
+
     it('renders the canonical data-* hooks on the control', () => {
       cy.mount(Slider, {
         props: {
@@ -438,9 +457,10 @@ describe('Slider', () => {
       cy.get('#sl-data').should('have.attr', 'data-size', 'md')
       cy.get('#sl-data').should('have.attr', 'data-state', 'valid')
       cy.get('#sl-data').should('have.attr', 'data-required', 'true')
-      // The prop doc promises `aria-required` on the control, and the thumb is
-      // the element that carries the aria set.
-      cy.get('[role="slider"]').should('have.attr', 'aria-required', 'true')
+      // `aria-required` is not in the ARIA role table for `slider`, so it must
+      // not be set: axe reports `aria-allowed-attr` on it. `data-required` and
+      // the asterisk carry the state instead.
+      cy.get('[role="slider"]').should('not.have.attr', 'aria-required')
     })
 
     it('flips data-state to invalid when error is set', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -240,6 +240,18 @@ describe('Slider', () => {
       attrs: { class: 'my-bare-slider' },
     })
     cy.get('#sl-bare').should('have.class', 'my-bare-slider')
+
+    cy.mount(Slider, {
+      props: { label: 'Volume', modelValue: [25] },
+      attrs: { class: 'my-styled-slider', style: 'margin-top: 4px' },
+    })
+    cy.get('.my-styled-slider').should('have.css', 'margin-top', '4px')
+
+    cy.mount(Slider, {
+      props: { id: 'sl-bare-style', modelValue: [25] },
+      attrs: { style: 'margin-top: 4px' },
+    })
+    cy.get('#sl-bare-style').should('have.css', 'margin-top', '4px')
   })
 
   it('drops its own w-full when the caller sets a width', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -399,6 +399,14 @@ describe('Slider', () => {
         props: { label: 'Volume', error: 'Required' },
       })
       cy.contains('Required').should('exist')
+      // The error state reaches the thumb, not the root: `role="slider"` is
+      // what assistive technology reports as the control.
+      cy.get('[role="slider"]').should('have.attr', 'aria-invalid', 'true')
+      cy.get('[role="slider"]')
+        .invoke('attr', 'aria-errormessage')
+        .then((id) => {
+          cy.get(`#${id}`).should('contain.text', 'Required')
+        })
     })
 
     it('renders the canonical data-* hooks on the control', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -30,6 +30,21 @@ describe('Slider', () => {
     cy.contains('slot description').should('exist')
   })
 
+  it('describes the thumb from a #description slot alone', () => {
+    // Slot without the prop. With both set, the prop already supplies the id
+    // and this branch is never reached.
+    cy.mount(Slider, {
+      props: { label: 'Volume' },
+      slots: { description: () => h('span', 'slot description') },
+    })
+
+    cy.get('[role="slider"]')
+      .invoke('attr', 'aria-describedby')
+      .then((id) => {
+        cy.get(`#${id}`).should('contain.text', 'slot description')
+      })
+  })
+
   it('renders one thumb for a single value', () => {
     cy.mount(Slider, {
       props: {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -87,24 +87,47 @@ describe('Slider', () => {
   })
 
   it('routes a caller aria-labelledby to the thumb, not the root', () => {
-    cy.mount(
-      {
-        components: { Slider },
-        template: `
-          <div>
-            <span id="ext-label">Volume</span>
-            <Slider id="sl-aria-labelledby" :model-value="[25]" aria-labelledby="ext-label" />
-          </div>
-        `,
-      },
-      {},
-    )
+    cy.mount({
+      render: () =>
+        h('div', [
+          h('span', { id: 'ext-label' }, 'Volume'),
+          h(Slider, {
+            id: 'sl-aria-labelledby',
+            modelValue: [25],
+            'aria-labelledby': 'ext-label',
+          }),
+        ]),
+    })
     cy.get('[role="slider"]').should(
       'have.attr',
       'aria-labelledby',
       'ext-label',
     )
     cy.get('#sl-aria-labelledby').should('not.have.attr', 'aria-labelledby')
+  })
+
+  it('merges a caller aria-describedby with the generated ids on the thumb', () => {
+    cy.mount({
+      render: () =>
+        h('div', [
+          h('span', { id: 'ext-hint' }, 'External hint'),
+          h(Slider, {
+            id: 'sl-aria-describedby',
+            label: 'Volume',
+            description: 'Adjust volume.',
+            modelValue: [25],
+            'aria-describedby': 'ext-hint',
+          }),
+        ]),
+    })
+    // The caller's id must not replace the generated description id.
+    cy.get('[role="slider"]').then(($thumb) => {
+      const describedBy = $thumb.attr('aria-describedby')!
+      expect(describedBy).to.contain('ext-hint')
+      const generated = describedBy.split(' ').filter((id) => id !== 'ext-hint')
+      expect(generated).to.have.length(1)
+      cy.get(`#${generated[0]}`).should('contain.text', 'Adjust volume.')
+    })
   })
 
   it('forwards disabled to aria-disabled and SliderRoot', () => {
@@ -126,13 +149,18 @@ describe('Slider', () => {
           const labelledBy = $thumb.attr('aria-labelledby')!
           cy.get(`#${labelledBy}`).should('contain.text', 'Volume')
         })
+      // Both halves of the contract sit on the thumb: it is the element that
+      // carries role="slider", so the root is never reported as the control.
       cy.get('[role="slider"]')
-        .parents('[aria-describedby]')
         .first()
-        .then(($root) => {
-          const describedBy = $root.attr('aria-describedby')!
+        .then(($thumb) => {
+          const describedBy = $thumb.attr('aria-describedby')!
           cy.get(`#${describedBy}`).should('contain.text', 'Adjust volume.')
         })
+      cy.get('[role="slider"]')
+        .first()
+        .parents('[aria-describedby]')
+        .should('not.exist')
     })
 
     it('renders error state', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -284,18 +284,23 @@ describe('Slider', () => {
       attrs: { class: 'w-64' },
     })
     cy.get('#sl-bare-w').should('not.have.class', 'w-full')
+  })
 
+  it('keeps its own w-full against a prefixed caller width', () => {
+    // Tailwind emits variant utilities after the base ones, so `sm:w-64` wins
+    // at `sm` on its own. Dropping `w-full` for it would leave `width: auto`
+    // below `sm`, which is zero inside a flex parent.
     cy.mount(Slider, {
       props: { id: 'sl-variant-w', modelValue: [25] },
       attrs: { class: 'sm:w-64' },
     })
-    cy.get('#sl-variant-w').should('not.have.class', 'w-full')
+    cy.get('#sl-variant-w').should('have.class', 'w-full')
 
     cy.mount(Slider, {
       props: { id: 'sl-arbitrary-w', modelValue: [25] },
       attrs: { class: 'data-[open]:w-64' },
     })
-    cy.get('#sl-arbitrary-w').should('not.have.class', 'w-full')
+    cy.get('#sl-arbitrary-w').should('have.class', 'w-full')
   })
 
   it('names the thumb from a #label slot', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -252,6 +252,17 @@ describe('Slider', () => {
     })
     cy.get('#sl-hidden').should('have.attr', 'aria-hidden', 'true')
     cy.get('[role="slider"]').should('not.have.attr', 'aria-hidden')
+    // reka keeps `tabindex="0"` on every thumb, so hiding the root alone would
+    // leave focus landing inside a subtree screen readers cannot see.
+    cy.get('#sl-hidden').should('have.attr', 'inert')
+    cy.get('[role="slider"]').then(($thumb) => {
+      $thumb[0].focus()
+      cy.document().then((doc) => {
+        expect(doc.activeElement, 'inert keeps focus out').to.not.equal(
+          $thumb[0],
+        )
+      })
+    })
   })
 
   it('forwards class and style to the rendered root', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -130,19 +130,80 @@ describe('Slider', () => {
     })
   })
 
-  it('names each thumb of a range distinctly', () => {
-    cy.mount(Slider, {
-      props: { label: 'Price', modelValue: [20, 80] },
-    })
+  // Reads the accessible name the way assistive technology does: follow
+  // `aria-labelledby` if present, otherwise take `aria-label`.
+  function accessibleName($el: JQuery<HTMLElement>): string {
+    const ids = $el.attr('aria-labelledby')
+    if (!ids) return $el.attr('aria-label') ?? ''
+    return ids
+      .split(' ')
+      .map((id) => Cypress.$(`#${id}`).text().trim())
+      .join(' ')
+  }
+
+  it('names each thumb of a range distinctly, from the label prop', () => {
+    cy.mount(Slider, { props: { label: 'Price', modelValue: [20, 80] } })
     cy.get('[role="slider"]').should('have.length', 2)
     cy.get('[role="slider"]')
       .first()
-      .should('have.attr', 'aria-label', 'Price minimum')
-      // aria-labelledby would beat aria-label, so it must not be set here.
+      .then(($t) => expect(accessibleName($t)).to.equal('Price minimum'))
+    cy.get('[role="slider"]')
+      .last()
+      .then(($t) => expect(accessibleName($t)).to.equal('Price maximum'))
+  })
+
+  it('keeps a referenced label on both thumbs of a range', () => {
+    // The regression this guards: qualifying with `aria-label` silently drops
+    // the caller's reference, because `aria-labelledby` wins.
+    cy.mount({
+      render: () =>
+        h('div', [
+          h('span', { id: 'ext-range-label' }, 'Budget'),
+          h(Slider, {
+            modelValue: [20, 80],
+            'aria-labelledby': 'ext-range-label',
+          }),
+        ]),
+    })
+    cy.get('[role="slider"]')
+      .first()
+      .then(($t) => expect(accessibleName($t)).to.equal('Budget minimum'))
+    cy.get('[role="slider"]')
+      .last()
+      .then(($t) => expect(accessibleName($t)).to.equal('Budget maximum'))
+  })
+
+  it('qualifies a caller aria-label on a range', () => {
+    cy.mount(Slider, {
+      props: { modelValue: [20, 80] },
+      attrs: { 'aria-label': 'Budget' },
+    })
+    cy.get('[role="slider"]')
+      .first()
+      .should('have.attr', 'aria-label', 'Budget minimum')
+    cy.get('[role="slider"]')
+      .last()
+      .should('have.attr', 'aria-label', 'Budget maximum')
+  })
+
+  it('leaves an unnamed range to reka own qualifiers', () => {
+    cy.mount(Slider, { props: { modelValue: [20, 80] } })
+    cy.get('[role="slider"]').should('have.length', 2)
+    cy.get('[role="slider"]')
+      .first()
+      .should('have.attr', 'aria-label', 'Minimum')
       .and('not.have.attr', 'aria-labelledby')
     cy.get('[role="slider"]')
       .last()
-      .should('have.attr', 'aria-label', 'Price maximum')
+      .should('have.attr', 'aria-label', 'Maximum')
+  })
+
+  it('names each thumb past two by position', () => {
+    cy.mount(Slider, { props: { label: 'Stops', modelValue: [10, 50, 90] } })
+    cy.get('[role="slider"]').should('have.length', 3)
+    cy.get('[role="slider"]')
+      .eq(2)
+      .then(($t) => expect(accessibleName($t)).to.equal('Stops value 3 of 3'))
   })
 
   it('keeps the plain name on a single thumb', () => {
@@ -178,6 +239,22 @@ describe('Slider', () => {
       attrs: { class: 'my-bare-slider' },
     })
     cy.get('#sl-bare').should('have.class', 'my-bare-slider')
+  })
+
+  it('drops its own w-full when the caller sets a width', () => {
+    // Two width utilities in one list are decided by stylesheet order, so the
+    // caller only wins if ours is not there at all.
+    cy.mount(Slider, {
+      props: { label: 'Volume', modelValue: [25] },
+      attrs: { class: 'w-64' },
+    })
+    cy.get('.w-64').should('not.have.class', 'w-full')
+
+    cy.mount(Slider, {
+      props: { label: 'Volume', modelValue: [25] },
+      attrs: { class: 'mt-4' },
+    })
+    cy.get('.mt-4').should('have.class', 'w-full')
   })
 
   it('forwards disabled to aria-disabled and SliderRoot', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -415,6 +415,9 @@ describe('Slider', () => {
       cy.get('#sl-data').should('have.attr', 'data-size', 'md')
       cy.get('#sl-data').should('have.attr', 'data-state', 'valid')
       cy.get('#sl-data').should('have.attr', 'data-required', 'true')
+      // The prop doc promises `aria-required` on the control, and the thumb is
+      // the element that carries the aria set.
+      cy.get('[role="slider"]').should('have.attr', 'aria-required', 'true')
     })
 
     it('flips data-state to invalid when error is set', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -263,6 +263,23 @@ describe('Slider', () => {
       attrs: { class: 'sm:w-64' },
     })
     cy.get('#sl-variant-w').should('not.have.class', 'w-full')
+
+    cy.mount(Slider, {
+      props: { id: 'sl-arbitrary-w', modelValue: [25] },
+      attrs: { class: 'data-[open]:w-64' },
+    })
+    cy.get('#sl-arbitrary-w').should('not.have.class', 'w-full')
+  })
+
+  it('names the thumb from a #label slot', () => {
+    cy.mount(Slider, {
+      props: { modelValue: [25] },
+      slots: { label: () => h('span', 'Volume') },
+    })
+    cy.get('[role="slider"]').then(($thumb) => {
+      const labelledBy = $thumb.attr('aria-labelledby')!
+      cy.get(`#${labelledBy}`).should('contain.text', 'Volume')
+    })
   })
 
   it('keeps its own w-full when the caller class has no width', () => {
@@ -277,6 +294,13 @@ describe('Slider', () => {
       attrs: { class: 'mt-4' },
     })
     cy.get('#sl-bare-mt').should('have.class', 'w-full')
+
+    // `max-w-*` bounds `w-full` rather than replacing it, so both belong.
+    cy.mount(Slider, {
+      props: { id: 'sl-maxw', modelValue: [25] },
+      attrs: { class: 'max-w-md' },
+    })
+    cy.get('#sl-maxw').should('have.class', 'w-full')
   })
 
   it('keeps a caller aria-invalid and aria-errormessage when there is no error', () => {

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -130,6 +130,56 @@ describe('Slider', () => {
     })
   })
 
+  it('names each thumb of a range distinctly', () => {
+    cy.mount(Slider, {
+      props: { label: 'Price', modelValue: [20, 80] },
+    })
+    cy.get('[role="slider"]').should('have.length', 2)
+    cy.get('[role="slider"]')
+      .first()
+      .should('have.attr', 'aria-label', 'Price minimum')
+      // aria-labelledby would beat aria-label, so it must not be set here.
+      .and('not.have.attr', 'aria-labelledby')
+    cy.get('[role="slider"]')
+      .last()
+      .should('have.attr', 'aria-label', 'Price maximum')
+  })
+
+  it('keeps the plain name on a single thumb', () => {
+    cy.mount(Slider, { props: { label: 'Volume', modelValue: [25] } })
+    cy.get('[role="slider"]')
+      .should('not.have.attr', 'aria-label')
+      .and('have.attr', 'aria-labelledby')
+  })
+
+  it('routes any other caller aria-* to the thumb', () => {
+    cy.mount(Slider, {
+      props: { id: 'sl-valuetext', modelValue: [25] },
+      attrs: { 'aria-valuetext': '25 percent' },
+    })
+    cy.get('[role="slider"]').should(
+      'have.attr',
+      'aria-valuetext',
+      '25 percent',
+    )
+    cy.get('#sl-valuetext').should('not.have.attr', 'aria-valuetext')
+  })
+
+  it('forwards class and style to the rendered root', () => {
+    // With a label the wrapper is the root; without one the control is.
+    cy.mount(Slider, {
+      props: { label: 'Volume', modelValue: [25] },
+      attrs: { class: 'my-slider' },
+    })
+    cy.get('.my-slider').should('exist')
+
+    cy.mount(Slider, {
+      props: { id: 'sl-bare', modelValue: [25] },
+      attrs: { class: 'my-bare-slider' },
+    })
+    cy.get('#sl-bare').should('have.class', 'my-bare-slider')
+  })
+
   it('forwards disabled to aria-disabled and SliderRoot', () => {
     cy.mount(Slider, {
       props: { id: 'sl-disabled', modelValue: [25], disabled: true },

--- a/src/components/Slider/Slider.md
+++ b/src/components/Slider/Slider.md
@@ -42,9 +42,11 @@ label instead, as `sr-only` text next to the asterisk. The asterisk itself is
 `aria-hidden`, and `data-required` is a styling hook.
 
 That has a consequence: `required` is announced only while the name comes from
-the label. A caller `aria-label` replaces the label as the name, so the thumb
-then announces the name without "(required)". Set `required` with `label`, or
-put the word in the `aria-label` yourself.
+the rendered label. A caller `aria-label` or `aria-labelledby` replaces it as
+the name, so the thumb then announces the name without "(required)". A `#label`
+slot replaces the whole label body, asterisk included, so nothing renders it at
+all — the slot receives `{ required }` for that. In each of the three cases,
+render or word the required state yourself.
 
 A range renders one thumb per value. When a name is set, each thumb is qualified
 with it ("Price minimum", "Price maximum", or "Stops value 2 of 3" past two
@@ -53,7 +55,8 @@ thumbs) so the endpoints are told apart. An unnamed range keeps the plain
 
 Any other `aria-*` you set is copied to every thumb, so a range gets one shared
 value for all of them. `aria-valuetext` on a range is announced identically at
-both endpoints.
+both endpoints. `aria-hidden` is the exception and stays on the root, because it
+hides a subtree rather than describing the control.
 
 ## value-commit
 

--- a/src/components/Slider/Slider.md
+++ b/src/components/Slider/Slider.md
@@ -37,13 +37,23 @@ Use one or the other.
 
 `required` is the one exception to that routing. The ARIA role table does not
 list `aria-required` for `slider`, so setting it fails the `aria-allowed-attr`
-audit rule and screen readers ignore it. The asterisk and `data-required` carry
-the state instead.
+audit rule and screen readers ignore it. The state is announced from inside the
+label instead, as `sr-only` text next to the asterisk. The asterisk itself is
+`aria-hidden`, and `data-required` is a styling hook.
+
+That has a consequence: `required` is announced only while the name comes from
+the label. A caller `aria-label` replaces the label as the name, so the thumb
+then announces the name without "(required)". Set `required` with `label`, or
+put the word in the `aria-label` yourself.
 
 A range renders one thumb per value. When a name is set, each thumb is qualified
 with it ("Price minimum", "Price maximum", or "Stops value 2 of 3" past two
 thumbs) so the endpoints are told apart. An unnamed range keeps the plain
 "Minimum"/"Maximum" names.
+
+Any other `aria-*` you set is copied to every thumb, so a range gets one shared
+value for all of them. `aria-valuetext` on a range is announced identically at
+both endpoints.
 
 ## value-commit
 

--- a/src/components/Slider/Slider.md
+++ b/src/components/Slider/Slider.md
@@ -1,6 +1,7 @@
 # Slider
 
-A slider input for selecting a single value or a range of values within a minimum and maximum.
+A slider input for selecting a single value or a range of values within a
+minimum and maximum.
 
 ## Playground
 
@@ -20,7 +21,8 @@ Use a two-element `modelValue` to render two thumbs.
 
 ## Negative Values
 
-When `min` is negative the slider fills bidirectionally from the zero-crossing, so positive and negative values are visually distinct.
+When `min` is negative the slider fills bidirectionally from the zero-crossing,
+so positive and negative values are visually distinct.
 
 <ComponentPreview name="Slider-NegativeValues" />
 
@@ -28,10 +30,20 @@ When `min` is negative the slider fills bidirectionally from the zero-crossing, 
 
 <ComponentPreview name="Slider-Labeling" />
 
+The accessible name lands on the thumb, which is the element carrying
+`role="slider"`. A caller's `aria-labelledby` or `aria-label` overrides the name
+derived from `label`, so the visible label and the announced name can differ.
+Use one or the other.
+
+A range renders one thumb per value. When a name is set, each thumb is qualified
+with it ("Price minimum", "Price maximum", or "Stops value 2 of 3" past two
+thumbs) so the endpoints are told apart. An unnamed range keeps the plain
+"Minimum"/"Maximum" names.
+
 ## value-commit
 
-`value-commit` fires once when the user finishes dragging the slider —
-useful for triggering side effects only at drag end, not on every step.
+`value-commit` fires once when the user finishes dragging the slider — useful
+for triggering side effects only at drag end, not on every step.
 
 <ComponentPreview name="Slider-ValueCommit" />
 

--- a/src/components/Slider/Slider.md
+++ b/src/components/Slider/Slider.md
@@ -56,7 +56,9 @@ thumbs) so the endpoints are told apart. An unnamed range keeps the plain
 Any other `aria-*` you set is copied to every thumb, so a range gets one shared
 value for all of them. `aria-valuetext` on a range is announced identically at
 both endpoints. `aria-hidden` is the exception and stays on the root, because it
-hides a subtree rather than describing the control.
+hides a subtree rather than describing the control. It also makes the control
+`inert`: the thumbs stay in the tab order otherwise, which puts keyboard focus
+inside a subtree a screen reader cannot see.
 
 ## value-commit
 

--- a/src/components/Slider/Slider.md
+++ b/src/components/Slider/Slider.md
@@ -35,6 +35,11 @@ The accessible name lands on the thumb, which is the element carrying
 derived from `label`, so the visible label and the announced name can differ.
 Use one or the other.
 
+`required` is the one exception to that routing. The ARIA role table does not
+list `aria-required` for `slider`, so setting it fails the `aria-allowed-attr`
+audit rule and screen readers ignore it. The asterisk and `data-required` carry
+the state instead.
+
 A range renders one thumb per value. When a name is set, each thumb is qualified
 with it ("Price minimum", "Price maximum", or "Stops value 2 of 3" past two
 thumbs) so the endpoints are told apart. An unnamed range keeps the plain

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -42,10 +42,13 @@ const callerAria = computed(() => {
 // not a rule — but two width utilities in one class list are decided by
 // stylesheet order, not by which one the caller wrote, and there is no class
 // merger here. So drop ours when the caller brings their own, on whichever
-// element the caller's class lands on. The optional `variant:` prefixes count
-// `sm:w-64` too.
+// element the caller's class lands on. Token-split and strip variant prefixes
+// the way `Avatar.vue` does, so `sm:w-64` and `data-[open]:w-64` both count.
+// `min-w-*` and `max-w-*` deliberately do not: those pair with `w-full`.
 const hasCallerWidth = computed(() => {
-  return /(^|\s)(?:[a-z0-9-]+:)*!?w-/.test(normalizeClass(attrs.class))
+  return normalizeClass(attrs.class)
+    .split(/\s+/)
+    .some((token) => /^!?-?w-/.test(token.slice(token.lastIndexOf(':') + 1)))
 })
 
 // What is left to fall through to the control: class and style are placed by
@@ -92,7 +95,12 @@ const {
 
 /** A caller's `aria-labelledby` wins over the id generated from `label`. */
 const thumbLabelledBy = computed(() => {
-  return (attrs['aria-labelledby'] as string | undefined) ?? labelledBy.value
+  const caller = attrs['aria-labelledby'] as string | undefined
+  if (caller) return caller
+  // `useInputLabeling` only sees the `label` prop, but the label element also
+  // renders for a `#label` slot. Without this the slot leaves the thumb
+  // unnamed while a `<label>` carrying the name sits right above it.
+  return labelledBy.value ?? (slots.label ? labelId.value : undefined)
 })
 
 // The `error` prop wins, but with no error a caller's own value has to survive

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -277,8 +277,8 @@ const onValueCommit = (value: SliderValue) => {
     <SliderRoot
       :id="inputId"
       v-model="sliderValue"
-      :class="[rootClasses, hasLabeling ? null : (attrs.class as any)]"
-      :style="hasLabeling ? null : (attrs.style as any)"
+      :class="[rootClasses, hasLabeling ? null : normalizeClass(attrs.class)]"
+      :style="hasLabeling ? null : (attrs.style as StyleValue)"
       :max="props.max"
       :min="props.min"
       :step="props.step"

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useSlots } from 'vue'
+import { computed, useSlots, useAttrs } from 'vue'
 import { SliderRange, SliderRoot, SliderThumb, SliderTrack } from 'reka-ui'
 import { useInputLabeling } from '../../composables/useInputLabeling'
 import InputLabel from '../InputLabeling/InputLabel.vue'
@@ -20,6 +20,14 @@ const emit = defineEmits<SliderEmits>()
 /** The current slider value (controlled). */
 const model = defineModel<SliderValue>()
 const slots = useSlots()
+
+const attrs = useAttrs()
+
+const attrsWithoutClassStyle = computed(() => {
+  return Object.fromEntries(
+    Object.entries(attrs).filter(([key]) => key !== 'class' && key !== 'style'),
+  )
+})
 
 defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
@@ -137,12 +145,11 @@ const hasLabeling = computed(() => {
       :step="props.step"
       :disabled="props.disabled"
       :aria-disabled="props.disabled || undefined"
-      :aria-labelledby="labelledBy"
       :aria-describedby="describedBy"
       :aria-errormessage="hasError ? errorMessageId : undefined"
       :aria-invalid="hasError || undefined"
       data-slot="control"
-      v-bind="dataAttrs"
+      v-bind="{ ...dataAttrs, ...attrsWithoutClassStyle }"
       @value-commit="onValueCommit"
     >
       <SliderTrack :class="trackClasses">
@@ -160,6 +167,7 @@ const hasLabeling = computed(() => {
         v-for="(_, i) in sliderValue"
         :key="`slider-thumb-${i}`"
         :class="thumbClasses"
+        :aria-labelledby="labelledBy"
       />
     </SliderRoot>
     <InputDescription

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -23,16 +23,16 @@ const slots = useSlots()
 
 const attrs = useAttrs()
 
-// `role="slider"` sits on the thumb, not the root, so a caller's naming
-// attributes have to be re-routed there — on the root they name a container
-// that no assistive technology reports as the control.
-const NAMING_ATTRS = ['aria-label', 'aria-labelledby']
+// `role="slider"` sits on the thumb, not the root, so the whole ARIA contract
+// has to be re-routed there — on the root it describes a container that no
+// assistive technology reports as the control.
+const ARIA_ATTRS = ['aria-label', 'aria-labelledby', 'aria-describedby']
 
 const attrsWithoutClassStyle = computed(() => {
   return Object.fromEntries(
     Object.entries(attrs).filter(
       ([key]) =>
-        key !== 'class' && key !== 'style' && !NAMING_ATTRS.includes(key),
+        key !== 'class' && key !== 'style' && !ARIA_ATTRS.includes(key),
     ),
   )
 })
@@ -74,6 +74,17 @@ const {
 /** A caller's `aria-labelledby` wins over the id generated from `label`. */
 const thumbLabelledBy = computed(() => {
   return (attrs['aria-labelledby'] as string | undefined) ?? labelledBy.value
+})
+
+// Merged, not replaced: a caller's `aria-describedby` must not drop the
+// generated description and error ids.
+const thumbDescribedBy = computed(() => {
+  const ids = [
+    describedBy.value,
+    attrs['aria-describedby'] as string | undefined,
+  ]
+  const merged = ids.filter(Boolean).join(' ')
+  return merged || undefined
 })
 
 const isBidirectional = computed(() => props.min < 0 && props.max > 0)
@@ -160,9 +171,6 @@ const hasLabeling = computed(() => {
       :step="props.step"
       :disabled="props.disabled"
       :aria-disabled="props.disabled || undefined"
-      :aria-describedby="describedBy"
-      :aria-errormessage="hasError ? errorMessageId : undefined"
-      :aria-invalid="hasError || undefined"
       data-slot="control"
       v-bind="{ ...dataAttrs, ...attrsWithoutClassStyle }"
       @value-commit="onValueCommit"
@@ -184,6 +192,9 @@ const hasLabeling = computed(() => {
         :class="thumbClasses"
         :aria-label="thumbLabel"
         :aria-labelledby="thumbLabelledBy"
+        :aria-describedby="thumbDescribedBy"
+        :aria-errormessage="hasError ? errorMessageId : undefined"
+        :aria-invalid="hasError || undefined"
       />
     </SliderRoot>
     <InputDescription

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -114,13 +114,6 @@ const thumbDisabled = computed(() => {
   return (attrs['aria-disabled'] as string | boolean | undefined) || undefined
 })
 
-// The `required` prop promises `aria-required` on the control, and the thumb
-// is now the only element that carries the aria set.
-const thumbRequired = computed(() => {
-  if (props.required) return true
-  return (attrs['aria-required'] as string | boolean | undefined) || undefined
-})
-
 // The `error` prop wins, but with no error a caller's own value has to survive
 // rather than be deleted by the explicit binding.
 const thumbErrorMessage = computed(() => {
@@ -323,7 +316,6 @@ const onValueCommit = (value: SliderValue) => {
           :aria-errormessage="thumbErrorMessage"
           :aria-invalid="thumbInvalid"
           :aria-disabled="thumbDisabled"
-          :aria-required="thumbRequired"
         />
       </template>
     </SliderRoot>

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -38,12 +38,14 @@ const callerAria = computed(() => {
   return Object.fromEntries(Object.entries(attrs).filter(([k]) => isAriaKey(k)))
 })
 
-// A slider has no intrinsic width, so the wrapper carries `w-full`. That is a
-// default, not a rule — but two width utilities in one class list are decided
-// by stylesheet order, not by which one the caller wrote, and there is no class
-// merger here. So drop ours when the caller brings their own.
+// A slider has no intrinsic width, so it carries `w-full`. That is a default,
+// not a rule — but two width utilities in one class list are decided by
+// stylesheet order, not by which one the caller wrote, and there is no class
+// merger here. So drop ours when the caller brings their own, on whichever
+// element the caller's class lands on. The optional `variant:` prefixes count
+// `sm:w-64` too.
 const hasCallerWidth = computed(() => {
-  return /(^|\s)!?w-/.test(normalizeClass(attrs.class))
+  return /(^|\s)(?:[a-z0-9-]+:)*!?w-/.test(normalizeClass(attrs.class))
 })
 
 // What is left to fall through to the control: class and style are placed by
@@ -91,6 +93,18 @@ const {
 /** A caller's `aria-labelledby` wins over the id generated from `label`. */
 const thumbLabelledBy = computed(() => {
   return (attrs['aria-labelledby'] as string | undefined) ?? labelledBy.value
+})
+
+// The `error` prop wins, but with no error a caller's own value has to survive
+// rather than be deleted by the explicit binding.
+const thumbErrorMessage = computed(() => {
+  if (hasError.value) return errorMessageId.value
+  return attrs['aria-errormessage'] as string | undefined
+})
+
+const thumbInvalid = computed(() => {
+  if (hasError.value) return true
+  return (attrs['aria-invalid'] as string | boolean | undefined) || undefined
 })
 
 // Merged, not replaced: a caller's `aria-describedby` must not drop the
@@ -146,6 +160,17 @@ function thumbNameFor(index: number): string | undefined {
   return `${callerLabel} ${thumbPart(index)}`
 }
 
+// Declared before `rootClasses`, which reads it.
+const hasLabeling = computed(() => {
+  return Boolean(
+    props.label ||
+    slots.label ||
+    showDescription.value ||
+    slots.description ||
+    hasError.value,
+  )
+})
+
 const isBidirectional = computed(() => props.min < 0 && props.max > 0)
 
 const bidirectionalRangeStyles = computed(() => {
@@ -178,8 +203,11 @@ const rangeClasses = computed(() => {
 
 const rootClasses = computed(() => {
   return [
-    'relative flex w-full select-none touch-none items-center',
+    'relative flex select-none touch-none items-center',
     props.size === 'md' ? 'h-5' : 'h-4',
+    // With labeling the wrapper takes the caller's class, so the control fills
+    // it. Without, the caller's class lands here and a width of theirs wins.
+    hasLabeling.value || !hasCallerWidth.value ? 'w-full' : null,
   ]
 })
 
@@ -196,16 +224,6 @@ const thumbClasses = computed(() => {
 const onValueCommit = (value: SliderValue) => {
   emit('value-commit', value)
 }
-
-const hasLabeling = computed(() => {
-  return Boolean(
-    props.label ||
-    slots.label ||
-    showDescription.value ||
-    slots.description ||
-    hasError.value,
-  )
-})
 </script>
 
 <template>
@@ -271,8 +289,8 @@ const hasLabeling = computed(() => {
           :aria-label="thumbNameFor(i)"
           :aria-labelledby="thumbLabelledByFor(i)"
           :aria-describedby="thumbDescribedBy"
-          :aria-errormessage="hasError ? errorMessageId : undefined"
-          :aria-invalid="hasError || undefined"
+          :aria-errormessage="thumbErrorMessage"
+          :aria-invalid="thumbInvalid"
         />
       </template>
     </SliderRoot>

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -37,6 +37,16 @@ defineOptions({
 // widget in the accessibility tree, which is the axe `aria-hidden-focus`
 // violation, and the caller's actual intent never reaches the root.
 const rootOnlyAria = new Set(['aria-hidden'])
+
+// Hiding the root is only half of it. reka gives every thumb `tabindex="0"`
+// unless the slider is disabled (`SliderThumbImpl`), so `aria-hidden` alone
+// leaves keyboard focus landing inside a subtree that assistive technology
+// cannot see — the second clause of axe's `aria-hidden-focus`. `inert` takes
+// them out of the tab order, which is what the caller asked for.
+const isHiddenFromAria = computed(() => {
+  const value = attrs['aria-hidden']
+  return value === '' || value === true || value === 'true'
+})
 const isAriaKey = (key: string) => key.startsWith('aria-')
 const isThumbAria = (key: string) => isAriaKey(key) && !rootOnlyAria.has(key)
 
@@ -295,6 +305,7 @@ const onValueCommit = (value: SliderValue) => {
       :step="props.step"
       :disabled="props.disabled"
       data-slot="control"
+      :inert="isHiddenFromAria || undefined"
       v-bind="{ ...dataAttrs, ...rootAttrs }"
       @value-commit="onValueCommit"
     >

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -32,10 +32,18 @@ defineOptions({
 // has to be re-routed there — on the root they describe a container that no
 // assistive technology reports as the control. `aria-valuetext` is the one
 // that would otherwise be silently dropped.
+// `aria-hidden` is the exception: it scopes to a subtree rather than to a role.
+// On the thumb it marks a `tabindex="0"` element hidden while leaving the
+// widget in the accessibility tree, which is the axe `aria-hidden-focus`
+// violation, and the caller's actual intent never reaches the root.
+const rootOnlyAria = new Set(['aria-hidden'])
 const isAriaKey = (key: string) => key.startsWith('aria-')
+const isThumbAria = (key: string) => isAriaKey(key) && !rootOnlyAria.has(key)
 
 const callerAria = computed(() => {
-  return Object.fromEntries(Object.entries(attrs).filter(([k]) => isAriaKey(k)))
+  return Object.fromEntries(
+    Object.entries(attrs).filter(([k]) => isThumbAria(k)),
+  )
 })
 
 // A slider has no intrinsic width, so it carries `w-full`. That is a default,
@@ -56,11 +64,12 @@ const hasCallerWidth = computed(() => {
 })
 
 // What is left to fall through to the control: class and style are placed by
-// hand, and `aria-*` goes to the thumb.
+// hand, and the thumb-scoped `aria-*` goes to the thumb. `aria-hidden` stays
+// here.
 const rootAttrs = computed(() => {
   return Object.fromEntries(
     Object.entries(attrs).filter(
-      ([key]) => key !== 'class' && key !== 'style' && !isAriaKey(key),
+      ([key]) => key !== 'class' && key !== 'style' && !isThumbAria(key),
     ),
   )
 })

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -83,7 +83,6 @@ const {
   labelledBy,
   descriptionId,
   errorMessageId,
-  describedBy,
   hasError,
   errorLines,
   showDescription,
@@ -137,8 +136,14 @@ const thumbInvalid = computed(() => {
 // Merged, not replaced: a caller's `aria-describedby` must not drop the
 // generated description and error ids.
 const thumbDescribedBy = computed(() => {
+  // Built from what actually renders, not from `describedBy`: that one only
+  // sees the `description` prop, while `InputDescription` renders for the slot
+  // too — the same hole the `#label` slot had. Order matches `describedBy`.
   const ids = [
-    describedBy.value,
+    showDescription.value || slots.description
+      ? descriptionId.value
+      : undefined,
+    hasError.value ? errorMessageId.value : undefined,
     attrs['aria-describedby'] as string | undefined,
   ]
   const merged = ids.filter(Boolean).join(' ')

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, useSlots, useAttrs } from 'vue'
+import type { StyleValue } from 'vue'
 import { SliderRange, SliderRoot, SliderThumb, SliderTrack } from 'reka-ui'
 import { useInputLabeling } from '../../composables/useInputLabeling'
 import InputLabel from '../InputLabeling/InputLabel.vue'
@@ -23,21 +24,27 @@ const slots = useSlots()
 
 const attrs = useAttrs()
 
-// `role="slider"` sits on the thumb, not the root, so the whole ARIA contract
-// has to be re-routed there — on the root it describes a container that no
-// assistive technology reports as the control.
-const ARIA_ATTRS = ['aria-label', 'aria-labelledby', 'aria-describedby']
+defineOptions({
+  inheritAttrs: false,
+})
+
+// `role="slider"` sits on the thumb, not the root, so every caller `aria-*`
+// has to be re-routed there — on the root they describe a container that no
+// assistive technology reports as the control. `aria-valuetext` is the one
+// that would otherwise be silently dropped.
+const isAriaKey = (key: string) => key.startsWith('aria-')
+
+const callerAria = computed(() => {
+  return Object.fromEntries(Object.entries(attrs).filter(([k]) => isAriaKey(k)))
+})
 
 const attrsWithoutClassStyle = computed(() => {
   return Object.fromEntries(
     Object.entries(attrs).filter(
-      ([key]) =>
-        key !== 'class' && key !== 'style' && !ARIA_ATTRS.includes(key),
+      ([key]) => key !== 'class' && key !== 'style' && !isAriaKey(key),
     ),
   )
 })
-
-const thumbLabel = computed(() => attrs['aria-label'] as string | undefined)
 
 defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
@@ -86,6 +93,30 @@ const thumbDescribedBy = computed(() => {
   const merged = ids.filter(Boolean).join(' ')
   return merged || undefined
 })
+
+// A range slider renders one `role="slider"` per value. They need distinct
+// names, or assistive technology announces two identical controls. Only the
+// multi-thumb case is qualified — a single thumb keeps the plain name.
+const isRange = computed(() => sliderValue.value.length > 1)
+
+const baseName = computed(() => {
+  return (attrs['aria-label'] as string | undefined) ?? props.label
+})
+
+function thumbNameFor(index: number): string | undefined {
+  if (!isRange.value) return attrs['aria-label'] as string | undefined
+  const part =
+    sliderValue.value.length === 2
+      ? ['minimum', 'maximum'][index]
+      : `value ${index + 1}`
+  return baseName.value ? `${baseName.value} ${part}` : part
+}
+
+// `aria-labelledby` beats `aria-label`, so the generated reference has to drop
+// away on a range — otherwise the per-thumb name never wins.
+function thumbLabelledByFor(index: number): string | undefined {
+  return thumbNameFor(index) ? undefined : thumbLabelledBy.value
+}
 
 const isBidirectional = computed(() => props.min < 0 && props.max > 0)
 
@@ -150,7 +181,11 @@ const hasLabeling = computed(() => {
 </script>
 
 <template>
-  <LabelingWrapper :enabled="hasLabeling" wrapper-class="space-y-1.5 w-full">
+  <LabelingWrapper
+    :enabled="hasLabeling"
+    :wrapper-class="['space-y-1.5 w-full', attrs.class]"
+    :wrapper-style="attrs.style as StyleValue"
+  >
     <InputLabel
       v-if="props.label || $slots.label"
       :id="labelId"
@@ -165,7 +200,8 @@ const hasLabeling = computed(() => {
     <SliderRoot
       :id="inputId"
       v-model="sliderValue"
-      :class="rootClasses"
+      :class="[rootClasses, hasLabeling ? null : (attrs.class as any)]"
+      :style="hasLabeling ? null : (attrs.style as any)"
       :max="props.max"
       :min="props.min"
       :step="props.step"
@@ -190,8 +226,9 @@ const hasLabeling = computed(() => {
         v-for="(_, i) in sliderValue"
         :key="`slider-thumb-${i}`"
         :class="thumbClasses"
-        :aria-label="thumbLabel"
-        :aria-labelledby="thumbLabelledBy"
+        v-bind="callerAria"
+        :aria-label="thumbNameFor(i)"
+        :aria-labelledby="thumbLabelledByFor(i)"
         :aria-describedby="thumbDescribedBy"
         :aria-errormessage="hasError ? errorMessageId : undefined"
         :aria-invalid="hasError || undefined"

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -23,11 +23,21 @@ const slots = useSlots()
 
 const attrs = useAttrs()
 
+// `role="slider"` sits on the thumb, not the root, so a caller's naming
+// attributes have to be re-routed there — on the root they name a container
+// that no assistive technology reports as the control.
+const NAMING_ATTRS = ['aria-label', 'aria-labelledby']
+
 const attrsWithoutClassStyle = computed(() => {
   return Object.fromEntries(
-    Object.entries(attrs).filter(([key]) => key !== 'class' && key !== 'style'),
+    Object.entries(attrs).filter(
+      ([key]) =>
+        key !== 'class' && key !== 'style' && !NAMING_ATTRS.includes(key),
+    ),
   )
 })
+
+const thumbLabel = computed(() => attrs['aria-label'] as string | undefined)
 
 defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
@@ -59,6 +69,11 @@ const {
 } = useInputLabeling(props, {
   size: () => props.size,
   disabled: () => props.disabled,
+})
+
+/** A caller's `aria-labelledby` wins over the id generated from `label`. */
+const thumbLabelledBy = computed(() => {
+  return (attrs['aria-labelledby'] as string | undefined) ?? labelledBy.value
 })
 
 const isBidirectional = computed(() => props.min < 0 && props.max > 0)
@@ -167,7 +182,8 @@ const hasLabeling = computed(() => {
         v-for="(_, i) in sliderValue"
         :key="`slider-thumb-${i}`"
         :class="thumbClasses"
-        :aria-labelledby="labelledBy"
+        :aria-label="thumbLabel"
+        :aria-labelledby="thumbLabelledBy"
       />
     </SliderRoot>
     <InputDescription

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -115,6 +115,13 @@ const thumbDisabled = computed(() => {
   return (attrs['aria-disabled'] as string | boolean | undefined) || undefined
 })
 
+// The `required` prop promises `aria-required` on the control, and the thumb
+// is now the only element that carries the aria set.
+const thumbRequired = computed(() => {
+  if (props.required) return true
+  return (attrs['aria-required'] as string | boolean | undefined) || undefined
+})
+
 // The `error` prop wins, but with no error a caller's own value has to survive
 // rather than be deleted by the explicit binding.
 const thumbErrorMessage = computed(() => {
@@ -311,6 +318,7 @@ const onValueCommit = (value: SliderValue) => {
           :aria-errormessage="thumbErrorMessage"
           :aria-invalid="thumbInvalid"
           :aria-disabled="thumbDisabled"
+          :aria-required="thumbRequired"
         />
       </template>
     </SliderRoot>

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -97,10 +97,22 @@ const {
 const thumbLabelledBy = computed(() => {
   const caller = attrs['aria-labelledby'] as string | undefined
   if (caller) return caller
+  // A caller's `aria-label` is an explicit override, so the generated
+  // reference has to step aside — it would win the name order otherwise and
+  // the override would do nothing.
+  if (attrs['aria-label']) return undefined
   // `useInputLabeling` only sees the `label` prop, but the label element also
   // renders for a `#label` slot. Without this the slot leaves the thumb
   // unnamed while a `<label>` carrying the name sits right above it.
   return labelledBy.value ?? (slots.label ? labelId.value : undefined)
+})
+
+// reka puts `aria-disabled` on the root but not on the thumb, so without this
+// the element carrying `role="slider"` announces no disabled state. Caller
+// values survive when the prop is not set, same as the error attributes.
+const thumbDisabled = computed(() => {
+  if (props.disabled) return true
+  return (attrs['aria-disabled'] as string | boolean | undefined) || undefined
 })
 
 // The `error` prop wins, but with no error a caller's own value has to survive
@@ -264,7 +276,6 @@ const onValueCommit = (value: SliderValue) => {
       :min="props.min"
       :step="props.step"
       :disabled="props.disabled"
-      :aria-disabled="props.disabled || undefined"
       data-slot="control"
       v-bind="{ ...dataAttrs, ...rootAttrs }"
       @value-commit="onValueCommit"
@@ -299,6 +310,7 @@ const onValueCommit = (value: SliderValue) => {
           :aria-describedby="thumbDescribedBy"
           :aria-errormessage="thumbErrorMessage"
           :aria-invalid="thumbInvalid"
+          :aria-disabled="thumbDisabled"
         />
       </template>
     </SliderRoot>

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useSlots, useAttrs } from 'vue'
+import { computed, normalizeClass, useSlots, useAttrs } from 'vue'
 import type { StyleValue } from 'vue'
 import { SliderRange, SliderRoot, SliderThumb, SliderTrack } from 'reka-ui'
 import { useInputLabeling } from '../../composables/useInputLabeling'
@@ -38,7 +38,17 @@ const callerAria = computed(() => {
   return Object.fromEntries(Object.entries(attrs).filter(([k]) => isAriaKey(k)))
 })
 
-const attrsWithoutClassStyle = computed(() => {
+// A slider has no intrinsic width, so the wrapper carries `w-full`. That is a
+// default, not a rule — but two width utilities in one class list are decided
+// by stylesheet order, not by which one the caller wrote, and there is no class
+// merger here. So drop ours when the caller brings their own.
+const hasCallerWidth = computed(() => {
+  return /(^|\s)!?w-/.test(normalizeClass(attrs.class))
+})
+
+// What is left to fall through to the control: class and style are placed by
+// hand, and `aria-*` goes to the thumb.
+const rootAttrs = computed(() => {
   return Object.fromEntries(
     Object.entries(attrs).filter(
       ([key]) => key !== 'class' && key !== 'style' && !isAriaKey(key),
@@ -94,28 +104,46 @@ const thumbDescribedBy = computed(() => {
   return merged || undefined
 })
 
-// A range slider renders one `role="slider"` per value. They need distinct
-// names, or assistive technology announces two identical controls. Only the
-// multi-thumb case is qualified — a single thumb keeps the plain name.
+// A range slider renders one `role="slider"` per value. Unnamed, reka already
+// tells them apart ("Minimum"/"Maximum", or "Value N of M" past two — see
+// `getLabel` in reka-ui). A name of ours overrides that and lands on every
+// thumb at once, so it has to carry the qualifier itself. Same wording as
+// reka's, so a user never meets two vocabularies.
 const isRange = computed(() => sliderValue.value.length > 1)
 
-const baseName = computed(() => {
-  return (attrs['aria-label'] as string | undefined) ?? props.label
-})
-
-function thumbNameFor(index: number): string | undefined {
-  if (!isRange.value) return attrs['aria-label'] as string | undefined
-  const part =
-    sliderValue.value.length === 2
-      ? ['minimum', 'maximum'][index]
-      : `value ${index + 1}`
-  return baseName.value ? `${baseName.value} ${part}` : part
+function thumbPart(index: number): string {
+  const count = sliderValue.value.length
+  return count === 2
+    ? ['minimum', 'maximum'][index]
+    : `value ${index + 1} of ${count}`
 }
 
-// `aria-labelledby` beats `aria-label`, so the generated reference has to drop
-// away on a range — otherwise the per-thumb name never wins.
+function thumbPartId(index: number): string {
+  return `${inputId.value}-thumb-${index}`
+}
+
+// The qualifier has to reach the name the same way the name arrives. Against a
+// referenced label there is no string to append to — the text lives in an
+// element we do not own — so append a second id instead: `aria-labelledby`
+// takes a list and concatenates it. Reading the referenced element's text
+// would work in a browser and break in SSR.
 function thumbLabelledByFor(index: number): string | undefined {
-  return thumbNameFor(index) ? undefined : thumbLabelledBy.value
+  if (!thumbLabelledBy.value) return undefined
+  return isRange.value
+    ? `${thumbLabelledBy.value} ${thumbPartId(index)}`
+    : thumbLabelledBy.value
+}
+
+function thumbNameFor(index: number): string | undefined {
+  const callerLabel = attrs['aria-label'] as string | undefined
+  if (!isRange.value) return callerLabel
+  // A referenced name is qualified through `aria-labelledby`, which beats
+  // `aria-label`, so setting one here would only delete the reference.
+  if (thumbLabelledBy.value) return undefined
+  // Nothing names this slider, so leave reka's own "Minimum"/"Maximum" in
+  // place rather than restate it.
+  if (!callerLabel) return undefined
+  return `${callerLabel} ${thumbPart(index)}`
 }
 
 const isBidirectional = computed(() => props.min < 0 && props.max > 0)
@@ -183,7 +211,11 @@ const hasLabeling = computed(() => {
 <template>
   <LabelingWrapper
     :enabled="hasLabeling"
-    :wrapper-class="['space-y-1.5 w-full', attrs.class]"
+    :wrapper-class="[
+      'space-y-1.5',
+      hasCallerWidth ? null : 'w-full',
+      attrs.class,
+    ]"
     :wrapper-style="attrs.style as StyleValue"
   >
     <InputLabel
@@ -208,7 +240,7 @@ const hasLabeling = computed(() => {
       :disabled="props.disabled"
       :aria-disabled="props.disabled || undefined"
       data-slot="control"
-      v-bind="{ ...dataAttrs, ...attrsWithoutClassStyle }"
+      v-bind="{ ...dataAttrs, ...rootAttrs }"
       @value-commit="onValueCommit"
     >
       <SliderTrack :class="trackClasses">
@@ -222,17 +254,27 @@ const hasLabeling = computed(() => {
         />
       </SliderTrack>
 
-      <SliderThumb
-        v-for="(_, i) in sliderValue"
-        :key="`slider-thumb-${i}`"
-        :class="thumbClasses"
-        v-bind="callerAria"
-        :aria-label="thumbNameFor(i)"
-        :aria-labelledby="thumbLabelledByFor(i)"
-        :aria-describedby="thumbDescribedBy"
-        :aria-errormessage="hasError ? errorMessageId : undefined"
-        :aria-invalid="hasError || undefined"
-      />
+      <template v-for="(_, i) in sliderValue" :key="`slider-thumb-${i}`">
+        <!-- The second half of a range thumb's referenced name. Rendered only
+             when the name comes from an id, which is the one case the string
+             qualifier cannot reach. -->
+        <span
+          v-if="isRange && thumbLabelledBy"
+          :id="thumbPartId(i)"
+          class="sr-only"
+        >
+          {{ thumbPart(i) }}
+        </span>
+        <SliderThumb
+          :class="thumbClasses"
+          v-bind="callerAria"
+          :aria-label="thumbNameFor(i)"
+          :aria-labelledby="thumbLabelledByFor(i)"
+          :aria-describedby="thumbDescribedBy"
+          :aria-errormessage="hasError ? errorMessageId : undefined"
+          :aria-invalid="hasError || undefined"
+        />
+      </template>
     </SliderRoot>
     <InputDescription
       v-if="showDescription || $slots.description"

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -39,16 +39,20 @@ const callerAria = computed(() => {
 })
 
 // A slider has no intrinsic width, so it carries `w-full`. That is a default,
-// not a rule — but two width utilities in one class list are decided by
-// stylesheet order, not by which one the caller wrote, and there is no class
-// merger here. So drop ours when the caller brings their own, on whichever
-// element the caller's class lands on. Token-split and strip variant prefixes
-// the way `Avatar.vue` does, so `sm:w-64` and `data-[open]:w-64` both count.
-// `min-w-*` and `max-w-*` deliberately do not: those pair with `w-full`.
+// not a rule — but two unprefixed width utilities in one class list are decided
+// by stylesheet order, not by which one the caller wrote, and there is no class
+// merger here. So drop ours when the caller brings their own.
+//
+// Prefixed tokens are excluded on purpose. Tailwind emits variant utilities
+// after the base ones, so `w-full sm:w-64` already resolves the caller's way at
+// `sm` without our help. Dropping `w-full` for them instead leaves `width:auto`
+// everywhere the variant does not apply, which collapses the slider to zero
+// inside a flex parent. `min-w-*` and `max-w-*` are excluded too: those pair
+// with `w-full` rather than replace it.
 const hasCallerWidth = computed(() => {
   return normalizeClass(attrs.class)
     .split(/\s+/)
-    .some((token) => /^!?-?w-/.test(token.slice(token.lastIndexOf(':') + 1)))
+    .some((token) => !token.includes(':') && /^!?-?w-/.test(token))
 })
 
 // What is left to fall through to the control: class and style are placed by


### PR DESCRIPTION
### Problem

The `role="slider"` element (SliderThumb) had no accessible name. The `aria-labelledby` was placed on SliderRoot instead of the slider thumb. Additionally, Slider was the only LabelingWrapper consumer that did not call `useAttrs()`, so `aria-label` passed from call sites was silently dropped.

### Changes

1. **Import and call `useAttrs()`** — matches the pattern used by TextInput, Rating, and other LabelingWrapper consumers
2. **Move `aria-labelledby` from `SliderRoot` to each `SliderThumb`** — the `role="slider"` element now has an accessible name connected to the label
3. **Forward fallthrough attributes** — `v-bind="{ ...dataAttrs, ...attrsWithoutClassStyle }"` on SliderRoot so `aria-label` and other passthrough attrs work

Fixes #994

<!-- coverage-report:start -->
Coverage: 71.92% (+0.04% vs `main`)
<!-- coverage-report:end -->
















