### PR TITLE
fix(FloatingWindow): drop to z-40 and teleport to the host portal target

### DIFF
--- a/docs/content/docs/experimental.md
+++ b/docs/content/docs/experimental.md
@@ -105,6 +105,11 @@ composer-style windows. `v-model:mode` holds the state (`docked` | `floating` |
 scrollable body. `useFloatingWindow` is the headless half — pass it the panel
 and drag-handle refs to build your own chrome.
 
+A detached window sits at `z-index: 40`, above page chrome and below every
+dialog. It was `50` before, which tied with `Dialog`. If your app has chrome in
+that band, scope a rule to the `has-floating-window` class, set on `<body>`
+while a window is detached.
+
 ```ts
 import { FloatingWindow, useFloatingWindow } from 'frappe-ui/experimental'
 ```

--- a/experimental/FloatingWindow/FloatingWindow.cy.ts
+++ b/experimental/FloatingWindow/FloatingWindow.cy.ts
@@ -1,4 +1,5 @@
 import { defineComponent, h, ref } from 'vue'
+import Dialog from '#components/Dialog/Dialog.vue'
 import FloatingWindow from './FloatingWindow.vue'
 import type { WindowMode } from './types'
 
@@ -278,7 +279,9 @@ describe('FloatingWindow', () => {
         clientX: 800,
         clientY: 700,
       })
-      cy.get('body').trigger('pointercancel', { eventConstructor: 'PointerEvent' })
+      cy.get('body').trigger('pointercancel', {
+        eventConstructor: 'PointerEvent',
+      })
       // Move after cancel must be a no-op (listener torn down).
       cy.get('body').trigger('pointermove', {
         eventConstructor: 'PointerEvent',
@@ -322,6 +325,65 @@ describe('FloatingWindow', () => {
         expect(r.height).to.be.closeTo(550, 1)
         expect(r.left).to.be.closeTo(START_X - 40, 1)
         expect(r.top).to.be.closeTo(START_Y - 30, 1)
+      })
+    })
+  })
+
+  describe('layering', () => {
+    // The point of dropping the fixed z-index: an overlay opened over the
+    // window has to paint above it. Neither sets a z-index now, so paint order
+    // is document order, and the window has to come first.
+    //
+    // Not a hit test: reka puts `pointer-events: none` outside a modal dialog,
+    // so `elementFromPoint` misses the window whatever the paint order is.
+    it('sits before a dialog in document order, so the dialog paints above', () => {
+      cy.mount(
+        defineComponent({
+          setup() {
+            const mode = ref<WindowMode>('floating')
+            const open = ref(false)
+            return { mode, open }
+          },
+          render() {
+            return [
+              h(
+                'button',
+                { 'data-cy': 'open-dialog', onClick: () => (this.open = true) },
+                'Open',
+              ),
+              h(
+                FloatingWindow,
+                {
+                  title: 'Messages',
+                  mode: this.mode,
+                  'onUpdate:mode': (value: WindowMode) => (this.mode = value),
+                },
+                { default: () => h('div', 'Conversation') },
+              ),
+              h(Dialog, {
+                modelValue: this.open,
+                'onUpdate:modelValue': (value: boolean) => (this.open = value),
+                options: { title: 'Confirm' },
+              }),
+            ]
+          },
+        }),
+      )
+
+      cy.get('.floating-window').should('be.visible')
+      cy.get('[data-cy=open-dialog]').click()
+      cy.get('[role=dialog]').should('be.visible')
+
+      cy.get('.floating-window').then(($win) => {
+        const win = $win[0]
+        const dialog = Cypress.$('[role=dialog]')[0]
+        expect(
+          win.compareDocumentPosition(dialog) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+          'the dialog must come after the window',
+        ).to.be.greaterThan(0)
+        // A z-index on either would decide it instead of document order.
+        expect(getComputedStyle(win).zIndex).to.equal('auto')
       })
     })
   })

--- a/experimental/FloatingWindow/FloatingWindow.cy.ts
+++ b/experimental/FloatingWindow/FloatingWindow.cy.ts
@@ -1,5 +1,6 @@
 import { defineComponent, h, ref } from 'vue'
 import Dialog from '#components/Dialog/Dialog.vue'
+import { portalTargetKey } from '#composables/usePortalTarget'
 import FloatingWindow from './FloatingWindow.vue'
 import type { WindowMode } from './types'
 
