### PR TITLE
test(Tabs): guard ResizeObserver targets in a real browser (#1045)

### DIFF
--- a/src/components/Tabs/Tabs.resizeobserver.cy.ts
+++ b/src/components/Tabs/Tabs.resizeobserver.cy.ts
@@ -26,6 +26,17 @@ import TabPanel from './TabPanel.vue'
 // ResizeObserver at all, so a jsdom stub cannot reproduce or refute this. The
 // wrapper below only records what was handed over; the real call still runs,
 // so a bad target genuinely throws.
+//
+// Why this is a separate spec rather than a `describe` inside `Tabs.cy.ts`
+// (which is otherwise the repo's one-spec-per-component convention): it
+// monkey-patches `ResizeObserver.prototype.observe`, which is global to the
+// AUT window. Keeping that patch in its own file bounds the blast radius to
+// five tests that expect it, instead of having it wrap every observer in the
+// 40-test Tabs suite — including Breadcrumbs-style overflow observers pulled
+// in by other harnesses. It also lets this spec be re-run on its own against
+// a deliberately altered dependency resolution (see the version matrix in
+// #1058) without dragging the whole Tabs suite through a slow, unbundled
+// dev-server build.
 // ---------------------------------------------------------------------------
 
 type Observed = { isElement: boolean; described: string }
@@ -44,10 +55,15 @@ describe('Tabs — ResizeObserver target types (#801 / #1045)', () => {
     observed = []
     uncaught = []
     cy.on('uncaught:exception', (err) => {
-      // Record rather than fail here, so the assertion below reports the
-      // actual message instead of Cypress's generic bail-out.
-      uncaught.push(err.message)
-      return false
+      // Swallow ONLY the error under test, so the assertion below can report
+      // the actual message instead of Cypress's generic bail-out. Anything
+      // else — a genuine mount failure in one of these harnesses — must still
+      // fail the test, so fall through to `undefined` (matches
+      // `Breadcrumbs.cy.ts`).
+      if (/ResizeObserver/.test(err.message)) {
+        uncaught.push(err.message)
+        return false
+      }
     })
     cy.window().then((win) => {
       const RO = (win as any).ResizeObserver
@@ -76,10 +92,9 @@ describe('Tabs — ResizeObserver target types (#801 / #1045)', () => {
 
   function expectCleanObservation(minTargets: number) {
     cy.then(() => {
-      expect(
-        uncaught.filter((m) => /ResizeObserver/.test(m)),
-        'no uncaught ResizeObserver error',
-      ).to.deep.equal([])
+      // `uncaught` only ever collects ResizeObserver errors; any other error
+      // has already failed the test at the point it was thrown.
+      expect(uncaught, 'no uncaught ResizeObserver error').to.deep.equal([])
 
       expect(
         observed.filter((o) => !o.isElement).map((o) => o.described),
@@ -176,7 +191,7 @@ describe('Tabs — ResizeObserver target types (#801 / #1045)', () => {
         return h(Teleport, { to: 'body' }, [
           this.open
             ? h('div', { role: 'dialog' }, [
-                h(Tabs, { tabs: items, orientation: 'vertical' }, {
+                h(Tabs, { tabs: items, vertical: true }, {
                   'tab-panel': ({ tab }: any) =>
                     h('div', `${tab.label} content`),
                 } as any),
@@ -186,6 +201,15 @@ describe('Tabs — ResizeObserver target types (#801 / #1045)', () => {
       },
     })
     cy.mount(Harness)
+    // Self-check that this scenario is actually vertical — `vertical` is the
+    // public prop (`types.ts`), and reka's `updateIndicatorStyle` branches on
+    // orientation (offsetWidth/Left vs offsetHeight/Top), so without this the
+    // case silently degrades into a duplicate of the teleport test above.
+    cy.get('[role=dialog] [role=tablist]').should(
+      'have.attr',
+      'aria-orientation',
+      'vertical',
+    )
     cy.get('[role=dialog] [role=tab]').should('have.length', 2)
     expectCleanObservation(3)
   })

--- a/src/components/Tabs/Tabs.resizeobserver.cy.ts
+++ b/src/components/Tabs/Tabs.resizeobserver.cy.ts
@@ -1,0 +1,192 @@
+import { defineComponent, h, nextTick, ref, Teleport } from 'vue'
+import Tabs from './Tabs.vue'
+import TabList from './TabList.vue'
+import TabTrigger from './TabTrigger.vue'
+import TabPanel from './TabPanel.vue'
+
+// ---------------------------------------------------------------------------
+// Browser regression guard for #801 / #1045.
+//
+// #801 reported an uncaught `TypeError: Failed to execute 'observe' on
+// 'ResizeObserver': parameter 1 is not of type 'Element'` on every Tabs mount.
+// It originates in reka's TabsIndicator, which observes a computed array:
+//
+//   useResizeObserver(computed(() => [context.tabsList.value, ...tabs.value]), cb)
+//
+// Whether that is safe depends entirely on which @vueuse/core copy reka
+// resolves. @vueuse/core 10.x tests `Array.isArray(target)` against the raw
+// (still-wrapped) ComputedRef, so it never unwraps the array and hands the
+// whole Array to `observe()` — which throws. 14.x calls `toValue(target)`
+// first and observes each element individually, which is safe. reka-ui
+// declares `@vueuse/core: ^14.1.0`, so it cannot resolve a 10.x copy by
+// semver; this spec is what fails if that ever stops being true (a
+// `resolve.dedupe: ['@vueuse/core']`, an override, or a loosened reka range).
+//
+// This runs in a REAL browser against the REAL ResizeObserver — jsdom has no
+// ResizeObserver at all, so a jsdom stub cannot reproduce or refute this. The
+// wrapper below only records what was handed over; the real call still runs,
+// so a bad target genuinely throws.
+// ---------------------------------------------------------------------------
+
+type Observed = { isElement: boolean; described: string }
+
+const items = [
+  { value: 'home', label: 'Home' },
+  { value: 'activity', label: 'Activity' },
+]
+
+describe('Tabs — ResizeObserver target types (#801 / #1045)', () => {
+  let observed: Observed[] = []
+  let uncaught: string[] = []
+  let restore: (() => void) | null = null
+
+  beforeEach(() => {
+    observed = []
+    uncaught = []
+    cy.on('uncaught:exception', (err) => {
+      // Record rather than fail here, so the assertion below reports the
+      // actual message instead of Cypress's generic bail-out.
+      uncaught.push(err.message)
+      return false
+    })
+    cy.window().then((win) => {
+      const RO = (win as any).ResizeObserver
+      const original = RO.prototype.observe
+      RO.prototype.observe = function (target: unknown, ...rest: unknown[]) {
+        observed.push({
+          isElement: target instanceof (win as any).Element,
+          described:
+            Object.prototype.toString.call(target) +
+            (target && (target as any).tagName
+              ? `<${(target as any).tagName.toLowerCase()}>`
+              : ''),
+        })
+        return original.call(this, target, ...rest)
+      }
+      restore = () => {
+        RO.prototype.observe = original
+      }
+    })
+  })
+
+  afterEach(() => {
+    restore?.()
+    restore = null
+  })
+
+  function expectCleanObservation(minTargets: number) {
+    cy.then(() => {
+      expect(
+        uncaught.filter((m) => /ResizeObserver/.test(m)),
+        'no uncaught ResizeObserver error',
+      ).to.deep.equal([])
+
+      expect(
+        observed.filter((o) => !o.isElement).map((o) => o.described),
+        'every ResizeObserver target is a real Element',
+      ).to.deep.equal([])
+
+      // Non-vacuity: reka observes the tablist plus every [role=tab]. If a
+      // 10.x-style copy collapsed them into one un-unwrapped Array, this
+      // would be 1 (and would already have failed the Element check above).
+      expect(
+        observed.length,
+        'observer saw the tablist and each tab individually',
+      ).to.be.at.least(minTargets)
+    })
+  }
+
+  it('shorthand tabs, uncontrolled', () => {
+    cy.mount(Tabs, {
+      props: { tabs: items },
+      slots: {
+        'tab-panel': ({ tab }: any) => h('div', `${tab.label} content`),
+      },
+    })
+    cy.get('[role=tab]').should('have.length', 2)
+    expectCleanObservation(3)
+  })
+
+  it('composed tabs, uncontrolled', () => {
+    const Harness = defineComponent({
+      render: () =>
+        h(Tabs, null, () => [
+          h(TabList, null, () => [
+            h(TabTrigger, { value: 'home', label: 'Home' }),
+            h(TabTrigger, { value: 'activity', label: 'Activity' }),
+          ]),
+          h(TabPanel, { value: 'home' }, () => 'Home content'),
+        ]),
+    })
+    cy.mount(Harness)
+    cy.get('[role=tab]').should('have.length', 2)
+    expectCleanObservation(3)
+  })
+
+  it('tabs revealed inside a dialog-shaped v-if container', () => {
+    // The reported shape: Tabs mount while their container is being inserted,
+    // so TabsList's element is not settled on the indicator's first flush.
+    const Harness = defineComponent({
+      setup() {
+        const open = ref(false)
+        nextTick(() => {
+          open.value = true
+        })
+        return { open }
+      },
+      render(this: any) {
+        return this.open
+          ? h('div', { role: 'dialog' }, [
+              h(Tabs, { tabs: items }, {
+                'tab-panel': ({ tab }: any) => h('div', `${tab.label} content`),
+              } as any),
+            ])
+          : h('div')
+      },
+    })
+    cy.mount(Harness)
+    cy.get('[role=dialog] [role=tab]').should('have.length', 2)
+    expectCleanObservation(3)
+  })
+
+  it('tabs inside a Teleport', () => {
+    const Harness = defineComponent({
+      render: () =>
+        h(Teleport, { to: 'body' }, [
+          h(Tabs, { tabs: items }, {
+            'tab-panel': ({ tab }: any) => h('div', `${tab.label} content`),
+          } as any),
+        ]),
+    })
+    cy.mount(Harness)
+    cy.get('body [role=tab]').should('have.length', 2)
+    expectCleanObservation(3)
+  })
+
+  it('vertical tabs revealed inside a teleported dialog', () => {
+    const Harness = defineComponent({
+      setup() {
+        const open = ref(false)
+        nextTick(() => {
+          open.value = true
+        })
+        return { open }
+      },
+      render(this: any) {
+        return h(Teleport, { to: 'body' }, [
+          this.open
+            ? h('div', { role: 'dialog' }, [
+                h(Tabs, { tabs: items, orientation: 'vertical' }, {
+                  'tab-panel': ({ tab }: any) =>
+                    h('div', `${tab.label} content`),
+                } as any),
+              ])
+            : h('div'),
+        ])
+      },
+    })
+    cy.mount(Harness)
+    cy.get('[role=dialog] [role=tab]').should('have.length', 2)
+    expectCleanObservation(3)
+  })
+})


### PR DESCRIPTION
## Summary

#1045 asked whether #801 still throws on the pinned versions, and to reproduce it in a browser before guarding or closing it.

**It does not reproduce** — on the pin or on the reporter's versions. But the reason is not the one #801 and #1045 state, and the version arithmetic in both tickets needs correcting before #801 is closed. This PR adds the browser guard that actually covers the mechanism.

## The mechanism is not the falsy-only guard

Both issues attribute the crash to vueuse's guard being falsy-only, so a truthy non-`Element` reaches `observe()`. That guard is **identical** across the versions in play:

```js
// @vueuse/core 10.11.1
for (const _el of els) _el && observer.observe(_el, observerOptions)
// @vueuse/core 14.1.0
for (const _el of els) if (_el) observer.observe(_el, observerOptions)
```

So it cannot explain a version difference. The real difference is **array unwrapping**. reka's `TabsIndicator` passes a `computed(() => [...])`:

```js
useResizeObserver(computed(() => [context.tabsList.value, ...tabs.value]), updateIndicatorStyle)
```

```js
// 10.11.1 — Array.isArray tests the RAW, still-wrapped ComputedRef => false
computed(() => Array.isArray(target) ? target.map(el => unrefElement(el)) : [unrefElement(target)])
// => els = [ [tabsListEl, ...tabEls] ] — observes the whole Array — THROWS

// 14.1.0 / 14.3.0 — unwraps first
const _targets = toValue(target)
return Array.isArray(_targets) ? _targets.map(el => unrefElement(el)) : [unrefElement(_targets)]
// => els = [tabsListEl, tabEl, tabEl] — safe
```

Separately, reka's `useForwardExpose` already maps a `#text`/`#comment` `$el` to `nextElementSibling`, so `context.tabsList.value` is an `Element`, `null`, or `undefined` — never a truthy non-`Element`. `TabsIndicator` and `useForwardExpose` are byte-identical between 2.9.9 and 2.10.0 apart from a cosmetic `thickness` addition, confirming @adityapradhan10's note on #801 that the reka bump alone isn't the variable.

## Why it can't reproduce on what 1.0.0 ships

`reka-ui` declares `"@vueuse/core": "^14.1.0"` and carries its own nested copy. The tree has **two** vueuse copies:

```
node_modules/reka-ui/node_modules/@vueuse/core  ->  14.1.0   <- TabsIndicator imports this
node_modules/@vueuse/core                       ->  10.11.1  <- frappe-ui's own imports
```

`^14.1.0` cannot resolve to a 10.x copy by semver, so `TabsIndicator` never sees the broken unwrapping.

This also corrects both tickets: #1045's "this repo resolves reka 2.9.9 / vueuse 14.1.0" is **right** for the path that matters (reka's nested copy), even though `package.json` says `^10.4.1`. The 10.11.1 figure is real but applies only to frappe-ui's own imports — of which the sole `useResizeObserver` call is `Breadcrumbs.vue:122`, passing a single ref, which is safe on both.

## Version matrix (real browser, real ResizeObserver)

Cypress component tests in Electron 138 / Chromium. `observe()` is wrapped to record targets but still calls through, so a bad target genuinely throws. reka build confirmed per-run via the 2.10.0-only `--reka-tabs-indicator-thickness` var.

| reka-ui | @vueuse/core reaching TabsIndicator | Result |
|---|---|---|
| 2.9.9 (current pin) | 14.1.0 (reka's nested copy) | **5/5 pass** — no throw |
| 2.10.0 (reporter's, #801) | 14.3.0 (reporter's) | **5/5 pass** — no throw |
| 2.9.9 forced onto the 10.11.1 copy | 10.11.1 | **RED** — reproduces #801 |

The red run fails through the real `<Tabs>` component with #801's exact stack:

```
TypeError: Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element'.
    at watch.immediate (@vueuse/core/index.mjs:2525)
    at useResizeObserver (@vueuse/core/index.mjs:2518)
```

That red case is what makes this guard non-vacuous rather than a test that would stay green against a genuinely broken copy.

Also verified at the composable level directly: feeding reka's exact `computed(() => [el, el, el])` shape to each installed copy with a browser-accurate `ResizeObserver` — 10.11.1 throws, 14.1.0 and 14.3.0 do not.

PR #952 (`@vueuse/core` -> `^14.1.0`) does **not** affect this path, since reka has its own dependency either way.

## Browser evidence

Yes — a real browser was used throughout (Cypress 15.9.0, Electron 138 headless, real `ResizeObserver`). This matters: jsdom has no `ResizeObserver` at all, so a jsdom stub can neither reproduce nor refute this.

## Scenarios covered

Five shapes, including the reported "tabs in a dialog or teleport": shorthand uncontrolled, composed uncontrolled, tabs revealed inside a `v-if` dialog container, tabs inside a `Teleport`, and vertical tabs inside a teleported dialog.

## Relationship to #1049

#1049 targets the same issue with a jsdom spec. Two problems, [detailed in a review comment there](https://github.com/frappe/frappe-ui/pull/1049#issuecomment-5252760443):

1. Its stated evidence — "passes on the pinned versions (`reka-ui@2.9.9`, `@vueuse/core@10.11.1`)" — misattributes the version. Its tests exercise reka's nested 14.1.0; 10.11.1 is never reached from `TabsIndicator`.
2. Its `MockResizeObserver.observe` only pushes to an array and can never throw, so it would stay green against a copy that genuinely crashes.

Its *conclusion* ("does not reproduce on the pin") is correct — just not established by its evidence. This PR is a replacement for its test rather than a follow-up; I'd suggest landing this and dropping the jsdom spec, and in either case removing `Closes #801` from #1049 until the version claim is corrected. Not merging or closing anything myself.

## Recommendation on #801

**Closable**, on this evidence: it does not reproduce on the pin, nor on the reporter's own reka 2.10.0 / vueuse 14.3.0, in a real browser. The most likely explanation for the original report is a consumer tree where reka resolved the 10.x copy — via `resolve.dedupe: ['@vueuse/core']`, an `overrides`/`resolutions` entry, or a flat install. Worth asking the reporter for their lockfile resolution rather than closing silently.

That points at one release-relevant follow-on, independent of this PR: because frappe-ui pins `^10.4.1` while reka needs `^14.1.0`, every consumer ships two vueuse copies, and a consumer adding `resolve.dedupe: ['@vueuse/core']` — a commonly suggested fix for duplicate-instance problems — would collapse reka onto 10.x and hit this crash app-wide. That's a concrete argument for landing #952 before 1.0.0, and this spec is what would catch it if the dedupe ever happens.

## Verification

- `npx cypress run --component --spec src/components/Tabs/Tabs.resizeobserver.cy.ts` — 5 passing
- `npx cypress run --component --spec src/components/Tabs/Tabs.cy.ts` — 40 passing, no regression
- `npx vitest run src/components/Tabs/Tabs.test.ts` — 1 passing

No production code changed — the mechanism is upstream and unreachable on the shipped pin.

Part of #864
Closes #1045

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1058/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.79% (±0.00% vs `main`)
<!-- coverage-report:end -->

