### PR TITLE
fix(FloatingWindow): keep the remembered position when leaving the tray

### DIFF
--- a/experimental/FloatingWindow/useFloatingWindow.ts
+++ b/experimental/FloatingWindow/useFloatingWindow.ts
@@ -122,16 +122,21 @@ export function useFloatingWindow(
     persist()
   }
 
-  function anchorBottomRight() {
-    x.value = clamp(viewportWidth.value - width.value - EDGE_MARGIN, 0, viewportWidth.value - width.value)
-    y.value = clamp(viewportHeight.value - height.value - EDGE_MARGIN, 0, viewportHeight.value - height.value)
+  /**
+   * Pull the panel back inside the viewport. The window may have been resized
+   * while this one was docked or trayed, so a remembered position can now be
+   * off-screen. Only what falls outside moves.
+   */
+  function clampIntoViewport() {
+    x.value = clamp(x.value, 0, Math.max(0, viewportWidth.value - width.value))
+    y.value = clamp(y.value, 0, Math.max(0, viewportHeight.value - height.value))
   }
 
   const dock = () => setMode('docked')
   const minimize = () => setMode('minimized')
 
   function float() {
-    anchorBottomRight()
+    clampIntoViewport()
     setMode('floating')
   }
   const expandFromTray = float


### PR DESCRIPTION
`float()` calls `anchorBottomRight()` before switching mode, so expanding out of the tray throws away the position the user dragged the panel to. It always reappears in the corner.

The rect is not the problem — `minimize()` persists it, and it sits in storage untouched while the panel is trayed. This one call overwrites it on the way back.

Clamping into the viewport keeps the reason the anchor was there: the browser window may have been resized while the panel was docked or trayed, so a remembered position can now be off-screen. After this, only a panel that actually falls outside moves, instead of every panel on every expand.

The default is unchanged. A panel with no stored rect starts from a bottom-right fallback (`fallback` in the same file), and clamping leaves it exactly there.

Independent of #1064, which touches the same file — happy to rebase whichever lands second.

<!-- coverage-report:start -->
Coverage: 71.92% (±0.00% vs `main`)
<!-- coverage-report:end -->

