### PR TITLE
chore(deps): bump @vueuse/core to ^14.1.0

### DIFF
--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -20,6 +20,13 @@ or visual regressions.
 v1 requires **Node `>=20.19.0`** (`package.json` `engines`); this is a breaking
 bump from the 0.1.x line (Node 18).
 
+v1 also depends on **`@vueuse/core` `^14.1.0`**, up from `^10.4.1` in the 0.1.x
+line. VueUse 14 requires Vue `^3.5.0`, which v1 already requires. If your app
+depends on `@vueuse/core` directly, move it to `^14` as well. Two major ranges
+in one app install two copies of the library, and a `resolve.dedupe` entry for
+`@vueuse/core` then collapses them onto whichever copy wins. That breaks the
+components which expect the newer one.
+
 ## Dialog
 
 The `options` blob is flattened into top-level props. See the

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "@tiptap/starter-kit": "^3.26.0",
     "@tiptap/suggestion": "^3.26.0",
     "@tiptap/vue-3": "^3.26.0",
-    "@vueuse/core": "^10.4.1",
+    "@vueuse/core": "^14.1.0",
     "codemirror": "^6.0.1",
     "dayjs": "^1.11.13",
     "dompurify": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1615,11 +1615,6 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
   integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
 
-"@types/web-bluetooth@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz#f066abfcd1cbe66267cdbbf0de010d8a41b41597"
-  integrity sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==
-
 "@types/web-bluetooth@^0.0.21":
   version "0.0.21"
   resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz#525433c784aed9b457aaa0ee3d92aeb71f346b63"
@@ -2009,16 +2004,6 @@
     "@vueuse/metadata" "14.1.0"
     "@vueuse/shared" "14.1.0"
 
-"@vueuse/core@^10.4.1":
-  version "10.11.1"
-  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-10.11.1.tgz#15d2c0b6448d2212235b23a7ba29c27173e0c2c6"
-  integrity sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==
-  dependencies:
-    "@types/web-bluetooth" "^0.0.20"
-    "@vueuse/metadata" "10.11.1"
-    "@vueuse/shared" "10.11.1"
-    vue-demi ">=0.14.8"
-
 "@vueuse/integrations@^14.0.0":
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/@vueuse/integrations/-/integrations-14.1.0.tgz#cda3b828125487474632cbcfd2e140f7efa9becd"
@@ -2027,22 +2012,10 @@
     "@vueuse/core" "14.1.0"
     "@vueuse/shared" "14.1.0"
 
-"@vueuse/metadata@10.11.1":
-  version "10.11.1"
-  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-10.11.1.tgz#209db7bb5915aa172a87510b6de2ca01cadbd2a7"
-  integrity sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==
-
 "@vueuse/metadata@14.1.0":
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-14.1.0.tgz#70fc2e94775e4a07369f11f86f6f0a465b04a381"
   integrity sha512-7hK4g015rWn2PhKcZ99NyT+ZD9sbwm7SGvp7k+k+rKGWnLjS/oQozoIZzWfCewSUeBmnJkIb+CNr7Zc/EyRnnA==
-
-"@vueuse/shared@10.11.1":
-  version "10.11.1"
-  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-10.11.1.tgz#62b84e3118ae6e1f3ff38f4fbe71b0c5d0f10938"
-  integrity sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==
-  dependencies:
-    vue-demi ">=0.14.8"
 
 "@vueuse/shared@14.1.0", "@vueuse/shared@^14.1.0":
   version "14.1.0"
@@ -6995,7 +6968,7 @@ vue-component-meta@^3.1.8:
     "@vue/language-core" "3.2.4"
     path-browserify "^1.0.1"
 
-vue-demi@>=0.13.0, vue-demi@>=0.14.8:
+vue-demi@>=0.13.0:
   version "0.14.10"
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
   integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==


### PR DESCRIPTION
Resolves the decision in #1059: **land the bump** (Option 1), rather than document the hazard (Option 2).

## Why Option 1