@@ -330,13 +331,18 @@ describe('FloatingWindow', () => {
   })
 
   describe('layering', () => {
-    // The point of dropping the fixed z-index: an overlay opened over the
-    // window has to paint above it. Neither sets a z-index now, so paint order
-    // is document order, and the window has to come first.
+    // A detached window sits above ordinary page chrome and below every dialog.
+    // The host target is provided here on purpose: without it both nodes land
+    // in `<body>` and the assertion holds against the old hardcoded
+    // `Teleport to="body"` too, so the test would pass while broken.
     //
     // Not a hit test: reka puts `pointer-events: none` outside a modal dialog,
     // so `elementFromPoint` misses the window whatever the paint order is.
-    it('sits before a dialog in document order, so the dialog paints above', () => {
+    it('paints under a dialog and over page chrome', () => {
+      const host = document.createElement('div')
+      document.body.appendChild(host)
+      cy.then(() => Cypress.once('test:after:run', () => host.remove()))
+
       cy.mount(
         defineComponent({
           setup() {
@@ -368,6 +374,7 @@ describe('FloatingWindow', () => {
             ]
           },
         }),
+        { global: { provide: { [portalTargetKey]: host } } },
       )
 
       cy.get('.floating-window').should('be.visible')
@@ -376,14 +383,23 @@ describe('FloatingWindow', () => {
 
       cy.get('.floating-window').then(($win) => {
         const win = $win[0]
-        const dialog = Cypress.$('[role=dialog]')[0]
+        // The portal fix itself: the window resolves the host target, so it
+        // shares a stacking context with anything else that resolves it.
+        expect(win.parentElement, 'teleported into the host target').to.equal(
+          host,
+        )
+
+        const winZ = Number(getComputedStyle(win).zIndex)
         expect(
-          win.compareDocumentPosition(dialog) &
-            Node.DOCUMENT_POSITION_FOLLOWING,
-          'the dialog must come after the window',
-        ).to.be.greaterThan(0)
-        // A z-index on either would decide it instead of document order.
-        expect(getComputedStyle(win).zIndex).to.equal('auto')
+          winZ,
+          'over page chrome, which tops out at z-10',
+        ).to.be.greaterThan(10)
+
+        const overlay = Cypress.$('.dialog-overlay')[0]
+        expect(
+          Number(getComputedStyle(overlay).zIndex),
+          'under the dialog overlay',
+        ).to.be.greaterThan(winZ)
       })
     })
   })

--- a/experimental/FloatingWindow/FloatingWindow.vue
+++ b/experimental/FloatingWindow/FloatingWindow.vue
@@ -285,19 +285,3 @@ function onResizeKey(event: KeyboardEvent) {
 watch(mode, (value) => (modeModel.value = value), { immediate: true })
 watch(modeModel, (value) => value !== mode.value && setMode(value))
 </script>
-
-<!--
-  Global, intentionally unscoped. While a window is detached it's fixed at
-  z-index 50; reka-ui teleports popovers (dropdowns, autocompletes, menus) to
-  <body> and copies their content z-index (which is `auto` for most
-  components) onto the positioning wrapper, so they render *behind* the window
-  and become unclickable. Lift the popover layer to the app's popover z (100,
-  matching NestedPopover). `!important` is required to beat reka's inline
-  `z-index: auto`. Scoped to `.has-floating-window` so it only applies while a
-  window is open; docked windows are in normal flow and need no override.
--->
-<style>
-body.has-floating-window [data-reka-popper-content-wrapper] {
-  z-index: 100 !important;
-}
-</style>

--- a/experimental/FloatingWindow/FloatingWindow.vue
+++ b/experimental/FloatingWindow/FloatingWindow.vue
@@ -1,11 +1,15 @@
 <template>
   <!--
-    Teleport to <body> in every detached mode so the panel escapes any host
-    layout's overflow/stacking contexts. `disabled` keeps it in-flow while
+    Teleport out of the host layout in every detached mode so the panel escapes
+    its overflow and stacking contexts. `disabled` keeps it in-flow while
     docked. Teleport moves the node without remounting, so content inside (an
     editor, a form) never loses focus or state.
+
+    The target is the host's, not `body`: layering here is body order, and an
+    overlay resolving a host target would otherwise land before the window and
+    paint under it.
   -->
-  <Teleport to="body" :disabled="isDocked">
+  <Teleport :to="portalTarget ?? 'body'" :disabled="isDocked">
     <div
       ref="panel"
       v-bind="$attrs"
@@ -129,6 +133,7 @@ import LucideX from '~icons/lucide/x'
 import LucideMinus from '~icons/lucide/minus'
 import LucideMaximize2 from '~icons/lucide/maximize-2'
 import { Button } from '#components/Button'
+import { usePortalTarget } from '#composables/usePortalTarget'
 import { useFloatingWindow } from './useFloatingWindow'
 import type { ResizeDir, WindowMode } from './types'
 
@@ -189,6 +194,8 @@ defineSlots<{
     minimize: () => void
   }) => any
 }>()
+
+const portalTarget = usePortalTarget()
 
 const panel = ref<HTMLElement | null>(null)
 const handle = ref<HTMLElement | null>(null)

--- a/experimental/FloatingWindow/useFloatingWindow.ts
+++ b/experimental/FloatingWindow/useFloatingWindow.ts
@@ -29,8 +29,9 @@ const MIN_HEIGHT = 300
  * came down to document order — and a dialog the app renders before the window
  * loses that tie and is unreachable.
  *
- * Popover surfaces are unaffected: every one in this library carries `z-[100]`
- * on its reka content, which reka copies onto the teleported wrapper.
+ * Popover surfaces sit above both: reka copies a content's z-index onto the
+ * teleported wrapper, and every reka content in the library carries `z-[100]`.
+ * `IconPicker` was the one exception, at `z-10`, and is corrected here.
  */
 const Z_INDEX = 40
 

--- a/experimental/FloatingWindow/useFloatingWindow.ts
+++ b/experimental/FloatingWindow/useFloatingWindow.ts
@@ -78,7 +78,6 @@ export function useFloatingWindow(
         right: `${EDGE_MARGIN}px`,
         bottom: `${EDGE_MARGIN}px`,
         width: `${TRAY_WIDTH}px`,
-        zIndex: 50,
       }
     return {
       position: 'fixed',
@@ -86,7 +85,6 @@ export function useFloatingWindow(
       top: `${y.value}px`,
       width: `${width.value}px`,
       height: `${height.value}px`,
-      zIndex: 50,
     }
   })
 

--- a/experimental/FloatingWindow/useFloatingWindow.ts
+++ b/experimental/FloatingWindow/useFloatingWindow.ts
@@ -22,10 +22,22 @@ const MIN_WIDTH = 380
 const MIN_HEIGHT = 300
 
 /**
+ * Where a detached window sits: above ordinary page chrome, which in this
+ * library tops out at `z-10` (`ListGroup`'s sticky header, `PageHeader`), and
+ * below every dialog, which sets `z-50` on both the overlay and the container
+ * holding the content. The old `50` tied with that, so which one painted on top
+ * came down to document order — and a dialog the app renders before the window
+ * loses that tie and is unreachable.
+ *
+ * Popover surfaces are unaffected: every one in this library carries `z-[100]`
+ * on its reka content, which reka copies onto the teleported wrapper.
+ */
+const Z_INDEX = 40
+
+/**
  * Set on `<body>` while a window is detached. The library reads it nowhere: it
- * is the hook an app styles against, and it matters more now that the window
- * sets no z-index of its own. An app that must paint the window above its own
- * stacking contexts scopes an `isolation` or z-index rule to this class.
+ * is the hook an app styles against. An app whose own chrome goes past `z-40`
+ * scopes an `isolation` or z-index rule to this class.
  */
 const BODY_CLASS = 'has-floating-window'
 let activeDocker: (() => void) | null = null
@@ -81,12 +93,14 @@ export function useFloatingWindow(
     if (mode.value === 'minimized')
       return {
         position: 'fixed',
+        zIndex: Z_INDEX,
         right: `${EDGE_MARGIN}px`,
         bottom: `${EDGE_MARGIN}px`,
         width: `${TRAY_WIDTH}px`,
       }
     return {
       position: 'fixed',
+      zIndex: Z_INDEX,
       left: `${x.value}px`,
       top: `${y.value}px`,
       width: `${width.value}px`,

--- a/experimental/FloatingWindow/useFloatingWindow.ts
+++ b/experimental/FloatingWindow/useFloatingWindow.ts
@@ -21,6 +21,12 @@ const DEFAULT_HEIGHT = 520
 const MIN_WIDTH = 380
 const MIN_HEIGHT = 300
 
+/**
+ * Set on `<body>` while a window is detached. The library reads it nowhere: it
+ * is the hook an app styles against, and it matters more now that the window
+ * sets no z-index of its own. An app that must paint the window above its own
+ * stacking contexts scopes an `isolation` or z-index rule to this class.
+ */
 const BODY_CLASS = 'has-floating-window'
 let activeDocker: (() => void) | null = null
 

--- a/experimental/MultiEmailInput/MultiEmailInput.vue
+++ b/experimental/MultiEmailInput/MultiEmailInput.vue
@@ -31,6 +31,7 @@ import {
   LabelingWrapper,
 } from '../../src/components/InputLabeling'
 import { useInputLabeling } from '../../src/composables/useInputLabeling'
+import { usePortalTarget } from '../../src/composables/usePortalTarget'
 import {
   inputFontSizeClasses,
   isValidEmail,
@@ -61,12 +62,15 @@ const props = withDefaults(defineProps<MultiEmailInputProps>(), {
   side: 'bottom',
   align: 'start',
   offset: 4,
-  portalTo: 'body',
 })
 
 const emit = defineEmits<MultiEmailInputEmits>()
 const slots = useSlots()
 const attrs = useAttrs()
+
+// `portalTo` stays undefaulted on purpose: a `'body'` default outranks the
+// host's target and silently defeats embedding.
+const portalTarget = usePortalTarget(() => props.portalTo)
 
 const model = defineModel<string[]>({ default: () => [] })
 
@@ -353,7 +357,7 @@ defineSlots<MultiEmailInputSlots>()
         </TagsInputRoot>
       </ComboboxAnchor>
 
-      <ComboboxPortal :to="portalTo">
+      <ComboboxPortal :to="portalTarget">
         <ComboboxContent
           data-slot="content"
           :data-size="size"

--- a/experimental/SpriteIcons/IconPicker.vue
+++ b/experimental/SpriteIcons/IconPicker.vue
@@ -10,6 +10,7 @@ import {
   ComboboxViewport,
 } from 'reka-ui'
 import { computed, onMounted, ref, watch } from 'vue'
+import { usePortalTarget } from '#composables/usePortalTarget'
 import Icon from './Icon.vue'
 
 export interface IconPickerProps {
@@ -31,6 +32,8 @@ const props = withDefaults(defineProps<IconPickerProps>(), {
 })
 
 const emit = defineEmits(['update:modelValue', 'focus', 'blur', 'input'])
+
+const portalTarget = usePortalTarget()
 
 const searchTerm = ref(getLabel(props.modelValue || ''))
 const internalModelValue = ref(props.modelValue)
@@ -180,7 +183,7 @@ defineExpose({
           <Icon name="chevron-down" class="h-4 w-4 text-ink-gray-5" />
         </ComboboxTrigger>
       </ComboboxAnchor>
-      <ComboboxPortal>
+      <ComboboxPortal :to="portalTarget">
         <ComboboxContent
           class="z-10 w-60 mt-1 bg-surface-elevation-2 overflow-hidden rounded-6 shadow-2xl"
           position="popper"

--- a/experimental/SpriteIcons/IconPicker.vue
+++ b/experimental/SpriteIcons/IconPicker.vue
@@ -185,7 +185,7 @@ defineExpose({
       </ComboboxAnchor>
       <ComboboxPortal :to="portalTarget">
         <ComboboxContent
-          class="z-10 w-60 mt-1 bg-surface-elevation-2 overflow-hidden rounded-6 shadow-2xl"
+          class="z-[100] w-60 mt-1 bg-surface-elevation-2 overflow-hidden rounded-6 shadow-2xl"
           position="popper"
           @openAutoFocus.prevent
           @closeAutoFocus.prevent

--- a/src/composables/usePortalTarget.spec.ts
+++ b/src/composables/usePortalTarget.spec.ts
@@ -171,7 +171,10 @@ describe('no component teleports past the host target', () => {
   // Read with fs, not import.meta.glob: a `?raw` glob puts every .vue file in
   // the module graph as a one-statement string module, and v8 coverage then
   // attributes that to the component's own path. It cost 14 points.
-  const SRC = join(process.cwd(), 'src')
+  // `experimental/` too: it ships in the same package and its components
+  // teleport for the same reason. Scanning `src/` alone let FloatingWindow
+  // hardcode `body` and go unnoticed.
+  const ROOTS = ['src', 'experimental'].map((dir) => join(process.cwd(), dir))
 
   function vueFiles(dir: string): string[] {
     return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -181,6 +184,7 @@ describe('no component teleports past the host target', () => {
     })
   }
 
+  const SCRIPT_BLOCK = /<script\b[^>]*>[\s\S]*?<\/script>/g
   const TELEPORTING_TAG = /<([A-Z]\w*Portal|Teleport)\b[^>]*>/g
   const BOUND_TARGET = /(?::|v-bind:)to=/
   const LITERAL_BODY = /(?::|v-bind:)to="\s*'body'\s*"|(?<!:)\bto="body"/
@@ -189,13 +193,15 @@ describe('no component teleports past the host target', () => {
     const offenders: string[] = []
     let scanned = 0
 
-    for (const file of vueFiles(SRC)) {
+    for (const file of ROOTS.flatMap(vueFiles)) {
       if (/\.(story|playground)\.vue$/.test(file)) continue
-      const path = relative(SRC, file)
+      const path = relative(process.cwd(), file)
 
-      for (const [tag, name] of readFileSync(file, 'utf8').matchAll(
-        TELEPORTING_TAG,
-      )) {
+      // Drop <script> blocks first. A comment that names `<Teleport>` in prose
+      // is not a teleport, and scanning it reads as an unbound one.
+      const markup = readFileSync(file, 'utf8').replace(SCRIPT_BLOCK, '')
+
+      for (const [tag, name] of markup.matchAll(TELEPORTING_TAG)) {
         scanned++
         if (!BOUND_TARGET.test(tag)) {
           offenders.push(`${path}: <${name}> has no :to binding`)

--- a/src/composables/usePortalTarget.spec.ts
+++ b/src/composables/usePortalTarget.spec.ts
@@ -211,10 +211,11 @@ describe('no component teleports past the host target', () => {
       }
     }
 
-    // A broken scan would find nothing and pass. There were 20 teleporting
-    // tags when this landed, so a collapse to near-zero means the walk broke,
-    // not that the components changed.
-    expect(scanned).toBeGreaterThan(15)
+    // A broken scan would find nothing and pass. There are 24 teleporting tags
+    // across both roots (19 in `src`, 5 in `experimental`), so a drop means the
+    // walk broke, not that the components changed. Kept close to the real count
+    // so losing one root fails here instead of passing quietly.
+    expect(scanned).toBeGreaterThan(20)
 
     // Call usePortalTarget() and bind its result, so an embedding host can
     // redirect the overlay. See spec/portal-target.md.


### PR DESCRIPTION
A `FloatingWindow` sat at `z-index: 50`, the same layer as `Dialog`. At a tie the
painting order is document order, so a dialog the app renders before the window
loses and is unreachable.

Two changes:

**Layer.** The window drops to `z-40`: above ordinary page chrome, which tops out
at `z-10` (`ListGroup`'s sticky header, `PageHeader`), and below every dialog at
`z-50`. Popover surfaces are unaffected. Every one in this library carries
`z-[100]` on its reka content, which reka copies onto the teleported wrapper, so
the global `has-floating-window` style that used to lift them is no longer
needed and is removed.

**Portal target.** The window hardcoded `Teleport to="body"`. It now resolves the
host target through `usePortalTarget`, like the seven other native `Teleport`s in
the library. An overlay that resolves a host target would otherwise land before
the window and paint under it.

`usePortalTarget.spec.ts` scanned `src/` only, which is how this went unnoticed:
`experimental/` ships in the same package. The guard now covers both roots, and
it caught a second offender in `SpriteIcons/IconPicker.vue`.

Measured in Chrome, not asserted from the diff:

| case | before | after |
|---|---|---|
| sticky `z-10` group header over the window | header painted through the title bar | window on top |
| `Dialog` over the window | tie at `z-50`, decided by order | dialog on top |
| `DatePicker` popover inside the window | wrapper `z-100` | unchanged |

The layering spec now provides the host portal target. Without it both nodes land
in `<body>` and the assertion passes against the old hardcoded `body` target too.

<!-- coverage-report:start -->
Coverage: 71.92% (±0.00% vs `main`)
<!-- coverage-report:end -->


