### PR TITLE
fix(button): use text-ink-base on solid red in light mode

### DIFF
--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -96,7 +96,7 @@ export default defineComponent({
         blue: 'text-ink-base bg-surface-blue-6 hover:bg-surface-blue-7 active:bg-surface-blue-8',
         green:
           'text-ink-base bg-surface-green-7 hover:bg-surface-green-8 active:bg-surface-green-9',
-        red: 'text-ink-red-9 bg-surface-red-7 hover:bg-surface-red-8 active:bg-surface-red-9',
+        red: 'text-ink-base dark:text-ink-red-9 bg-surface-red-7 hover:bg-surface-red-8 active:bg-surface-red-9',
       }[props.theme]
 
       const subtleClasses = {


### PR DESCRIPTION
## What

Solid red `Button` now uses `text-ink-base` in light mode. Dark mode keeps `text-ink-red-9`.

```
- red: 'text-ink-red-9 bg-surface-red-7 ...'
+ red: 'text-ink-base dark:text-ink-red-9 bg-surface-red-7 ...'
```

## Why

Light mode put `ink-red-9` (red/900, L 0.348) on `surface-red-7` (red/600, L 0.556). Contrast was poor, and solid red was the only theme that did not use `ink-base`. The active state of solid red already used `text-ink-base`.

Dark mode is unchanged: there `ink-base` is near-black (gray/950), so `ink-red-9` (red/50) stays correct.

## Verification

- `vitest run src/components/Button/Button.test.ts` passes.
- Docs page computed color: light = white on red, dark = pale red on red.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1063/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.79% (±0.00% vs `main`)
<!-- coverage-report:end -->