frappe-ui pinned `@vueuse/core@^10.4.1` while reka-ui needs `^14.1.0`, so **every consumer installed two copies**. The split was safe only by accident of hoisting. A consumer who adds `resolve.dedupe: ['@vueuse/core']`, the standard fix for duplicate-instance problems, collapses reka-ui onto our 10.x copy. There `useResizeObserver` tests `Array.isArray()` against a still-wrapped `ComputedRef` and hands the whole array to `observe()`. #1045 reproduced exactly that in a real browser: it throws on every Tabs instance, app-wide.

Confirmed against the two installed copies:

```js
// 10.11.1 — Array.isArray on the still-wrapped target
computed(() => Array.isArray(target) ? target.map(unrefElement) : [unrefElement(target)])

// 14.1.0 — unwraps first
computed(() => { const _targets = toValue(target); return Array.isArray(_targets) ? ... })
```

frappe-ui ships **raw ESM source** (`exports` map points at `./src/index.ts`, no bundle, no `require` condition). The range in `dependencies` therefore decides what every consumer installs. That makes this a range change apps build against, so it belongs before rc.1, not during the soak.

## Call-site audit

All 19 `@vueuse/core` imports, checked against the actual 10.11.1 and 14.1.0 `.d.ts` and dist sources plus vueuse's v11/v12/v13/v14 release notes. **Nothing we use was renamed or removed.**

| Call site | API | Verdict |
|---|---|---|
| `src/data-fetching/useFrappeFetch.ts:65` | `createFetch` | unchanged |
| `src/data-fetching/useCall/useCall.ts:2` | `UseFetchOptions`, `AfterFetchContext` | unchanged (contexts only gained fields) |
| `src/data-fetching/useDoc/useDoc.ts:9` | `UseFetchOptions`, `AfterFetchContext` | unchanged |
| `src/data-fetching/useList/useList.ts:11` | `AfterFetchContext`, `OnFetchErrorContext`, `UseFetchOptions` | unchanged |
| `src/components/Breadcrumbs/Breadcrumbs.vue:95` | `useResizeObserver` | unchanged (target type widened) |
| `src/components/PageHeader/PageHeaderMobile.vue:38` | `useElementSize` | unchanged (`Ref` → `ShallowRef`, we only read) |
| `src/components/ScrollArea/ScrollBar.vue:26` | `useEventListener` | unchanged (params widened) |
| `src/components/SettingsDialog/SettingsDialog.vue:33` | `useEventListener` | unchanged |
| `src/components/Sidebar/Sidebar.vue:16` | `useBreakpoints`, `breakpointsTailwind` | unchanged (`Ref` → `ComputedRef`, `smaller('sm')` is read-only) |
| `src/molecules/list/useVirtualRows.ts:9` | `useEventListener`, `useVirtualList` | unchanged (`T[]` → `readonly T[]` widened) |
| `experimental/FloatingWindow/useFloatingWindow.ts:9` | `useEventListener`, `useStorage`, `useWindowSize` | unchanged (`useStorage` key widened; `useWindowSize` gained `type`, default unchanged) |
| `experimental/ListView/ListHeaderItem.vue:35` | `useDebounceFn` | unchanged |
| `src/components/Combobox/stories/ServerSearch.vue:3` | `useDebounceFn` | unchanged |
| `src/components/MultiSelect/stories/AsyncOptions.vue:3` | `useDebounceFn` | unchanged |
| `src/components/Progress/stories/Animated.vue:3` | `useIntervalFn` | unchanged |
| `docs/.../ComposeDesktop.vue:3`, `ComposeMobile.vue:3` | `useTextareaAutosize` | unchanged in effect (see note) |
| `docs/.../RecipeExample.vue:10` | `useMediaQuery` | unchanged (`Ref` → `ComputedRef`, read-only) |
| `vitepress/index.node.ts:82` | name in `optimizeDeps.include` | unchanged, no API use |

Two things I checked rather than assumed:

