### PR TITLE
refactor!: close four cross-family vocabulary mismatches before the freeze

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,7 +47,11 @@ The only two axes used to color components — there is intentionally **no** sem
 (`intent`/`severity`/`appearance`/`kind`/`status`):
 
 - **variant** — visual style: `solid | outline | subtle | ghost` (Button, Badge)
-- **theme** — color tone, by color name: `yellow | blue | red | green | amber | …` (Button, Badge, Alert, Dialog; the Alert/SidebarCard palette is `gray | blue | green | amber | red`)
+- **theme** — color tone, by color name: `gray | blue | green | amber | red | …` (Button, Badge, Alert, Dialog; the Alert/SidebarCard palette is `gray | blue | green | amber | red`)
+
+The warning tone is **`amber`** everywhere. No exported component accepts
+`theme="yellow"` — Dialog was the last one and moved to `amber` (#1054).
+_Avoid_: `yellow`
 
 A legacy `appearance` (`warning | info | danger | success`) maps to `theme` color names.
 

--- a/docs/components/recipes/DiscussionsDesktop.vue
+++ b/docs/components/recipes/DiscussionsDesktop.vue
@@ -741,7 +741,7 @@ const spaceActions = [
       </div>
     </DesktopShell>
 
-    <SettingsDialog v-model="showSettings" v-model:tab="settingsTab" size="5xl">
+    <SettingsDialog v-model:open="showSettings" v-model:tab="settingsTab" size="5xl">
       <SettingsSidebar>
         <SettingsNavGroup label="User settings">
           <SettingsNavItem value="profile">

--- a/docs/content/docs/changelog.md
+++ b/docs/content/docs/changelog.md
@@ -672,7 +672,7 @@ and `Rating` exports `RatingEmits`.
   independent of the auto-header).
 - Canonical slots `#default`, `#title`, `#actions` (scoped with
   `{ close, actions }`). The legacy `#body*` slots are removed — see below.
-- `icon.theme` (`yellow | blue | red | green`) replaces `icon.appearance`,
+- `icon.theme` (`amber | blue | red | green`) replaces `icon.appearance`,
   which is removed — see below.
 - Auto-header no longer renders an "Untitled" fallback.
 
@@ -709,7 +709,7 @@ aliased and nothing warns.
   dialog silently becomes dismissible. Use `dismissible`.
 - **Breaking, silent:** `icon.appearance` and `DialogIconAppearance` are gone;
   only `icon.theme` remains. An `appearance` key is dropped, so the icon
-  renders with no tone. Map `warning → yellow`, `info → blue`, `danger → red`,
+  renders with no tone. Map `warning → amber`, `info → blue`, `danger → red`,
   `success → green`.
 - **Breaking, silent:** the legacy `#body`, `#body-content`, `#body-main`,
   `#body-title` and `#body-header` slots are gone. Vue drops an unknown named

--- a/docs/content/docs/changelog.md
+++ b/docs/content/docs/changelog.md
@@ -197,6 +197,60 @@ Changed since `1.0.0-beta.41`, the first beta that shipped the family:
   `useChartTokens`, which re-resolves on a theme flip; `currentColorScheme` was
   the root `resolvedColorScheme` under another name.
 
+### DatePicker family — trigger slot props renamed to `open` / `toggle` (breaking, silent)
+
+`#trigger`, `#prefix` and `#suffix` on `DatePicker`, `DateRangePicker`,
+`DateTimePicker` and `TimePicker` now receive `{ open, toggle }` instead of
+`{ isOpen, togglePopover }` (#1054). `Popover`, `HoverCard`, `Dropdown`,
+`Select`, `Combobox` and `MultiSelect` all name the boolean `open`, and
+`Popover`'s trigger slot already names the flip `toggle`. `isOpen` is on
+`CONTEXT.md`'s avoid list for a public API, and `togglePopover` named the
+mechanism rather than the behavior (P1). The same
+components already gave `#actions` a `close()`, so one component shipped two
+vocabularies for one concept. `displayLabel` and `inputValue` are unchanged.
+
+**Silent break:** a destructured `isOpen` becomes `undefined`, so a class
+bound to it stops applying with no error; `togglePopover()` throws only if you
+call it. Grep for both names. See the
+[migration guide](/docs/migration#trigger-slot-props).
+
+### SettingsDialog — open state moves to `v-model:open` (breaking, silent)
+
+`v-model` → `v-model:open`, and `update:modelValue` → `update:open` (#1054).
+`CONTEXT.md` says the visibility of an overlay is `open`, "always bound via
+`v-model:open`", and lists bare `v-model` for visibility among the names to
+avoid. `Dialog`'s dual binding is a documented carve-out for `Dialog` alone,
+which P2 says new components do not inherit. `v-model:tab` is unchanged.
+
+**Silent break:** Vue accepts the unknown `modelValue` prop with no error, so
+the dialog never opens. See the
+[migration guide](/docs/migration#settingsdialog).
+
+### CommandPalette — `searchQuery` renamed to `query` (breaking, silent)
+
+`v-model:searchQuery` → `v-model:query`, and `update:searchQuery` →
+`update:query` (#1054). `Combobox` and `MultiSelect` already bind the
+controlled search text as `v-model:query`; one concept gets one name (P1).
+
+**Silent break:** the unknown `searchQuery` prop is accepted, so the palette
+holds its own query and your binding never updates. See the
+[migration guide](/docs/migration#commandpalette).
+
+### Dialog — `theme: 'yellow'` renamed to `'amber'` (breaking, silent)
+
+`DialogTheme` held the library's last `yellow` (#1054). `Alert`, `SidebarCard`,
+`Badge` and `Avatar` all spell the warning tone `amber`, and `Dialog` already
+rendered `yellow` with the amber tokens (`bg-surface-amber-2`,
+`text-ink-amber-5`), so the value name disagreed with the token it resolved to.
+Applies to `icon.theme` and to the `theme` argument of `dialog.confirm` /
+`dialog.danger`. Only the word changes, not the color.
+
+**Silent break** for JavaScript call sites: `yellow` is no longer a key in the
+tone maps, so the icon renders untinted and nothing throws. TypeScript call
+sites get a union error. This also corrects the `warning → yellow` mapping
+given in the `icon.appearance` entry below. See the
+[migration guide](/docs/migration#dialog).
+
 ### Charts (v1) family — moved to `frappe-ui/experimental` (breaking)
 
 The first chart family is not taken to bar at root for `1.0.0` (#942).

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -2048,16 +2048,23 @@ usePageMeta(() => ({ title: pageTitle.value, emoji: '🌈' }))
 vocabulary. This is a **silent break**: Vue accepts the unknown `show` prop
 with no error, so the palette just never opens.
 
-| Before                  | After                    |
-| ------------------------ | ------------------------ |
-| `v-model:show="show"`    | `v-model:open="open"`    |
+`searchQuery` is renamed to `query`, the name `Combobox` and `MultiSelect`
+already use for the same controlled search text. Same silent break: the
+unknown `searchQuery` prop is accepted, so the palette holds its own query
+and yours never updates.
+
+| Before                          | After                    |
+| -------------------------------- | ------------------------ |
+| `v-model:show="show"`            | `v-model:open="open"`    |
+| `v-model:search-query="q"`       | `v-model:query="q"`      |
+| `@update:searchQuery="onSearch"` | `@update:query="onSearch"` |
 
 ```vue
 <!-- Before -->
-<CommandPalette v-model:show="show" :groups="groups" @select="onSelect" />
+<CommandPalette v-model:show="show" v-model:search-query="q" :groups="groups" @select="onSelect" />
 
 <!-- After -->
-<CommandPalette v-model:open="open" :groups="groups" @select="onSelect" />
+<CommandPalette v-model:open="open" v-model:query="q" :groups="groups" @select="onSelect" />
 ```
 
 `Mod+K` now opens the palette on its own (registered internally via

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -144,6 +144,36 @@ throwing. TypeScript callers get a compile error instead. `#target` is the
 one slot case — content in a leftover `<template #target>` silently stops
 rendering.
 
+### Trigger slot props
+
+`#trigger`, `#prefix` and `#suffix` receive `{ open, toggle }` — the same two
+names `Popover`, `HoverCard`, `Dropdown`, `Select`, `Combobox` and
+`MultiSelect` hand out. `TimePicker`'s `#suffix` follows.
+
+| Before          | After    |
+| --------------- | -------- |
+| `isOpen`        | `open`   |
+| `togglePopover` | `toggle` |
+
+`displayLabel` and `inputValue` are unchanged, and `#actions` already used
+`close` — that stays too.
+
+This is a **silent break**: a destructured `isOpen` becomes `undefined`, so a
+class bound to it stops applying with no error, and `togglePopover()` throws
+`togglePopover is not a function` only if you call it.
+
+```vue
+<!-- Before -->
+<template #trigger="{ togglePopover, isOpen }">
+  <Button :class="isOpen && 'ring-2'" label="Pick a date" @click="togglePopover" />
+</template>
+
+<!-- After -->
+<template #trigger="{ toggle, open }">
+  <Button :class="open && 'ring-2'" label="Pick a date" @click="toggle" />
+</template>
+```
+
 Behavior changes that apply even if you don't touch your code:
 
 - `DateRangePicker` emits a `[from, to]` tuple. Update handlers that called

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -158,6 +158,10 @@ names `Popover`, `HoverCard`, `Dropdown`, `Select`, `Combobox` and
 `displayLabel` and `inputValue` are unchanged, and `#actions` already used
 `close` — that stays too.
 
+`toggle` also takes `Popover`'s signature, `(flag?: boolean | Event) => void`:
+a bare call flips, a boolean sets, and a DOM event is ignored. `togglePopover`
+only ever flipped, so nothing that worked before behaves differently.
+
 This is a **silent break**: a destructured `isOpen` becomes `undefined`, so a
 class bound to it stops applying with no error, and `togglePopover()` throws
 `togglePopover is not a function` only if you call it.

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -36,7 +36,7 @@ The `options` blob is flattened into top-level props. See the
 | `<template #body-header>`             | `<template #title>` (no direct replacement) |
 | `<template #body>`                    | `bare` prop + default slot       |
 | `onClick: (close) => …`               | `onClick: ({ close }) => …`      |
-| `:icon="{ appearance: 'warning' }"`   | `:icon="{ theme: 'yellow' }"`    |
+| `:icon="{ appearance: 'warning' }"`   | `:icon="{ theme: 'amber' }"`     |
 | `dialogRef.close()`                   | `v-model:open` / `close` slot prop |
 | manual focus hacks / `v-focus`        | `autofocus` attr on a descendant |
 
@@ -72,12 +72,28 @@ open) and wrap your app root in `<FrappeUIProvider>`.
 <Dialog :icon="{ name: 'lucide-alert-triangle', appearance: 'warning' }" ... />
 
 <!-- After -->
-<Dialog :icon="{ name: 'lucide-alert-triangle', theme: 'yellow' }" ... />
+<Dialog :icon="{ name: 'lucide-alert-triangle', theme: 'amber' }" ... />
 ```
 
 `appearance` is dropped silently — Vue accepts the unknown key with no error,
-so the icon renders with no tone. Map `warning → yellow`, `info → blue`,
+so the icon renders with no tone. Map `warning → amber`, `info → blue`,
 `danger → red`, `success → green`.
+
+### `theme: 'yellow'` → `theme: 'amber'`
+
+The warning tone is `amber`, matching `Alert`, `SidebarCard`, `Badge` and
+`Avatar`. `Dialog` was the last component spelling it `yellow`, and it already
+rendered that value with the amber tokens — only the word changes, not the
+color.
+
+| Before                     | After                     |
+| -------------------------- | ------------------------- |
+| `:icon="{ theme: 'yellow' }"` | `:icon="{ theme: 'amber' }"` |
+| `dialog.confirm({ theme: 'yellow' })` | `dialog.confirm({ theme: 'amber' })` |
+
+This is a **silent break** for JavaScript call sites: `yellow` is no longer a
+key in the tone maps, so the icon renders with no tone and nothing throws.
+TypeScript call sites get a union error.
 
 ### A template ref no longer exposes `close()`
 

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -988,6 +988,30 @@ for the full API.
 padding — that's app-owned now (see the component page's Collapse section for
 the full composition contract).
 
+## SettingsDialog
+
+Open state moves from the unnamed `v-model` to `v-model:open`, the name every
+other overlay in the library uses.
+
+This is a **silent break**: Vue accepts the unknown `modelValue` prop with no
+error, so the dialog just never opens.
+
+| Before                          | After                                |
+| ------------------------------- | ------------------------------------ |
+| `v-model="showSettings"`        | `v-model:open="showSettings"`        |
+| `@update:modelValue="onToggle"` | `@update:open="onToggle"`            |
+
+```vue
+<!-- Before -->
+<SettingsDialog v-model="showSettings" v-model:tab="tab">…</SettingsDialog>
+
+<!-- After -->
+<SettingsDialog v-model:open="showSettings" v-model:tab="tab">…</SettingsDialog>
+```
+
+`v-model:tab` is unchanged. Unlike `Dialog`, `SettingsDialog` has no legacy
+unnamed-`v-model` binding to keep — `open` is the only visibility channel.
+
 ## Tabs
 
 The monolithic `Tabs` is replaced by a composed family: `Tabs`, `TabList`,

--- a/experimental/Calendar/Calendar.cy.ts
+++ b/experimental/Calendar/Calendar.cy.ts
@@ -142,6 +142,19 @@ describe('Calendar', () => {
     cy.contains('button', 'Today').should('not.exist')
   })
 
+  // The default header binds DatePicker's `#trigger` slot prop `toggle`. The
+  // picker's slot props are a public contract, so a rename there breaks this
+  // button silently — nothing throws, the month picker just stops opening.
+  it('opens the month picker from the default header', () => {
+    cy.mount(Calendar, { props: { events: [] } })
+
+    cy.get('[role=dialog]').should('not.exist')
+    // The month/year button is the header's first control.
+    cy.get('button').first().click()
+    cy.get('[role=dialog]').should('exist')
+    cy.get('[aria-label=cycle-calendar-view]').should('exist')
+  })
+
   it('renders the #event-popover-content slot inside the event popover', () => {
     cy.mount(Calendar, {
       props: { events },

--- a/experimental/Calendar/Calendar.vue
+++ b/experimental/Calendar/Calendar.vue
@@ -25,13 +25,13 @@
             @update:modelValue="(val) => onMonthYearChange(val)"
             :clearable="false"
           >
-            <template #trigger="{ togglePopover }">
+            <template #trigger="{ toggle }">
               <Button
                 variant="ghost"
                 class="text-lg-medium text-ink-gray-7"
                 :label="currentMonthYear"
                 iconRight="lucide-chevron-down"
-                @click="togglePopover"
+                @click="toggle"
               />
             </template>
           </DatePicker>

--- a/experimental/Calendar/stories/CustomHeader.vue
+++ b/experimental/Calendar/stories/CustomHeader.vue
@@ -110,13 +110,13 @@ const events = ref([
               @update:modelValue="(val) => headerProps.onMonthYearChange(val)"
               :clearable="false"
             >
-              <template #trigger="{ togglePopover }">
+              <template #trigger="{ toggle }">
                 <Button
                   variant="ghost"
                   class="text-lg-medium text-ink-gray-7"
                   :label="headerProps.currentMonthYear"
                   iconRight="lucide-chevron-down"
-                  @click="togglePopover"
+                  @click="toggle"
                 />
               </template>
             </DatePicker>

--- a/spec/date-picker.md
+++ b/spec/date-picker.md
@@ -326,7 +326,7 @@ type DatePickerEmits = {
 }
 ```
 
-Slots: `target`, `prefix`, `suffix` (all with `{ togglePopover, isOpen, displayLabel, inputValue }`).
+Slots: `trigger`, `prefix`, `suffix` (all with `{ open, toggle, displayLabel, inputValue }`).
 
 Exposed: `open(): void`
 
@@ -476,7 +476,7 @@ type TimePickerEmits = {
 }
 ```
 
-Slots: `prefix`, `suffix` (suffix exposes `{ togglePopover, isOpen }`).
+Slots: `prefix`, `suffix` (suffix exposes `{ open, toggle }`).
 
 ---
 

--- a/spec/date-picker.md
+++ b/spec/date-picker.md
@@ -327,6 +327,8 @@ type DatePickerEmits = {
 ```
 
 Slots: `trigger`, `prefix`, `suffix` (all with `{ open, toggle, displayLabel, inputValue }`).
+`toggle` carries `Popover`'s signature, `(flag?: boolean | Event) => void`: a bare
+call flips, a boolean sets, a DOM event is ignored. One name, one meaning.
 
 Exposed: `open(): void`
 
@@ -476,7 +478,8 @@ type TimePickerEmits = {
 }
 ```
 
-Slots: `prefix`, `suffix` (suffix exposes `{ open, toggle }`).
+Slots: `prefix`, `suffix` (suffix exposes `{ open, toggle }`, with `toggle` the
+same `(flag?: boolean | Event) => void` as on the date pickers and `Popover`).
 
 ---
 

--- a/spec/dialog.md
+++ b/spec/dialog.md
@@ -28,7 +28,7 @@ Apps reach for the imperative `dialog.*` helpers when they need a one-off confir
 | Chrome control | `bare: boolean` (default `false`); replaces the legacy `#body` slot |
 | Close button | `showCloseButton: boolean` (default `true`); independent of header |
 | Size scale | All 11 sizes kept (`xs` → `7xl`); maps to Tailwind `max-w-*` |
-| Color vocabulary | `theme` with color names (`'yellow' \| 'blue' \| 'red' \| 'green'`). No semantic axis. (`Alert.theme` uses its own palette: `gray \| blue \| green \| amber \| red`.) |
+| Color vocabulary | `theme` with color names (`'amber' \| 'blue' \| 'red' \| 'green'`). No semantic axis. (`Alert.theme` uses its own palette: `gray \| blue \| green \| amber \| red`.) |
 | Slots | Canonical only: `#default`, `#title`, `#actions`. Legacy slots were removed (ADR-0008). |
 | Imperative API | Callback-based `dialog.confirm`, `dialog.danger`, `dialog.prompt`. `onConfirm` resolving auto-closes; throwing keeps the dialog open with the thrown message rendered inline. Each helper returns a synchronous `DialogHandle` for programmatic dismissal. |
 | Mount mechanism | `<FrappeUIProvider>` renders `<Dialogs />` next to `<Toasts />`. `<Dialogs />` is still exported for callers who don't use the provider. |
@@ -42,7 +42,7 @@ type DialogSize =
   | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
   | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '7xl'
 
-type DialogTheme = 'yellow' | 'blue' | 'red' | 'green'
+type DialogTheme = 'amber' | 'blue' | 'red' | 'green'
 
 type DialogPosition = 'center' | 'top'
 
@@ -291,7 +291,7 @@ When `theme` is set without an explicit `icon`, the helper uses these defaults (
 | `theme` | Default icon | Confirm button color |
 |---|---|---|
 | `red` | `lucide-alert-triangle` | red solid |
-| `yellow` | `lucide-alert-triangle` | default solid (Button doesn't have a `yellow` theme — icon theme is honored, button falls back) |
+| `amber` | `lucide-alert-triangle` | default solid (Button doesn't have an `amber` theme — icon theme is honored, button falls back) |
 | `blue` | `lucide-info` | blue solid |
 | `green` | `lucide-check-circle` | green solid |
 | *(unset)* | none | default solid |
@@ -391,7 +391,7 @@ Every surface in the table below was deleted before 1.0.0, per [ADR-0008](./adr/
 |---|---|
 | `options` blob prop | Flat top-level props |
 | `disableOutsideClickToClose` | `dismissible` (inverted) |
-| `icon: { appearance: 'warning' \| 'info' \| 'danger' \| 'success' }` | `icon: { theme: 'yellow' \| 'blue' \| 'red' \| 'green' }` |
+| `icon: { appearance: 'warning' \| 'info' \| 'danger' \| 'success' }` | `icon: { theme: 'amber' \| 'blue' \| 'red' \| 'green' }` |
 | `#body-content`, `#body-main` slots | `#default` |
 | `#body-title` slot | `#title` |
 | `#body-header` slot | (no replacement — use `#title` for extras) |
@@ -403,6 +403,23 @@ Every surface in the table below was deleted before 1.0.0, per [ADR-0008](./adr/
 `<Dialogs />` is **not** deprecated — it remains exported and is now rendered by `<FrappeUIProvider>` alongside `<Toasts />`. Apps that already mount it in their template continue to work; rendering it twice is safe — only the first mounted host renders the stack, whether the extra host is nested or a sibling; the others warn in dev. When the rendering host unmounts, the claim hands over to the next mounted host, so the stack never loses its renderer.
 
 ## Migration notes
+
+### From `theme: 'yellow'` to `theme: 'amber'`
+
+`DialogTheme`'s warning tone is `amber`, not `yellow`. The rest of the library
+already spells it that way — `Alert` and `SidebarCard` (`StatusTheme`), `Badge`
+and `Avatar` — and `Dialog` itself rendered `yellow` with the `amber` tokens
+(`bg-surface-amber-2` / `text-ink-amber-5`), so only the word changes.
+
+```vue
+<!-- before -->
+<Dialog :icon="{ name: 'lucide-alert-triangle', theme: 'yellow' }" />
+
+<!-- after -->
+<Dialog :icon="{ name: 'lucide-alert-triangle', theme: 'amber' }" />
+```
+
+The same applies to the `theme` argument of `dialog.confirm` / `dialog.danger`.
 
 ### From `options` blob to flat props
 

--- a/spec/imperative-api.md
+++ b/spec/imperative-api.md
@@ -237,7 +237,7 @@ rule.
 (`builder/.../MoreStylesPanel.vue:179`).
 
 **`open` is always a verb here.** The boolean lives on `v-model:open` and on
-slot props as `isOpen`. Nothing handed back through a ref is ever a boolean
+slot props as `open`. Nothing handed back through a ref is ever a boolean
 named `open`. This fixes §1.1 and costs nothing — no component does that today.
 
 `focus(options?)` takes the standard `FocusOptions`, so

--- a/src/components/CommandPalette/CommandPalette.api.md
+++ b/src/components/CommandPalette/CommandPalette.api.md
@@ -20,8 +20,8 @@
     default: 'false'
   },
   {
-    name: 'searchQuery',
-    description: '',
+    name: 'query',
+    description: 'The search text. Filter `groups` against it. Cleared when the palette closes.',
     required: false,
     type: 'string',
     default: '""'
@@ -35,14 +35,14 @@
     type: '[value: boolean]'
   },
   {
+    name: 'update:query',
+    description: 'Fired when the query changes.',
+    type: '[value: string]'
+  },
+  {
     name: 'select',
     description: '',
     type: '[item: CommandPaletteItemData]'
-  },
-  {
-    name: 'update:searchQuery',
-    description: 'Fired when the search query changes.',
-    type: '[value: string]'
   }
 ]
 

--- a/src/components/CommandPalette/CommandPalette.cy.ts
+++ b/src/components/CommandPalette/CommandPalette.cy.ts
@@ -28,8 +28,8 @@ const Harness = (initialOpen: boolean, onSelect?: (item: unknown) => void) =>
         h(CommandPalette, {
           open: open.value,
           'onUpdate:open': (v: boolean) => (open.value = v),
-          searchQuery: searchQuery.value,
-          'onUpdate:searchQuery': (v: string) => (searchQuery.value = v),
+          query: searchQuery.value,
+          'onUpdate:query': (v: string) => (searchQuery.value = v),
           groups,
           onSelect,
         })

--- a/src/components/CommandPalette/CommandPalette.cy.ts
+++ b/src/components/CommandPalette/CommandPalette.cy.ts
@@ -66,7 +66,7 @@ describe('CommandPalette', () => {
     cy.get('[role=dialog]').should('not.exist')
   })
 
-  it('updates search-query while typing', () => {
+  it('updates query while typing', () => {
     cy.mount(Harness(true))
     cy.get('input[placeholder="Search"]').type('inb')
     cy.get('input[placeholder="Search"]').should('have.value', 'inb')

--- a/src/components/CommandPalette/CommandPalette.vue
+++ b/src/components/CommandPalette/CommandPalette.vue
@@ -4,7 +4,7 @@
     size="xl"
     position="top"
     bare
-    @after-leave="searchQuery = ''"
+    @after-leave="query = ''"
   >
     <template #default>
       <div>
@@ -16,7 +16,7 @@
             <ComboboxInput
               placeholder="Search"
               class="w-full border-none bg-transparent py-3 pl-11.5 pr-4.5 text-base text-ink-gray-8 placeholder-ink-gray-4 focus:ring-0"
-              v-model="searchQuery"
+              v-model="query"
               autocomplete="off"
             />
           </div>
@@ -81,7 +81,8 @@ const emit = defineEmits<{
 }>()
 
 const open = defineModel<boolean>('open', { default: false })
-const searchQuery = defineModel<string>('searchQuery', { default: '' })
+/** The search text. Filter `groups` against it. Cleared when the palette closes. */
+const query = defineModel<string>('query', { default: '' })
 
 function select(item: CommandPaletteItemData | null) {
   if (!item) return

--- a/src/components/CommandPalette/stories/Example.vue
+++ b/src/components/CommandPalette/stories/Example.vue
@@ -40,7 +40,7 @@ function select(item) {
     </p>
     <CommandPalette
       v-model:open="open"
-      v-model:search-query="searchQuery"
+      v-model:query="searchQuery"
       :groups="groups"
       @select="select"
     />

--- a/src/components/DatePicker/DatePicker.cy.ts
+++ b/src/components/DatePicker/DatePicker.cy.ts
@@ -1,6 +1,9 @@
 import { h } from 'vue'
 import DatePicker from './DatePicker.vue'
-import type { DatePickerActionsSlotProps } from './types'
+import type {
+  DatePickerActionsSlotProps,
+  DatePickerTriggerSlotProps,
+} from './types'
 
 // Slot factory used by tests that need a sidebar Clear button.
 // The new #actions slot renders to the left of the calendar; consumers
@@ -232,6 +235,71 @@ describe('DatePicker', () => {
     cy.get('input').click()
     cy.get('input').clear().type('2025-06-25{enter}')
     cy.get('input').should('have.value', '2025-06-15')
+  })
+
+  describe('#trigger slot props', () => {
+    // These two names are the public contract, so a rename here is a silent
+    // break in consumer templates. Popover carries the same test
+    // (Popover.cy.ts, "exposes reactive open state to the #trigger slot").
+    it('exposes open and toggle to the #trigger slot', () => {
+      cy.mount(DatePicker, {
+        props: { modelValue: '2025-06-15' },
+        slots: {
+          trigger: ({ open, toggle }: DatePickerTriggerSlotProps) =>
+            h(
+              'button',
+              {
+                'data-cy': 'trigger',
+                class: open ? 'is-open' : 'is-closed',
+                onClick: () => toggle(),
+              },
+              open ? 'Close' : 'Open',
+            ),
+        },
+      })
+
+      cy.get('[data-cy="trigger"]')
+        .should('have.class', 'is-closed')
+        .and('have.text', 'Open')
+      cy.get('[role=dialog]').should('not.exist')
+
+      cy.get('[data-cy="trigger"]').click()
+      cy.get('[role=dialog]').should('exist')
+      cy.get('[data-cy="trigger"]')
+        .should('have.class', 'is-open')
+        .and('have.text', 'Close')
+    })
+
+    it('toggle sets the open state when passed a boolean', () => {
+      // Same signature as Popover's `toggle`: a boolean sets, so `toggle(true)`
+      // on an open picker is a no-op rather than a close. Called directly
+      // because a `#trigger` click is not auto-wired here — the slot owns it.
+      let toggle: DatePickerTriggerSlotProps['toggle'] | null = null
+
+      cy.mount(DatePicker, {
+        props: { modelValue: '2025-06-15' },
+        slots: {
+          trigger: (props: DatePickerTriggerSlotProps) => {
+            toggle = props.toggle
+            return h('button', { 'data-cy': 'trigger' }, 'Open')
+          },
+        },
+      })
+
+      cy.then(() => toggle?.(true))
+      cy.get('[role=dialog]').should('exist')
+
+      // A flip would close it here. Setting must be idempotent.
+      cy.then(() => toggle?.(true))
+      cy.get('[role=dialog]').should('exist')
+
+      cy.then(() => toggle?.(false))
+      cy.get('[role=dialog]').should('not.exist')
+
+      // A bare call still flips.
+      cy.then(() => toggle?.())
+      cy.get('[role=dialog]').should('exist')
+    })
   })
 
   describe('keyboard navigation', () => {

--- a/src/components/DatePicker/DateRangePicker.cy.ts
+++ b/src/components/DatePicker/DateRangePicker.cy.ts
@@ -1,6 +1,9 @@
 import { h } from 'vue'
 import DateRangePicker from './DateRangePicker.vue'
-import type { DateRangePickerActionsSlotProps } from './types'
+import type {
+  DateRangePickerActionsSlotProps,
+  DatePickerTriggerSlotProps,
+} from './types'
 
 // Slot factory: renders a Clear button when there is a value, and exposes
 // a Last-7-days preset that exercises setRange.
@@ -285,6 +288,37 @@ describe('DateRangePicker', () => {
       const last = spy.lastCall.args[0]
       expect(last).to.deep.equal(['2025-06-10', '2025-06-15'])
     })
+  })
+
+  // `open` and `toggle` are the public slot contract, so a rename here is a
+  // silent break in consumer templates. Popover carries the same test.
+  it('exposes open and toggle to the #trigger slot', () => {
+    cy.mount(DateRangePicker, {
+      props: { modelValue: ['2025-06-10', '2025-06-15'] },
+      slots: {
+        trigger: ({ open, toggle }: DatePickerTriggerSlotProps) =>
+          h(
+            'button',
+            {
+              'data-cy': 'trigger',
+              class: open ? 'is-open' : 'is-closed',
+              onClick: () => toggle(),
+            },
+            open ? 'Close' : 'Open',
+          ),
+      },
+    })
+
+    cy.get('[data-cy="trigger"]')
+      .should('have.class', 'is-closed')
+      .and('have.text', 'Open')
+    cy.get('[role=dialog]').should('not.exist')
+
+    cy.get('[data-cy="trigger"]').click()
+    cy.get('[role=dialog]').should('exist')
+    cy.get('[data-cy="trigger"]')
+      .should('have.class', 'is-open')
+      .and('have.text', 'Close')
   })
 
   describe('dual-pane mode', () => {

--- a/src/components/DatePicker/DateTimePicker.cy.ts
+++ b/src/components/DatePicker/DateTimePicker.cy.ts
@@ -1,6 +1,9 @@
 import { h } from 'vue'
 import DateTimePicker from './DateTimePicker.vue'
-import type { DateTimePickerActionsSlotProps } from './types'
+import type {
+  DateTimePickerActionsSlotProps,
+  DatePickerTriggerSlotProps,
+} from './types'
 
 const clearSlot = {
   actions: (props: DateTimePickerActionsSlotProps) =>
@@ -178,5 +181,36 @@ describe('DateTimePicker', () => {
     // Split view: scrollable year list beside a scrollable month list.
     cy.get('[role=listbox][aria-label="Select year"]').should('exist')
     cy.get('[role=listbox][aria-label="Select month"]').should('exist')
+  })
+
+  // `open` and `toggle` are the public slot contract, so a rename here is a
+  // silent break in consumer templates. Popover carries the same test.
+  it('exposes open and toggle to the #trigger slot', () => {
+    cy.mount(DateTimePicker, {
+      props: { modelValue: '2025-06-15 10:30:00' },
+      slots: {
+        trigger: ({ open, toggle }: DatePickerTriggerSlotProps) =>
+          h(
+            'button',
+            {
+              'data-cy': 'trigger',
+              class: open ? 'is-open' : 'is-closed',
+              onClick: () => toggle(),
+            },
+            open ? 'Close' : 'Open',
+          ),
+      },
+    })
+
+    cy.get('[data-cy="trigger"]')
+      .should('have.class', 'is-closed')
+      .and('have.text', 'Open')
+    cy.get('[role=dialog]').should('not.exist')
+
+    cy.get('[data-cy="trigger"]').click()
+    cy.get('[role=dialog]').should('exist')
+    cy.get('[data-cy="trigger"]')
+      .should('have.class', 'is-open')
+      .and('have.text', 'Close')
   })
 })

--- a/src/components/DatePicker/stories/Examples.vue
+++ b/src/components/DatePicker/stories/Examples.vue
@@ -135,10 +135,10 @@ const rowCls =
     <div class="flex flex-col gap-1.5">
       <span class="text-sm text-ink-gray-7">Task card affordance</span>
       <DatePicker v-model="dueDate" format="MMM D">
-        <template #trigger="{ togglePopover, displayLabel }">
+        <template #trigger="{ toggle, displayLabel }">
           <Button
             :variant="dueDate ? 'subtle' : 'ghost'"
-            @click="togglePopover"
+            @click="toggle"
           >
             <template #prefix>
               <span class="lucide-calendar-plus size-4" />

--- a/src/components/DatePicker/stories/Range.vue
+++ b/src/components/DatePicker/stories/Range.vue
@@ -230,11 +230,11 @@ const ret = computed(() =>
 
     <!-- 5. Flight booking — split trigger over one shared popover -->
     <DateRangePicker v-model="flight" dual-pane :min="today">
-      <template #trigger="{ togglePopover, isOpen }">
+      <template #trigger="{ toggle, open }">
         <div
           class="grid grid-cols-2 divide-x divide-outline-gray-2 rounded-4 border bg-surface-base text-sm transition-colors"
           :class="
-            isOpen
+            open
               ? 'border-outline-gray-4 ring-2 ring-outline-gray-2'
               : 'border-outline-gray-2 hover:border-outline-gray-3'
           "
@@ -242,7 +242,7 @@ const ret = computed(() =>
           <button
             type="button"
             class="flex items-center gap-2 rounded-l-4 px-3 py-2 text-left hover:bg-surface-gray-1"
-            @click="togglePopover"
+            @click="toggle"
           >
             <span
               class="lucide-plane-takeoff size-4 text-ink-gray-5"
@@ -258,7 +258,7 @@ const ret = computed(() =>
           <button
             type="button"
             class="flex items-center gap-2 rounded-r-4 px-3 py-2 text-left hover:bg-surface-gray-1"
-            @click="togglePopover"
+            @click="toggle"
           >
             <span
               class="lucide-plane-landing size-4 text-ink-gray-5"

--- a/src/components/DatePicker/types.ts
+++ b/src/components/DatePicker/types.ts
@@ -128,8 +128,8 @@ export type DateTimePickerEmits = DatePickerEmits
 
 /** Props bound to the trigger / prefix / suffix slots on all three pickers. */
 export interface DatePickerTriggerSlotProps {
-  /** Flips the popover open state. */
-  toggle: () => void
+  /** Flips the popover open state, or sets it when passed a boolean. */
+  toggle: (flag?: boolean | Event) => void
   /** Whether the popover is currently open. */
   open: boolean
   displayLabel: string

--- a/src/components/DatePicker/types.ts
+++ b/src/components/DatePicker/types.ts
@@ -128,8 +128,10 @@ export type DateTimePickerEmits = DatePickerEmits
 
 /** Props bound to the trigger / prefix / suffix slots on all three pickers. */
 export interface DatePickerTriggerSlotProps {
-  togglePopover: () => void
-  isOpen: boolean
+  /** Flips the popover open state. */
+  toggle: () => void
+  /** Whether the popover is currently open. */
+  open: boolean
   displayLabel: string
   inputValue: string
 }

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -274,7 +274,7 @@ const dialogIconBgClasses = computed(() => {
   const theme = iconTheme.value
   if (!theme) return 'bg-surface-gray-2'
   const map: Record<DialogTheme, string> = {
-    yellow: 'bg-surface-amber-2',
+    amber: 'bg-surface-amber-2',
     blue: 'bg-surface-blue-2',
     red: 'bg-surface-red-2',
     green: 'bg-surface-green-2',
@@ -286,7 +286,7 @@ const dialogIconClasses = computed(() => {
   const theme = iconTheme.value
   if (!theme) return 'text-ink-gray-5'
   const map: Record<DialogTheme, string> = {
-    yellow: 'text-ink-amber-5',
+    amber: 'text-ink-amber-5',
     blue: 'text-ink-blue-5',
     red: 'text-ink-red-7',
     green: 'text-ink-green-5',

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -14,7 +14,7 @@ export type DialogSize =
   | '6xl'
   | '7xl'
 
-export type DialogTheme = 'yellow' | 'blue' | 'red' | 'green'
+export type DialogTheme = 'amber' | 'blue' | 'red' | 'green'
 
 export type DialogPosition = 'center' | 'top'
 

--- a/src/components/SettingsDialog/SettingsDialog.api.md
+++ b/src/components/SettingsDialog/SettingsDialog.api.md
@@ -27,7 +27,7 @@
     default: 'true'
   },
   {
-    name: 'modelValue',
+    name: 'open',
     description: 'Controls whether the dialog is open.',
     required: false,
     type: 'boolean',
@@ -61,8 +61,8 @@
 
   const settingsDialogEmits = [
   {
-    name: 'update:modelValue',
-    description: 'Fired when the model value changes.',
+    name: 'update:open',
+    description: 'Fired when the open state changes.',
     type: '[value: boolean]'
   },
   {

--- a/src/components/SettingsDialog/SettingsDialog.cy.ts
+++ b/src/components/SettingsDialog/SettingsDialog.cy.ts
@@ -19,16 +19,16 @@ const tabs = [
 // reka-ui Tabs owns selection, the consumer only binds `tab` and supplies a
 // matching `value` on each nav item and panel.
 const Harness = defineComponent({
-  props: { modelValue: { type: Boolean, default: true } },
-  emits: ['update:modelValue'],
+  props: { open: { type: Boolean, default: true } },
+  emits: ['update:open'],
   setup(props, { emit }) {
     const active = ref(tabs[0].value)
     return () =>
       h(
         SettingsDialog,
         {
-          modelValue: props.modelValue,
-          'onUpdate:modelValue': (v: boolean) => emit('update:modelValue', v),
+          open: props.open,
+          'onUpdate:open': (v: boolean) => emit('update:open', v),
           tab: active.value,
           'onUpdate:tab': (v: string) => (active.value = v),
         },
@@ -57,11 +57,11 @@ const Harness = defineComponent({
 })
 
 describe('SettingsDialog', () => {
-  it('does not render while closed; renders when open (v-model)', () => {
-    cy.mount(Harness, { props: { modelValue: false } })
+  it('does not render while closed; renders when open (v-model:open)', () => {
+    cy.mount(Harness, { props: { open: false } })
     cy.get('[role=dialog]').should('not.exist')
 
-    cy.mount(Harness, { props: { modelValue: true } })
+    cy.mount(Harness, { props: { open: true } })
     cy.get('[role=dialog]').should('exist')
   })
 
@@ -114,10 +114,10 @@ describe('SettingsDialog', () => {
     cy.get('[role=tabpanel]').should('have.text', 'General content')
   })
 
-  it('emits update:modelValue when the dialog is closed', () => {
+  it('emits update:open when the dialog is closed', () => {
     const onUpdate = cy.spy().as('onUpdate')
     cy.mount(Harness, {
-      props: { modelValue: true, 'onUpdate:modelValue': onUpdate },
+      props: { open: true, 'onUpdate:open': onUpdate },
     })
     cy.get('[role=dialog]').should('exist')
     cy.get('body').type('{esc}')

--- a/src/components/SettingsDialog/SettingsDialog.md
+++ b/src/components/SettingsDialog/SettingsDialog.md
@@ -13,7 +13,7 @@ It's a [reka-ui Tabs](https://reka-ui.com/docs/components/tabs) set, so you get
 Instead of tracking an `active` flag, give each nav item and panel a matching
 `value`.
 
-- **`SettingsDialog`** — wraps `Dialog`; owns open state (`v-model`), the
+- **`SettingsDialog`** — wraps `Dialog`; owns open state (`v-model:open`), the
   selected tab (`v-model:tab`), and the `Cmd/Ctrl+Shift+,` shortcut. Full-screen
   on mobile, centered panel on desktop.
 - **`SettingsSidebar`** / **`SettingsNavGroup`** / **`SettingsNavItem`** — the

--- a/src/components/SettingsDialog/SettingsDialog.vue
+++ b/src/components/SettingsDialog/SettingsDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <Dialog v-model="modelValue" :size="size" bare>
+  <Dialog v-model:open="open" :size="size" bare>
     <!--
       TabsRoot wires the sidebar (TabsList) to the panels (TabsContent): roving
       arrow-key focus, aria-selected/aria-controls, and one visible panel at a
@@ -42,7 +42,7 @@ const props = withDefaults(defineProps<SettingsDialogProps>(), {
 })
 
 /** Controls whether the dialog is open. */
-const modelValue = defineModel<boolean>({ default: false })
+const open = defineModel<boolean>('open', { default: false })
 
 /**
  * The selected tab — pairs with SettingsNavItem `:value` and SettingsPanel
@@ -69,7 +69,7 @@ useEventListener(
     if (!props.shortcut) return
     if (e.code === 'Comma' && e.shiftKey && (e.metaKey || e.ctrlKey)) {
       e.preventDefault()
-      modelValue.value = !modelValue.value
+      open.value = !open.value
     }
   },
 )

--- a/src/components/SettingsDialog/stories/Default.vue
+++ b/src/components/SettingsDialog/stories/Default.vue
@@ -62,7 +62,7 @@ const activeTab = ref(tabs[0].value)
 
 <template>
   <Button @click="open = true">Open settings</Button>
-  <SettingsDialog v-model="open" v-model:tab="activeTab">
+  <SettingsDialog v-model:open="open" v-model:tab="activeTab">
     <SettingsSidebar>
       <SettingsNavGroup
         v-for="group in groups"

--- a/src/components/SettingsDialog/types.ts
+++ b/src/components/SettingsDialog/types.ts
@@ -17,7 +17,7 @@ export interface SettingsDialogProps {
 
 export interface SettingsDialogEmits {
   /** Fired when the dialog is opened or closed. */
-  'update:modelValue': [value: boolean]
+  'update:open': [value: boolean]
 }
 
 /**

--- a/src/components/TimePicker/TimePicker.api.md
+++ b/src/components/TimePicker/TimePicker.api.md
@@ -173,7 +173,7 @@
   {
     name: 'suffix',
     description: 'Rendered inside the trigger input, after the typed value. Defaults to a\nchevron-down that toggles the popover.',
-    type: '{ toggle: () => void; open: boolean; }'
+    type: '{ toggle: (flag?: boolean | Event | undefined) => void; open: boolean; }'
   }
 ]
 

--- a/src/components/TimePicker/TimePicker.api.md
+++ b/src/components/TimePicker/TimePicker.api.md
@@ -173,7 +173,7 @@
   {
     name: 'suffix',
     description: 'Rendered inside the trigger input, after the typed value. Defaults to a\nchevron-down that toggles the popover.',
-    type: '{ togglePopover: () => void; isOpen: boolean; }'
+    type: '{ toggle: () => void; open: boolean; }'
   }
 ]
 
@@ -182,6 +182,11 @@
     name: 'open',
     description: 'Fired when the component opens.',
     type: '[]'
+  },
+  {
+    name: 'update:modelValue',
+    description: 'Fired when the model value changes.',
+    type: '[value: string]'
   },
   {
     name: 'update:open',
@@ -194,16 +199,6 @@
     type: '[value: string]'
   },
   {
-    name: 'close',
-    description: 'Fired when the component closes.',
-    type: '[]'
-  },
-  {
-    name: 'update:modelValue',
-    description: 'Fired when the model value changes.',
-    type: '[value: string]'
-  },
-  {
     name: 'input-invalid',
     description: '',
     type: '[input: string]'
@@ -212,6 +207,11 @@
     name: 'invalid-change',
     description: '',
     type: '[invalid: boolean]'
+  },
+  {
+    name: 'close',
+    description: 'Fired when the component closes.',
+    type: '[]'
   }
 ]
 </script>

--- a/src/components/TimePicker/TimePicker.cy.ts
+++ b/src/components/TimePicker/TimePicker.cy.ts
@@ -1,4 +1,12 @@
+import { h } from 'vue'
 import TimePicker from './TimePicker.vue'
+
+// TimePicker declares its `#suffix` slot props inline rather than in `types.ts`,
+// so the shape is mirrored here.
+type SuffixSlotProps = {
+  open: boolean
+  toggle: (flag?: boolean | Event) => void
+}
 
 describe('TimePicker', () => {
   it('renders', () => {
@@ -240,5 +248,71 @@ describe('TimePicker', () => {
     cy.get('input').click()
     cy.get('input').type('3:07pm{enter}')
     cy.get('input').should('have.value', '03:07 PM')
+  })
+
+  describe('#suffix slot props', () => {
+    // TimePicker has no `#trigger`; `#suffix` is where it hands out the same
+    // two names as the date pickers and Popover. A rename here is silent.
+    it('exposes open and toggle to the #suffix slot', () => {
+      cy.mount(TimePicker, {
+        props: { modelValue: '10:00:00' },
+        slots: {
+          suffix: ({ open, toggle }: SuffixSlotProps) =>
+            h(
+              'button',
+              {
+                'data-cy': 'suffix',
+                class: open ? 'is-open' : 'is-closed',
+                onMousedown: (e: MouseEvent) => {
+                  e.preventDefault()
+                  toggle()
+                },
+              },
+              open ? 'Close' : 'Open',
+            ),
+        },
+      })
+
+      cy.get('[data-cy="suffix"]')
+        .should('have.class', 'is-closed')
+        .and('have.text', 'Open')
+      cy.get('[role=dialog]').should('not.exist')
+
+      cy.get('[data-cy="suffix"]').click()
+      cy.get('[role=dialog]').should('exist')
+      cy.get('[data-cy="suffix"]')
+        .should('have.class', 'is-open')
+        .and('have.text', 'Close')
+    })
+
+    it('toggle sets the open state when passed a boolean', () => {
+      // Same signature as Popover's `toggle`: a boolean sets, a bare call
+      // flips. Called directly, since a click also dismisses the popover.
+      let toggle: SuffixSlotProps['toggle'] | null = null
+
+      cy.mount(TimePicker, {
+        props: { modelValue: '10:00:00' },
+        slots: {
+          suffix: (props: SuffixSlotProps) => {
+            toggle = props.toggle
+            return h('span', { 'data-cy': 'suffix' })
+          },
+        },
+      })
+
+      cy.then(() => toggle?.(true))
+      cy.get('[role=dialog]').should('exist')
+
+      // A flip would close it here. Setting must be idempotent.
+      cy.then(() => toggle?.(true))
+      cy.get('[role=dialog]').should('exist')
+
+      cy.then(() => toggle?.(false))
+      cy.get('[role=dialog]').should('not.exist')
+
+      // A bare call still flips.
+      cy.then(() => toggle?.())
+      cy.get('[role=dialog]').should('exist')
+    })
   })
 })

--- a/src/components/TimePicker/TimePicker.vue
+++ b/src/components/TimePicker/TimePicker.vue
@@ -146,7 +146,10 @@ defineSlots<{
    * Rendered inside the trigger input, after the typed value. Defaults to a
    * chevron-down that toggles the popover.
    */
-  suffix?: (props: { toggle: () => void; open: boolean }) => any
+  suffix?: (props: {
+    toggle: (flag?: boolean | Event) => void
+    open: boolean
+  }) => any
 }>()
 
 defineOptions({ inheritAttrs: false })
@@ -380,8 +383,11 @@ function selectOption(value: string) {
 
 // ── Popover + keyboard wiring ──
 
-function togglePopover() {
-  isOpen.value = !isOpen.value
+// Bound out as the `toggle` slot prop, so it carries `Popover`'s signature: a
+// bare call flips, a boolean sets, a DOM event is ignored.
+function togglePopover(flag?: boolean | Event) {
+  if (flag instanceof Event) flag = undefined
+  isOpen.value = flag ?? !isOpen.value
 }
 
 function onClickInput() {

--- a/src/components/TimePicker/TimePicker.vue
+++ b/src/components/TimePicker/TimePicker.vue
@@ -37,7 +37,7 @@
           <template #suffix>
             <slot
               name="suffix"
-              v-bind="{ togglePopover, isOpen }"
+              v-bind="{ toggle: togglePopover, open: isOpen }"
             >
               <span
                 class="lucide-chevron-down size-4 cursor-pointer"
@@ -146,7 +146,7 @@ defineSlots<{
    * Rendered inside the trigger input, after the typed value. Defaults to a
    * chevron-down that toggles the popover.
    */
-  suffix?: (props: { togglePopover: () => void; isOpen: boolean }) => any
+  suffix?: (props: { toggle: () => void; open: boolean }) => any
 }>()
 
 defineOptions({ inheritAttrs: false })

--- a/src/components/shared/picker/PickerShell.vue
+++ b/src/components/shared/picker/PickerShell.vue
@@ -31,7 +31,7 @@
                 <slot name="suffix" v-bind="triggerSlotProps">
                   <LucideChevronDown
                     class="h-4 w-4 cursor-pointer"
-                    @mousedown.prevent="togglePopover"
+                    @mousedown.prevent="toggle"
                   />
                 </slot>
               </template>
@@ -148,8 +148,10 @@ const inputValue = defineModel<string>('inputValue', { default: '' })
 const typing = defineModel<boolean>('typing', { default: false })
 
 interface TriggerSlotProps {
-  togglePopover: () => void
-  isOpen: boolean
+  /** Flips the popover open state. */
+  toggle: () => void
+  /** Whether the popover is currently open. */
+  open: boolean
   displayLabel: string
   inputValue: string
 }
@@ -169,7 +171,7 @@ const anchorEl = computed(() => {
   return textInputRef.value?.inputElement ?? undefined
 })
 
-function togglePopover() {
+function toggle() {
   open.value = !open.value
 }
 
@@ -221,8 +223,8 @@ function onArrowDown() {
 }
 
 const triggerSlotProps = computed<TriggerSlotProps>(() => ({
-  togglePopover,
-  isOpen: open.value,
+  toggle,
+  open: open.value,
   displayLabel: props.displayLabel,
   inputValue: inputValue.value,
 }))

--- a/src/components/shared/picker/PickerShell.vue
+++ b/src/components/shared/picker/PickerShell.vue
@@ -148,8 +148,8 @@ const inputValue = defineModel<string>('inputValue', { default: '' })
 const typing = defineModel<boolean>('typing', { default: false })
 
 interface TriggerSlotProps {
-  /** Flips the popover open state. */
-  toggle: () => void
+  /** Flips the popover open state, or sets it when passed a boolean. */
+  toggle: (flag?: boolean | Event) => void
   /** Whether the popover is currently open. */
   open: boolean
   displayLabel: string
@@ -171,8 +171,12 @@ const anchorEl = computed(() => {
   return textInputRef.value?.inputElement ?? undefined
 })
 
-function toggle() {
-  open.value = !open.value
+// Same signature and semantics as `Popover`'s `toggle` slot prop: a bare call
+// flips, a boolean sets, and a DOM event (from `@click="toggle"`) is ignored so
+// the handler argument does not read as `true`.
+function toggle(flag?: boolean | Event) {
+  if (flag instanceof Event) flag = undefined
+  open.value = flag ?? !open.value
 }
 
 function closePopover() {

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -215,7 +215,7 @@ function remove(id: number) {
 
 const THEME_DEFAULT_ICON: Record<DialogTheme, string> = {
   red: 'lucide-alert-triangle',
-  yellow: 'lucide-alert-triangle',
+  amber: 'lucide-alert-triangle',
   blue: 'lucide-info',
   green: 'lucide-check-circle',
 }
@@ -224,8 +224,8 @@ type ButtonTheme = NonNullable<ButtonProps['theme']>
 
 function themeToButtonTheme(theme?: DialogTheme): ButtonTheme | undefined {
   if (!theme) return undefined
-  // Button doesn't have `yellow`; fall back to default solid (no theme).
-  if (theme === 'yellow') return undefined
+  // Button doesn't have `amber`; fall back to default solid (no theme).
+  if (theme === 'amber') return undefined
   return theme as ButtonTheme
 }
 


### PR DESCRIPTION
One pass across the whole exported surface for the four axes in #1054, then four renames. Every other divergence is recorded on the issue with the reason it stays, so the next pass does not relitigate it.

Full inventory and verdicts: https://github.com/frappe/frappe-ui/issues/1054

## The four renames

One commit each, so any one can be dropped.

### 1. Picker trigger slot props — `{ isOpen, togglePopover }` → `{ open, toggle }`

`DatePicker`, `DateRangePicker`, `DateTimePicker`, `TimePicker`.

`isOpen` is on CONTEXT.md's avoid list for public API, and `togglePopover` names the mechanism rather than the behavior (P1). #872 already made this exact rename on `Popover` — it is in the guide under "Popover / HoverCard / Tooltip → Slot props" — and #876 did not follow. The same three components already hand `#actions` a `close()`, so one component shipped two vocabularies for one concept.

**Blast radius:** custom `#trigger` / `#prefix` / `#suffix` on a date or time picker. Silent — a destructured `isOpen` becomes `undefined`, so a bound class stops applying with no error. **Four internal call sites**, all migrated here: two DatePicker stories, plus `experimental/Calendar/Calendar.vue` and its CustomHeader story, which drive the month/year picker from `#trigger`. Every app that already migrated `Popover` has done this rename once.

### 2. `SettingsDialog` — bare `v-model` → `v-model:open`

CONTEXT.md: `open` is "always bound via `v-model:open`"; bare `v-model` for overlay visibility is on the avoid list. Dialog's dual binding is a documented carve-out for Dialog alone, and P2 says new components do not propagate it. #880 kept the SettingsDialog family "as-is" on a keep-or-remove question and never argued the model name.

**Blast radius:** gameplan and suite, the two consumers named in #880. Silent — Vue accepts the unknown `modelValue` prop, so the dialog never opens. `v-model:tab` is unchanged.

### 3. `CommandPalette` — `v-model:searchQuery` → `v-model:query`

`Combobox` and `MultiSelect` bind the same controlled search text as `v-model:query`. One concept, one name (P1).

**Blast radius:** suite's sheets app, the consumer #880 kept the component for. Silent — the palette keeps its own query and the app's binding never updates. Documented next to #880's `show` → `open` row in the same guide section.

### 4. `Dialog` — `theme: 'yellow'` → `theme: 'amber'`

`DialogTheme` held the library's last `yellow`. Three pieces of evidence this is drift, not a considered choice:

- `Dialog.vue` rendered `yellow` with the **amber** tokens — `bg-surface-amber-2`, `text-ink-amber-5`. The value name disagreed with the token it resolved to.
- `utils/dialog.ts` carried `// Button doesn't have 'yellow'; fall back to default solid` — a special case that exists only because of the spelling.
- CONTEXT.md already lists `yellow` under the names **Alert** must avoid, and #881 moved Alert to `amber`.

**Blast radius:** `Dialog`'s `icon.theme` and the `theme` argument of `dialog.confirm` / `dialog.danger`. Silent for JavaScript (the tone map loses the key, the icon renders untinted), loud for TypeScript. `spec/dialog.md` is updated, and #873's `warning → yellow` mapping in the `icon.appearance` entry is corrected to `warning → amber` in the same commit.

## What was checked and left alone

- **`#tab-prefix` / `#tab-suffix` vs `#prefix` / `#suffix` (the ticket's slot question) — justified, no change.** `Tabs` is the only dual-mode component in the family; the unit prefix is what tells shorthand from composed at the call site, and per-tab slots are P6's repeated-unit case. `TabButtons` keeps plain `#prefix` / `#suffix`: it has one mode, and `Breadcrumbs` has the identical per-item shape with the same plain names. #1056's guide entry stands unchanged.
- **`setOpen` on the selection family** vs `toggle` on Popover — different signatures, documented in `spec/selection.md`.
- **`change` beside `update:modelValue`** on the pickers and Editor — nobody uses `change` *instead of* `update:modelValue`, so no concept carries two names.
- **`collapsed` on Sidebar**, **`expanded` on Tree**, **`dismiss` on Alert/SidebarCard**, **`TabsVariant`**, **`RailItem.variant`**, every `size` range — justified or settled by #872, #877, #878, #881. Reasons are on the issue.

Nine further findings that are not renames — including `Badge`'s undocumented deprecated `theme="orange"` alias, which ADR-0008 says cannot ship and which can only be discharged before the tag — are listed on the issue under "Handed on".

## Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json` — **77 errors, unchanged from the `origin/main` baseline**, all in `vitepress/`, `src/mocks/handlers.ts`, `src/components/Menu/`, the editor extensions and `experimental/Charts`. Zero in any file this PR touches.
  - **Correction.** The first version of this PR said 78 and called it the baseline. It was 77 baseline plus one error this PR introduced — `experimental/Calendar/Calendar.vue(28,35): Property 'togglePopover' does not exist on type 'DatePickerTriggerSlotProps'`. It was missed by comparing per-file error *counts* instead of the error *list*. The Calendar call sites are fixed and the count is back to 77.
- Cypress, targeted — **170 / 170 passing** across 11 specs: DatePicker 23, DateRangePicker 21, DateTimePicker 15, TimePicker 20, SettingsDialog 7, SettingsPanel 8, CommandPalette 5, Dialog 22, `utils/dialog` 35, FrappeUIProvider 7, `experimental/Calendar` 7.
- Migration entries added for all four renames, each marked **silent**, in the existing before/after table style. Each rename also has a `## Unreleased` changelog entry naming the silent break and linking its guide section; the convention that requires both is recorded on #1054. Generated `*.api.md` regenerated for the components whose surface changed.
- No codemod change: the repo's only codemod (`tailwind/migrate-tokens-v2.js`) rewrites Tailwind classes and tokens and has no component-API mode, so the guide is the whole migration path — the same conclusion #877 reached for Tabs.
- Docs not built (`docs:build` OOMs on this box); the guide change is four table-and-prose blocks, checked for GFM table validity.

Part of #864
Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-report:start -->
Coverage: 71.85% (+0.02% vs `main`)
<!-- coverage-report:end -->

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1068/
<!-- docs-preview:end -->





