### PR TITLE
docs: separate removed components from parked ones

### DIFF
--- a/docs/content/docs/components/legacy.md
+++ b/docs/content/docs/components/legacy.md
@@ -1,10 +1,26 @@
 # Legacy components
 
+Two different things happened to the v0 library. They need different work
+from you, so check which one applies before you start.
+
+| State | Import path | What to do |
+| --- | --- | --- |
+| **Removed** | none — the import fails | Rewrite the call site against the replacement |
+| **Parked** | `frappe-ui/experimental` | Change the import path, then plan the move |
+
+A removed component is gone for good and has a named replacement. A parked
+component still ships and still works: it moved to the
+[`frappe-ui/experimental`](/docs/experimental) subpath while its future is
+decided, and it can come back to the root export or be deleted in any
+release. Parked components are exempt from the deprecation policy, so treat
+the import-path change as a stopgap, not a destination.
+
 ## Removed in v1
 
-These are no longer in the library. The
-[migration guide](../migration#autocomplete-removed) has a before/after for
-each.
+These are no longer in the library. The import fails at build time unless the
+entry says otherwise. Most have a before/after in the
+[migration guide](../migration); the rest are in the
+[changelog](../changelog).
 
 - **`Input`** — use [`TextInput`](./textinput) for text-like inputs (`text`,
   `number`, `email`, `password`, `date`), [`Textarea`](./textarea),
@@ -21,8 +37,52 @@ each.
   standalone [`Combobox`](./combobox), which exposes the full set of slots
   and props without the wrapper layer. Removing this one is **silent**:
   the type falls through to a plain text input rather than failing.
+- **`MonthPicker`** — use [`Select`](./select) with month options. It
+  duplicated `Select` for a narrower case.
+- **`CircularProgressBar`** — use [`Progress`](./progress), or copy the old
+  SFC into your app if you need the radial form. It was a second component
+  for `Progress`'s concept, with hardcoded light-mode colors.
+- **`FeatherIcon`** — use a `lucide-*` icon class, or pass a component. See
+  [Icons](../other/icons) for the icon-class system.
+- **`NestedPopover`** — use [`Popover`](./popover). It never nested anything.
+- **`Card`, `ListItem`, standalone `<Toast>`** — three unmaintained wrappers.
+  `Card` and `ListItem` have no drop-in replacement; rebuild the layout with
+  plain markup (the migration guide has the before/after). For `<Toast>`, call
+  the imperative [`toast`](./toast) API, which is unchanged.
+- **`ListFilter`** — build filter UI in app code with [`Select`](./select)
+  and [`Combobox`](./combobox).
+- **`GridLayout`** — depend on `grid-layout-plus` directly. It was a thin
+  passthrough with no docs page and no tests.
+
+## Parked in `frappe-ui/experimental`
+
+These still work. They left the root export, so the import path changes, and
+they carry no stability promise while they sit there. The
+[Experimental overview](/docs/experimental) states what each one is waiting
+on.
+
+- **`ListView`** and its row/column parts — import from
+  [`frappe-ui/experimental`](/docs/experimental#listview).
+  [`frappe-ui/list`](../molecules/list) is the replacement for new code, but
+  it has no equivalent for ListView's config-driven columns yet, so ListView
+  stays parked until it does. Page:
+  [ListView](../experimental/listview).
+- **`Calendar`** — import from
+  [`frappe-ui/experimental`](/docs/experimental#calendar). The public API is
+  unchanged; it stays parked until a redesigned calendar family replaces it.
+  Page: [Calendar](../experimental/calendar).
 - **`TextEditor`, `TextEditorBubbleMenu`, `TextEditorFixedMenu`,
-  `TextEditorFloatingMenu`, `TextEditorContent`, `createEditorButton`** — use
+  `TextEditorFloatingMenu`, `TextEditorContent`, `createEditorButton`** —
+  import from [`frappe-ui/experimental`](/docs/experimental#texteditor-v0).
   [`Editor`](../molecules/editor) and its building blocks from the
-  `frappe-ui/editor` subpath. See the [Editor migration
-  section](../migration#editor) for the full before/after.
+  `frappe-ui/editor` subpath are the replacement; see the
+  [Editor migration section](../migration#editor) for the full before/after.
+- **`AxisChart`, `DonutChart`, `FunnelChart`, `NumberChart`, `ECharts`,
+  `useAxisChartOptions`** — import from
+  [`frappe-ui/experimental`](/docs/experimental#charts-v1).
+  [`frappe-ui/charts`](../charts/overview) is the replacement family and
+  draws everything these did.
+- **`Icon`, `IconPicker`, `spritePlugin`** (the sprite icon trio) — import
+  from [`frappe-ui/experimental`](/docs/experimental#sprite-icons).
+  `lucide-*` classes and the root [`Icon`](./icon) component are the
+  canonical way to render icons, so this trio will be removed.

--- a/docs/content/docs/experimental.md
+++ b/docs/content/docs/experimental.md
@@ -13,6 +13,34 @@ time, some of them get promoted to the public API and others get removed.
 > **not** import this subpath from product apps or third-party code — pin to a
 > public entry point instead.
 
+## Parked or incubating
+
+An export lands here for one of two reasons, and the reason tells you which way
+it is likely to move:
+
+- **Parked** — it was public in v0, left the root export in `1.0.0`, and sits
+  here as an interim import path. It still works. It leaves by being deleted
+  once apps migrate, not by being promoted.
+- **Incubating** — it was never public. It leaves by being promoted to the root
+  export, or by being dropped.
+
+| Export | State | Waiting on |
+| --- | --- | --- |
+| [`Accordion`](#accordion) | Incubating | Its API settling |
+| [`Calendar`](#calendar) | Parked | A redesigned calendar family |
+| [Charts (v1)](#charts-v1) | Parked | Apps moving to [`frappe-ui/charts`](/docs/charts/overview) |
+| [`CodeEditor`](#codeeditor) | Incubating | Its API settling |
+| [`FloatingWindow`](#floatingwindow) | Incubating | Its API settling |
+| [`ListView`](#listview) | Parked | [`frappe-ui/list`](/docs/molecules/list) reaching parity |
+| [`MultiEmailInput`](#multiemailinput) | Incubating | Its API settling |
+| [Sprite icons](#sprite-icons) | Parked | Apps moving to `lucide-*` classes |
+| [TextEditor (v0)](#texteditor-v0) | Parked | Apps moving to [`frappe-ui/editor`](/docs/molecules/editor) |
+| [Input labeling](#useinputlabeling) | Incubating | Its API settling |
+
+A component that is **removed** rather than parked is a third case: it has no
+import path at all and needs a replacement. Those are on the
+[Legacy components](/docs/components/legacy) page.
+
 ## Accordion
 
 Stacks sections of content behind labelled headers that expand and collapse.
@@ -67,6 +95,20 @@ import { CodeEditor, CodePreview } from 'frappe-ui/experimental'
 See the [CodeEditor page](/docs/experimental/codeeditor) for languages, sizes,
 variants, and the labeling contract.
 
+## FloatingWindow
+
+A panel that docks, floats, or collapses to a bottom-right tray, for
+composer-style windows. `v-model:mode` holds the state (`docked` | `floating` |
+`minimized`); `storageKey` persists the mode and geometry across sessions, and
+`minimizable: false` drops the tray state. The `#header`, `#actions`, and
+`#footer` slots replace or extend the title bar and pin a region below the
+scrollable body. `useFloatingWindow` is the headless half — pass it the panel
+and drag-handle refs to build your own chrome.
+
+```ts
+import { FloatingWindow, useFloatingWindow } from 'frappe-ui/experimental'
+```
+
 ## ListView
 
 A config-driven data table: resizable columns, per-column `getLabel`/`prefix`
@@ -95,6 +137,23 @@ import { TextEditor, TextEditorFixedMenu } from 'frappe-ui/experimental'
 
 See the [Editor migration section](/docs/migration#editor) for the
 before/after.
+
+## Sprite icons
+
+The sprite-based `Icon`, `IconPicker`, and `spritePlugin`, moved out of
+`frappe-ui/icons` in `1.0.0`. They draw from a 468 KB SVG sprite that
+`spritePlugin` injects into `<body>`. `lucide-*` classes — and the root
+[`Icon`](/docs/components/icon) component, which wraps one — are the canonical
+way to render icons, so this trio is parked only while apps migrate, and it
+will be removed. Nothing about the components changed; only the subpath did.
+
+```ts
+// Root `frappe-ui` exports a different `Icon` — alias one if you import both.
+import { Icon as SpriteIcon, IconPicker, spritePlugin } from 'frappe-ui/experimental'
+```
+
+The named SFC icons (`CircleCheckIcon`, `HelpIcon`, …) stay on
+`frappe-ui/icons`.
 
 ## MultiEmailInput
 

--- a/docs/content/public/llms.txt
+++ b/docs/content/public/llms.txt
@@ -26,7 +26,6 @@ Two cross-cutting conventions to know before reading anything else:
 - [Badge](https://ui.frappe.io/docs/components/badge): status pill; same `variant` + `theme` axes as Button.
 - [Breadcrumbs](https://ui.frappe.io/docs/components/breadcrumbs): page-header trail; takes `items: { label, route }[]`.
 - [Button](https://ui.frappe.io/docs/components/button): primary trigger element; supports `route`/`link` for nav, `icon`/`iconLeft`/`iconRight`, `loading`, `disabled`.
-- [Calendar](https://ui.frappe.io/docs/experimental/calendar): month/week calendar view (experimental).
 - [Charts](https://ui.frappe.io/docs/charts/overview): chart family (line, bar, etc.); one page per chart under `/docs/charts`.
 - [Checkbox](https://ui.frappe.io/docs/components/checkbox): boolean input; standard labeling contract.
 - [Combobox](https://ui.frappe.io/docs/components/combobox): single-select with search; `v-model` value + `v-model:query`.
@@ -34,11 +33,12 @@ Two cross-cutting conventions to know before reading anything else:
 - [Dialog](https://ui.frappe.io/docs/components/dialog): modal overlay; `v-model:open`, `title`/`message`/`icon`/`theme`/`actions`/`dismissible`/`bare`. Imperative API: `dialog.confirm`, `dialog.alert`, `dialog.prompt`.
 - [Divider](https://ui.frappe.io/docs/components/divider): horizontal/vertical rule.
 - [Dropdown](https://ui.frappe.io/docs/components/dropdown): action menu anchored to a trigger; takes `options` (flat or grouped).
+- [Editor](https://ui.frappe.io/docs/molecules/editor): TipTap-based rich editor, from the `frappe-ui/editor` subpath (heavy, and not SSR-safe — use only when needed).
 - [ErrorMessage](https://ui.frappe.io/docs/components/errormessage): inline error display.
 - [FileUploader](https://ui.frappe.io/docs/components/fileuploader): Frappe-native file upload with progress.
 - [FormControl](https://ui.frappe.io/docs/components/formcontrol): the default labeled-field wrapper; pick `type` to render text/textarea/select/checkbox/combobox with the shared `label`/`description`/`error`/`required` contract.
 - [ItemListRow](https://ui.frappe.io/docs/components/itemlistrow): single-row list item primitive.
-- [ListView](https://ui.frappe.io/docs/components/listview): table/grid list with selection, sorting, virtualization.
+- [List](https://ui.frappe.io/docs/molecules/list): the list primitive, from the `frappe-ui/list` subpath; `List` + `ListRow`/`ListCell`, feed or table mode.
 - [MultiSelect](https://ui.frappe.io/docs/components/multiselect): multi-value select; value is `string[]`.
 - [Password](https://ui.frappe.io/docs/components/password): masked input with show/hide.
 - [Popover](https://ui.frappe.io/docs/components/popover): anchored floating panel; `v-model:open`, `#target` + `#body` slots.
@@ -50,20 +50,27 @@ Two cross-cutting conventions to know before reading anything else:
 - [Switch](https://ui.frappe.io/docs/components/switch): boolean toggle for settings.
 - [Tabs](https://ui.frappe.io/docs/components/tabs): full content tabs and inline TabButtons.
 - [Textarea](https://ui.frappe.io/docs/components/textarea): multi-line text input.
-- [TextEditor](https://ui.frappe.io/docs/components/texteditor): TipTap-based rich editor (heavy — use only when needed).
 - [TextInput](https://ui.frappe.io/docs/components/textinput): single-line text input.
 - [TimePicker](https://ui.frappe.io/docs/components/timepicker): time input.
 - [Toast](https://ui.frappe.io/docs/components/toast): imperative notifications: `toast.success/error/info`.
 - [Tooltip](https://ui.frappe.io/docs/components/tooltip): hover hint; not for actionable content (use Popover/Dropdown).
 - [Tree](https://ui.frappe.io/docs/components/tree): hierarchical list.
 
-## Design system
+## Foundations
 
-- [Background color tokens](https://ui.frappe.io/docs/design-system/background-color): `bg-surface-*` semantic surface tokens.
-- [Text color tokens](https://ui.frappe.io/docs/design-system/text): `text-ink-*` semantic foreground tokens.
-- [Border color tokens](https://ui.frappe.io/docs/design-system/border-color): `border-outline-*` semantic border tokens.
-- [Border radius](https://ui.frappe.io/docs/design-system/border-radius): radius scale.
-- [Drop shadow](https://ui.frappe.io/docs/design-system/drop-shadow): shadow scale.
+- [Tailwind setup](https://ui.frappe.io/docs/foundations/tailwind): wiring the preset into an app.
+- [Base colors](https://ui.frappe.io/docs/foundations/colors/base): the raw color scales.
+- [Semantic colors](https://ui.frappe.io/docs/foundations/colors/semantic): `bg-surface-*`, `text-ink-*`, `border-outline-*` tokens.
+- [Chart colors](https://ui.frappe.io/docs/foundations/colors/charts): the categorical chart palette.
+- [Typography](https://ui.frappe.io/docs/foundations/typography): the type scale.
+- [Radius](https://ui.frappe.io/docs/foundations/radius): radius scale.
+- [Elevation](https://ui.frappe.io/docs/foundations/elevation): shadow scale.
+- [Focus ring](https://ui.frappe.io/docs/foundations/focus-ring): the shared focus treatment.
+
+## Experimental and legacy
+
+- [Experimental](https://ui.frappe.io/docs/experimental): everything on the `frappe-ui/experimental` subpath — parked v0 families (`Calendar`, `ListView`, v1 charts, v0 `TextEditor`, sprite icons) and incubating exports. Unstable: no deprecation promise. Do not import it from product apps.
+- [Legacy components](https://ui.frappe.io/docs/components/legacy): what was removed in v1 and the replacement for each, plus which families were parked rather than removed.
 
 ## Data fetching
 

--- a/experimental/Calendar/Calendar.md
+++ b/experimental/Calendar/Calendar.md
@@ -2,6 +2,16 @@
 
 A date and event view for schedules, with Month, Week, and Day modes.
 
+> **Parked** — `Calendar` left the root export in `1.0.0` and now ships from
+> [`frappe-ui/experimental`](/docs/experimental) with its public API unchanged.
+> It stays there, exempt from the deprecation policy, until a redesigned
+> calendar family replaces it.
+
+```ts
+import { Calendar } from 'frappe-ui/experimental'
+import type { CalendarEvent, CalendarConfig } from 'frappe-ui/experimental'
+```
+
 ## Default
 
 <ComponentPreview name="Calendar-Examples" csr="true" />

--- a/experimental/ListView/ListView.md
+++ b/experimental/ListView/ListView.md
@@ -2,6 +2,26 @@
 
 Displays data in a structured, scrollable list with support for columns, groups, and custom content. Makes large sets of information easy to view, select, and interact with.
 
+> **Parked** — `ListView` left the root export in `1.0.0` and now ships from
+> [`frappe-ui/experimental`](/docs/experimental), exempt from the deprecation
+> policy. [`frappe-ui/list`](/docs/molecules/list) is the replacement for new
+> code, but it has no equivalent for ListView's config-driven columns yet, so
+> `ListView` stays here until it does.
+
+```ts
+import { ListView } from 'frappe-ui/experimental'
+
+// The parts a custom list composes:
+import {
+  ListHeader,
+  ListHeaderItem,
+  ListRows,
+  ListRow,
+  ListRowItem,
+  ListSelectBanner,
+} from 'frappe-ui/experimental'
+```
+
 ## Simple List
 
 <ComponentPreview name="ListView-Examples" />


### PR DESCRIPTION
Docs-only. Makes the site say which state each v0 component is in.

## What I found

The two per-page items in the issue were already fixed on `main`. The
issue was written against `f517c7d1b`; since then #958 deleted
`CircularProgressBar` (page and all), and the parking PRs moved each
family's colocated docs page along with its source, so `listview`,
`calendar`, `texteditor`, `codeeditor`, and `charts` no longer sit under
`/docs/components/`. I verified this against `buildSidebar()` and the
proxy generator rather than the file tree alone: no removed component has
a live route, and no parked family has an orphaned one.

What was still wrong was the part the issue calls "the actual question".

## Deleted

Nothing. There was nothing left to delete.

## Moved

- The v0 `TextEditor` family, off the "Removed in v1" list. It is parked,
  not removed — `experimental.ts` still exports `TextEditor`,
  `TextEditorBubbleMenu`, `TextEditorFixedMenu`, `TextEditorFloatingMenu`,
  `TextEditorContent`, and `createEditorButton`. Calling it removed was
  the single worst piece of drift on the page.

## The Legacy vs Experimental decision

**Two states, named on both pages, cross-linked. No redirects, no third
page.**

- **Removed** — no import path at all, the import fails, needs a
  replacement. Lives on [Legacy components](https://ui.frappe.io/docs/components/legacy).
- **Parked** — still ships, from `frappe-ui/experimental` only, no
  stability promise, leaves by being deleted once apps migrate. Lives on
  [Experimental](https://ui.frappe.io/docs/experimental).

Reasoning: the two pages were not overlapping by accident, they were
overlapping because neither one said what it was for. A reader arrives at
whichever page search hands them, so the distinction has to be legible on
both, not resolved by reading the migration guide. So:

- The Legacy page opens with a two-row table (state → import path → what
  to do), then splits into "Removed in v1" and "Parked in
  `frappe-ui/experimental`". A parked family is named there because that
  is where a reader looks for it after a `1.0.0` import breaks.
- The Experimental overview adds a "Parked or incubating" section: parked
  exports were public and are on their way out, incubating exports were
  never public and are on their way in. A table lists every export with
  its state and what it is waiting on, and points at the Legacy page for
  the removed case.

A third state ("removed") is explicitly named on the Experimental page so
the reader knows the taxonomy is complete.

Rejected: redirects from the old `/docs/components/<name>` URLs. The
pages were physically moved by earlier PRs, so any redirect would be
retroactive, and the sidebar plus the search index already point at the
new routes.

## Also fixed

- **Completed the removed list.** It named 3 removals. The changelog
  records 10 component removals in v1. Added `MonthPicker`,
  `CircularProgressBar`, `FeatherIcon`, `NestedPopover`, `Card` /
  `ListItem` / standalone `<Toast>`, `ListFilter`, `GridLayout`, each
  with its replacement.
- **`Calendar` and `ListView` pages** had no experimental banner and no
  import example at all — a reader landing from search got no signal that
  the root import stopped working. Both now carry a "Parked" callout and
  a `frappe-ui/experimental` import block. `Accordion` and `CodeEditor`
  already did this.
- **Two undocumented exports.** `FloatingWindow` and the sprite icon trio
  (`Icon`, `IconPicker`, `spritePlugin`) ship from
  `frappe-ui/experimental` with no mention on the overview. The sprite
  trio matters most: the migration guide sends readers to
  `/docs/experimental` for it, and the page had nothing. Both now have a
  section.
- **`llms.txt` had 7 dead URLs** — `/docs/components/listview`,
  `/docs/components/texteditor`, and a whole `/docs/design-system/`
  section that is now `/docs/foundations/`. Repointed at `List`,
  `Editor`, the real Foundations pages, and the Experimental / Legacy
  pages.

## Verification

- Wrote an ad-hoc internal-link checker over every markdown source
  (`docs/content` + the colocated `src/**` and `experimental/**` pages),
  resolving against the routes `buildSidebar()` and the proxy generator
  actually produce. Baseline on `main`: 7 dead links. After: 0.
- Checked every anchor I introduced resolves to a real heading slug
  (`#listview`, `#calendar`, `#charts-v1`, `#texteditor-v0`,
  `#sprite-icons`, `#floatingwindow`, `#useinputlabeling`,
  `migration#editor`).
- Rendered each changed page through VitePress's markdown renderer and
  compiled the output with `@vue/compiler-dom`: no errors.
- Ran `getComponentItems()` / `getExperimentalItems()` to confirm the
  sidebar tree is unchanged (Experimental: Overview, Accordion, Calendar,
  CodeEditor, ListView).
- A full `vitepress build` OOMs on the machine this was written on (8 GB),
  so it is **not verified** end to end. Every changed file is prose,
  tables, and fenced code — no frontmatter or `@include` changes.

## Not done

- `docs/content/docs/migration.md` — deliberately untouched, #1055 is
  editing it. Two findings belong there and are reported separately:
  `CircularProgressBar`, `ListFilter`, and `GridLayout` have no migration
  section (changelog only), and nothing in the guide contrasts "removed"
  with "parked".
- `experimental/ListView/ListView.api.md` is generated but included by
  nothing, so the ListView page has no API table. Left alone — the
  generated props all have empty descriptions.
- `/docs/components/keyboardshortcutsmodal` is reachable but absent from
  the sidebar: the folder ships a page and no `stories/`. Unrelated to
  this issue, and the component is live.
- `llms.txt` is missing ~20 components added since it was written. Link
  repair only here.
- `skills/frappe-ui/COMPONENTS.md` lists `Calendar` with no note that it
  is parked. Out of `docs/`.

Part of #864
Closes #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1067/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.79% (±0.00% vs `main`)
<!-- coverage-report:end -->
