### PR TITLE
refactor(data-fetching): centralize the stale-write gate in docStore and listStore

### DIFF
--- a/docs/content/docs/changelog.md
+++ b/docs/content/docs/changelog.md
@@ -15,18 +15,20 @@ Two concurrent writes to one document could leave `docStore`, `listStore`
 (and every view bound to them) on the response that settled last instead of
 the newest one, while `data` already held the fresh response (#1017).
 
-The gate lives in the stores. Every request takes a dispatch version; the
-response's store writes carry it, and the stores reject a write for a
-document that a later-dispatched request has already written. One freshness
-domain covers every writer — the `docs` side channel, the `useDoctype` /
-`useList` / `useDoc` hooks, and any mix of instances or paths writing the
-same document. A version is recorded only when a mutating write lands: a
-newer request that failed wrote nothing on the server, so it does not make
-the older success stale, and a read (GET) is admitted on its version but
-records nothing — the server may answer a later reload before an earlier
-save commits, and the save must still land. A delete records a fresh
-version when it settles — a delete is terminal — so no in-flight write or
-reload, whatever its dispatch order, can re-create a deleted document.
+The gate lives in the stores. Every request takes a monotonic sequence
+number when it is dispatched; the response's store writes carry it, and the
+stores reject a write for a document that a later-dispatched request has
+already written. A sequence, not a timestamp — clocks move and two responses
+can share a millisecond. One freshness domain covers every writer — the
+`docs` side channel, the `useDoctype` / `useList` / `useDoc` hooks, and any
+mix of instances or paths writing the same document. A sequence is recorded
+only when a mutating write lands: a newer request that failed wrote nothing
+on the server, so it does not make the older success stale, and a read (GET)
+is admitted on its sequence but records nothing — the server may answer a
+later reload before an earlier save commits, and the save must still land. A
+delete seals the document when it settles — a delete is terminal — so no
+in-flight write or reload, whatever its dispatch order, can re-create a
+deleted document.
 One accepted limitation: the gate orders by dispatch time, so a read
 dispatched after a save, handled by the server before the save committed
 and answered after it, is admitted and republishes the pre-save value —
@@ -36,7 +38,7 @@ resolving that needs server-side sequencing, which this design trades away.
 newer same-key submit of the same instance already outran — the store gate
 protects the stores, this skip only avoids re-running hook side effects
 with a stale response. `useDoc`'s write members and `useNewDoc` skip their
-hooks the same way, but their store writes stay outside that skip: only the
+hooks the same way. No store write is inside any of those skips: only the
 store gate decides them. It compares per document and knows whether the
 newer request landed, so an overtaken insert of a different document still
 lands, and an older success is kept when the newer submit failed.

--- a/src/data-fetching/docStore.test.ts
+++ b/src/data-fetching/docStore.test.ts
@@ -4,6 +4,7 @@
 import { computed, watchSyncEffect } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { docStore } from './docStore'
+import { LOCAL_WRITE } from './writeGate'
 import { idbStore } from './idbStore'
 
 const DOCTYPE = 'User'
@@ -76,7 +77,9 @@ describe('docStore', () => {
     // Regression: before the fix this rejects. Assigning docRef.value synchronously
     // re-enters getDoc, which (lastFetched unset) saw the entry as stale, evicted
     // the ref it had just created, and the reader dereferenced undefined.
-    await expect(docStore.setDoc({ ...record })).resolves.toBeUndefined()
+    await expect(
+      docStore.setDoc({ ...record }, LOCAL_WRITE),
+    ).resolves.toBeUndefined()
 
     expect(doc.value).toMatchObject(record)
     // The IDB copy setDoc wrote must survive — no spurious stale-reload eviction.
@@ -87,7 +90,7 @@ describe('docStore', () => {
   it('stale access: getDoc never returns undefined (no self-eviction under its caller)', async () => {
     const name = 'user2'
     const record = { doctype: DOCTYPE, name }
-    await docStore.setDoc({ ...record })
+    await docStore.setDoc({ ...record }, LOCAL_WRITE)
 
     makeStale(name)
 
@@ -111,7 +114,7 @@ describe('docStore', () => {
     const { doc, seen, stop } = subscribeLikeUseDoc(name)
     expect(doc.value).toBe(null)
 
-    await docStore.setDoc({ ...fresh })
+    await docStore.setDoc({ ...fresh }, LOCAL_WRITE)
     expect(doc.value).toMatchObject(fresh)
 
     cachedRead.resolve(stale)
@@ -127,7 +130,7 @@ describe('docStore', () => {
 
   it('concurrent reads of one stale key hit IDB once', async () => {
     const name = 'user4'
-    await docStore.setDoc({ doctype: DOCTYPE, name })
+    await docStore.setDoc({ doctype: DOCTYPE, name }, LOCAL_WRITE)
     makeStale(name)
 
     const getSpy = vi.spyOn(idbStore, 'get')
@@ -147,7 +150,7 @@ describe('docStore', () => {
     const write = defer<void>()
     const setSpy = vi.spyOn(idbStore, 'set').mockReturnValue(write.promise)
 
-    const pending = docStore.setDoc({ ...record })
+    const pending = docStore.setDoc({ ...record }, LOCAL_WRITE)
     // Readers see the new value even while the write is in flight — and even if
     // it never lands. Matches setDocs, which already assigns before writing.
     expect(docStore.getDoc(DOCTYPE, name).value).toMatchObject(record)

--- a/src/data-fetching/docStore.ts
+++ b/src/data-fetching/docStore.ts
@@ -1,5 +1,6 @@
 import { Ref, ref, MaybeRefOrGetter, toValue } from 'vue'
 import { idbStore } from './idbStore'
+import { docKey, writeGate, type DocKey, type WriteStamp } from './writeGate'
 
 type Doc = {
   doctype: string
@@ -7,45 +8,21 @@ type Doc = {
   [key: string]: any
 }
 
-type DocKey = `${string}/${string}`
-
-/**
- * A write's identity for the gate: the dispatch version of the request that
- * produced it, and whether the write may record that version (mutating
- * request) or is only admitted on it (read). Always handled whole — carrying
- * the halves separately invites passing a version without its `record` and
- * silently letting a read gate out saves.
- */
-export type DispatchStamp = { version: number; record: boolean }
-
 class DocStore {
   private docs: Map<DocKey, Ref<Doc | null>>
   private lastFetched: Map<DocKey, number>
   private revisions: Map<DocKey, number>
   private inflight: Map<DocKey, Promise<void>>
+  // Publish revisions, not the write gate: this orders the two publishes a key
+  // gets per round (IndexedDB copy, then server copy) so a slow cached read can
+  // tell it has been overtaken. Freshness across REQUESTS is `writeGate`'s job,
+  // and the two counters stay separate because they answer different questions
+  // — this one moves on every publish, including ones the gate never saw.
+  //
   // Store-wide and only ever incremented. A per-key counter that restarts at 0
   // would let a snapshot taken before a key was cleaned up match the value a
   // later slot starts from, which is how a deleted doc comes back to life.
   private revisionCounter = 0
-  // The write gate (#1017). A network write carries the dispatch version of
-  // the request that produced it (taken from `nextWriteVersion` when the
-  // request is dispatched, not when it settles). The store rejects a write for
-  // a document that a later-dispatched request has already written, so two
-  // concurrent writes to one document always land on the newer one — no
-  // matter which composable instance or channel (docs side channel, hook)
-  // carried them. A version is recorded only when a MUTATING write lands:
-  // a later-dispatched request that failed wrote nothing on the server, so
-  // it must not gate out an older success — and a read (GET) is not an
-  // ordered write at all. The server may answer a later-dispatched read
-  // before an earlier save commits, so a read is admitted on its version but
-  // records nothing, or it would gate the save's response out for good.
-  // Grows like `revisions`: one number per document ever written, cleared
-  // with `clearAll`.
-  private writeVersions: Map<DocKey, number>
-  // Ambient version for hooks: `useCall` runs its `onSuccess` inside
-  // `runWithWriteVersion`, so store writes made synchronously from a hook are
-  // versioned without threading a parameter through every hook signature.
-  private currentWrite: DispatchStamp | null = null
   private cacheTimeout: number = 5 * 60 * 1000 // 5 minutes
   private storePrefix = 'doc:'
 
@@ -54,63 +31,6 @@ class DocStore {
     this.lastFetched = new Map()
     this.revisions = new Map()
     this.inflight = new Map()
-    this.writeVersions = new Map()
-  }
-
-  /**
-   * Take a dispatch version for a write. Called when a request is dispatched;
-   * the number rides along and is handed back to `setDoc`/`setDocs` when the
-   * response writes the store. Shares `revisionCounter`, so versions and
-   * publish revisions never collide on monotonicity.
-   */
-  nextWriteVersion(): number {
-    return ++this.revisionCounter
-  }
-
-  /**
-   * Run `fn` with `write` as the ambient write stamp for store writes — the
-   * response's dispatch version plus whether the request mutates the server
-   * (anything but GET): only mutating writes record their version. The stamp
-   * comes whole from `getDispatchStamp`, so the rule has one source.
-   *
-   * The ambient stamp is synchronous: a hook that writes the store after an
-   * `await` runs outside it, and that write is unversioned — always admitted,
-   * never recorded. Consumer hooks must write the stores before any `await`.
-   */
-  runWithWriteVersion<T>(write: DispatchStamp | undefined, fn: () => T): T {
-    const previous = this.currentWrite
-    this.currentWrite = write ?? null
-    try {
-      return fn()
-    } finally {
-      this.currentWrite = previous
-    }
-  }
-
-  /**
-   * Whether a write at `version` may land on this document — no
-   * later-dispatched request has written it. Pure check, records nothing;
-   * `listStore` uses it to drop stale row updates. An unversioned write
-   * (no argument, no ambient version) is always admitted: it did not come
-   * from a dispatched request, so there is no order to compare.
-   */
-  admitsWrite(doctype: string, name: string, version?: number): boolean {
-    const v = version ?? this.currentWrite?.version
-    if (v == null) return true
-    const key = this.getKey(doctype, String(name))
-    return v >= (this.writeVersions.get(key) ?? 0)
-  }
-
-  /**
-   * `admitsWrite` plus recording: a landed mutating write makes older writes
-   * stale. A read (`record: false`) is admitted on its version but records
-   * nothing — see the `writeVersions` comment.
-   */
-  private admitAndRecord(key: DocKey, write: DispatchStamp | null): boolean {
-    if (write == null) return true
-    if (write.version < (this.writeVersions.get(key) ?? 0)) return false
-    if (write.record) this.writeVersions.set(key, write.version)
-    return true
   }
 
   /**
@@ -141,15 +61,21 @@ class DocStore {
     this.cacheTimeout = minutes * 60 * 1000
   }
 
-  async setDoc(doc: Doc, stamp?: DispatchStamp) {
+  /**
+   * `stamp` is required, and there is no default. Every store write has to
+   * say which request it came from — or say `LOCAL_WRITE` and mean it. A
+   * future write site cannot forget the gate; it cannot compile without
+   * answering the question.
+   */
+  async setDoc(doc: Doc, stamp: WriteStamp) {
     if (!doc?.doctype || !doc?.name) {
       throw new Error('Invalid doc: must have doctype and name')
     }
     doc.name = doc.name.toString()
-    const key = this.getKey(doc.doctype, doc.name)
+    const key = docKey(doc.doctype, doc.name)
     // A stale write is dropped whole: no publish, no IDB write — persisting
     // it would hand the stale doc right back on the next cached read.
-    if (!this.admitAndRecord(key, stamp ?? this.currentWrite)) return
+    if (!writeGate.admit(key, stamp)) return
     // Publish before persisting, the way setDocs already does. Awaiting the
     // write first would leave readers on stale data for the length of an IDB
     // round trip, and widen the window a cached read can land in.
@@ -252,16 +178,16 @@ class DocStore {
     this.publish(key, idbDoc)
   }
 
-  async setDocs(docs: Doc[], stamp?: DispatchStamp) {
-    const write = stamp ?? this.currentWrite
+  /** Same rule as `setDoc`: the stamp is required, per response. */
+  async setDocs(docs: Doc[], stamp: WriteStamp) {
     const docMap: Record<string, Doc> = {}
     for (const doc of docs) {
       if (!doc?.doctype || !doc?.name) continue
       doc.name = doc.name.toString()
-      const key = this.getKey(doc.doctype, doc.name)
+      const key = docKey(doc.doctype, doc.name)
       // Stale per document, not per response: one response can carry a fresh
       // doc next to one that a later-dispatched request already wrote.
-      if (!this.admitAndRecord(key, write)) continue
+      if (!writeGate.admit(key, stamp)) continue
       this.publish(key, doc)
       docMap[this.storePrefix + key] = doc
     }
@@ -276,35 +202,24 @@ class DocStore {
    */
   async invalidateDoc(doctype: string, name: string) {
     if (!doctype || !name) return
-    const key = this.getKey(doctype, name)
-    await this.cleanup(key)
+    await this.cleanup(docKey(doctype, name))
   }
 
   /**
-   * The document is deleted on the server. Records a FRESH version, not the
-   * delete's dispatch version: a delete becomes true when it settles. Any
-   * write already in flight — dispatched before or after the delete — must
-   * have been committed by the server before the delete to have succeeded,
-   * so its response is dead data and must not re-create the document. The
-   * same stamp covers a racing reload answered before the delete committed.
-   * Anything dispatched after this point takes a higher number and is
-   * admitted. The delete itself is never gated — a delete that succeeded is
-   * truthful whatever the dispatch order. `max`: the record only ever moves
-   * forward.
+   * The document is deleted on the server. Takes no stamp: a delete that
+   * succeeded is truthful whatever the dispatch order, so it is never gated —
+   * it SEALS the key instead, rejecting every write still in flight for it
+   * (see `writeGate.seal`).
    */
   removeDoc(doctype: string, name: string) {
     if (doctype && name) {
-      const key = this.getKey(doctype, name)
-      this.writeVersions.set(
-        key,
-        Math.max(this.writeVersions.get(key) ?? 0, ++this.revisionCounter),
-      )
+      writeGate.seal(docKey(doctype, name))
     }
     return this.invalidateDoc(doctype, name)
   }
 
   private getKey(doctype: string, name: string): DocKey {
-    return `${doctype.trim()}/${name.trim()}` as DocKey
+    return docKey(doctype, name)
   }
 
   private isStale(key: DocKey): boolean {
@@ -321,9 +236,9 @@ class DocStore {
     // and clearing the entry would hand the next slot a revision an older read
     // still matches.
     this.revisions.set(key, ++this.revisionCounter)
-    // No `writeVersions` stamp here: cleanup serves invalidation too, and an
+    // The gate is not sealed here: cleanup serves invalidation too, and an
     // invalidated doc still exists on the server — an in-flight write must
-    // stay admitted. The terminal stamp for real deletes lives in `removeDoc`.
+    // stay admitted. Sealing for a real delete lives in `removeDoc`.
     await idbStore.delete(this.storePrefix + key)
   }
 
@@ -338,7 +253,7 @@ class DocStore {
       this.lastFetched.clear()
       this.revisions.clear()
       this.inflight.clear()
-      this.writeVersions.clear()
+      writeGate.clear()
     } catch (error) {
       console.error('Failed to clear all docs:', error)
       throw error

--- a/src/data-fetching/index.ts
+++ b/src/data-fetching/index.ts
@@ -1,5 +1,22 @@
+import type { BasicParams, UseCallOptions } from './useCall/types'
+import { useCall as useCallWithStoreWrite } from './useCall/useCall'
+
 export * from './useCall/types'
-export { useCall } from './useCall/useCall'
+
+/**
+ * Narrowed to `UseCallOptions` on the way out of the package. The
+ * implementation's parameter type also carries `onStoreWrite`, the internal
+ * seam every store write goes through — inert for a consumer, since
+ * `WriteStamp`, `docStore` and `listStore` are all unexported, but ADR-0012
+ * freezes this surface at 1.0.0 and a type that admits a member we never
+ * intend to support is one a consumer finds and then argues about after the
+ * freeze. Internal callers import the implementation directly.
+ */
+export const useCall: <TResponse, TParams extends BasicParams = undefined>(
+  options: UseCallOptions<TResponse, TParams>,
+) => ReturnType<typeof useCallWithStoreWrite<TResponse, TParams>> =
+  useCallWithStoreWrite
+
 export { useDoc } from './useDoc/useDoc'
 export { useDoctype } from './useDoctype/useDoctype'
 // `useFrappeFetch` stays internal — it is the raw `createFetch` instance

--- a/src/data-fetching/staleWrites.test.ts
+++ b/src/data-fetching/staleWrites.test.ts
@@ -6,6 +6,7 @@ import { delay, http, HttpResponse } from 'msw'
 import { server } from '../mocks/node'
 import { baseUrl, url } from '../mocks/utils'
 import { docStore } from './docStore'
+import { LOCAL_WRITE } from './writeGate'
 import { useDoc } from './useDoc/useDoc'
 import { useDoctype } from './useDoctype/useDoctype'
 import { useList } from './useList/useList'
@@ -16,14 +17,24 @@ interface User {
   email: string
 }
 
-// Cross-instance staleness (#1017): every composable instance used to keep its
-// own freshness state, so two instances writing the same document never saw
-// each other. The gate now lives in `docStore`: a write carries the dispatch
-// version of the request that produced it, and the store rejects a write for a
-// document that a later-dispatched request has already written.
+// The stale-write gate (#1017, #1028). Every request takes a sequence number
+// when it is dispatched; `docStore` and `listStore` reject a write whose
+// sequence is older than the newest already applied for that document. These
+// tests enumerate the matrix that gate exists for, rather than one ordering
+// per write path:
 //
-// The mock server answers slowly when a value starts with `slow`, so the test
-// controls which submit settles last. Dispatch order is submit-call order.
+//   1. write path x write path x settle ordering, for the four paths that
+//      carry a mutating write into the stores (below);
+//   2. the other three write kinds the gate distinguishes — a read (admitted,
+//      records nothing), a delete (seals the key), a local write (neither) —
+//      each against both settle orderings;
+//   3. two submits from ONE instance, where the composable's own newest-wins
+//      rule could otherwise decide the store write.
+//
+// The mock server answers slowly when a value starts with `slow`, so each
+// cell controls which of its two writes settles last. Dispatch order is
+// pinned by `inDispatchOrder` rather than assumed from call order — the four
+// paths do not take the same number of microtasks to reach `fetch`.
 
 function makeList() {
   return useList<User>({
@@ -34,311 +45,478 @@ function makeList() {
   })
 }
 
-async function seedUser1() {
-  await docStore.setDoc({
+function makeDoc() {
+  return useDoc<User>({
     doctype: 'User',
     name: 'user1',
-    email: 'old@example.com',
+    baseUrl,
+    immediate: false,
   })
+}
+
+async function seedUser1() {
+  await docStore.setDoc(
+    {
+      doctype: 'User',
+      name: 'user1',
+      email: 'old@example.com',
+    },
+    // Not from a dispatched request, so it takes no sequence: seeding must
+    // not gate out the writes the test is about.
+    LOCAL_WRITE,
+  )
 }
 
 function storedEmail() {
   return docStore.getDoc('User', 'user1').value?.email
 }
 
-describe('cross-instance stale writes: two useList instances', () => {
-  // Four orderings: which instance dispatches first x which submit settles
-  // first. In every case the store must end on the later-dispatched submit.
+/**
+ * Call `first`, wait until its request has actually gone out, then call
+ * `second`. The sequence is taken inside the fetch wrapper, so once the spy
+ * has fired, `first` holds the lower number whatever its composable did on
+ * the way there. Dispatch is a bounded chain of microtasks — the mock only
+ * delays server-side — so draining them deterministically reaches it.
+ */
+async function inDispatchOrder(
+  first: () => Promise<unknown>,
+  second: () => Promise<unknown>,
+) {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+  const older = first()
+  for (let i = 0; i < 200 && fetchSpy.mock.calls.length === 0; i++) {
+    await Promise.resolve()
+  }
+  expect(fetchSpy).toHaveBeenCalled()
+  fetchSpy.mockRestore()
+  const newer = second()
+  return [older, newer] as const
+}
 
-  it('first instance dispatches first and settles last', async () => {
-    await seedUser1()
-    let a = makeList()
-    let b = makeList()
-
-    await Promise.all([
-      a.setValue.submit({ name: 'user1', email: 'slow-stale@example.com' }),
-      b.setValue.submit({ name: 'user1', email: 'quick-fresh@example.com' }),
-    ])
-
-    expect(storedEmail()).toBe('quick-fresh@example.com')
-  })
-
-  it('first instance dispatches first and settles first', async () => {
-    await seedUser1()
-    let a = makeList()
-    let b = makeList()
-
-    await Promise.all([
-      a.setValue.submit({ name: 'user1', email: 'quick-stale@example.com' }),
-      b.setValue.submit({ name: 'user1', email: 'slow-fresh@example.com' }),
-    ])
-
-    expect(storedEmail()).toBe('slow-fresh@example.com')
-  })
-
-  it('second instance dispatches first and settles last', async () => {
-    await seedUser1()
-    let a = makeList()
-    let b = makeList()
-
-    await Promise.all([
-      b.setValue.submit({ name: 'user1', email: 'slow-stale@example.com' }),
-      a.setValue.submit({ name: 'user1', email: 'quick-fresh@example.com' }),
-    ])
-
-    expect(storedEmail()).toBe('quick-fresh@example.com')
-  })
-
-  it('second instance dispatches first and settles first', async () => {
-    await seedUser1()
-    let a = makeList()
-    let b = makeList()
-
-    await Promise.all([
-      b.setValue.submit({ name: 'user1', email: 'quick-stale@example.com' }),
-      a.setValue.submit({ name: 'user1', email: 'slow-fresh@example.com' }),
-    ])
-
-    expect(storedEmail()).toBe('slow-fresh@example.com')
-  })
-})
-
-describe('cross-instance stale writes: useList with useDoctype', () => {
-  it('a stale useList setValue does not overwrite a useDoctype setValue', async () => {
-    await seedUser1()
-    let list = makeList()
-    let dt = useDoctype<User>('User', { baseUrl })
-
-    await Promise.all([
-      list.setValue.submit({ name: 'user1', email: 'slow-stale@example.com' }),
-      dt.setValue.submit({ name: 'user1', email: 'quick-fresh@example.com' }),
-    ])
-
-    expect(storedEmail()).toBe('quick-fresh@example.com')
-  })
-
-  it('a stale useDoctype setValue does not overwrite a useList setValue', async () => {
-    await seedUser1()
-    let list = makeList()
-    let dt = useDoctype<User>('User', { baseUrl })
-
-    await Promise.all([
-      dt.setValue.submit({ name: 'user1', email: 'slow-stale@example.com' }),
-      list.setValue.submit({ name: 'user1', email: 'quick-fresh@example.com' }),
-    ])
-
-    expect(storedEmail()).toBe('quick-fresh@example.com')
-  })
-})
-
-describe('mixed docs-channel and hook-path stale writes', () => {
-  // `runDocMethod update_email` answers with a `docs` array, which the global
-  // `afterFetch` pushes into the stores. `setValue` writes through its
-  // `onSuccess` hook. The two paths must share one freshness domain.
-
-  it('a stale docs-channel response does not overwrite a hook write', async () => {
-    await seedUser1()
-    let dt = useDoctype<User>('User', { baseUrl })
-
-    await Promise.all([
+// The four paths a mutating write reaches the stores by. Each entry builds a
+// FRESH composable instance, so pairing a path with itself is the
+// cross-instance case (#1017's original report). Every one of them writes
+// `docStore` and `listStore` for User/user1.
+const writePaths: Record<string, () => (email: string) => Promise<unknown>> = {
+  // useAction -> onStoreWrite
+  'useList().setValue': () => {
+    const list = makeList()
+    return (email) => list.setValue.submit({ name: 'user1', email })
+  },
+  // useAction -> onStoreWrite, a different composable on the same document
+  'useDoctype().setValue': () => {
+    const dt = useDoctype<User>('User', { baseUrl })
+    return (email) => dt.setValue.submit({ name: 'user1', email })
+  },
+  // useIsolatedCall -> onStoreWrite
+  'useDoc().setValue': () => {
+    const doc = makeDoc()
+    return (email) => doc.setValue.submit({ email })
+  },
+  // The docs side channel in useFrappeFetch's global afterFetch, which runs
+  // before any per-call hook and so cannot be covered by a composable's gate.
+  'docs side channel': () => {
+    const dt = useDoctype<User>('User', { baseUrl })
+    return (email) =>
       dt.runDocMethod.submit({
         name: 'user1',
         method: 'update_email',
-        params: { email: 'slow-stale@example.com' },
-      }),
-      dt.setValue.submit({ name: 'user1', email: 'quick-fresh@example.com' }),
-    ])
+        params: { email },
+      })
+  },
+}
 
-    expect(storedEmail()).toBe('quick-fresh@example.com')
-  })
+const pathNames = Object.keys(writePaths)
 
-  it('a stale hook write does not overwrite a docs-channel response', async () => {
-    await seedUser1()
-    let dt = useDoctype<User>('User', { baseUrl })
+// Both settle orderings for one dispatch order. The store must end on the
+// later-dispatched write either way — dispatch order is the intent, settle
+// order is the network.
+const settleOrderings = [
+  {
+    name: 'older settles last',
+    olderEmail: 'slow-stale@example.com',
+    newerEmail: 'fresh@example.com',
+  },
+  {
+    name: 'older settles first',
+    olderEmail: 'stale@example.com',
+    newerEmail: 'slow-fresh@example.com',
+  },
+] as const
 
-    await Promise.all([
-      dt.setValue.submit({ name: 'user1', email: 'slow-stale@example.com' }),
-      dt.runDocMethod.submit({
-        name: 'user1',
-        method: 'update_email',
-        params: { email: 'quick-fresh@example.com' },
-      }),
-    ])
+describe('write path x write path x settle ordering', () => {
+  // A list holding a user1 row, so every cell asserts the row fan-out too:
+  // `listStore.updateRow` asks the same gate `docStore.setDoc` does, and a
+  // row left on a stale value is the same bug one level up.
+  async function mountListWithUser1() {
+    server.use(
+      http.get(url('/api/v2/document/User'), () =>
+        HttpResponse.json({
+          data: [{ name: 'user1', email: 'seed@example.com' }],
+        }),
+      ),
+    )
+    const list = makeList()
+    await list.reload()
+    server.resetHandlers()
+    return list
+  }
 
-    expect(storedEmail()).toBe('quick-fresh@example.com')
-  })
+  for (const olderPath of pathNames) {
+    for (const newerPath of pathNames) {
+      for (const ordering of settleOrderings) {
+        it(`${olderPath} then ${newerPath}, ${ordering.name}`, async () => {
+          await seedUser1()
+          const list = await mountListWithUser1()
+          const older = writePaths[olderPath]()
+          const newer = writePaths[newerPath]()
+
+          const [a, b] = await inDispatchOrder(
+            () => older(ordering.olderEmail),
+            () => newer(ordering.newerEmail),
+          )
+          await Promise.all([a, b])
+
+          expect(storedEmail()).toBe(ordering.newerEmail)
+          expect(list.data?.find((row) => row.name === 'user1')?.email).toBe(
+            ordering.newerEmail,
+          )
+        })
+      }
+    }
+  }
 })
 
-describe('deletes record a version', () => {
-  it('an older in-flight write cannot resurrect a deleted document', async () => {
-    await seedUser1()
-    let dt = useDoctype<User>('User', { baseUrl })
+describe('a read is admitted on its sequence and records nothing', () => {
+  // A GET is not an ordered write: the server may answer a later-dispatched
+  // read before an earlier save commits. So a read may never make a save
+  // stale, and a save always makes an older read stale. Both orderings must
+  // end on the save, for every path the save can take.
 
-    // The save is dispatched first and settles last; the delete is dispatched
-    // later and lands first. The server ends with the document deleted, so
-    // the older save response must not re-create it in the store.
-    await Promise.all([
-      dt.setValue.submit({ name: 'user1', email: 'slow-stale@example.com' }),
-      dt.delete.submit({ name: 'user1' }),
-    ])
+  function slowRead() {
+    server.use(
+      http.get(url('/api/v2/document/User/user1'), async () => {
+        await delay(60)
+        return HttpResponse.json({
+          data: { name: 'user1', email: 'read@example.com' },
+        })
+      }),
+    )
+  }
+
+  function quickRead() {
+    server.use(
+      http.get(url('/api/v2/document/User/user1'), () =>
+        HttpResponse.json({
+          data: { name: 'user1', email: 'read@example.com' },
+        }),
+      ),
+    )
+  }
+
+  for (const path of pathNames) {
+    it(`read dispatched first and settling last loses to ${path}`, async () => {
+      await seedUser1()
+      slowRead()
+      const doc = makeDoc()
+      const save = writePaths[path]()
+
+      const [read, write] = await inDispatchOrder(
+        () => doc.reload(),
+        () => save('saved@example.com'),
+      )
+      await Promise.all([read, write])
+
+      expect(storedEmail()).toBe('saved@example.com')
+    })
+
+    it(`read dispatched second and settling first does not gate out ${path}`, async () => {
+      await seedUser1()
+      quickRead()
+      const doc = makeDoc()
+      const save = writePaths[path]()
+
+      const [write, read] = await inDispatchOrder(
+        () => save('slow-saved@example.com'),
+        () => doc.reload(),
+      )
+      await Promise.all([write, read])
+
+      expect(storedEmail()).toBe('slow-saved@example.com')
+    })
+  }
+})
+
+describe('a delete seals the document', () => {
+  // A delete becomes true when it SETTLES: any write still in flight at that
+  // moment must have been committed by the server before the delete to have
+  // succeeded, so its response is dead data. All four dispatch x settle cells
+  // therefore end with the document gone.
+
+  function slowDelete() {
+    server.use(
+      http.delete(url('/api/v2/document/User/:name'), async () => {
+        await delay(60)
+        return HttpResponse.json({ data: 'deleted' })
+      }),
+    )
+  }
+
+  it('delete dispatched first, settling first', async () => {
+    await seedUser1()
+    const dt = useDoctype<User>('User', { baseUrl })
+
+    const [del, save] = await inDispatchOrder(
+      () => dt.delete.submit({ name: 'user1' }),
+      () => dt.setValue.submit({ name: 'user1', email: 'slow@example.com' }),
+    )
+    await Promise.all([del, save])
 
     expect(docStore.getDoc('User', 'user1').value).toBe(null)
   })
 
-  it('a later-dispatched write settling after the delete cannot resurrect it either', async () => {
+  it('delete dispatched first, settling last', async () => {
     await seedUser1()
-    let dt = useDoctype<User>('User', { baseUrl })
+    slowDelete()
+    const dt = useDoctype<User>('User', { baseUrl })
 
-    // The delete is dispatched first and lands first; the save is dispatched
-    // later but settles last. For that save to have succeeded the server must
-    // have committed it before the delete, so the server still holds the
-    // document deleted — a delete is terminal regardless of dispatch order.
-    await Promise.all([
-      dt.delete.submit({ name: 'user1' }),
-      dt.setValue.submit({ name: 'user1', email: 'slow-stale@example.com' }),
-    ])
+    const [del, save] = await inDispatchOrder(
+      () => dt.delete.submit({ name: 'user1' }),
+      () => dt.setValue.submit({ name: 'user1', email: 'quick@example.com' }),
+    )
+    await Promise.all([del, save])
+
+    expect(docStore.getDoc('User', 'user1').value).toBe(null)
+  })
+
+  it('delete dispatched second, settling first', async () => {
+    await seedUser1()
+    const dt = useDoctype<User>('User', { baseUrl })
+
+    const [save, del] = await inDispatchOrder(
+      () => dt.setValue.submit({ name: 'user1', email: 'slow@example.com' }),
+      () => dt.delete.submit({ name: 'user1' }),
+    )
+    await Promise.all([save, del])
+
+    expect(docStore.getDoc('User', 'user1').value).toBe(null)
+  })
+
+  it('delete dispatched second, settling last', async () => {
+    await seedUser1()
+    slowDelete()
+    const dt = useDoctype<User>('User', { baseUrl })
+
+    const [save, del] = await inDispatchOrder(
+      () => dt.setValue.submit({ name: 'user1', email: 'quick@example.com' }),
+      () => dt.delete.submit({ name: 'user1' }),
+    )
+    await Promise.all([save, del])
 
     expect(docStore.getDoc('User', 'user1').value).toBe(null)
   })
 
   it('a reload racing a delete cannot re-publish the deleted doc', async () => {
     await seedUser1()
-    let dt = useDoctype<User>('User', { baseUrl })
-    let doc = useDoc<User>({
-      doctype: 'User',
-      name: 'user1',
-      baseUrl,
-      immediate: false,
-    })
+    const dt = useDoctype<User>('User', { baseUrl })
+    const doc = makeDoc()
 
     // The reload is dispatched after the delete but can be answered before
-    // the delete commits. Whatever order the two settle in, the document
-    // stays deleted.
+    // the delete commits. It is a read, so it records nothing and the seal
+    // still stands.
     await Promise.all([dt.delete.submit({ name: 'user1' }), doc.reload()])
 
     expect(docStore.getDoc('User', 'user1').value).toBe(null)
   })
 })
 
-describe('reads do not record a version', () => {
-  it('a reload answered before a slower save commits does not gate the save out', async () => {
+describe('a local write is admitted and records nothing', () => {
+  it('lands after a network write, whatever that write recorded', async () => {
     await seedUser1()
-    let doc = useDoc<User>({
-      doctype: 'User',
-      name: 'user1',
-      baseUrl,
-      immediate: false,
-    })
+    const dt = useDoctype<User>('User', { baseUrl })
 
-    // The save is dispatched first (slow); the reload is dispatched later and
-    // the server answers it before the save commits (the GET mock returns the
-    // pre-save email). The read is admitted but must not record: the save is
-    // the mutation, and the server's final state holds it.
-    let save = doc.setValue.submit({ email: 'slow-fresh@example.com' })
-    let read = doc.reload()
+    await dt.setValue.submit({ name: 'user1', email: 'saved@example.com' })
+    await docStore.setDoc(
+      { doctype: 'User', name: 'user1', email: 'local@example.com' },
+      LOCAL_WRITE,
+    )
 
-    await Promise.all([save, read])
-
-    expect(storedEmail()).toBe('slow-fresh@example.com')
+    expect(storedEmail()).toBe('local@example.com')
   })
-})
 
-describe('invalidation is not a delete', () => {
-  it('an in-flight save repopulates the store after a transform-throws eviction', async () => {
-    await docStore.setDoc({
-      doctype: 'User',
+  it('does not gate out a network write dispatched before it', async () => {
+    await seedUser1()
+    const dt = useDoctype<User>('User', { baseUrl })
+
+    const save = dt.setValue.submit({
       name: 'user1',
-      email: 'poison',
+      email: 'slow-saved@example.com',
     })
-    let doc = useDoc<User>({
-      doctype: 'User',
-      name: 'user1',
-      baseUrl,
-      immediate: false,
-      transform: (d) => {
-        if (d.email === 'poison') throw new Error('bad doc')
-        return d
-      },
-    })
-
-    // The save is in flight when the transform throws and evicts the doc.
-    // Eviction invalidates — the server still has the document — so the
-    // save's response must land and repopulate the store. Only a real
-    // delete records the terminal stamp that rejects in-flight writes.
-    // Pin the ordering without wall-clock margins: the fetch wrapper takes
-    // the dispatch version right before calling the global fetch, so once
-    // the spy has fired, the PUT holds its stamp. Dispatch is a bounded
-    // chain of microtasks (the slow mock only delays server-side), so
-    // draining them deterministically reaches it.
-    const fetchSpy = vi.spyOn(globalThis, 'fetch')
-    let save = doc.setValue.submit({ email: 'slow-fresh@example.com' })
-    for (let i = 0; i < 100 && fetchSpy.mock.calls.length === 0; i++) {
-      await Promise.resolve()
-    }
-    expect(fetchSpy).toHaveBeenCalled()
-    fetchSpy.mockRestore()
-
-    expect(doc.doc).toBe(null) // reads the poisoned doc, evicts it
+    await docStore.setDoc(
+      { doctype: 'User', name: 'user1', email: 'local@example.com' },
+      LOCAL_WRITE,
+    )
     await save
 
-    expect(storedEmail()).toBe('slow-fresh@example.com')
+    expect(storedEmail()).toBe('slow-saved@example.com')
   })
 })
 
-describe('docs channel robustness', () => {
-  it('ignores a docs entry without doctype and still lands the response', async () => {
+describe('a sequence is recorded only by a write that landed', () => {
+  // A newer submit that FAILED wrote nothing on the server, so it must not
+  // make an older success stale. Both settle orderings.
+
+  it('newer failure settles first, older success last', async () => {
     await seedUser1()
-    server.use(
-      http.post(url('/api/v2/method/User/mixed_docs'), () =>
-        HttpResponse.json({
-          data: 'ok',
-          docs: [
-            // No doctype, or no entry at all: identifies no document, must
-            // be skipped — not throw inside the global afterFetch and
-            // reject the response.
-            null,
-            { name: 'orphan' },
-            {
-              doctype: 'User',
-              name: 'user1',
-              email: 'mixed-fresh@example.com',
-            },
-          ],
-        }),
-      ),
-    )
-    let dt = useDoctype<User>('User', { baseUrl })
+    const a = makeList()
+    const b = makeList()
 
-    await expect(dt.runMethod.submit({ method: 'mixed_docs' })).resolves.toBe(
-      'ok',
-    )
-    expect(storedEmail()).toBe('mixed-fresh@example.com')
+    const older = a.setValue.submit({
+      name: 'user1',
+      email: 'slow-old@example.com',
+    })
+    const newer = b.setValue.submit({ name: 'user1', email: 'quickfail' })
+
+    await expect(newer).rejects.toThrow('setValue user1 failed')
+    await older
+
+    expect(storedEmail()).toBe('slow-old@example.com')
+  })
+
+  it('older success settles first, newer failure last', async () => {
+    await seedUser1()
+    const a = makeList()
+    const b = makeList()
+
+    const older = a.setValue.submit({
+      name: 'user1',
+      email: 'old@example.com',
+    })
+    const newer = b.setValue.submit({ name: 'user1', email: 'slow-quickfail' })
+
+    await older
+    await expect(newer).rejects.toThrow('setValue user1 failed')
+
+    expect(storedEmail()).toBe('old@example.com')
   })
 })
 
-describe('useNewDoc writes are stamped', () => {
-  it('a stale earlier-dispatched write cannot overwrite a landed insert', async () => {
-    let dt = useDoctype<User>('User', { baseUrl })
+describe('one instance, two submits: the store gate decides, not submit order', () => {
+  // A composable's own newest-wins rule is instance-wide and knows only which
+  // submit STARTED last. Left in charge of store writes it drops writes the
+  // per-document gate would have kept.
 
-    // The setValue is dispatched first (slow); the insert to the same
-    // caller-supplied name is dispatched later and lands first. The insert's
-    // store write must carry its dispatch stamp and record, so the older
-    // response is rejected — before the fix it ran outside the gate.
-    let stale = dt.setValue.submit({
+  it('the later-dispatched submit wins when it settles first', async () => {
+    await seedUser1()
+    const dt = useDoctype<User>('User', { baseUrl })
+
+    const [older, newer] = await inDispatchOrder(
+      () =>
+        dt.setValue.submit({ name: 'user1', email: 'slow-old@example.com' }),
+      () => dt.setValue.submit({ name: 'user1', email: 'new@example.com' }),
+    )
+    await Promise.all([older, newer])
+
+    expect(storedEmail()).toBe('new@example.com')
+  })
+
+  it('the later-dispatched submit wins when it settles last', async () => {
+    await seedUser1()
+    const dt = useDoctype<User>('User', { baseUrl })
+
+    const [older, newer] = await inDispatchOrder(
+      () => dt.setValue.submit({ name: 'user1', email: 'old@example.com' }),
+      () =>
+        dt.setValue.submit({ name: 'user1', email: 'slow-new@example.com' }),
+    )
+    await Promise.all([older, newer])
+
+    expect(storedEmail()).toBe('slow-new@example.com')
+  })
+
+  it('an overtaken insert still lands in the store', async () => {
+    const maker = useNewDoc<User>('User', {}, { baseUrl })
+
+    // Two inserts from one instance, each creating a different document. The
+    // first is slow, so the second overtakes it. Both documents exist on the
+    // server, so both must be in the store: they share no key for the gate
+    // to reject.
+    maker.doc.name = 'slow-overtaken'
+    maker.doc.email = 'overtaken@example.com'
+    const first = maker.submit()
+
+    maker.doc.name = 'quick-winner'
+    maker.doc.email = 'winner@example.com'
+    const second = maker.submit()
+
+    await Promise.all([first, second])
+
+    expect(docStore.getDoc('User', 'slow-overtaken').value?.email).toBe(
+      'overtaken@example.com',
+    )
+    expect(docStore.getDoc('User', 'quick-winner').value?.email).toBe(
+      'winner@example.com',
+    )
+  })
+
+  it('a newer failed submit does not gate out an older success', async () => {
+    await seedUser1()
+    const doc = makeDoc()
+
+    const older = doc.setValue.submit({ email: 'slow-old@example.com' })
+    const newer = doc.setValue.submit({ email: 'quickfail' })
+
+    await Promise.all([older, newer])
+
+    expect(storedEmail()).toBe('slow-old@example.com')
+  })
+})
+
+describe('useNewDoc inserts are stamped', () => {
+  // An insert to a caller-supplied name is a write to a named document like
+  // any other, so it takes both settle orderings against a save on that name.
+
+  it('a stale earlier-dispatched save cannot overwrite a landed insert', async () => {
+    const dt = useDoctype<User>('User', { baseUrl })
+
+    const stale = dt.setValue.submit({
       name: 'race-insert',
       email: 'slow-stale@example.com',
     })
-    let maker = useNewDoc<User>(
+    const maker = useNewDoc<User>(
       'User',
       { name: 'race-insert', email: 'inserted@example.com' },
       { baseUrl },
     )
-    let created = await maker.submit()
+    const created = await maker.submit()
     await stale
 
     expect(created).toMatchObject({ email: 'inserted@example.com' })
     expect(docStore.getDoc('User', 'race-insert').value?.email).toBe(
       'inserted@example.com',
+    )
+  })
+
+  it('a later-dispatched save overwrites an insert that settled first', async () => {
+    const dt = useDoctype<User>('User', { baseUrl })
+    const maker = useNewDoc<User>(
+      'User',
+      { name: 'insert-then-save', email: 'inserted@example.com' },
+      { baseUrl },
+    )
+
+    const [insert, save] = await inDispatchOrder(
+      () => maker.submit(),
+      () =>
+        dt.setValue.submit({
+          name: 'insert-then-save',
+          email: 'saved@example.com',
+        }),
+    )
+    await Promise.all([insert, save])
+
+    expect(docStore.getDoc('User', 'insert-then-save').value?.email).toBe(
+      'saved@example.com',
     )
   })
 
@@ -380,75 +558,70 @@ describe('useNewDoc writes are stamped', () => {
   })
 })
 
-// `useIsolatedCall` keeps its own newest-started rule for `data` and `error`.
-// That rule is instance-wide, so it used to skip the store write of any
-// overtaken submit — losing a write the per-document gate would have kept.
-describe('one instance, two submits: the store gate decides, not submit order', () => {
-  it('an overtaken insert still lands in the store', async () => {
-    let maker = useNewDoc<User>('User', {}, { baseUrl })
-
-    // Two inserts from one instance, each creating a different document. The
-    // first is slow, so the second overtakes it. Both documents exist on the
-    // server, so both must be in the store: they share no key for the gate
-    // to reject.
-    maker.doc.name = 'slow-overtaken'
-    maker.doc.email = 'overtaken@example.com'
-    let first = maker.submit()
-
-    maker.doc.name = 'quick-winner'
-    maker.doc.email = 'winner@example.com'
-    let second = maker.submit()
-
-    await Promise.all([first, second])
-
-    expect(docStore.getDoc('User', 'slow-overtaken').value?.email).toBe(
-      'overtaken@example.com',
+describe('invalidation is not a delete', () => {
+  it('an in-flight save repopulates the store after a transform-throws eviction', async () => {
+    await docStore.setDoc(
+      {
+        doctype: 'User',
+        name: 'user1',
+        email: 'poison',
+      },
+      LOCAL_WRITE,
     )
-    expect(docStore.getDoc('User', 'quick-winner').value?.email).toBe(
-      'winner@example.com',
-    )
-  })
-
-  it('a newer failed submit does not gate out an older success', async () => {
-    await seedUser1()
     let doc = useDoc<User>({
       doctype: 'User',
       name: 'user1',
       baseUrl,
       immediate: false,
+      transform: (d) => {
+        if (d.email === 'poison') throw new Error('bad doc')
+        return d
+      },
     })
 
-    // Same pair as the cross-instance case below, from one instance: the
-    // older submit is slow and succeeds, the newer one fails at once. The
-    // failed submit wrote nothing on the server, so the older response is
-    // what the server holds.
-    let older = doc.setValue.submit({ email: 'slow-old@example.com' })
-    let newer = doc.setValue.submit({ email: 'quickfail' })
+    // The save is in flight when the transform throws and evicts the doc.
+    // Eviction invalidates — the server still has the document — so the
+    // save's response must land and repopulate the store. Only a real
+    // delete seals the key against in-flight writes.
+    const [save] = await inDispatchOrder(
+      () => doc.setValue.submit({ email: 'slow-fresh@example.com' }),
+      async () => {
+        expect(doc.doc).toBe(null) // reads the poisoned doc, evicts it
+      },
+    )
+    await save
 
-    await Promise.all([older, newer])
-
-    expect(storedEmail()).toBe('slow-old@example.com')
+    expect(storedEmail()).toBe('slow-fresh@example.com')
   })
 })
 
-describe('store gate records on success only', () => {
-  it('a newer failed submit does not gate out an older success', async () => {
+describe('docs channel robustness', () => {
+  it('ignores a docs entry without doctype and still lands the response', async () => {
     await seedUser1()
-    let a = makeList()
-    let b = makeList()
+    server.use(
+      http.post(url('/api/v2/method/User/mixed_docs'), () =>
+        HttpResponse.json({
+          data: 'ok',
+          docs: [
+            // No doctype, or no entry at all: identifies no document, must
+            // be skipped — not throw inside the global afterFetch and
+            // reject the response.
+            null,
+            { name: 'orphan' },
+            {
+              doctype: 'User',
+              name: 'user1',
+              email: 'mixed-fresh@example.com',
+            },
+          ],
+        }),
+      ),
+    )
+    let dt = useDoctype<User>('User', { baseUrl })
 
-    // The older submit is slow and succeeds; the newer one (from another
-    // instance) fails at once. The failed submit wrote nothing on the server,
-    // so the older response is what the server holds — it must land.
-    let older = a.setValue.submit({
-      name: 'user1',
-      email: 'slow-old@example.com',
-    })
-    let newer = b.setValue.submit({ name: 'user1', email: 'quickfail' })
-
-    await expect(newer).rejects.toThrow('setValue user1 failed')
-    await older
-
-    expect(storedEmail()).toBe('slow-old@example.com')
+    await expect(dt.runMethod.submit({ method: 'mixed_docs' })).resolves.toBe(
+      'ok',
+    )
+    expect(storedEmail()).toBe('mixed-fresh@example.com')
   })
 })

--- a/src/data-fetching/useAction.ts
+++ b/src/data-fetching/useAction.ts
@@ -1,5 +1,6 @@
 import { computed, effectScope, ref, Ref } from 'vue'
 import { useCall } from './useCall/useCall'
+import type { WriteStamp } from './writeGate'
 
 export interface UseActionOptions<TResponse, TParams> {
   method: 'POST' | 'PUT' | 'DELETE'
@@ -15,6 +16,20 @@ export interface UseActionOptions<TResponse, TParams> {
   key?: (params: TParams) => string
   /** Return a message to reject the submit before any request is sent. */
   validate?: (params: TParams) => string | void
+  /**
+   * Where a submit writes the shared stores — `useCall`'s internal seam,
+   * carrying this response's `WriteStamp`, which `docStore`/`listStore`
+   * require.
+   *
+   * Fires for EVERY successful submit, never filtered by the per-target check
+   * below. `key` happens to be the document name for every action today, so
+   * filtering store writes on it would agree with the gate by coincidence;
+   * key `setValue` by anything finer later (`name/fieldname`, say) and two
+   * saves to one document stop sharing a target, and the check would start
+   * dropping writes the store would have kept. Freshness of a store write is
+   * the store's decision, not this instance's.
+   */
+  onStoreWrite?: (data: TResponse, params: TParams, stamp: WriteStamp) => void
   onSuccess?: (data: TResponse, params: TParams) => void
   onError?: (error: Error, params: TParams) => void
 }
@@ -57,11 +72,11 @@ export interface UseActionOptions<TResponse, TParams> {
  * holds the older submit's value in that case. Submits with different keys
  * (or no key) are independent writes, and every one of them fires its hooks.
  *
- * This gate only decides which hooks fire, and only within this instance.
- * Store freshness does not depend on it: every store write carries its
- * request's dispatch version and `docStore`/`listStore` reject a write that a
- * later-dispatched request has overtaken, across instances and across the
- * docs side channel (#1017).
+ * This gate only decides which CONSUMER hooks fire, and only within this
+ * instance. Store writes go through `onStoreWrite`, which it never filters:
+ * every store write carries its request's sequence number and
+ * `docStore`/`listStore` reject the ones a later-dispatched request has
+ * overtaken, across instances and across the docs side channel (#1017).
  */
 export function useAction<TResponse, TParams extends Record<string, any>>(
   options: UseActionOptions<TResponse, TParams>,
@@ -139,9 +154,7 @@ export function useAction<TResponse, TParams extends Record<string, any>>(
     // conflict on — two keyless submits (two inserts) are always independent
     // writes, and gating them would drop the first one's hook.
     let isFreshForTarget = () =>
-      target != null
-        ? sequence > (lastWrittenByTarget.get(target) ?? 0)
-        : true
+      target != null ? sequence > (lastWrittenByTarget.get(target) ?? 0) : true
     startPending(target)
 
     // Detached so the per-submit call is not tied to whichever component
@@ -156,9 +169,14 @@ export function useAction<TResponse, TParams extends Record<string, any>>(
           baseUrl,
           immediate: false,
           refetch: false,
-          // Gated: this is where `useDoctype` and `useList` write the shared
-          // stores, and a stale same-target submit must not hand them its
-          // response.
+          // Ungated, and the only route to the shared stores from here.
+          onStoreWrite: options.onStoreWrite
+            ? (response, stamp) =>
+                options.onStoreWrite!(response, params, stamp)
+            : undefined,
+          // Gated: a stale same-target submit must not re-run a consumer's
+          // side effects (for `useList`, a needless refetch) with an answer
+          // a newer submit has already replaced.
           // Always wrapped, even without a consumer hook: a success must be
           // recorded either way, or it could not make older answers stale.
           onSuccess: (response) => {

--- a/src/data-fetching/useCall/useCall.ts
+++ b/src/data-fetching/useCall/useCall.ts
@@ -11,8 +11,9 @@ import { idbStore } from '../idbStore'
 import { BasicParams, UseCallOptions } from './types'
 
 /**
- * `onStoreWrite` is internal — deliberately not on `UseCallOptions`, so it
- * stays off the documented surface (ADR-0012) while `useDoc`, `useList`,
+ * `onStoreWrite` is internal. It is deliberately not on `UseCallOptions`, and
+ * `index.ts` re-exports `useCall` narrowed to `UseCallOptions`, so the seam is
+ * unreachable from the package (ADR-0012) while `useDoc`, `useList`,
  * `useDoctype` and `useNewDoc` write the shared stores through it.
  *
  * It exists because it is the only hook handed the response's `WriteStamp`,

--- a/src/data-fetching/useCall/useCall.ts
+++ b/src/data-fetching/useCall/useCall.ts
@@ -5,13 +5,34 @@ import {
   getDispatchStamp,
   useFrappeFetch,
 } from '../useFrappeFetch'
-import { docStore } from '../docStore'
+import { LOCAL_WRITE, type WriteStamp } from '../writeGate'
 import { unrefObject, makeGetParams, normalizeCacheKey } from '../utils'
 import { idbStore } from '../idbStore'
 import { BasicParams, UseCallOptions } from './types'
 
+/**
+ * `onStoreWrite` is internal — deliberately not on `UseCallOptions`, so it
+ * stays off the documented surface (ADR-0012) while `useDoc`, `useList`,
+ * `useDoctype` and `useNewDoc` write the shared stores through it.
+ *
+ * It exists because it is the only hook handed the response's `WriteStamp`,
+ * and `docStore`/`listStore` will not take a write without one. That is the
+ * seam: store writes can only be made from here, and the consumer-facing
+ * `onSuccess` cannot reach the stores even by accident.
+ *
+ * Unlike `onSuccess`, it is never gated by a caller's newest-wins rule — the
+ * gate decides per document, which is finer and better informed than any
+ * per-instance or per-target check a composable can make.
+ */
+export type StoreWritingCallOptions<
+  TResponse,
+  TParams extends BasicParams,
+> = UseCallOptions<TResponse, TParams> & {
+  onStoreWrite?: (data: TResponse, stamp: WriteStamp) => void
+}
+
 export function useCall<TResponse, TParams extends BasicParams = undefined>(
-  options: UseCallOptions<TResponse, TParams>,
+  options: StoreWritingCallOptions<TResponse, TParams>,
 ) {
   const {
     url,
@@ -27,6 +48,7 @@ export function useCall<TResponse, TParams extends BasicParams = undefined>(
     beforeSubmit,
     onSuccess,
     onError,
+    onStoreWrite,
   } = options
 
   let submitParams = ref<TParams | null | undefined>(null)
@@ -72,8 +94,7 @@ export function useCall<TResponse, TParams extends BasicParams = undefined>(
     // response is `{ data: TResponse }`), so the seed value has to be
     // wrapped the same way — an unwrapped `initialData` would read as
     // `undefined` on that `.data` lookup and fall through to `null`.
-    initialData:
-      initialData !== undefined ? { data: initialData } : undefined,
+    initialData: initialData !== undefined ? { data: initialData } : undefined,
     afterFetch(ctx: AfterFetchContext<FrappeResponse<TResponse>>) {
       if (ctx.data) {
         if (transform) {
@@ -88,19 +109,26 @@ export function useCall<TResponse, TParams extends BasicParams = undefined>(
           idbStore.set(normalizedCacheKey, ctx.data.data)
         }
 
+        if (onStoreWrite) {
+          try {
+            // The stamp is handed over, not made ambient. An ambient stamp
+            // only covers writes made before the hook's first `await` — a
+            // rule the hook has to remember, and the store cannot check.
+            // A parameter travels with the write wherever it goes.
+            // A response that never went through the wrapped fetch has no
+            // dispatch order to place it in: `LOCAL_WRITE`.
+            onStoreWrite(
+              ctx.data.data,
+              getDispatchStamp(ctx.response) ?? LOCAL_WRITE,
+            )
+          } catch (e) {
+            console.error('Error in onStoreWrite hook:', e)
+          }
+        }
+
         if (onSuccess) {
           try {
-            // The hook runs under this response's dispatch stamp, so store
-            // writes made from it (`useDoc`, `useDoctype`, `useList` write
-            // their stores here) are dropped when a later-dispatched request
-            // has already written the same document (#1017). The stamp also
-            // says whether the write records (mutating request) or is only
-            // admitted (GET) — see `runWithWriteVersion`. The stamp is
-            // ambient and synchronous: hooks must write the stores before
-            // any `await`.
-            docStore.runWithWriteVersion(getDispatchStamp(ctx.response), () =>
-              onSuccess(ctx.data!.data),
-            )
+            onSuccess(ctx.data.data)
           } catch (e) {
             console.error('Error in onSuccess hook:', e)
           }

--- a/src/data-fetching/useDoc/useDoc.test.ts
+++ b/src/data-fetching/useDoc/useDoc.test.ts
@@ -5,6 +5,7 @@ import { ref } from 'vue'
 import { baseUrl, waitUntilValueChanges } from '../../mocks/utils'
 import { useCall, useDoc } from '../index'
 import { docStore } from '../docStore'
+import { LOCAL_WRITE } from '../writeGate'
 
 describe('useDoc', () => {
   it('it returns expected object', async () => {
@@ -363,7 +364,7 @@ describe('useDoc concurrency', () => {
   })
 
   it('runs two delete submits at once and gives each its own response', async () => {
-    await docStore.setDoc({ doctype: 'User', name: 'user1' })
+    await docStore.setDoc({ doctype: 'User', name: 'user1' }, LOCAL_WRITE)
     const user = useDoc<User>({
       baseUrl,
       doctype: 'User',

--- a/src/data-fetching/useDoc/useDoc.ts
+++ b/src/data-fetching/useDoc/useDoc.ts
@@ -8,6 +8,7 @@ import {
 } from 'vue'
 import { UseFetchOptions, AfterFetchContext } from '@vueuse/core'
 import { getDispatchStamp, useFrappeFetch } from '../useFrappeFetch'
+import { LOCAL_WRITE } from '../writeGate'
 import { useCall } from '../useCall/useCall'
 import { useIsolatedCall } from '../useIsolatedCall'
 import { UseCallOptions } from '../useCall/types'
@@ -89,18 +90,18 @@ export function useDoc<TDoc extends { name: string }, TMethods = {}>(
           doctype,
           name: String(ctx.data.data.name),
         }
-        // Versioned with the request's dispatch stamp, so a reload that an
-        // in-between write has overtaken cannot put the older doc back
-        // (#1017). The stamp's `record` is false for this GET: a read is
-        // admitted on its version but must not record — the server may
-        // answer it before an earlier-dispatched save commits, and recording
-        // here would gate that save's response out for good.
-        let stamp = getDispatchStamp(ctx.response)
+        // Stamped with the request's sequence, so a reload that an in-between
+        // write has overtaken cannot put the older doc back (#1017). The
+        // stamp's `record` is false for this GET: a read is admitted on its
+        // sequence but must not record — the server may answer it before an
+        // earlier-dispatched save commits, and recording here would gate that
+        // save's response out for good.
+        let stamp = getDispatchStamp(ctx.response) ?? LOCAL_WRITE
         docStore.setDoc(doc, stamp)
         if (transform) {
           doc = transform(doc)
         }
-        listStore.updateRow(doctype, ctx.data.data, stamp?.version)
+        listStore.updateRow(doctype, ctx.data.data, stamp)
         triggerSuccessCallbacks(doc)
       }
       return ctx
@@ -146,12 +147,12 @@ export function useDoc<TDoc extends { name: string }, TMethods = {}>(
     baseUrl,
     immediate: false,
     refetch: false,
-    onStoreWrite(data) {
+    onStoreWrite(data, stamp) {
       // Store the untransformed doc; the `doc` computed applies `transform` on
       // read. Transforming here too would run it twice (a bug for any
       // non-idempotent transform). Mirrors afterFetch.
-      docStore.setDoc({ ...data, doctype })
-      listStore.updateRow(doctype, data)
+      docStore.setDoc({ ...data, doctype }, stamp)
+      listStore.updateRow(doctype, data, stamp)
     },
   })
 

--- a/src/data-fetching/useDoctype/useDoctype.test.ts
+++ b/src/data-fetching/useDoctype/useDoctype.test.ts
@@ -5,6 +5,7 @@
 import { baseUrl, waitUntilValueChanges } from '../../mocks/utils'
 import { useDoctype } from '../index'
 import { docStore } from '../docStore'
+import { LOCAL_WRITE } from '../writeGate'
 
 interface User {
   name: string
@@ -133,8 +134,8 @@ describe('useDoctype concurrency', () => {
   })
 
   it('deletes two documents at once and removes both from the doc store', async () => {
-    await docStore.setDoc({ doctype: 'User', name: 'slow-user' })
-    await docStore.setDoc({ doctype: 'User', name: 'quick-user' })
+    await docStore.setDoc({ doctype: 'User', name: 'slow-user' }, LOCAL_WRITE)
+    await docStore.setDoc({ doctype: 'User', name: 'quick-user' }, LOCAL_WRITE)
 
     let user = useDoctype<User>('User', { baseUrl })
 
@@ -256,7 +257,7 @@ describe('useDoctype submit outcome', () => {
   })
 
   it('rejects a failed delete and leaves the document in the store', async () => {
-    await docStore.setDoc({ doctype: 'User', name: 'quick-fail' })
+    await docStore.setDoc({ doctype: 'User', name: 'quick-fail' }, LOCAL_WRITE)
 
     let user = useDoctype<User>('User', { baseUrl })
 
@@ -277,11 +278,14 @@ describe('useDoctype submit outcome', () => {
 // that writes on settle leaves the store on the stale document.
 describe('useDoctype stale store writes', () => {
   it('does not let a stale docs-channel response overwrite the doc store', async () => {
-    await docStore.setDoc({
-      doctype: 'User',
-      name: 'user1',
-      email: 'old@example.com',
-    })
+    await docStore.setDoc(
+      {
+        doctype: 'User',
+        name: 'user1',
+        email: 'old@example.com',
+      },
+      LOCAL_WRITE,
+    )
     let user = useDoctype<User>('User', { baseUrl })
 
     // `update_email` answers with a `docs` array, which `useFrappeFetch`
@@ -305,11 +309,14 @@ describe('useDoctype stale store writes', () => {
   })
 
   it('does not let a stale setValue success overwrite the doc store', async () => {
-    await docStore.setDoc({
-      doctype: 'User',
-      name: 'user1',
-      email: 'old@example.com',
-    })
+    await docStore.setDoc(
+      {
+        doctype: 'User',
+        name: 'user1',
+        email: 'old@example.com',
+      },
+      LOCAL_WRITE,
+    )
     let user = useDoctype<User>('User', { baseUrl })
 
     let [slow, quick] = await Promise.all([

--- a/src/data-fetching/useDoctype/useDoctype.ts
+++ b/src/data-fetching/useDoctype/useDoctype.ts
@@ -61,7 +61,7 @@ function useDelete(doctype: string, options: UseDoctypeOptions = {}) {
     method: 'DELETE',
     baseUrl,
     key: ({ name }) => name,
-    onSuccess(_data, { name }) {
+    onStoreWrite(_data, { name }) {
       docStore.removeDoc(doctype, name)
       listStore.removeRow(doctype, name)
     },
@@ -150,9 +150,9 @@ function useSetValue<T extends Record<string, any>>(
     method: 'PUT',
     baseUrl,
     key: ({ name }) => name,
-    onSuccess(data) {
-      docStore.setDoc({ doctype, ...data })
-      listStore.updateRow(doctype, data)
+    onStoreWrite(data, _params, stamp) {
+      docStore.setDoc({ doctype, ...data }, stamp)
+      listStore.updateRow(doctype, data, stamp)
     },
   })
 

--- a/src/data-fetching/useFrappeFetch.ts
+++ b/src/data-fetching/useFrappeFetch.ts
@@ -1,6 +1,7 @@
 import { createFetch } from '@vueuse/core'
-import { docStore, type DispatchStamp } from './docStore'
+import { docStore } from './docStore'
 import { listStore } from './useList/listStore'
+import { LOCAL_WRITE, writeGate, type DispatchStamp } from './writeGate'
 
 export class FrappeResponseError extends Error {
   title: string
@@ -36,17 +37,11 @@ export class FrappeResponseError extends Error {
   }
 }
 
-// Every request takes a dispatch version from `docStore` when it is
-// dispatched, carried on its Response. The stores gate their writes on it: a
-// document is written only if no later-dispatched request has written it
-// already — without this, two concurrent writes to one document leave the
-// store on whichever response settled last (#1017). The bookkeeping lives in
-// `docStore`, so the docs side channel below and every store-writing hook
-// share one freshness domain.
-// `record` is whether the request mutates the server (anything but GET): only
-// mutating responses record their version in the store, a read is admitted on
-// its version but must not make an earlier-dispatched save stale.
-export type { DispatchStamp } from './docStore'
+// This is where a request takes its sequence number: every request stamped on
+// dispatch, the stamp carried on its Response, and the stores gate their
+// writes on it. See `writeGate` for the rule — this module is only the place
+// the number is minted and the place it is read back off the response.
+export type { DispatchStamp } from './writeGate'
 
 const dispatchStamps = new WeakMap<Response, DispatchStamp>()
 
@@ -67,10 +62,15 @@ export const useFrappeFetch = createFetch({
     // Wrapping the global fetch is required for vitest, and stamps each
     // response with its request's dispatch version.
     fetch: (input, init) => {
-      const version = docStore.nextWriteVersion()
-      const record = (init?.method ?? 'GET').toUpperCase() !== 'GET'
+      // The sequence is taken here, before the request goes out — dispatch
+      // order, not settle order, is what the gate compares. `record` is the
+      // one place the mutating/read rule is decided, so no other module has
+      // to re-derive it from a method string.
+      const stamp = writeGate.next(
+        (init?.method ?? 'GET').toUpperCase() !== 'GET',
+      )
       return fetch(input, init).then((response) => {
-        dispatchStamps.set(response, { version, record })
+        dispatchStamps.set(response, stamp)
         return response
       })
     },
@@ -90,21 +90,15 @@ export const useFrappeFetch = createFetch({
         console.groupEnd()
       }
       if (responseData.docs) {
-        // A missing stamp means the response did not come from the wrapped
-        // fetch; treat it as the newest, and as recording. Unreachable today
-        // — every call site goes through the wrapped fetch — and it answers
-        // "no stamp" differently from `admitsWrite`, which treats an
-        // unstamped write as admitted-and-never-recording. Kept as the safer
-        // default for a docs payload (a mutation, in practice) if the fetch
-        // wrapper is ever bypassed. The stores gate per document. `setDocs`
-        // runs synchronously up to its IDB write, so its records are in
-        // place when `updateRows` checks them.
-        let stamp = getDispatchStamp(ctx.response) ?? {
-          version: docStore.nextWriteVersion(),
-          record: true,
-        }
+        // A response with no stamp did not come from the wrapped fetch above,
+        // so there is no dispatch order to place it in: `LOCAL_WRITE` — the
+        // one answer every store write gives to "no stamp". Unreachable
+        // today; every call site goes through the wrapped fetch. Both stores
+        // get the same stamp, so the docs and the rows of one response are
+        // gated as one write per document.
+        let stamp = getDispatchStamp(ctx.response) ?? LOCAL_WRITE
         docStore.setDocs(responseData.docs, stamp)
-        listStore.updateRows(responseData.docs, stamp.version)
+        listStore.updateRows(responseData.docs, stamp)
       }
       return ctx
     },

--- a/src/data-fetching/useIsolatedCall.ts
+++ b/src/data-fetching/useIsolatedCall.ts
@@ -8,10 +8,14 @@ import {
   unref,
   watch,
 } from 'vue'
-import { canUseCachedFallback, useCall } from './useCall/useCall'
+import {
+  canUseCachedFallback,
+  useCall,
+  type StoreWritingCallOptions,
+} from './useCall/useCall'
 import { idbStore } from './idbStore'
 import { makeGetParams, normalizeCacheKey, unrefObject } from './utils'
-import { BasicParams, UseCallOptions } from './useCall/types'
+import { BasicParams } from './useCall/types'
 
 /**
  * A `useCall`-shaped object whose every `submit()` runs its own request.
@@ -36,7 +40,7 @@ import { BasicParams, UseCallOptions } from './useCall/types'
  *
  * Store writes do NOT follow that rule — they go through `onStoreWrite`,
  * which fires for every successful submit. `docStore`/`listStore` gate
- * themselves: every write carries its request's dispatch version, and the
+ * themselves: every write carries its request's sequence number, and the
  * stores reject a write for a document a later-dispatched request has
  * already written (#1017). That gate is per document and knows whether the
  * newer request actually landed, which this instance-wide rule does not: it
@@ -50,20 +54,14 @@ import { BasicParams, UseCallOptions } from './useCall/types'
  * One default differs from `useCall`: `immediate` is `false` here, because
  * every consumer is a write member that must only fire on `submit()`.
  */
-// `onStoreWrite` is internal: `useDoc` and `useNewDoc` use it to write the
-// shared stores. It is not part of the public call options, because the
-// stores decide freshness for it and a consumer callback cannot.
-type IsolatedCallOptions<
-  TResponse,
-  TParams extends BasicParams,
-> = UseCallOptions<TResponse, TParams> & {
-  onStoreWrite?: (data: TResponse) => void
-}
-
+// Options are `useCall`'s, including its internal `onStoreWrite` seam, which
+// this composable passes straight through: `useDoc` and `useNewDoc` use it to
+// write the shared stores, and it carries the response's `WriteStamp` because
+// the stores will not take a write without one.
 export function useIsolatedCall<
   TResponse,
   TParams extends BasicParams = undefined,
->(options: IsolatedCallOptions<TResponse, TParams>) {
+>(options: StoreWritingCallOptions<TResponse, TParams>) {
   const {
     url,
     method = 'GET',
@@ -154,8 +152,9 @@ export function useIsolatedCall<
     // happened to call submit, and stopped below so its watchers and
     // computeds do not pile up one set per submit.
     let scope = effectScope(true)
-    let call: ReturnType<typeof useCall<TResponse, Record<string, any>>> | null =
-      null
+    let call: ReturnType<
+      typeof useCall<TResponse, Record<string, any>>
+    > | null = null
     try {
       call = scope.run(() =>
         useCall<TResponse, Record<string, any>>({
@@ -166,13 +165,12 @@ export function useIsolatedCall<
           refetch: false,
           staleOnError,
           transform,
+          // Passed straight through, ungated: store writes run for every
+          // successful submit, carrying this request's stamp, and the stores
+          // reject the stale ones per document — a finer and better-informed
+          // rule than the newest-started gate below.
+          onStoreWrite,
           onSuccess: (data: TResponse) => {
-            // Store writes run for every successful submit. They carry this
-            // request's dispatch stamp (this hook runs inside `useCall`'s
-            // write-version window), and the stores reject the stale ones
-            // per document — a finer and better-informed rule than the
-            // newest-started gate below.
-            onStoreWrite?.(data)
             // The consumer hooks and the cache write are shared side
             // effects, so they keep the newest-wins gate that `data` and
             // `error` use: a stale response must not overwrite a fresher

--- a/src/data-fetching/useList/listStore.ts
+++ b/src/data-fetching/useList/listStore.ts
@@ -1,4 +1,4 @@
-import { docStore } from '../docStore'
+import { docKey, writeGate, type WriteStamp } from '../writeGate'
 
 export interface ListInstanceMethods {
   updateRow: (doc: Partial<{ name: string }> & Record<string, unknown>) => void
@@ -22,34 +22,43 @@ class ListStore {
     this.byDocType[doctype].push(list)
   }
 
-  updateRows(docs: Array<Doc>, version?: number) {
+  /** Same rule as `docStore.setDocs`: the stamp is required, per response. */
+  updateRows(docs: Array<Doc>, stamp: WriteStamp) {
     for (let doc of docs) {
       // `doc?.` matches `setDocs`'s guard: a `null` entry in a docs payload
       // must fall through to `updateRow`'s guard, not throw here and reject
       // the whole response.
-      this.updateRow(doc?.doctype, doc, version)
+      this.updateRow(doc?.doctype, doc, stamp)
     }
   }
 
-  updateRow(doctype: string, doc: Doc, version?: number) {
+  /**
+   * `stamp` is required for the same reason it is on `docStore.setDoc`: a row
+   * update is a write to a document, and the caller has to say which request
+   * it came from.
+   */
+  updateRow(doctype: string, doc: Doc, stamp: WriteStamp) {
     // An entry without doctype or name identifies no row. Skipped, matching
-    // `setDocs`'s guard — reaching `admitsWrite` with it would throw on
-    // `doctype.trim()` and reject the whole response it rode in on.
-    if (!doctype || !doc.name) return
-    // Same freshness domain as the doc store (#1017): a row update from a
-    // request that a later-dispatched request has already overtaken for this
-    // document is dropped. `docStore` is the bookkeeper; the matching
-    // `docStore.setDoc`/`setDocs` call recorded this write's version, so an
-    // equal version passes.
-    if (!docStore.admitsWrite(doctype, doc.name, version)) {
-      return
-    }
+    // `setDocs`'s guard.
+    if (!doctype || !doc?.name) return
+    // The same gate `docStore` asks, so a row update and the doc write from
+    // one response get one answer. Admitting also records, so a row update
+    // that arrives without a matching `setDoc` still makes older writes to
+    // that document stale — this store no longer relies on `docStore` having
+    // been called first. The paired call records the same number, and an
+    // equal sequence passes.
+    if (!writeGate.admit(docKey(doctype, doc.name), stamp)) return
     this.ensureList(doctype)
     this.byDocType[doctype].forEach((list) => {
       list.updateRow(doc)
     })
   }
 
+  /**
+   * Takes no stamp, like `docStore.removeDoc`: a removal is terminal, never
+   * gated. Its paired `removeDoc` seals the key, so an in-flight `updateRow`
+   * settling afterwards cannot put the row back.
+   */
   removeRow(doctype: string, name: string) {
     this.ensureList(doctype)
     this.byDocType[doctype].forEach((list) => {

--- a/src/data-fetching/useList/useList.ts
+++ b/src/data-fetching/useList/useList.ts
@@ -200,9 +200,14 @@ export function useList<T extends { name: string }>(
     method: 'PUT',
     baseUrl,
     key: ({ name }) => name,
-    onSuccess(data) {
-      docStore.setDoc({ doctype, ...data })
-      listStore.updateRow(doctype, data)
+    onStoreWrite(data, _params, stamp) {
+      docStore.setDoc({ doctype, ...data }, stamp)
+      listStore.updateRow(doctype, data, stamp)
+    },
+    onSuccess() {
+      // Gated per target: a stale same-row save must not trigger a refetch
+      // with an answer a newer save has already replaced. The store writes
+      // above are not part of that decision.
       if (refetch) execute()
     },
   })
@@ -224,10 +229,12 @@ export function useList<T extends { name: string }>(
     method: 'DELETE',
     baseUrl,
     key: ({ name }) => name,
-    onSuccess(_data, { name }) {
-      if (refetch) execute()
+    onStoreWrite(_data, { name }) {
       docStore.removeDoc(doctype, name)
       listStore.removeRow(doctype, name)
+    },
+    onSuccess() {
+      if (refetch) execute()
     },
   })
 

--- a/src/data-fetching/useNewDoc/useNewDoc.ts
+++ b/src/data-fetching/useNewDoc/useNewDoc.ts
@@ -39,15 +39,14 @@ export function useNewDoc<T extends object>(
     },
     immediate: false,
     ...options,
-    // The store write lives here, not in `submit()`'s `.then`: this hook
-    // runs inside `useCall`'s `runWithWriteVersion` window, so the write
-    // carries the POST's dispatch stamp and records. In the `.then` it ran
-    // after the window closed — unversioned, always admitted, never
-    // recording — the one store write outside the gate (#1017). Matters
-    // when the caller supplies `name`: a stale earlier-dispatched response
-    // for the same document must not overwrite the insert.
-    onStoreWrite(created: DocResponse) {
-      docStore.setDoc({ doctype, ...created })
+    // The store write lives here, not in `submit()`'s `.then`: this hook is
+    // handed the POST's stamp, so the write records. In the `.then` there is
+    // no stamp to hand it — it would have to claim `LOCAL_WRITE` and never
+    // record, the one store write outside the gate (#1017). Matters when the
+    // caller supplies `name`: a stale earlier-dispatched response for the
+    // same document must not overwrite the insert.
+    onStoreWrite(created: DocResponse, stamp) {
+      docStore.setDoc({ doctype, ...created }, stamp)
     },
   })
 

--- a/src/data-fetching/writeGate.test.ts
+++ b/src/data-fetching/writeGate.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, expect, it } from 'vitest'
+import { docKey, LOCAL_WRITE, writeGate } from './writeGate'
+
+// The gate's contract, asserted at the seam. `staleWrites.test.ts` proves the
+// same rules hold end to end through real requests; these pin them directly,
+// so a change in the rule fails here first and reads as one line rather than
+// as a network round trip.
+//
+// The gate is a module singleton with a counter that only rises, so each test
+// takes its own key: sequences from one test can never collide with another's.
+
+let keySeq = 0
+const freshKey = () => docKey('User', `gate-${++keySeq}`)
+
+describe('writeGate', () => {
+  it('admits a newer sequence and rejects an older one', () => {
+    const key = freshKey()
+    const older = writeGate.next(true)
+    const newer = writeGate.next(true)
+
+    expect(writeGate.admit(key, newer)).toBe(true)
+    expect(writeGate.admit(key, older)).toBe(false)
+  })
+
+  it('admits an equal sequence, so a doc write and its row update agree', () => {
+    const key = freshKey()
+    const stamp = writeGate.next(true)
+
+    // `docStore.setDoc` then `listStore.updateRow`, one response.
+    expect(writeGate.admit(key, stamp)).toBe(true)
+    expect(writeGate.admit(key, stamp)).toBe(true)
+  })
+
+  it('records nothing for a read, so it cannot gate out an older save', () => {
+    const key = freshKey()
+    const save = writeGate.next(true)
+    const read = writeGate.next(false)
+
+    expect(writeGate.admit(key, read)).toBe(true)
+    // The read was dispatched later but recorded nothing, so the save — which
+    // the server may well have committed after answering the read — still
+    // lands.
+    expect(writeGate.admit(key, save)).toBe(true)
+  })
+
+  it('seals against a write dispatched after the delete but equal to its own', () => {
+    const key = freshKey()
+    const inflight = writeGate.next(true)
+
+    writeGate.seal(key)
+
+    // Nothing in flight when the delete settled may re-create the document,
+    // whichever side of the delete it was dispatched on. The seal takes a
+    // fresh number, so even a write that outranks the delete's own dispatch
+    // is rejected.
+    expect(writeGate.admit(key, inflight)).toBe(false)
+    const later = writeGate.next(true)
+    expect(writeGate.admit(key, later)).toBe(true)
+  })
+
+  it('never records a local write', () => {
+    const key = freshKey()
+    const older = writeGate.next(true)
+
+    expect(writeGate.admit(key, LOCAL_WRITE)).toBe(true)
+    // Had `LOCAL_WRITE` recorded anything, this earlier-dispatched write would
+    // now be rejected. A local write has no place in the dispatch order.
+    expect(writeGate.admit(key, older)).toBe(true)
+  })
+
+  it('always admits a local write, whatever was recorded', () => {
+    const key = freshKey()
+    writeGate.admit(key, writeGate.next(true))
+
+    expect(writeGate.admit(key, LOCAL_WRITE)).toBe(true)
+  })
+
+  it('clears the per-document records but not the counter', () => {
+    const key = freshKey()
+    const before = writeGate.next(true)
+    writeGate.admit(key, before)
+
+    writeGate.clear()
+
+    // The records are gone, so the key starts fresh...
+    expect(writeGate.admit(key, writeGate.next(true))).toBe(true)
+    // ...but the counter does not restart. A sequence minted before the clear
+    // must never outrank one minted after it — that is how a stamp held by a
+    // request in flight across a `clearAll` would resurrect a stale write.
+    expect(writeGate.next(true).sequence).toBeGreaterThan(before.sequence)
+  })
+})

--- a/src/data-fetching/writeGate.ts
+++ b/src/data-fetching/writeGate.ts
@@ -1,0 +1,121 @@
+/**
+ * The stale-write gate for `docStore` and `listStore` (#1017, #1028).
+ *
+ * Two concurrent writes to one document must leave the stores on the newer
+ * one, not on whichever response settled last. The order that matters is the
+ * order the requests were DISPATCHED in: a request dispatched later carries
+ * the newer intent, whatever the network does with it afterwards.
+ *
+ * So every request takes a sequence number when it is dispatched, and a store
+ * write presents that number to `admit` before it lands. A write whose
+ * sequence is older than the newest already applied for that document is
+ * rejected. The record is per document, so one response can carry a fresh doc
+ * next to one a later-dispatched request already wrote, and two writes to
+ * different documents never gate each other.
+ *
+ * A sequence counter, not a timestamp: clocks move, and two responses can
+ * share a millisecond. The counter is store-wide and only ever incremented —
+ * a per-document counter restarting at 0 would let a number minted for one
+ * key match a later slot's, which is how a deleted doc comes back to life.
+ * Comparison is still per document, which is what "per-key sequence" buys.
+ *
+ * This module is the only bookkeeper. `docStore` and `listStore` both ask it,
+ * so a row update and a doc write from the same response share one answer,
+ * and a write from any composable instance — or from the docs side channel in
+ * `useFrappeFetch` — is ordered against every other.
+ */
+
+export type DocKey = `${string}/${string}`
+
+/**
+ * What a network write presents to the gate: the sequence number of the
+ * request that produced it, and whether the write may RECORD that number.
+ *
+ * Only a mutating request records. A later-dispatched request that failed
+ * wrote nothing on the server, so it must not make an older success stale;
+ * and a read (GET) is not an ordered write at all — the server may answer a
+ * later-dispatched read before an earlier save commits, so recording it would
+ * gate that save's response out for good. A read is admitted on its sequence
+ * and records nothing.
+ *
+ * The two halves always travel together. Carried separately, a caller can
+ * pass a sequence and forget `record`, which silently lets a read gate out
+ * saves.
+ */
+export type DispatchStamp = { sequence: number; record: boolean }
+
+/**
+ * A write that did not come from a dispatched request — seeding the store in
+ * a test, a response that never went through the wrapped fetch. There is no
+ * order to compare it against, so it is always admitted and records nothing.
+ *
+ * It is a value a caller has to name, not an argument they can omit: every
+ * store write takes a `WriteStamp`, so the un-ordered case is a decision at
+ * the call site rather than the silent default of a forgotten parameter.
+ */
+export const LOCAL_WRITE = Symbol('local write')
+
+export type WriteStamp = DispatchStamp | typeof LOCAL_WRITE
+
+class WriteGate {
+  // Only ever incremented; shared by every document. See the module comment
+  // for why this is not per key and not a clock.
+  private counter = 0
+  // The newest sequence applied to each document. Grows by one number per
+  // document ever written, and is cleared with `docStore.clearAll`.
+  private applied = new Map<DocKey, number>()
+
+  /**
+   * Take the next sequence number. Called when a request is dispatched — not
+   * when it settles — so the number reflects the order the writes were
+   * intended in.
+   */
+  next(record: boolean): DispatchStamp {
+    return { sequence: ++this.counter, record }
+  }
+
+  /**
+   * Whether this write may land on this document.
+   *
+   * Asking is booking: an admitted mutating write is recorded as the newest
+   * for the key, so a later call carrying an older sequence is rejected.
+   * There is deliberately no way to check without recording — a check that
+   * did not record is how a stale write slips in behind an admitted one.
+   */
+  admit(key: DocKey, stamp: WriteStamp): boolean {
+    if (stamp === LOCAL_WRITE) return true
+    if (stamp.sequence < (this.applied.get(key) ?? 0)) return false
+    if (stamp.record) this.applied.set(key, stamp.sequence)
+    return true
+  }
+
+  /**
+   * The document is gone on the server: reject every write in flight for it.
+   *
+   * Stamped with a FRESH number rather than the delete's own, because a
+   * delete becomes true when it SETTLES. Any write still in flight at that
+   * moment — dispatched before or after the delete — must have been committed
+   * by the server before the delete to have succeeded, so its response is
+   * dead data and must not re-create the document. Anything dispatched after
+   * this point takes a higher number and is admitted again. `max` keeps the
+   * record moving forward only.
+   */
+  seal(key: DocKey) {
+    this.applied.set(key, Math.max(this.applied.get(key) ?? 0, ++this.counter))
+  }
+
+  clear() {
+    this.applied.clear()
+  }
+}
+
+export const writeGate = new WriteGate()
+
+/**
+ * The identity a write is gated on. `docStore` keys its documents by the same
+ * string, so the gate, the doc refs and the list rows all agree on what "the
+ * same document" means.
+ */
+export function docKey(doctype: string, name: string | number): DocKey {
+  return `${String(doctype).trim()}/${String(name).trim()}` as DocKey
+}

--- a/src/data-fetching/writeGate.ts
+++ b/src/data-fetching/writeGate.ts
@@ -97,11 +97,14 @@ class WriteGate {
    * moment — dispatched before or after the delete — must have been committed
    * by the server before the delete to have succeeded, so its response is
    * dead data and must not re-create the document. Anything dispatched after
-   * this point takes a higher number and is admitted again. `max` keeps the
-   * record moving forward only.
+   * this point takes a higher number and is admitted again.
+   *
+   * A plain assignment, not a `max`: every number in `applied` was minted by
+   * an earlier `next` or `seal`, so a fresh `++counter` already outranks all
+   * of them. The record moves forward because the counter does.
    */
   seal(key: DocKey) {
-    this.applied.set(key, Math.max(this.applied.get(key) ?? 0, ++this.counter))
+    this.applied.set(key, ++this.counter)
   }
 
   clear() {


### PR DESCRIPTION
## Summary

Implements the centralized stale-write gate decided on #1023. #1018 already
moved the gate into the stores, and it is correct today — but a write site
could still opt out of it by accident, which is the thing #1023 asked to
make impossible. This PR closes that.

## The design

**The problem with the gate as it stands.** `setDoc`/`setDocs`/`updateRows`
took an *optional* stamp. A caller that omitted it fell back to an ambient
stamp `useCall` installed around `onSuccess` via `runWithWriteVersion`. That
ambient stamp is synchronous: it only covers writes made before the hook's
first `await` — a rule the hook has to remember and the store cannot check.
A write site outside that window was silently ungated (admitted always,
recorded never), and nothing failed. `listStore` had a second weakness: it
called `docStore.admitsWrite`, a *pure* check that recorded nothing, and
relied on the paired `docStore.setDoc`/`setDocs` call having recorded first.

**The seam.** A new `src/data-fetching/writeGate.ts` owns the monotonic
sequence counter and the per-document record of the newest sequence applied.
Both stores ask it. Three properties do the work:

1. **One bookkeeper.** A row update and a doc write from one response get one
   answer. `listStore` no longer borrows `docStore`'s bookkeeping and no
   longer depends on call ordering between the two stores.
2. **Asking is booking.** `writeGate.admit(key, stamp)` checks *and* records
   in one call. There is deliberately no way to check without recording — a
   check that did not record is how a stale write slips in behind an admitted
   one.
3. **The stamp is a required argument.** `setDoc`, `setDocs`, `updateRow` and
   `updateRows` take a `WriteStamp` with no default. A write that did not
   come from a dispatched request must name `LOCAL_WRITE` and mean it. A
   future write site cannot forget the gate — it cannot compile without
   answering the question. This is the "hard to bypass by construction"
   requirement, discharged by the type checker rather than by a comment.

**One way in.** Store writes move onto `onStoreWrite`, `useCall`'s internal
hook and the only one handed the response's stamp. `runWithWriteVersion` and
the ambient stamp are deleted, and with them the undocumentable
write-before-any-`await` rule. `useAction` gains the same `onStoreWrite` seam
`useIsolatedCall` already had. Net effect: the consumer-facing `onSuccess`
cannot reach the stores even by accident, because it has no stamp to present.

**Sequence, not timestamp.** As specified in #1023 — clocks move and two
responses can share a millisecond. One note on "per-key": the counter is
store-wide and *compared* per document, which is what gives per-key ordering.
A genuinely per-key counter is not implementable at dispatch time — a request
does not know which documents its response will carry (a `docs` payload can
carry several), and a per-key counter restarting at 0 is what lets a deleted
doc come back, per the existing comment in `docStore`. The record map, the
comparison and the seal are all per document; only the mint is shared.

## The matrix tested

`staleWrites.test.ts` is rebuilt around the enumeration rather than one
ordering per path. Dispatch order is *pinned* with a fetch spy
(`inDispatchOrder`) instead of assumed from call order — the four paths do
not take the same number of microtasks to reach `fetch`, so call order is not
dispatch order.

**A. mutating write path x write path x settle ordering — 4 x 4 x 2 = 32 cells.**
Every cell asserts both `docStore` and the `listStore` row fan-out.

| dispatched first \ dispatched second | `useList().setValue` | `useDoctype().setValue` | `useDoc().setValue` | docs side channel |
|---|---|---|---|---|
| `useList().setValue`    | OK / OK | OK / OK | OK / OK | OK / OK |
| `useDoctype().setValue` | OK / OK | OK / OK | OK / OK | OK / OK |
| `useDoc().setValue`     | OK / OK | OK / OK | OK / OK | OK / OK |
| docs side channel       | OK / OK | OK / OK | OK / OK | OK / OK |

(each cell is two tests — *older settles last* / *older settles first*; each
path builds a fresh instance, so the diagonal is the cross-instance case)

**B. the other three write kinds the gate distinguishes, both orderings each.**

| kind | orderings asserted | count |
|---|---|---|
| read (GET: admitted, records nothing) | read dispatched first + settling last / read dispatched second + settling first, against all 4 write paths | 8 |
| delete (seals the key) | delete dispatched first/second x settling first/last, + reload racing a delete | 5 |
| local write (`LOCAL_WRITE`) | lands after a recorded network write / does not gate out a write dispatched before it | 2 |
| failure (records only on success) | newer failure settles first / older success settles first | 2 |

**C. one instance, two submits** (where the composable's own newest-wins rule
could otherwise decide the store write): later-dispatched wins settling first
/ settling last, overtaken insert still lands, newer failed submit does not
gate out an older success — 4. Plus `useNewDoc` insert vs save in both
orderings, cross-instance insert, invalidation-is-not-a-delete, docs-channel
robustness.

**Counts.** `staleWrites.test.ts` 58 passed (was 19). Whole data-fetching
suite **153 passed / 153** (was 114). `vue-tsc --noEmit -p tsconfig.app.json`:
0 errors in any file this PR touches; the 78 repo-wide errors are the known
baseline (`vitepress/`, `src/components/Menu`, `src/mocks`, editor
extensions), untouched.

**Not vacuous:** with `writeGate.admit`'s comparison stubbed out, 25 of the 58
go red. The other 33 are the natural-order control cells, which is what they
are for.

## #1018's per-site checks: removed vs kept

**Removed — the central gate covers them:**

- `docStore.runWithWriteVersion` + the ambient `currentWrite`. Replaced by a
  required parameter. This also retires the "hooks must write the stores
  before any `await`" rule, which was a convention the store could not check.
- `docStore.admitsWrite` — the pure, non-recording check `listStore` used,
  and its implicit dependency on `setDoc`/`setDocs` having recorded first.
- `useAction`'s per-target `isFreshForTarget` gate **over store writes**.
  Store writes move to the ungated `onStoreWrite`. This was only safe because
  `key` is the document name for every action today; the gate decides per
  document and is right regardless of how `key` is chosen later.
- `useIsolatedCall`'s hand-rolled `onStoreWrite?.(data)` call from inside the
  gated `onSuccess` — now a first-class pass-through on `useCall`, so the
  ordering guarantee lives in one place instead of being re-implemented per
  composable.
- `useFrappeFetch.afterFetch`'s special "no stamp means newest-and-recording"
  fallback, which answered "no stamp" differently from the stores. Now
  `LOCAL_WRITE`, the single answer. Unreachable either way (every call site
  goes through the wrapped fetch); the point is that there is now one rule
  rather than two.

**Kept — each guards something the store cannot see:**

- `useAction`'s `isFreshForTarget` over the **consumer** `onSuccess`/`onError`.
  These drive `useList`'s auto-refetch and a caller's own side effects. The
  store has no view of a refetch or a user callback, so it cannot decide them.
- `useAction`/`useIsolatedCall`'s instance-wide newest-started rule for
  `data`, `error` and the idb cache write. These are per-instance state with a
  documented newest-wins contract; the store does not know they exist.
- `useNewDoc.submit()` resolving with the caller's own response rather than
  the store copy. Not a gate — the complement of one: which caller's document
  won the store must not change what a caller is handed.
- `docStore.revisions` / `revisionCounter` and the `readFromCache` revision
  snapshot. These order the two publishes a key gets per round (IndexedDB
  copy, then server copy) so a slow cached read can tell it was overtaken.
  That is within-key publish ordering, a different question from cross-request
  ordering, and the gate never sees the IDB read. Kept as a separate counter
  for exactly that reason.
- `useDoc`'s transform-throws eviction calling `invalidateDoc` rather than
  `removeDoc`. Semantic, not a staleness check: the server still has the doc,
  so the key must not be sealed.

## Relationship to the open PRs #1042 and #1048

Both are follow-ups to the same review round, and both raise the same second
point: *`useAction`'s skip can start deciding store writes again* if `key` is
ever narrowed past the document name.

- **#1042** fixes it structurally — adds an `onStoreWrite` seam to
  `useAction` and moves the `useList`/`useDoctype` store writes onto it. This
  PR does the same thing, arrived at from the other direction (the stores now
  *require* a stamp, and `onStoreWrite` is the only hook that has one). **That
  half of #1042 is redundant with this PR.** The two implementations agree on
  the shape; this one additionally threads the `WriteStamp` through the hook,
  which #1042's does not (it still relies on the ambient window this PR
  removes).
- **#1048** fixes it with a `SAFETY` comment at both sites tying the safety to
  `key === name`. **This PR makes that comment obsolete** — the coupling it
  warns about no longer exists, because the skip has nothing to do with store
  writes.
- **Neither PR's `useNewDoc` fix is touched here.** `String(response.name)` on
  the resolved doc (#1034) is an orthogonal normalization bug; whichever of
  #1042/#1048 lands should keep it. This PR does not address it and does not
  conflict with it.

**Conflict risk if this merges first:** high but mechanical, and confined to
`useAction.ts`, `useList.ts` and `useDoctype.ts`.

- Against **#1042**: both edit the same hunks to the same end. Resolution is
  "take this branch's version of those three files, keep #1042's
  `useNewDoc.ts` line". #1042's `onStoreWrite` signature is `(data) => void`;
  this one is `(data, params, stamp) => void`.
- Against **#1048**: conflicts only on the two `SAFETY` comments, which should
  be dropped rather than merged. Its `useNewDoc.ts` change and its new
  `AutoIncrementDoc` test apply cleanly.

If either lands first instead, this branch rebases onto it and deletes the
overlapping work. Nothing here depends on which order is chosen.

## Release

Internal only — `docStore`, `listStore`, `writeGate` and `onStoreWrite` are
all unexported from every entry point, and the v2 surface stays frozen
(ADR-0012). No public API change.

**Ships in a `1.0.x` patch, after the tag. It does not gate `1.0.0`** —
#1018's fix is correct today, and this is defense against future write sites.

The Unreleased changelog entry from #1018 is updated in place (it has not
shipped): "dispatch version" becomes "sequence number", and the claim that
`useAction` store writes sit inside its hook skip is corrected, since they no
longer do.

Part of #864
Closes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1057/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.96% (+0.04% vs `main`)
<!-- coverage-report:end -->

