### PR TITLE
refactor(Badge)!: remove the deprecated theme="orange" alias, harden the theme lookup

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,6 +49,9 @@ The only two axes used to color components — there is intentionally **no** sem
 - **variant** — visual style: `solid | outline | subtle | ghost` (Button, Badge)
 - **theme** — color tone, by color name: `yellow | blue | red | green | amber | …` (Button, Badge, Alert, Dialog; the Alert/SidebarCard palette is `gray | blue | green | amber | red`)
 
+Badge themes are `gray | blue | green | amber | red | violet`.
+_Avoid_ (Badge): `orange` — an alias for `amber`, removed in `1.0.0` (ADR-0008)
+
 A legacy `appearance` (`warning | info | danger | success`) maps to `theme` color names.
 
 **theme** means color tone and nothing else. It is the library's most-used

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -61,7 +61,7 @@ onBeforeUnmount(() =>
           <Badge
             v-if="devBranch"
             :title="`git branch: ${devBranch}`"
-            theme="orange"
+            theme="amber"
             variant="outline"
             class="hidden md:flex"
           >
@@ -90,7 +90,7 @@ onBeforeUnmount(() =>
           <Badge
             v-if="devBranch"
             :title="`git branch: ${devBranch}`"
-            theme="orange"
+            theme="amber"
             variant="outline"
             class="hidden md:flex"
           >

--- a/docs/components/Home/Showcase/col2.vue
+++ b/docs/components/Home/Showcase/col2.vue
@@ -149,7 +149,7 @@ const resetState = () => {
         <label class="w-full">Status</label>
 
         <Badge theme="blue" class="rounded-1"> Stable</Badge>
-        <Badge theme="orange" class="rounded-1"> Moderate</Badge>
+        <Badge theme="amber" class="rounded-1"> Moderate</Badge>
       </div>
     </div>
 

--- a/docs/content/docs/changelog.md
+++ b/docs/content/docs/changelog.md
@@ -9,19 +9,37 @@ one-time dev-mode warning (unless noted). Removal is post-v1.
 
 ## Unreleased
 
-### Badge — `theme="orange"` removed (breaking, loud)
+### Badge — `theme="orange"` removed (breaking; loud in TS, silent in JS)
 
 `orange` was a deprecated alias that resolved to `amber`, so `theme="amber"`
 renders exactly what `theme="orange"` used to. ADR-0008 keeps nothing
 deprecated in `1.0.0`, and the alias was never on the removal list, so no
 earlier census counted it (found by #1054).
 
-**Loud break:** `Badge` indexes a class map by theme, so an unknown value
-throws `TypeError: Cannot read properties of undefined (reading 'subtle')`
-while rendering. The badge does not appear, and the error takes the parent
-render with it. TypeScript call sites fail earlier, at `vue-tsc`. Check bound
-themes as well as literal attributes — a status-to-theme map that yields
-`'orange'` throws the same way and no grep for `theme="orange"` finds it.
+TypeScript call sites fail at `vue-tsc`, because the `theme` union no longer
+accepts the string. JavaScript call sites and bound values render the default
+`gray` theme and log a one-time dev-mode warning naming the component, prop and
+value. Check bound themes as well as literal attributes — a status-to-theme map
+that yields `'orange'`, or an `?? 'orange'` default, goes grey and no grep for
+`theme="orange"` finds it.
+
+### Badge — an unsupported `theme`, `variant` or `size` no longer crashes (fix)
+
+`Badge` indexed a class map by theme and then indexed that result by variant.
+A theme outside the union made the second lookup read a property of
+`undefined`, throwing `TypeError: Cannot read properties of undefined (reading
+'subtle')` mid-render — the badge vanished and the error took the parent render
+with it, so one stale colour name in a status map could blank a page.
+
+All three axes now fall back to the prop's default (`gray` / `subtle` / `md`)
+and warn once per offending value in dev. `variant` and `size` never threw —
+they ended their lookup chains and rendered untinted or unsized — but they were
+silently wrong, and now report themselves too.
+
+The public types are unchanged: `theme` still accepts only the six supported
+values, so TypeScript keeps rejecting anything else at compile time. The
+fallback is a runtime net for JS call sites and bound values, not a widening of
+the API.
 
 ### Editor — images and embeds resize from a bottom-right corner handle
 
@@ -1790,4 +1808,4 @@ names.
 | `useFileUpload` / `FileUploadHandler` unset privacy | explicit `private` / `is_private` | **Default changed** — silent; now resolves to private |
 | `fileToBase64`, `formatBytes`, `getMaxFileSize`, `fileSizeLimitMessage` | none (internal only) | **Removed** — import fails |
 | `frappe-ui/charts` `ColorScheme` type | root `ResolvedColorScheme` (re-exported from `frappe-ui/charts`) | **Removed** — loud; type import fails |
-| `Badge theme="orange"`             | `theme="amber"`                      | **Removed in 1.0.0** (ADR-0008) — loud; throws while rendering |
+| `Badge theme="orange"`             | `theme="amber"`                      | **Removed in 1.0.0** (ADR-0008) — loud in TS (compile error); silent in JS (renders gray, dev-only warning) |

--- a/docs/content/docs/changelog.md
+++ b/docs/content/docs/changelog.md
@@ -9,6 +9,20 @@ one-time dev-mode warning (unless noted). Removal is post-v1.
 
 ## Unreleased
 
+### Badge — `theme="orange"` removed (breaking, loud)
+
+`orange` was a deprecated alias that resolved to `amber`, so `theme="amber"`
+renders exactly what `theme="orange"` used to. ADR-0008 keeps nothing
+deprecated in `1.0.0`, and the alias was never on the removal list, so no
+earlier census counted it (found by #1054).
+
+**Loud break:** `Badge` indexes a class map by theme, so an unknown value
+throws `TypeError: Cannot read properties of undefined (reading 'subtle')`
+while rendering. The badge does not appear, and the error takes the parent
+render with it. TypeScript call sites fail earlier, at `vue-tsc`. Check bound
+themes as well as literal attributes — a status-to-theme map that yields
+`'orange'` throws the same way and no grep for `theme="orange"` finds it.
+
 ### Editor — images and embeds resize from a bottom-right corner handle
 
 Selecting an image, video, or embed used to reveal two vertical pills centered
@@ -1776,3 +1790,4 @@ names.
 | `useFileUpload` / `FileUploadHandler` unset privacy | explicit `private` / `is_private` | **Default changed** — silent; now resolves to private |
 | `fileToBase64`, `formatBytes`, `getMaxFileSize`, `fileSizeLimitMessage` | none (internal only) | **Removed** — import fails |
 | `frappe-ui/charts` `ColorScheme` type | root `ResolvedColorScheme` (re-exported from `frappe-ui/charts`) | **Removed** — loud; type import fails |
+| `Badge theme="orange"`             | `theme="amber"`                      | **Removed in 1.0.0** (ADR-0008) — loud; throws while rendering |

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -952,16 +952,29 @@ If the alert was really a promotional card in a sidebar, use the new
 | ----------------- | ---------------- |
 | `theme="orange"`  | `theme="amber"`  |
 
-Unlike the `Alert` row above, this break is **loud**. `Badge` looks its theme
-up in a class map, so a value that is not in the map throws while rendering:
+How the break shows up depends on whether the call site is typed:
+
+- **TypeScript: loud.** `vue-tsc` rejects the value, because the `theme` prop
+  union no longer accepts the string. You get a compile error, not a surprise
+  in production.
+- **JavaScript and bound values: silent.** The badge renders in the default
+  `gray` theme and logs a one-time dev-mode warning naming the component, the
+  prop and the value. Production logs nothing.
 
 ```
-TypeError: Cannot read properties of undefined (reading 'subtle')
+[frappe-ui] Badge.theme="orange" is not a supported value — falling back to
+"gray". Supported: gray, blue, green, amber, red, violet.
 ```
 
-The badge does not render at all, and the error takes the parent render down
-with it. TypeScript call sites fail earlier, at `vue-tsc`, because the `theme`
-prop union no longer accepts the string.
+A missed site is therefore a grey badge, not a broken page. `Badge` used to
+index a class map by theme and then index the result again by variant, so an
+unknown theme threw `TypeError: Cannot read properties of undefined` mid-render
+and took the parent render with it. All three of `theme`, `variant` and `size`
+now fall back to their defaults instead.
+
+Do not rely on the fallback. It is a safety net for the upgrade, not a
+supported way to pass a colour — a grey badge where a coloured one belongs is
+still a bug, and the dev warning is the only thing that will tell you.
 
 ```vue
 <!-- Before -->
@@ -972,7 +985,7 @@ prop union no longer accepts the string.
 ```
 
 Check bound themes too, not only literal attributes. A status-to-theme map or
-a computed that returns `'orange'` throws the same way, and neither `vue-tsc`
+a computed that returns `'orange'` degrades the same way, and neither `vue-tsc`
 nor a grep for `theme="orange"` finds it:
 
 ```ts
@@ -983,11 +996,11 @@ const themeByStatus = { open: 'orange', closed: 'green' }
 const themeByStatus = { open: 'amber', closed: 'green' }
 ```
 
-The worst shape is `orange` as a **fallback**, because then every caller that
-omits a theme crashes, not just the ones that ask for orange:
+Watch for `orange` as a **fallback**, which affects more sites than it looks —
+every caller that omits a theme lands on it:
 
 ```vue
-<!-- Before — crashes whenever `badge.theme` is undefined -->
+<!-- Before — every caller without `badge.theme` renders grey -->
 <Badge :theme="badge.theme ?? 'orange'" />
 
 <!-- After -->

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -943,6 +943,64 @@ const primaryAction = {
 If the alert was really a promotional card in a sidebar, use the new
 [`SidebarCard`](./components/sidebar) component instead.
 
+## Badge
+
+`theme="orange"` is removed. It was a deprecated alias that resolved to
+`amber`, so the replacement renders the same badge it always did.
+
+| Before            | After            |
+| ----------------- | ---------------- |
+| `theme="orange"`  | `theme="amber"`  |
+
+Unlike the `Alert` row above, this break is **loud**. `Badge` looks its theme
+up in a class map, so a value that is not in the map throws while rendering:
+
+```
+TypeError: Cannot read properties of undefined (reading 'subtle')
+```
+
+The badge does not render at all, and the error takes the parent render down
+with it. TypeScript call sites fail earlier, at `vue-tsc`, because the `theme`
+prop union no longer accepts the string.
+
+```vue
+<!-- Before -->
+<Badge theme="orange" label="In Progress" />
+
+<!-- After -->
+<Badge theme="amber" label="In Progress" />
+```
+
+Check bound themes too, not only literal attributes. A status-to-theme map or
+a computed that returns `'orange'` throws the same way, and neither `vue-tsc`
+nor a grep for `theme="orange"` finds it:
+
+```ts
+// Before
+const themeByStatus = { open: 'orange', closed: 'green' }
+
+// After
+const themeByStatus = { open: 'amber', closed: 'green' }
+```
+
+The worst shape is `orange` as a **fallback**, because then every caller that
+omits a theme crashes, not just the ones that ask for orange:
+
+```vue
+<!-- Before — crashes whenever `badge.theme` is undefined -->
+<Badge :theme="badge.theme ?? 'orange'" />
+
+<!-- After -->
+<Badge :theme="badge.theme ?? 'amber'" />
+```
+
+If your app keeps its own colour vocabulary and cannot rename `orange` at the
+source, translate at the boundary instead of passing it through:
+
+```ts
+const badgeTheme = tone === 'orange' ? 'amber' : tone
+```
+
 ## Sidebar
 
 `Sidebar` is a bare frame — compose `SidebarHeader` / `SidebarSection` /

--- a/src/components/Badge/Badge.api.md
+++ b/src/components/Badge/Badge.api.md
@@ -9,7 +9,7 @@
     name: 'theme',
     description: 'Visual color theme of the badge',
     required: false,
-    type: '"gray" | "blue" | "green" | "amber" | "red" | "violet" | "orange"',
+    type: '"gray" | "blue" | "green" | "amber" | "red" | "violet"',
     default: '"gray"'
   },
   {

--- a/src/components/Badge/Badge.cy.ts
+++ b/src/components/Badge/Badge.cy.ts
@@ -1,5 +1,6 @@
 import Badge from './Badge.vue'
 import { h } from 'vue'
+import { _resetResolvePropValue } from '../../utils/resolvePropValue'
 
 describe('<Badge />', () => {
   it('renders default badge', () => {
@@ -288,5 +289,85 @@ describe('<Badge />', () => {
       },
     })
     cy.get('[data-cy="prefix-icon"]').parent().should('have.class', 'size-3')
+  })
+
+  // A value outside a prop's union used to reach a raw table lookup. For
+  // `theme` that was the first of two chained lookups, so the second one read
+  // a property of `undefined` and threw `TypeError: Cannot read properties of
+  // undefined (reading 'subtle')` mid-render — the badge vanished and the
+  // error took the parent render with it. `theme="orange"` (a removed alias,
+  // still live in consumer apps) is the case that made this reachable.
+  describe('unsupported prop values', () => {
+    beforeEach(() => {
+      _resetResolvePropValue()
+    })
+
+    it('falls back to the default theme instead of throwing', () => {
+      cy.mount(Badge, {
+        props: { theme: 'orange' as any, label: 'Orange' },
+      })
+
+      // Renders at all — this is the regression guard.
+      cy.get('.inline-flex.rounded-full').should('have.text', 'Orange')
+      // ...wearing the default gray subtle classes.
+      cy.get('.inline-flex.rounded-full').should('have.class', 'text-ink-gray-6')
+      cy.get('.inline-flex.rounded-full').should(
+        'have.class',
+        'bg-surface-gray-2',
+      )
+    })
+
+    it('warns in dev, naming the component, prop and value', () => {
+      cy.window().then((win) => {
+        cy.spy(win.console, 'warn').as('consoleWarn')
+      })
+      cy.mount(Badge, { props: { theme: 'orange' as any, label: 'Orange' } })
+
+      cy.get('@consoleWarn').should(
+        'have.been.calledWithMatch',
+        /Badge\.theme="orange" is not a supported value.*falling back to "gray".*gray, blue, green, amber, red, violet/,
+      )
+    })
+
+    it('warns once per offending value, not once per render', () => {
+      cy.window().then((win) => {
+        cy.spy(win.console, 'warn').as('consoleWarn')
+      })
+      cy.mount(Badge, { props: { theme: 'orange' as any, label: 'A' } })
+      cy.mount(Badge, { props: { theme: 'orange' as any, label: 'B' } })
+
+      cy.get('@consoleWarn').should('have.been.calledOnce')
+    })
+
+    it('falls back to the default variant', () => {
+      cy.mount(Badge, {
+        props: { variant: 'bogus' as any, label: 'Variant' },
+      })
+      cy.get('.inline-flex.rounded-full').should('have.class', 'text-ink-gray-6')
+      cy.get('.inline-flex.rounded-full').should(
+        'have.class',
+        'bg-surface-gray-2',
+      )
+    })
+
+    it('falls back to the default size', () => {
+      cy.mount(Badge, {
+        props: { size: 'bogus' as any, label: 'Size' },
+      })
+      cy.get('.inline-flex.rounded-full').should('have.class', 'h-5')
+      cy.get('.inline-flex.rounded-full').should('have.class', 'text-xs')
+    })
+
+    it('still renders every supported theme unchanged', () => {
+      cy.mount(Badge, { props: { theme: 'amber', label: 'Amber' } })
+      cy.get('.inline-flex.rounded-full').should(
+        'have.class',
+        'text-ink-amber-7',
+      )
+      cy.get('.inline-flex.rounded-full').should(
+        'have.class',
+        'bg-surface-amber-2',
+      )
+    })
   })
 })

--- a/src/components/Badge/Badge.cy.ts
+++ b/src/components/Badge/Badge.cy.ts
@@ -64,16 +64,6 @@ describe('<Badge />', () => {
     cy.get('.inline-flex.rounded-full').should('have.class', 'text-ink-amber-7')
     cy.get('.inline-flex.rounded-full').should('have.class', 'bg-surface-amber-2')
 
-    // Orange (deprecated alias for amber)
-    cy.mount(Badge, {
-      props: {
-        theme: 'orange',
-        label: 'Orange',
-      },
-    })
-    cy.get('.inline-flex.rounded-full').should('have.class', 'text-ink-amber-7')
-    cy.get('.inline-flex.rounded-full').should('have.class', 'bg-surface-amber-2')
-
     // Red
     cy.mount(Badge, {
       props: {

--- a/src/components/Badge/Badge.vue
+++ b/src/components/Badge/Badge.vue
@@ -23,6 +23,7 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
+import { resolvePropValue } from '../../utils/resolvePropValue'
 import type { BadgeProps } from './types'
 
 const props = withDefaults(defineProps<BadgeProps>(), {
@@ -31,62 +32,84 @@ const props = withDefaults(defineProps<BadgeProps>(), {
   variant: 'subtle',
 })
 
+// The semantic scale (Figma export → tailwind/generated/colors.json) is
+// consistent across all themes — gray is the only exception (`-7` is its
+// saturated step, since gray needs more headroom). Tailwind's JIT needs
+// literal class names so the per-theme strings are inlined below.
+//   surface/{color}-2  pale bg          surface/{color}-5  saturated bg
+//   outline/{color}-2  pale border
+//   ink/{color}-1      pale text        ink/{color}-4      saturated text
+const themeClasses = {
+  gray: {
+    solid: 'text-ink-base bg-surface-gray-10',
+    subtle: 'text-ink-gray-6 bg-surface-gray-2',
+    outline: 'text-ink-gray-6 border border-outline-gray-2',
+    ghost: 'text-ink-gray-6',
+  },
+  blue: {
+    solid: 'text-white bg-surface-blue-7',
+    subtle: 'text-ink-blue-7 bg-surface-blue-2',
+    outline: 'text-ink-blue-7 border border-outline-blue-3',
+    ghost: 'text-ink-blue-7',
+  },
+  green: {
+    solid: 'text-white bg-surface-green-7',
+    subtle: 'text-ink-green-7 bg-surface-green-2',
+    outline: 'text-ink-green-7 border border-outline-green-3',
+    ghost: 'text-ink-green-7',
+  },
+  amber: {
+    solid: 'text-white bg-surface-amber-7',
+    subtle: 'text-ink-amber-7 bg-surface-amber-2',
+    outline: 'text-ink-amber-7 border border-outline-amber-3',
+    ghost: 'text-ink-amber-7',
+  },
+  red: {
+    solid: 'text-white bg-surface-red-7',
+    subtle: 'text-ink-red-7 bg-surface-red-2',
+    outline: 'text-ink-red-7 border border-outline-red-3',
+    ghost: 'text-ink-red-7',
+  },
+  violet: {
+    solid: 'text-white bg-surface-violet-7',
+    subtle: 'text-ink-violet-7 bg-surface-violet-2',
+    outline: 'text-ink-violet-7 border border-outline-violet-3',
+    ghost: 'text-ink-violet-7',
+  },
+}
+
+const sizeClasses = {
+  sm: 'h-4 px-1.5 text-xs',
+  md: 'h-5 px-1.5 text-xs',
+  lg: 'h-6 px-2 text-[13px] tracking-[0.02em]',
+}
+
+// Each axis resolves through `resolvePropValue`, so a value outside the union
+// degrades to the prop's default instead of rendering wrong or throwing. Only
+// `theme` could actually crash — it is the first of two chained lookups, so an
+// unknown theme made the second one read a property of `undefined`. `variant`
+// and `size` end their chains and merely rendered untinted or unsized, which
+// is quieter but still wrong. All three now warn in dev.
 const classes = computed(() => {
-  // The semantic scale (Figma export → tailwind/generated/colors.json) is
-  // consistent across all themes — gray is the only exception (`-7` is its
-  // saturated step, since gray needs more headroom). Tailwind's JIT needs
-  // literal class names so the per-theme strings are inlined below.
-  //   surface/{color}-2  pale bg          surface/{color}-5  saturated bg
-  //   outline/{color}-2  pale border
-  //   ink/{color}-1      pale text        ink/{color}-4      saturated text
-  const themeClasses = {
-    gray: {
-      solid: 'text-ink-base bg-surface-gray-10',
-      subtle: 'text-ink-gray-6 bg-surface-gray-2',
-      outline: 'text-ink-gray-6 border border-outline-gray-2',
-      ghost: 'text-ink-gray-6',
-    },
-    blue: {
-      solid: 'text-white bg-surface-blue-7',
-      subtle: 'text-ink-blue-7 bg-surface-blue-2',
-      outline: 'text-ink-blue-7 border border-outline-blue-3',
-      ghost: 'text-ink-blue-7',
-    },
-    green: {
-      solid: 'text-white bg-surface-green-7',
-      subtle: 'text-ink-green-7 bg-surface-green-2',
-      outline: 'text-ink-green-7 border border-outline-green-3',
-      ghost: 'text-ink-green-7',
-    },
-    amber: {
-      solid: 'text-white bg-surface-amber-7',
-      subtle: 'text-ink-amber-7 bg-surface-amber-2',
-      outline: 'text-ink-amber-7 border border-outline-amber-3',
-      ghost: 'text-ink-amber-7',
-    },
-    red: {
-      solid: 'text-white bg-surface-red-7',
-      subtle: 'text-ink-red-7 bg-surface-red-2',
-      outline: 'text-ink-red-7 border border-outline-red-3',
-      ghost: 'text-ink-red-7',
-    },
-    violet: {
-      solid: 'text-white bg-surface-violet-7',
-      subtle: 'text-ink-violet-7 bg-surface-violet-2',
-      outline: 'text-ink-violet-7 border border-outline-violet-3',
-      ghost: 'text-ink-violet-7',
-    },
-  }[props.theme]
+  const themeVariants = resolvePropValue(themeClasses, props.theme, 'gray', {
+    component: 'Badge',
+    prop: 'theme',
+  })
 
-  const variantClasses = themeClasses[props.variant]
+  const variantClasses = resolvePropValue(
+    themeVariants,
+    props.variant,
+    'subtle',
+    { component: 'Badge', prop: 'variant' },
+  )
 
-  const sizeClasses = {
-    sm: 'h-4 px-1.5 text-xs',
-    md: 'h-5 px-1.5 text-xs',
-    lg: 'h-6 px-2 text-[13px] tracking-[0.02em]',
-  }[props.size]
-
-  return [variantClasses, sizeClasses]
+  return [
+    variantClasses,
+    resolvePropValue(sizeClasses, props.size, 'md', {
+      component: 'Badge',
+      prop: 'size',
+    }),
+  ]
 })
 
 const iconSize = computed(() => (props.size === 'lg' ? 'size-3' : 'size-2.5'))

--- a/src/components/Badge/Badge.vue
+++ b/src/components/Badge/Badge.vue
@@ -31,9 +31,6 @@ const props = withDefaults(defineProps<BadgeProps>(), {
   variant: 'subtle',
 })
 
-// `orange` is kept as a deprecated alias for `amber`
-const theme = computed(() => (props.theme === 'orange' ? 'amber' : props.theme))
-
 const classes = computed(() => {
   // The semantic scale (Figma export → tailwind/generated/colors.json) is
   // consistent across all themes — gray is the only exception (`-7` is its
@@ -79,7 +76,7 @@ const classes = computed(() => {
       outline: 'text-ink-violet-7 border border-outline-violet-3',
       ghost: 'text-ink-violet-7',
     },
-  }[theme.value]
+  }[props.theme]
 
   const variantClasses = themeClasses[props.variant]
 

--- a/src/components/Badge/types.ts
+++ b/src/components/Badge/types.ts
@@ -4,7 +4,7 @@ interface Label {
 
 export interface BadgeProps {
   /** Visual color theme of the badge */
-  theme?: 'gray' | 'blue' | 'green' | 'amber' | 'red' | 'violet' | 'orange'
+  theme?: 'gray' | 'blue' | 'green' | 'amber' | 'red' | 'violet'
 
   /** Controls the size of the badge */
   size?: 'sm' | 'md' | 'lg'

--- a/src/components/ContextMenu/stories/Groups.vue
+++ b/src/components/ContextMenu/stories/Groups.vue
@@ -74,7 +74,7 @@ const actions: ContextMenuOptions = [
       class="w-72 cursor-default select-none rounded-7 border border-outline-gray-2 bg-surface-base p-4 shadow-sm"
     >
       <div class="mb-3 flex items-start justify-between gap-2">
-        <Badge theme="orange" label="In Progress" />
+        <Badge theme="amber" label="In Progress" />
         <span class="text-p-sm text-ink-gray-4">Due Friday</span>
       </div>
       <p class="mb-2 text-sm-medium text-ink-gray-8">

--- a/src/components/MultiSelect/stories/TagsTrigger.vue
+++ b/src/components/MultiSelect/stories/TagsTrigger.vue
@@ -5,7 +5,7 @@ import { Badge, MultiSelect } from 'frappe-ui'
 type Tag = {
   label: string
   value: string
-  theme: 'gray' | 'blue' | 'green' | 'orange' | 'red'
+  theme: 'gray' | 'blue' | 'green' | 'amber' | 'red'
 }
 
 const tags = ref<string[]>(['bug', 'p0'])
@@ -15,7 +15,7 @@ const tagOptions: Tag[] = [
   { label: 'Feature', value: 'feature', theme: 'blue' },
   { label: 'Enhancement', value: 'enhancement', theme: 'green' },
   { label: 'P0', value: 'p0', theme: 'red' },
-  { label: 'P1', value: 'p1', theme: 'orange' },
+  { label: 'P1', value: 'p1', theme: 'amber' },
   { label: 'P2', value: 'p2', theme: 'gray' },
   { label: 'Frontend', value: 'frontend', theme: 'blue' },
   { label: 'Backend', value: 'backend', theme: 'gray' },

--- a/src/components/MultiSelect/stories/TagsTrigger.vue
+++ b/src/components/MultiSelect/stories/TagsTrigger.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Badge, MultiSelect } from 'frappe-ui'
+import { Badge, MultiSelect, type BadgeProps } from 'frappe-ui'
 
 type Tag = {
   label: string
   value: string
-  theme: 'gray' | 'blue' | 'green' | 'amber' | 'red'
+  // Derived from Badge, never hand-written. A copied union is how the
+  // deprecated `orange` theme outlived the ADR-0008 sweep: nothing failed when
+  // the real union changed. Note `tsconfig.app.json` excludes `stories/**`, so
+  // this does not fail CI today — it fails in the editor, and it fails the
+  // moment stories join the type-check program.
+  theme: BadgeProps['theme']
 }
 
 const tags = ref<string[]>(['bug', 'p0'])

--- a/src/utils/resolvePropValue.test.ts
+++ b/src/utils/resolvePropValue.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { resolvePropValue, _resetResolvePropValue } from './resolvePropValue'
+
+const table = {
+  gray: 'is-gray',
+  blue: 'is-blue',
+  amber: 'is-amber',
+}
+
+const context = { component: 'Badge', prop: 'theme' }
+
+let warn: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  _resetResolvePropValue()
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warn.mockRestore()
+  vi.unstubAllEnvs()
+})
+
+describe('resolvePropValue', () => {
+  it('returns the mapped value for a supported key', () => {
+    expect(resolvePropValue(table, 'blue', 'gray', context)).toBe('is-blue')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the default for an unsupported value', () => {
+    expect(resolvePropValue(table, 'orange', 'gray', context)).toBe('is-gray')
+  })
+
+  it('falls back silently when the prop was not passed at all', () => {
+    // `undefined` means "no prop", which `withDefaults` normally covers.
+    // Reporting it would warn on ordinary usage.
+    expect(resolvePropValue(table, undefined, 'gray', context)).toBe('is-gray')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('ignores inherited Object.prototype keys', () => {
+    // A plain `value in table` guard would accept these and return a
+    // function where a class name belongs.
+    expect(resolvePropValue(table, 'toString', 'gray', context)).toBe('is-gray')
+    expect(resolvePropValue(table, 'constructor', 'gray', context)).toBe(
+      'is-gray',
+    )
+  })
+
+  it('names the component, prop, value, fallback and supported set', () => {
+    resolvePropValue(table, 'orange', 'gray', context)
+
+    expect(warn).toHaveBeenCalledOnce()
+    const message = warn.mock.calls[0][0] as string
+    expect(message).toContain('[frappe-ui]')
+    expect(message).toContain('Badge.theme="orange"')
+    expect(message).toContain('falling back to "gray"')
+    expect(message).toContain('gray, blue, amber')
+  })
+
+  it('warns once for repeated calls with the same value', () => {
+    // These fire from computeds, so a per-render warning would flood.
+    resolvePropValue(table, 'orange', 'gray', context)
+    resolvePropValue(table, 'orange', 'gray', context)
+    resolvePropValue(table, 'orange', 'gray', context)
+
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('warns once per distinct value, not once per component and prop', () => {
+    // Guards the `=${value}` part of the dedup key. Without it, the second
+    // and third bad values here would be swallowed and an app fixing one
+    // typo would never hear about the next.
+    resolvePropValue(table, 'orange', 'gray', context)
+    resolvePropValue(table, 'yellow', 'gray', context)
+    resolvePropValue(table, 'purple', 'gray', context)
+
+    expect(warn).toHaveBeenCalledTimes(3)
+    const messages = warn.mock.calls.map((call) => call[0] as string)
+    expect(messages[0]).toContain('"orange"')
+    expect(messages[1]).toContain('"yellow"')
+    expect(messages[2]).toContain('"purple"')
+  })
+
+  it('keeps the dedup key scoped to the component and prop', () => {
+    resolvePropValue(table, 'orange', 'gray', context)
+    resolvePropValue(table, 'orange', 'gray', {
+      component: 'Badge',
+      prop: 'variant',
+    })
+    resolvePropValue(table, 'orange', 'gray', {
+      component: 'Alert',
+      prop: 'theme',
+    })
+
+    expect(warn).toHaveBeenCalledTimes(3)
+  })
+
+  it('stays silent in production but still falls back', () => {
+    vi.stubEnv('PROD', true)
+
+    expect(resolvePropValue(table, 'orange', 'gray', context)).toBe('is-gray')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('does not burn the dedup entry while silenced in production', () => {
+    // The PROD gate sits after the dedup set is consulted, so a value first
+    // seen in prod must still warn in dev.
+    vi.stubEnv('PROD', true)
+    resolvePropValue(table, 'orange', 'gray', context)
+    expect(warn).not.toHaveBeenCalled()
+
+    vi.unstubAllEnvs()
+    resolvePropValue(table, 'orange', 'gray', context)
+    expect(warn).toHaveBeenCalledOnce()
+  })
+})

--- a/src/utils/resolvePropValue.ts
+++ b/src/utils/resolvePropValue.ts
@@ -1,0 +1,59 @@
+/**
+ * Resolve a prop value against a lookup table, falling back to the
+ * component's own default when the value is not a key of that table.
+ *
+ * Components pick class names with table lookups like
+ * `{ gray: …, blue: … }[props.theme]`. A value outside the prop's union makes
+ * that return `undefined`. Where the result is indexed again — `Badge` indexes
+ * by theme, then by variant — the `undefined` throws a `TypeError` mid-render,
+ * which Vue propagates up and which takes the parent render down with it. So a
+ * typo, a stale theme name in a status map, or a value renamed by the library
+ * crashes a page instead of mis-colouring one badge.
+ *
+ * TypeScript still rejects these values at the call site. This is the runtime
+ * net for JS call sites and for bound values (`:theme="statusMap[s]"`) that
+ * TypeScript cannot see through.
+ */
+
+const warned = new Set<string>()
+
+export function resolvePropValue<T, K extends string>(
+  table: Record<K, T>,
+  value: string | undefined,
+  fallback: K,
+  context: { component: string; prop: string },
+): T {
+  if (value !== undefined && Object.prototype.hasOwnProperty.call(table, value))
+    return table[value as K]
+
+  warnUnsupportedPropValue(table, value, fallback, context)
+  return table[fallback]
+}
+
+function warnUnsupportedPropValue(
+  table: Record<string, unknown>,
+  value: string | undefined,
+  fallback: string,
+  { component, prop }: { component: string; prop: string },
+) {
+  // `undefined` means the prop was simply not passed, which `withDefaults`
+  // normally covers. Nothing to report.
+  if (value === undefined) return
+  if (import.meta.env.PROD) return
+
+  // These fire from computeds on every recompute; warn once per offending
+  // value, not once per render.
+  const key = `${component}.${prop}=${value}`
+  if (warned.has(key)) return
+  warned.add(key)
+
+  console.warn(
+    `[frappe-ui] ${component}.${prop}="${value}" is not a supported value — ` +
+      `falling back to "${fallback}". Supported: ${Object.keys(table).join(', ')}.`,
+  )
+}
+
+/** Test-only: clear the dedup set so each test sees a fresh warning surface. */
+export function _resetResolvePropValue() {
+  warned.clear()
+}

--- a/v1-release/deprecated-removals.md
+++ b/v1-release/deprecated-removals.md
@@ -50,9 +50,11 @@ Three rows sit outside it and are the easy ones to miss:
   `@deprecated` tag at all — only a line comment in `Badge.vue` — so no
   mechanical scan could see it, and it reached the list late via the
   cross-family vocabulary pass ([#1054](https://github.com/frappe/frappe-ui/issues/1054))
-  rather than the sweep. Unlike the other value removal, this one breaks
-  **loudly**: `Badge` indexes a class map by theme, so an unknown value
-  throws during render.
+  rather than the sweep. Removing it exposed a second bug: `Badge` chained two
+  raw table lookups, so an unknown theme threw mid-render and blanked the
+  parent. `Badge` now degrades an unsupported `theme`, `variant` or `size` to
+  the prop's default and warns in dev, so the removal breaks **loudly in
+  TypeScript** (compile error) and **silently in JavaScript** (gray badge).
 
 The TextEditor rows are one deletion each in `src/index.ts`, but seven
 `@deprecated` names behind them (`default`, `TextEditor`,

--- a/v1-release/deprecated-removals.md
+++ b/v1-release/deprecated-removals.md
@@ -30,10 +30,11 @@ exported today**, except the rows marked done.
 | ~~TextEditor extension barrels~~  | removed in [#884](https://github.com/frappe/frappe-ui/issues/884)    | extensions from `frappe-ui/editor`                              | —                                                                                                                  |
 | ~~`FormControl type="autocomplete"`~~ | removed in [#926](https://github.com/frappe/frappe-ui/issues/926) | `Combobox` | — |
 | ~~`Autocomplete` (whole barrel)~~ | removed in [#926](https://github.com/frappe/frappe-ui/issues/926) | `Combobox` (single) / `MultiSelect` (multiple) | — |
+| ~~`Badge theme="orange"`~~ | removed in [#1069](https://github.com/frappe/frappe-ui/issues/1069) | `theme="amber"` | — |
 
-Twelve of the thirteen rows come from the one
+Twelve of the fourteen rows come from the one
 `// Deprecated component compatibility` block in `src/index.ts` (lines 103–132).
-Two rows sit outside it and are the easy ones to miss:
+Three rows sit outside it and are the easy ones to miss:
 
 - **`FormControl type="autocomplete"`** is a value in a prop union, not an
   export, so it does not appear in that block. It went at the same time as
@@ -44,6 +45,14 @@ Two rows sit outside it and are the easy ones to miss:
   `src/index.ts` with no `@deprecated` JSDoc, even though it warned on mount —
   so ADR-0008's mechanical rule missed the largest removal on the list. It
   carried the marker into the deprecated block before being deleted.
+- **`Badge theme="orange"`** is the same shape as the `FormControl` row: a
+  value in a prop union, aliased to `amber` in the component. It carried no
+  `@deprecated` tag at all — only a line comment in `Badge.vue` — so no
+  mechanical scan could see it, and it reached the list late via the
+  cross-family vocabulary pass ([#1054](https://github.com/frappe/frappe-ui/issues/1054))
+  rather than the sweep. Unlike the other value removal, this one breaks
+  **loudly**: `Badge` indexes a class map by theme, so an unknown value
+  throws during render.
 
 The TextEditor rows are one deletion each in `src/index.ts`, but seven
 `@deprecated` names behind them (`default`, `TextEditor`,

--- a/v1-release/deprecated-removals.md
+++ b/v1-release/deprecated-removals.md
@@ -5,9 +5,11 @@ The work list for
 `@deprecated` ships in `1.0.0`, so everything below is deleted before the tag
 rather than carried through `1.x`.
 
-This covers whole exports — components, composables, and the one prop value that
-pulls a component in with it. Member-level removals (individual props, slots,
-and emits on components that survive) go in the published migration guide,
+This covers whole exports — components, composables — plus deprecated **prop
+values**, whether or not they pull an export out with them. A prop value is not
+an export, so no scan of `src/index.ts` finds one; keeping them here is what
+makes them countable. Member-level removals (individual props, slots, and emits
+on components that survive) go in the published migration guide,
 [`docs/content/docs/migration.md`](../docs/content/docs/migration.md).
 
 ## The list
@@ -32,7 +34,7 @@ exported today**, except the rows marked done.
 | ~~`Autocomplete` (whole barrel)~~ | removed in [#926](https://github.com/frappe/frappe-ui/issues/926) | `Combobox` (single) / `MultiSelect` (multiple) | — |
 | ~~`Badge theme="orange"`~~ | removed in [#1069](https://github.com/frappe/frappe-ui/issues/1069) | `theme="amber"` | — |
 
-Twelve of the fourteen rows come from the one
+Eleven of the fourteen rows come from the one
 `// Deprecated component compatibility` block in `src/index.ts` (lines 103–132).
 Three rows sit outside it and are the easy ones to miss:
 


### PR DESCRIPTION
Two commits: the ADR-0008 removal, and a fix for the crash the removal exposed.

`Badge` kept `theme="orange"` as a deprecated alias for `amber`. ADR-0008 allows no "ships but deprecated" state at `1.0.0`, so it goes before the tag. `theme="amber"` renders exactly what `orange` used to.

The alias carried **no `@deprecated` tag** — only a line comment in `Badge.vue`. That is why no mechanical scan saw it, why it was never on `v1-release/deprecated-removals.md`, and why the sweep missed it. It reached the list late via the cross-family vocabulary pass (#1054). It is on the list now, with that reason recorded next to it.

## The removal exposed a crash, so this PR fixes that too

I mounted a Badge with `theme="orange"` after the removal rather than reasoning about it. It threw:

```
TypeError: Cannot read properties of undefined (reading 'subtle')
    at ComputedRefImpl.fn (src/components/Badge/Badge.vue:53:42)
```

`Badge` indexed a class map by theme and then indexed that result by variant. An unknown theme made the second lookup read a property of `undefined`, and Vue propagated the error up — the screenshot showed an empty mount area, so the badge vanished **and took the parent render with it**. With ~70 affected sites across 11 apps, that was ~70 blanked pages rather than ~70 wrong-coloured badges.

`resolvePropValue` (new, `src/utils/`) now backs all three lookup axes. An unsupported value falls back to the prop's default (`gray` / `subtle` / `md`) and warns once per offending value in dev:

```
[frappe-ui] Badge.theme="orange" is not a supported value — falling back to
"gray". Supported: gray, blue, green, amber, red, violet.
```

I probed `variant` and `size` before changing them: **neither ever threw.** They end their lookup chains, so they rendered untinted or unsized — quieter, but still wrong. They now warn too.

**The public type is not widened.** `orange` stays out of the union. TypeScript users still get a compile error; the runtime fallback is a net for JS call sites and bound values (`:theme="statusMap[s]"`) that TypeScript cannot see through. It is an upgrade cushion, not a supported way to pass a colour — the migration guide says so explicitly.

The warning follows the existing `warnUnsupportedIconString` idiom (DEV-only, deduped, names component/prop/value) rather than inventing a pattern. `warnDeprecated` was the wrong helper — its wording is deprecation-specific.

## Failure mode after this PR

| Call site | Behaviour |
| --- | --- |
| TypeScript | **Loud** — `vue-tsc` rejects the value at compile time |
| JavaScript / bound value | **Silent** — renders `gray`, one-time dev warning, nothing in prod |

## Census

49 direct `theme="orange"` Badge hits across 11 repos, plus 21 indirect bindings (ternaries, status maps, exported `BadgeTheme` unions).

| App | Direct | Indirect |
| --- | --- | --- |
| crm | 14 | 2 |
| lms | 11 | 2 |
| wiki | 7 | 0 |
| helpdesk | 4 | 1 |
| insights | 4 | 0 |
| central | 2 | 7 |
| suite | 2 | 3 |
| Letters | 2 | 0 |
| builder | 1 | 1 |
| press | 1 | 3 |
| slides | 1 | 0 |
| frappe (`ui/` package) | 0 | 2 |
| gameplan | 0 | 0 |

Because of the fix above, **these sites now render a grey badge rather than crashing a page.** They still need migrating — a grey badge where a coloured one belongs is a bug, and the dev warning is the only thing that will surface it.

Two sites reach more callers than they look like they do:

- `helpdesk/desk/src/components/PageInfo.vue:22` — `:theme="badge.theme ?? 'orange'"`. Every caller that omits `theme` lands on the fallback, so all of them go grey.
- `frappe/frappe` `ui/src/components/DataImport/dataImport.ts:4-13` — `getBadgeColor()` returns `"orange"` for three statuses. This is the first-party `@framework/ui` package.

Two apps already noticed the vocabulary mismatch and shimmed it. This is the pattern for apps that keep their own colour names:

- `central/dashboard/src/lib/roles.ts:82` — `/** Avatar themes use amber where badges use orange. */` plus a translation map.
- `pilot` `Updates.vue` — `theme: tone === 'orange' ? 'amber' : tone`.

### Census caveats — a lower bound, not exhaustive

- GitHub code search indexes default branches only.
- Punctuation-heavy queries (`:theme="'orange'"`, `theme: 'orange'`) return zero despite those forms demonstrably existing, so **the indirect column is a lower bound**.
- The rate limit truncated the press and lms sweeps.
- `builder`'s `GlobalDomains.vue`, `shop`'s `UiStatusBadge.vue` and `press`'s `site.js` are high-confidence but unconfirmed attributions.

### Out of scope, noted not acted on

`Button` and `Alert` accept `theme="orange"` at 5 sites across suite, Letters and toolbox. Neither documents an `orange` theme, so those are likely broken today already. Outside this ticket.

## Changes

- Deleted the alias computed and `'orange'` from the `BadgeProps` theme union.
- Added `src/utils/resolvePropValue.ts` and routed Badge's three lookups through it.
- Migrated internal call sites to `amber`: the docs dev-branch badge (2), the homepage showcase, the ContextMenu story, and the MultiSelect `TagsTrigger` story including its local type union and a `{ theme: 'orange' }` map entry.
- Kept the probe's finding as a real regression test: six specs covering fallback rendering for all three axes, the dev warning's contents, and its once-per-value dedup.
- Regenerated `Badge.api.md` via `yarn docs:gen`.
- Migration guide, changelog (removal + fix entries, deprecation-log row), and the `deprecated-removals.md` row.
- `spec/` needs no change: no Badge spec exists, and `orange` appears zero times under `spec/`.

## Verification

- `npx cypress run --component --spec src/components/Badge/Badge.cy.ts` — **17/17 pass** (11 existing + 6 new).
- ContextMenu **14/14**, MultiSelect **30/30**.
- `npx vue-tsc --noEmit -p tsconfig.app.json` — **77 errors**, matching the known baseline (vitepress/, Menu, src/mocks, editor extensions). **Zero in changed files.**
- Prettier clean on the new and changed source files.

Note for reviewers: ContextMenu and MultiSelect each reported a full-spec failure once when several agents shared this box, then passed on re-run. That is a dev-server port collision, not a flake in the specs.

## Expected conflict

`docs/content/docs/migration.md` is being rewritten concurrently by #1055, and `docs/content/docs/` pages by #1053. The Badge entry here is additive (one new `## Badge` section between `## Alert` and `## Sidebar`), so expect a mechanical conflict there and resolve by keeping both.

## Upgrade text for the per-app issues — NOT posted

I did not write to any other repo. Text for a human to append to the standing per-app upgrade issues:

> **`Badge theme="orange"` is removed** (frappe/frappe-ui#1069, part of frappe/frappe-ui#864).
>
> Replace with `theme="amber"`. It renders identically — `orange` was only ever an alias for `amber`.
>
> **How you find out you missed a site depends on your call sites.** TypeScript rejects the value at compile time. JavaScript and bound values render a **grey** badge and log a one-time dev-mode warning; production logs nothing. So a missed site is a wrong-coloured badge that only the dev console reports.
>
> Grep for all three shapes — the last two are the ones that bite:
> - `theme="orange"` — the literal attribute.
> - `:theme="... ? 'orange' : ..."` — ternaries and status-to-theme maps. `vue-tsc` will not always catch these.
> - `?? 'orange'` / `|| 'orange'` — an orange **default** affects every caller that omits a theme, not just the ones asking for orange.
>
> Watch the dev console for `[frappe-ui] Badge.theme="orange" is not a supported value` while you soak — that is the reliable signal for the bound cases.
>
> If your app keeps its own colour vocabulary and cannot rename `orange` at the source, translate at the boundary: `const badgeTheme = tone === 'orange' ? 'amber' : tone`. `central` and `pilot` already do this.

Part of #864
Closes #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1072/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.88% (+0.05% vs `main`)
<!-- coverage-report:end -->