- **`breakpointsTailwind` values are byte-identical** in both dists (`sm:640, md:768, lg:1024, xl:1280, 2xl:1536`). No Tailwind v4 rename, so `Sidebar`'s `smaller('sm')` breakpoint does not silently move.
- **`useTextareaAutosize`** now returns `Ref<HTMLTextAreaElement | null | undefined>`, which would need `?.` under `strictNullChecks`. Both call sites are in `docs/`, use plain `<script setup>` with no `lang="ts"`, and only bind the ref in a template. No change needed.

### createFetch, the deepest risk

The whole data-fetching layer is built on it. `CreateFetchOptions` and `UseFetchOptions` keep their exact shape; `AfterFetchContext` and `OnFetchErrorContext` only **gained** fields (`context`, `execute`, and `response` on the error context). Our handlers return the received `ctx`, and `useFetch` only destructures `{ data }` / `{ error, data }` from it, so the extra fields are inert.

Four runtime deltas exist inside `useFetch`. None reach us:

| Delta | Applies here? |
|---|---|
| Array payloads now `JSON.stringify`d | No. `computedParams` is a plain params object or `undefined`. |
| Falsy ref payload sends no body | No. 10.x already ended with `body === undefined` for a falsy payload, and our `beforeFetch` sets `Content-Type` unconditionally. |
| `combination: 'overwrite'` picks the last non-null callback | No. We use the default `'chain'`. |
| `baseUrl` + url slash de-duplication | No. Our `createFetch` sets no `baseUrl`. |

Also relevant and clear: vueuse 13 dropped the CJS build. frappe-ui is `"type": "module"` with import-only `exports`, and nothing in the repo `require()`s vueuse. vueuse 14 needs Vue `^3.5.0`; we already peer `vue >=3.5.0`.

## Verification

Ran against a **real 14.1.0 package**, aliased in (the same technique the #1045 investigation used), not against a hypothetical.

| Check | Result |
|---|---|
| `vitest run src experimental` under vueuse 14.1.0 | **82 files, 1079 tests passed** |
| `vitest run src/data-fetching` under vueuse 14.1.0 | **8 files, 114 tests passed** (the `createFetch` layer) |
| `vue-tsc --noEmit -p tsconfig.app.json` | **77 errors, byte-identical to main's 77** (`diff` of sorted output exits 0). Zero new. |

The 77 are the known pre-existing baseline in `vitepress/`, `Menu`, `src/mocks`, `experimental/Charts`, and editor extensions. None of the error files are files this PR touches.

Resolution was proved, not assumed: `tsc --traceResolution` reports

```
Module name '@vueuse/core' was successfully resolved to
'.../@vueuse/core/dist/index.d.ts' with Package ID '@vueuse/core/dist/index.d.ts@14.1.0'
```

### The nested copies really do collapse

Verified by two full `yarn install` runs in a scratch dir, not by assuming semver dedupes:

| | before (`^10.4.1`) | after (`^14.1.0`) |
|---|---|---|
| `node_modules/@vueuse/core` | 10.11.1 | **14.1.0** |
| `vitepress/node_modules/@vueuse/core` | 14.1.0 | gone |
| `reka-ui/node_modules/@vueuse/core` | 14.1.0 | gone |
| `@vueuse/integrations/node_modules/@vueuse/core` | 14.1.0 | gone |

**4 copies become 1.** `@vueuse/shared` and `@vueuse/metadata` collapse to one copy each as well, and no `@vueuse` package depends on `vue-demi` any more. With the committed lockfile, `^14.1.0` resolves to 14.1.0 (the entry already existed for reka-ui), so this is a de-duplication, not a version jump. `yarn install --frozen-lockfile` passes on the committed lock.

## Also

Adds a note to the migration guide's Requirements section, since a consumer pinning `@vueuse/core@^10` in their own app is now the party that creates the duplicate.

The regression spec in #1058 is what catches this if resolution ever collapses again. Not duplicated here.

## Credit

Supersedes #952 by @adityapradhan10, which proposed this bump first. The `package.json` and `yarn.lock` edits here are identical to theirs. What this PR adds is the call-site audit and the verification that made the bump landable.

Part of #864
Closes #1059

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1066/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.79% (±0.00% vs `main`)
<!-- coverage-report:end -->
