### PR TITLE
docs(migration): add the two missing Tabs breaks

### DIFF
--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -1001,6 +1001,7 @@ See the [Tabs](./components/tabs) component page for the full API.
 | `label` implied the value                   | `value` is required on every trigger                                       |
 | `as="div"`                                  | removed — compose and style the container directly                         |
 | `<template #tab-item="{ tab, selected }">`  | `TabTrigger` props (`icon`, `iconLeft`, `route`) and slots (`#prefix`, default, `#suffix`), or `#tab-label` in shorthand mode |
+| `#prefix` / `#suffix` alongside `:tabs`     | `#tab-prefix` / `#tab-suffix` — every shorthand slot carries the `tab-` prefix (`#tab-prefix`, `#tab-label`, `#tab-suffix`, `#tab-panel`); composed `TabTrigger` keeps plain `#prefix` / `#suffix`. An unknown slot name renders nothing, nothing throws |
 | extra fields on a `tabs` item (`{ value, content }`) | `data: { content }`, read as `tab.data.content` — extra keys are now a type error |
 | `<template #tab-panel="{ tab }">`           | `<TabPanel :value>` children; the shorthand slot keeps the same name       |
 | `Tab.route` string + hand-rolled route sync | `route: RouteLocationRaw` on the trigger; selection derives from the route |
@@ -1075,6 +1076,8 @@ and aligns its vocabulary with the Tabs family. See the
 | Before                                      | After                                       |
 | ------------------------------------------- | ------------------------------------------- |
 | `type="ghost"`                              | `variant="ghost"`                           |
+| `direction="right"`                         | `side="right"` — the same prop name on `TabList` |
+| `TabButtonsType` / `TabButtonsDirection` types | `TabsVariant` / `TabsSide`, shared with the Tabs family |
 | `:buttons="items"` (deprecated)             | `:options="items"`                          |
 | `{ label: 'Day' }` (label as value)         | `value` is required on every option         |
 | `{ active: true }` fallback                 | the `v-model` is the single source of truth |


### PR DESCRIPTION
Adds the two Tabs breaks from #1024 that never made it into
`docs/content/docs/migration.md`, plus one adjacent gap found while verifying.
#877 settled that there is no codemod for Tabs, so the guide is the whole
migration path.

## What's added

**`## TabButtons`**

- `direction="right"` → `side="right"` — the same prop name lands on `TabList`.
- `TabButtonsType` / `TabButtonsDirection` type exports → `TabsVariant` /
  `TabsSide`. Not on the PR's break table, but both types were exported from
  `src/components/TabButtons/index.ts` in v0 and are gone in v1.

**`## Tabs`**

- The shorthand slots carry a `tab-` prefix: `#tab-prefix`, `#tab-label`,
  `#tab-suffix`, `#tab-panel`. Composed `TabTrigger` keeps plain `#prefix` /
  `#suffix`. This is the silent one — an unknown slot name renders nothing and
  nothing throws, and the guide's own `#tab-item` row points readers at
  `#prefix` / `#suffix` without saying that those names only work in composed
  mode.

## Verification

- `direction` is real v0: `58b9c7f44^1:src/components/TabButtons/types.ts` has
  `direction?: TabButtonsDirection` and `TabButtons.vue` defaults it to
  `'left'`. v1 is `side?: TabsSide` on `TabButtonsProps`, `TabListProps`, and
  `TabsProps` (`src/components/Tabs/types.ts`, `src/components/TabButtons/types.ts`).
- Current shorthand slot names confirmed in `src/components/Tabs/Tabs.vue`
  (`tab-prefix` / `tab-label` / `tab-suffix` / `tab-panel`), and `TabTrigger.vue`
  still declares `prefix` / `default` / `suffix`.
- One correction to the issue: the `#prefix` → `#tab-prefix` rename is **not** a
  v0 → v1 rename. v0 `Tabs` declared only `#tab-item` and `#tab-panel`, and v1
  `TabButtons` still uses `#prefix` / `#suffix` unchanged. The rename happened
  inside the rewrite (`spec/tabs.md`, 2026-08-10 vocabulary entry: the shorthand
  slots "were `#prefix` / `#tab` / `#suffix` / `#panel`"), so it never shipped
  under the old names. The entry is still worth having — it is exactly the trap
  the guide's `#tab-item` row walks readers into — so it is worded as the
  shorthand-vs-composed naming split rather than as a v0 rename.
- Re-checked the PR's 13-row break table against the guide: the other 11 were
  already covered, so the count in the issue holds.
- Docs not built (`docs:build` OOMs on this box); the change is two table rows,
  checked for GFM table validity. `migration.md` already fails
  `prettier --check` on `main`, so it was left unformatted rather than
  restyling every existing table.

Part of #864
Closes #1044

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1056/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.92% (±0.00% vs `main`)
<!-- coverage-report:end -->
