### PR TITLE
feat(charts): upgrade echarts to v6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "codemirror": "^6.0.1",
     "dayjs": "^1.11.13",
     "dompurify": "^3.4.0",
-    "echarts": "^5.6.0",
+    "echarts": "^6.1.0",
     "es-module-lexer": "^1.7.0",
     "fuzzysort": "^3.1.0",
     "highlight.js": "^11.11.1",

--- a/src/charts/axisChartCommon.ts
+++ b/src/charts/axisChartCommon.ts
@@ -192,20 +192,20 @@ export function axisChartBase(
 
 /**
  * Chrome (title, legend, tooltip body) is Vue-rendered HTML around the plot, so
- * the grid only reserves room for its own axis labels. `containLabel` covers
- * those but not data labels, which sit past the end of a mark and would
- * otherwise be clipped by the plot edge — hence `labelGutter`.
+ * the grid only reserves room for its own axis labels and names. echarts does
+ * that reservation itself: it measures the labels it has already laid out and
+ * shrinks the plot until they fit the outer bounds. What it does not cover is
+ * data labels, which sit past the end of a mark and would otherwise be clipped
+ * by the plot edge — hence `labelGutter`.
  *
- * `containLabel` measures a label as the box its rotation gives it, so a tilted
- * category axis (see `categoryLabelFit`) takes its own height out of the plot
- * without the grid saying anything. What keeps that from eating the plot is the
- * cap on the label, not a number here.
+ * A label is measured as the box its rotation gives it, so a tilted category
+ * axis (see `categoryLabelFit`) takes its own height out of the plot without the
+ * grid saying anything. What keeps that from eating the plot is the cap on the
+ * label, not a number here.
  */
-// `containLabel` reserves against a DOM measurement of the same text in the
-// same font the plot renders it in (see measureText.ts), so the reservation is
-// the truth. What is left is rounding: echarts drops fractions at several
-// layout steps, and the widest label loses a px or two of glyph edge in rare
-// cases — this covers that, nothing more.
+// The air between the outermost label and the edge of the canvas. The bounds are
+// this rect rather than the canvas, so the pad is held open: echarts shrinks the
+// plot to keep the labels inside it and never spends the two pixels.
 const EDGE_PAD = 2
 
 export function buildAxisGrid(opts: {
@@ -223,7 +223,12 @@ export function buildAxisGrid(opts: {
     bottom: 0,
     left: EDGE_PAD + (isRTL ? endGutter : 0),
     right: (xAxisTitle && horizontal ? 24 : EDGE_PAD) + (isRTL ? 0 : endGutter),
-    containLabel: true,
+    // What `containLabel` did until echarts 6, plus the two things it never did:
+    // it reserves on both dimensions, so the label at either end of a horizontal
+    // axis stops overhanging the canvas, and `all` covers the axis name as well
+    // as the labels. `same` reads the bounds off the rect above.
+    outerBoundsMode: 'same',
+    outerBoundsContain: 'all',
   }
 }
 

--- a/src/charts/axisChartCommon.ts
+++ b/src/charts/axisChartCommon.ts
@@ -513,12 +513,27 @@ function tickColumnWidth(
     axisConfig?.min ?? (low === Infinity ? 0 : low),
     axisConfig?.max ?? (high === -Infinity ? 0 : high),
   ]
+  const tick = drawnTick(axisConfig)
   const widest = Math.max(
-    ...ends.map((value) =>
-      estimateTextWidth(formatValue(value, 1, true), AXIS_LABEL_FONT_SIZE),
-    ),
+    ...ends.map((value) => estimateTextWidth(tick(value), AXIS_LABEL_FONT_SIZE)),
   )
   return Math.ceil(widest) + AXIS_LABEL_MARGIN
+}
+
+/**
+ * The text a value-axis tick actually prints. An axis `format` reaches echarts as
+ * an `axisLabel.formatter` (see `applyAxisFormatters`) and wins over the compact
+ * number the axis would print itself, so it is what the column has to be read
+ * from: a currency that spells out `₹ 1,234,567.00` holds open several times the
+ * width of `1.2M`, and the categories only get what is left. Same rule as
+ * `drawnLabel` on the other axis.
+ */
+function drawnTick(axisConfig: ChartYAxisConfig | undefined) {
+  const formatter = axisConfig?.echartOptions?.axisLabel?.formatter
+  if (typeof formatter !== 'function') {
+    return (value: number) => formatValue(value, 1, true)
+  }
+  return (value: number) => String(formatter(value) ?? '')
 }
 
 function categoryLabelWidth(width?: number) {

--- a/src/charts/axisChartCommon.ts
+++ b/src/charts/axisChartCommon.ts
@@ -54,22 +54,14 @@ const TILT_SIN = Math.sin((TILT_ANGLE * Math.PI) / 180)
 /** Clear air either side of a flat label, under which two of them read as one. */
 const CATEGORY_LABEL_GAP = 8
 /**
- * How far past its tick a tilted label may reach. It is one number for two
- * budgets, because at 45° a label reaches exactly as far below its tick as it
- * does to the side: the plot keeps its height (the grid reserves this much for
- * the labels) and the leading label stays inside the canvas.
+ * How far below its tick a tilted label may reach, which is how much plot height
+ * the axis is allowed to spend on saying more.
  */
 const TILTED_LABEL_EXTENT = 72
 /** A label's own line box, which turns into reach of its own once rotated. */
 const LABEL_LINE_HEIGHT = 13
-/**
- * What one value axis takes out of the chart before the categories divide up
- * what is left: a compact tick — `1.2M`, `450` — and its `axisLabel.margin`.
- * The ticks are echarts' to pick, so this is an estimate, and it rounds up:
- * reading the plot wider than it is would leave labels flat that do not fit,
- * which is the failure the measuring is here to prevent.
- */
-const VALUE_AXIS_RESERVE = 44
+/** The gap every axis here keeps between a label and the plot. */
+const AXIS_LABEL_MARGIN = 8
 
 const DEFAULT_PALETTE: ChartPaletteName = 'sequential'
 
@@ -287,7 +279,7 @@ export function buildXAxis(
       // neighbour instead. Not for time axes: their end is a round tick, not a
       // datapoint, so labelling it says nothing about where the series stops.
       ...(type === 'category' ? { showMaxLabel: true } : {}),
-      margin: 8,
+      margin: AXIS_LABEL_MARGIN,
       color: tokens.axisLabel,
       fontSize: AXIS_LABEL_FONT_SIZE,
       // The formatter does the shortening (echarts only ellipsises the end),
@@ -394,7 +386,7 @@ function categoryLabelFit(
     return { rotate: 0 }
 
   const flat = Math.floor(slot - CATEGORY_LABEL_GAP)
-  const tilted = tiltedLabelWidth(slot)
+  const tilted = tiltedLabelWidth()
   if (flat >= tilted) return { rotate: 0, labelWidth: flat }
 
   return {
@@ -419,8 +411,7 @@ function categorySlotWidth(
 ) {
   if (!opts.width) return undefined
 
-  const valueAxes = hasSecondaryValueAxis(config) ? 2 : 1
-  const plot = opts.width - 2 * EDGE_PAD - valueAxes * VALUE_AXIS_RESERVE
+  const plot = opts.width - 2 * EDGE_PAD - valueAxisReserve(config)
   // `boundaryGap` gives every category a slot of its own to sit in the middle
   // of; without it they sit on the dividers, so what has to hold a label is
   // the distance between two ticks.
@@ -461,17 +452,73 @@ function fitsFlat(
 }
 
 /**
- * How much text a tilted label may carry: whichever is smaller of the standing
- * budget and the room beside the leading tick, which is its half slot plus the
- * column the value axis holds open. Both bound the same diagonal, so one
- * division converts either of them into a width.
+ * How much text a tilted label may carry: the standing budget, turned into a
+ * width along the diagonal it runs on.
+ *
+ * A second bound used to shorten it on a crowded axis — the room beside the
+ * leading tick, so that one label would not overhang the canvas. echarts holds
+ * that room open itself now (see `buildAxisGrid`), and length is all a tilted
+ * label costs: two of them run parallel, so a long one reaches further down
+ * rather than into its neighbour. Crowding no longer decides what a tilt can
+ * say, which is why this takes no slot.
  */
-function tiltedLabelWidth(slot: number) {
-  const reach = Math.min(
-    TILTED_LABEL_EXTENT,
-    EDGE_PAD + VALUE_AXIS_RESERVE + slot / 2,
+function tiltedLabelWidth() {
+  return Math.floor(
+    (TILTED_LABEL_EXTENT - LABEL_LINE_HEIGHT * TILT_SIN) / TILT_SIN,
   )
-  return Math.floor((reach - LABEL_LINE_HEIGHT * TILT_SIN) / TILT_SIN)
+}
+
+/**
+ * What the value axes take out of the width before the categories divide up
+ * what is left: the widest tick each of them prints, and its margin.
+ *
+ * The ticks are echarts' to pick, so this prints the ends of the scale the way
+ * the axis will and measures those. `formatValue` compresses a magnitude to a
+ * few characters — `1.2M`, `450` — so a round tick between two ends is no wider
+ * than the wider end. What is left is a layout decision and nothing more:
+ * echarts reserves the room the labels actually need, so a few pixels out here
+ * costs a tilt that could have stayed flat, never a clipped label.
+ */
+function valueAxisReserve(config: AxisChartBaseConfig): number {
+  if (!hasSecondaryValueAxis(config))
+    return tickColumnWidth(config, config.series, config.yAxis)
+
+  const onY2 = (series: AxisChartSeriesConfig) => series.axis === 'y2'
+  return (
+    tickColumnWidth(config, config.series.filter((s) => !onY2(s)), config.yAxis) +
+    tickColumnWidth(config, config.series.filter(onY2), config.y2Axis)
+  )
+}
+
+/** The widest tick one value axis prints, from what it is asked to plot. */
+function tickColumnWidth(
+  config: AxisChartBaseConfig,
+  series: AxisChartSeriesConfig[],
+  axisConfig: ChartYAxisConfig | undefined,
+): number {
+  let low = Infinity
+  let high = -Infinity
+  for (const row of config.data ?? []) {
+    for (const one of series) {
+      const value = toNumber(row[one.name])
+      if (value === null) continue
+      if (value < low) low = value
+      if (value > high) high = value
+    }
+  }
+
+  // An axis told where to start or stop prints ticks between those, whatever the
+  // rows hold. An axis with nothing numeric to plot still draws, and prints 0.
+  const ends = [
+    axisConfig?.min ?? (low === Infinity ? 0 : low),
+    axisConfig?.max ?? (high === -Infinity ? 0 : high),
+  ]
+  const widest = Math.max(
+    ...ends.map((value) =>
+      estimateTextWidth(formatValue(value, 1, true), AXIS_LABEL_FONT_SIZE),
+    ),
+  )
+  return Math.ceil(widest) + AXIS_LABEL_MARGIN
 }
 
 function categoryLabelWidth(width?: number) {
@@ -567,7 +614,7 @@ export function buildValueAxis(
       // A value axis is read by its extremes, so the top (or right-hand) end of
       // the scale keeps its label even in a short plot.
       showMaxLabel: true,
-      margin: 8,
+      margin: AXIS_LABEL_MARGIN,
       color: tokens.axisLabel,
       fontSize: AXIS_LABEL_FONT_SIZE,
       formatter: (value: number) => formatValue(value, 1, true),

--- a/src/charts/barChartOptions.test.ts
+++ b/src/charts/barChartOptions.test.ts
@@ -588,7 +588,7 @@ describe('bar chart option escape hatches', () => {
       echartOptions: { grid: { left: 40 }, animation: false },
     })
     expect(option.grid.left).toBe(40)
-    expect(option.grid.containLabel).toBe(true)
+    expect(option.grid.outerBoundsContain).toBe('all')
     expect(option.animation).toBe(false)
   })
 

--- a/src/charts/categoryAxisFit.test.ts
+++ b/src/charts/categoryAxisFit.test.ts
@@ -216,6 +216,23 @@ describe('the slot a label is measured against', () => {
     )
   })
 
+  it('reads the tick the value axis is told to print', () => {
+    // A currency or a spelled-out number holds open several times the width of
+    // the compact tick the axis would print itself, and the categories only get
+    // what is left.
+    const wide = label(12)
+    const formatted = {
+      yAxis: { echartOptions: { axisLabel: { formatter: () => wide } } },
+    }
+    const chars = widestFlat(PLOT / 4)
+    expect(labelsOf(build(repeat(4, chars))).width).toBeUndefined()
+
+    const column = Math.ceil(estimateTextWidth(wide, AXIS_LABEL_FONT_SIZE)) + 8
+    expect(labelsOf(build(repeat(4, chars), formatted)).width).toBe(
+      Math.floor((WIDTH - 4 - column) / 4 - GAP),
+    )
+  })
+
   it('measures the label the caller formats, not the raw value', () => {
     const long = repeat(8, 20)
     expect(labelsOf(build(long)).rotate).toBe(45)

--- a/src/charts/categoryAxisFit.test.ts
+++ b/src/charts/categoryAxisFit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { buildAxisChartOption } from './axisChartOptions'
 import { AXIS_LABEL_FONT_SIZE } from './axisChartCommon'
-import { estimateTextWidth } from './format'
+import { estimateTextWidth, formatValue } from './format'
 import type { ChartTokens } from './tokens'
 import type { AxisChartConfig } from './types'
 
@@ -26,8 +26,23 @@ const tokens: ChartTokens = {
 
 /** The plot width every case measures against, unless it says otherwise. */
 const WIDTH = 600
-/** `width - 2 * EDGE_PAD - VALUE_AXIS_RESERVE`: the room the categories share. */
-const PLOT = WIDTH - 4 - 44
+/** The value every row carries, which is what the value axis has to print. */
+const VALUE = 1
+/** What one value axis takes: the widest tick it prints, and its margin. */
+const valueAxis = (...ends: number[]) =>
+  Math.ceil(
+    Math.max(
+      ...ends.map((end) =>
+        estimateTextWidth(formatValue(end, 1, true), AXIS_LABEL_FONT_SIZE),
+      ),
+    ),
+  ) + 8
+/**
+ * `width - 2 * EDGE_PAD - the value axis`: the room the categories share. Every
+ * case plots the same one-digit value, so the column it prints is one number
+ * here rather than a term in each expectation.
+ */
+const PLOT = WIDTH - 4 - valueAxis(VALUE)
 /** Clear air a flat label keeps either side of it. */
 const GAP = 8
 
@@ -40,7 +55,7 @@ function build(
   const width = measured ?? undefined
   const config: AxisChartConfig = {
     type: 'bar',
-    data: categories.map((month, i) => ({ month, sales: i })),
+    data: categories.map((month) => ({ month, sales: VALUE })),
     xAxis: { key: 'month', type: 'category' },
     series: [{ name: 'sales' }],
     ...overrides,
@@ -110,12 +125,14 @@ describe('crowded category labels', () => {
     expect(labelsOf(build(repeat(8, 20), { dir: 'rtl' })).rotate).toBe(-45)
   })
 
-  it('shortens the cap as the categories crowd in', () => {
+  it('keeps the whole tilt budget however crowded the axis is', () => {
     const crowded = labelsOf(build(repeat(60, 16)))
     expect(crowded.rotate).toBe(45)
-    // The room beside the leading tick is its half slot plus the column the
-    // value axis holds open, and at 60 categories that half slot is nothing.
-    expect(crowded.width).toBe(58)
+    // Two tilted labels run parallel, so a long one reaches further down rather
+    // than into its neighbour, and echarts holds open the room the leading one
+    // needs past the plot. Crowding costs the axis nothing it could have said.
+    expect(crowded.width).toBe(88)
+    expect(labelsOf(build(repeat(8, 20))).width).toBe(88)
     // Whatever still collides at that spacing is thinned out, as before.
     expect(crowded.hideOverlap).toBe(true)
     expect(crowded.showMaxLabel).toBe(true)
@@ -131,9 +148,9 @@ describe('long category labels with room around them', () => {
   it('shortens them where they stand rather than tilting the axis', () => {
     const axisLabel = labelsOf(build(repeat(3, 40)))
     expect(axisLabel.rotate).toBeUndefined()
-    // A slot of its own is worth more than a diagonal: 176px of text flat
+    // A slot of its own is worth more than a diagonal: 185px of text flat
     // against the 88px a tilted label could carry.
-    expect(axisLabel.width).toBe(176)
+    expect(axisLabel.width).toBe(185)
     expect(axisLabel.formatter(label(40))).toMatch(/^n+…n+$/)
   })
 
@@ -157,7 +174,7 @@ describe('the slot a label is measured against', () => {
   it('gives a bar chart one slot per category', () => {
     const chars = widestFlat(PLOT / 4)
     expect(labelsOf(build(repeat(4, chars))).width).toBeUndefined()
-    expect(labelsOf(build(repeat(4, chars + 1))).width).toBe(130)
+    expect(labelsOf(build(repeat(4, chars + 1))).width).toBe(137)
   })
 
   it('measures a line chart between its ticks, there being no slot', () => {
@@ -166,16 +183,37 @@ describe('the slot a label is measured against', () => {
     const line = { type: 'line' as const }
     const chars = widestFlat(PLOT / 3)
     expect(labelsOf(build(repeat(4, chars), line)).width).toBeUndefined()
-    expect(labelsOf(build(repeat(4, chars))).width).toBe(130)
+    expect(labelsOf(build(repeat(4, chars))).width).toBe(137)
   })
 
   it('takes a second value axis out of the room first', () => {
     const dual = {
       series: [{ name: 'sales' }, { name: 'rate', axis: 'y2' as const }],
     }
+    // Long enough to be capped either way, so the two caps are the comparison.
+    const long = repeat(4, 60)
+    const one = labelsOf(build(long)).width
+    const two = labelsOf(build(long, dual)).width
+    expect(one).toBe(Math.floor(PLOT / 4 - GAP))
+    expect(two).toBe(
+      Math.floor((WIDTH - 4 - valueAxis(VALUE) - valueAxis(0)) / 4 - GAP),
+    )
+    expect(two).toBeLessThan(one)
+  })
+
+  it('reads the value axis off the numbers it will print', () => {
+    // Millions print a wider tick than single digits, and the categories divide
+    // up what is left — so the same labels have less room beside the larger
+    // series. A constant would have read both charts the same.
     const chars = widestFlat(PLOT / 4)
     expect(labelsOf(build(repeat(4, chars))).width).toBeUndefined()
-    expect(labelsOf(build(repeat(4, chars), dual)).width).toBe(119)
+
+    const millions = {
+      data: repeat(4, chars).map((month) => ({ month, sales: 12_345_678 })),
+    }
+    expect(labelsOf(build(repeat(4, chars), millions)).width).toBe(
+      Math.floor((WIDTH - 4 - valueAxis(0, 12_345_678)) / 4 - GAP),
+    )
   })
 
   it('measures the label the caller formats, not the raw value', () => {
@@ -247,6 +285,8 @@ describe('category labels measured without a DOM', () => {
     ).toBeGreaterThan(slot)
 
     expect(labelsOf(build(repeat(5, chars))).width).toBeUndefined()
-    expect(labelsOf(build(repeat(5, chars + 1))).width).toBe(102)
+    expect(labelsOf(build(repeat(5, chars + 1))).width).toBe(
+      Math.floor(slot - GAP),
+    )
   })
 })

--- a/src/charts/heatmapOptions.test.ts
+++ b/src/charts/heatmapOptions.test.ts
@@ -409,6 +409,6 @@ describe('hoverCellColor', () => {
     const option = build({ echartOptions: { grid: { top: 40 } } })
 
     expect(option.grid.top).toBe(40)
-    expect(option.grid.containLabel).toBe(true)
+    expect(option.grid.outerBoundsContain).toBe('all')
   })
 })

--- a/src/charts/heatmapOptions.ts
+++ b/src/charts/heatmapOptions.ts
@@ -238,7 +238,10 @@ export function buildHeatmapOption(
       bottom: 0,
       left: 0,
       right: 4,
-      containLabel: true,
+      // See `buildAxisGrid`: echarts reserves the room the labels and the axis
+      // names need, on both dimensions, inside the rect above.
+      outerBoundsMode: 'same',
+      outerBoundsContain: 'all',
     },
     xAxis: {
       type: 'category',

--- a/src/charts/lineChartOptions.test.ts
+++ b/src/charts/lineChartOptions.test.ts
@@ -332,7 +332,7 @@ describe('line chart option escape hatches', () => {
       series: [{ name: 'sales', echartOptions: { symbolSize: 10 } }],
     })
     expect(option.grid.left).toBe(40)
-    expect(option.grid.containLabel).toBe(true)
+    expect(option.grid.outerBoundsContain).toBe('all')
     expect(option.animation).toBe(false)
     expect(option.xAxis.inverse).toBe(true)
     expect(option.yAxis.splitLine.show).toBe(false)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3149,13 +3149,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.6.0.tgz#2377874dca9fb50f104051c3553544752da3c9d6"
-  integrity sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==
+echarts@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-6.1.0.tgz#ae0f68590f5ebbd728d900907c27acde7c5456d1"
+  integrity sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==
   dependencies:
     tslib "2.3.0"
-    zrender "5.6.1"
+    zrender "6.1.0"
 
 electron-to-chromium@^1.5.263:
   version "1.5.279"
@@ -6221,16 +6221,7 @@ string-argv@^0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6289,14 +6280,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7148,7 +7132,7 @@ why-is-node-running@^2.3.0:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7161,15 +7145,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -7304,10 +7279,10 @@ yoctocolors-cjs@^2.1.3:
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz#7e4964ea8ec422b7a40ac917d3a344cfd2304baa"
   integrity sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==
 
-zrender@5.6.1:
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.6.1.tgz#e08d57ecf4acac708c4fcb7481eb201df7f10a6b"
-  integrity sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==
+zrender@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-6.1.0.tgz#c3ef06e6426d5c28865b7183035680d685e00136"
+  integrity sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==
   dependencies:
     tslib "2.3.0"
 


### PR DESCRIPTION
`grid.containLabel` reserves room across an axis only — height for a horizontal one, width for a vertical one. Two clips follow from that:

- the label at each end of a horizontal axis sits on a tick at the plot edge, so half of it falls outside the canvas
- `containLabel` sizes its reservation with `getTextRect`, which does not fall back to the global `textStyle`. echarts measures the label in sans-serif and draws it in Inter, so the widest label on a row chart clips

echarts 6 replaces `containLabel` with `outerBounds`. It measures the labels it has laid out and shrinks the plot until they fit, on both dimensions. `outerBoundsContain: 'all'` covers the axis name too.

No import or option changes: every entry point and option key `src/charts` uses still exists, and a time axis still passes the tick level to its formatter. An app that imports echarts itself must move in the same step, because echarts keeps registered maps in module state.

The last two commits drop the estimates that existed only to prevent the clipping. They change one behaviour: a crowded axis keeps the whole tilt budget, because echarts now reserves what the leading label overhangs.

Tested with the 572 unit tests, the 246 component tests over nine chart types, and the Insights dashboard that showed the clipping.

<!-- coverage-report:start -->
Coverage: 71.71% (+0.03% vs `main`)
<!-- coverage-report:end -->
