### PR TITLE
fix(Toast): replay toasts fired before Toaster mounts (Fixes #963)

### DIFF
--- a/src/components/Toast/ToastProvider.vue
+++ b/src/components/Toast/ToastProvider.vue
@@ -27,7 +27,51 @@
 </template>
 
 <script setup lang="ts">
-import { Toaster } from 'vue-sonner'
+import { onMounted } from 'vue'
+import { Toaster, toast as sonnerToast } from 'vue-sonner'
+
+onMounted(() => {
+  // Re-publish any toasts that were created before the <Toaster> mounted.
+  // vue-sonner's ToastState stores all toasts globally, but the <Toaster>
+  // component only sees toasts published *after* it subscribes in its
+  // watchEffect. Toasts fired before createApp().mount() or before
+  // FrappeUIProvider renders are therefore silently dropped.
+  //
+  // Here we re-dispatch each pending toast with the same message and id so
+  // ToastState.update() re-publishes it to the now-active subscriber.
+  const pending = sonnerToast.getToasts()
+  if (pending.length > 0) {
+    pending.forEach((t) => {
+      const data = {
+        id: t.id,
+        description: t.description,
+        duration: t.duration,
+        dismissible: t.dismissible,
+        important: t.important,
+      }
+      const message = t.title as string
+      switch (t.type) {
+        case 'success':
+          sonnerToast.success(message, data)
+          break
+        case 'error':
+          sonnerToast.error(message, data)
+          break
+        case 'warning':
+          sonnerToast.warning(message, data)
+          break
+        case 'info':
+          sonnerToast.info(message, data)
+          break
+        case 'loading':
+          sonnerToast.loading(message, data)
+          break
+        default:
+          sonnerToast(message, data)
+      }
+    })
+  }
+})
 </script>
 
 <style>


### PR DESCRIPTION
## Summary

Fixes the remaining case in #963: a toast fired **before** `createApp().mount()` (or before `FrappeUIProvider` renders) is silently dropped.

## Root cause

`vue-sonner`'s `ToastState` is a module singleton: `toast.*` calls go straight into `ToastState.create()`, which stores every toast globally. But the `<Toaster>` component is a pure subscriber — it only sees toasts published *after* its `watchEffect` called `ToastState.subscribe()`. So a toast published before the `<Toaster>` mounts lands in `ToastState.toasts` yet never reaches the view.

The existing fix (#1026) renders `<ToastProvider />` ahead of the slot, which covers toasts fired from a slot child's `setup()`/`onMounted()`. But a toast fired *before the app is mounted* (e.g. at module scope / before `createApp().mount()`) still has zero subscribers and is lost.

## Fix

In `ToastProvider.vue`, on mount, read any pending toasts from `sonnerToast.getToasts()` and re-dispatch each one with its **original message and id**. Because the id already exists in `ToastState.toasts`, `ToastState.create()` takes the update path and `publish()`es the toast to the now-active subscriber — so the pre-mount toast finally renders, without duplicating it.

Type is preserved per-toast via a `switch` on `t.type` so success/error/warning/info styling is kept.

## Verification

- `Toast.cy.ts` existing suite still passes.
- No public API change; `Toaster` props unchanged.

<!-- coverage-report:start -->
Coverage: 71.78% (-0.01% vs `main`)
<!-- coverage-report:end -->
