### PR TITLE
fix(textarea): use text-p tokens and add min height

### DIFF
--- a/src/components/Textarea/Textarea.cy.ts
+++ b/src/components/Textarea/Textarea.cy.ts
@@ -110,18 +110,19 @@ describe('Textarea', () => {
 
   describe('sizes', () => {
     const sizes = [
-      { size: 'sm', fontClass: 'text-base', px: 14 },
-      { size: 'md', fontClass: 'text-lg', px: 16 },
-      { size: 'lg', fontClass: 'text-2xl', px: 18 },
-      { size: 'xl', fontClass: 'text-3xl', px: 20 },
+      { size: 'sm', fontClass: 'text-p-base', minHClass: 'min-h-7', px: 14 },
+      { size: 'md', fontClass: 'text-p-lg', minHClass: 'min-h-8', px: 16 },
+      { size: 'lg', fontClass: 'text-p-2xl', minHClass: 'min-h-10', px: 18 },
+      { size: 'xl', fontClass: 'text-p-3xl', minHClass: 'min-h-10', px: 20 },
     ] as const
 
-    sizes.forEach(({ size, fontClass, px }) => {
-      it(`size="${size}" applies ${fontClass} and renders at ${px}px`, () => {
+    sizes.forEach(({ size, fontClass, minHClass, px }) => {
+      it(`size="${size}" applies ${fontClass}, ${minHClass}, and renders at ${px}px`, () => {
         cy.mount(Textarea, { props: { size } })
 
         cy.get('textarea')
           .should('have.class', fontClass)
+          .and('have.class', minHClass)
           .and('have.css', 'font-size', `${px}px`)
       })
     })

--- a/src/components/Textarea/Textarea.cy.ts
+++ b/src/components/Textarea/Textarea.cy.ts
@@ -110,13 +110,37 @@ describe('Textarea', () => {
 
   describe('sizes', () => {
     const sizes = [
-      { size: 'sm', fontClass: 'text-p-base', minHClass: 'min-h-7', px: 14 },
-      { size: 'md', fontClass: 'text-p-lg', minHClass: 'min-h-8', px: 16 },
-      { size: 'lg', fontClass: 'text-p-2xl', minHClass: 'min-h-10', px: 18 },
-      { size: 'xl', fontClass: 'text-p-3xl', minHClass: 'min-h-10', px: 20 },
+      {
+        size: 'sm',
+        fontClass: 'text-p-base',
+        minHClass: 'min-h-9',
+        px: 14,
+        lineHeight: '21px',
+      },
+      {
+        size: 'md',
+        fontClass: 'text-p-lg',
+        minHClass: 'min-h-10',
+        px: 16,
+        lineHeight: '24px',
+      },
+      {
+        size: 'lg',
+        fontClass: 'text-p-2xl',
+        minHClass: 'min-h-11',
+        px: 18,
+        lineHeight: '27px',
+      },
+      {
+        size: 'xl',
+        fontClass: 'text-p-3xl',
+        minHClass: 'min-h-11',
+        px: 20,
+        lineHeight: '29.6px',
+      },
     ] as const
 
-    sizes.forEach(({ size, fontClass, minHClass, px }) => {
+    sizes.forEach(({ size, fontClass, minHClass, px, lineHeight }) => {
       it(`size="${size}" applies ${fontClass}, ${minHClass}, and renders at ${px}px`, () => {
         cy.mount(Textarea, { props: { size } })
 
@@ -124,6 +148,7 @@ describe('Textarea', () => {
           .should('have.class', fontClass)
           .and('have.class', minHClass)
           .and('have.css', 'font-size', `${px}px`)
+          .and('have.css', 'line-height', lineHeight)
       })
     })
 

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -113,11 +113,12 @@ const attrsWithoutClassStyle = computed(() => {
 })
 
 const inputClasses = computed(() => {
+  // Each min-height fits one full line: line-height + py-1.5 + borders.
   let sizeClasses = {
-    sm: 'text-p-base rounded-4 min-h-7',
-    md: 'text-p-lg rounded-4 min-h-8',
-    lg: 'text-p-2xl rounded-5 min-h-10',
-    xl: 'text-p-3xl rounded-5 min-h-10',
+    sm: 'text-p-base rounded-4 min-h-9',
+    md: 'text-p-lg rounded-4 min-h-10',
+    lg: 'text-p-2xl rounded-5 min-h-11',
+    xl: 'text-p-3xl rounded-5 min-h-11',
   }[props.size]
 
   let paddingClasses = {

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -114,10 +114,10 @@ const attrsWithoutClassStyle = computed(() => {
 
 const inputClasses = computed(() => {
   let sizeClasses = {
-    sm: 'text-base rounded-4',
-    md: 'text-lg rounded-4',
-    lg: 'text-2xl rounded-5',
-    xl: 'text-3xl rounded-5',
+    sm: 'text-p-base rounded-4 min-h-7',
+    md: 'text-p-lg rounded-4 min-h-8',
+    lg: 'text-p-2xl rounded-5 min-h-10',
+    xl: 'text-p-3xl rounded-5 min-h-10',
   }[props.size]
 
   let paddingClasses = {


### PR DESCRIPTION
## Problem

Reported by jacob@frappe.io in the Raven-frappe-ui channel.

- `Textarea` used the tight `text-*` scale (line-height 1.15). Multi-line text needs the `text-p-*` paragraph scale (line-height ~1.5).
- The textarea had no min-height. The browser resize handle could collapse it to near zero.

## Fix

- Each size keeps its step and moves to the paragraph scale: `text-p-base` / `text-p-lg` / `text-p-2xl` / `text-p-3xl`. The px sizes do not change.
- Radius tokens stay as on `main` (`rounded-4` / `rounded-5`).
- Each size gets a min-height that fits one full line (line-height + `py-1.5` + borders): `min-h-9` / `min-h-10` / `min-h-11` / `min-h-11`.
- The existing size tests now assert the paragraph class, the min-height class, and the computed line-height next to the px checks.

## Out of scope

`Textarea`'s size steps (`base/lg/2xl/3xl`) differ from `TextInput`'s (`base/base/lg/2xl`) on `main`. This PR keeps that as it is; aligning the two scales is a separate decision.

## Verification

Ran `cypress run --component --spec src/components/Textarea/Textarea.cy.ts`. All 19 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1073/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.83% (±0.00% vs `main`)
<!-- coverage-report:end -->
