### PR TITLE
fix(tabs): clip the active pill's shadow to the track

### DIFF
--- a/spec/tabs.md
+++ b/spec/tabs.md
@@ -310,7 +310,10 @@ value input, not a panel switcher. The two share:
 - `data-slot="tab-prefix"`, `data-slot="tab-suffix"` on the trigger regions
 - `data-slot="tab-indicator"` on the sliding indicator, in `TabList` and in
   `TabButtons`. The two are pixel-identical at the same variant, so indicator
-  CSS must reach both with one selector
+  CSS must reach both with one selector. On `subtle` and `ghost` the indicator
+  paints inside a layer clipped to the track, so anything a consumer adds
+  through this hook that reaches past the track edge — a larger shadow, an
+  outline, a scale — is cut there. See the 2026-08-12 changelog entry
 - `TabButtons` names its track `data-slot="tab-buttons"` and its shells
   `data-slot="tab-button"`. The track and shell names differ from `TabList`
   because the roles differ (radiogroup, not tablist); the shared parts —

--- a/spec/tabs.md
+++ b/spec/tabs.md
@@ -375,8 +375,10 @@ value input, not a panel switcher. The two share:
   own component, or the routed items arrived after mount — whether they came
   through `tabs` or through a `v-for` over a resource in composed mode
 - every focusable trigger carries `focus-visible:focus-ring` (P12), and no
-  track may clip it. The subtle track has 1px of padding, so it cannot use
-  `overflow-hidden` — the active pill's shadow spills a little instead
+  track may clip it. The subtle track has 1px of padding, so `overflow-hidden`
+  on the track would cut the outer half of the ring — it never sets it. The
+  active pill's shadow is clipped one layer down instead, by a layer that
+  holds the indicator and nothing else
 - the root never hands the reka primitive an undefined model. reka reads
   that as uncontrolled and starts driving selection itself, which would flip
   `aria-selected` onto a trigger the rest of the component still draws as
@@ -401,6 +403,18 @@ Before/afters live in [`migration.md`](../docs/content/docs/migration.md):
   `#suffix` slot covers trailing content
 
 ## Changelog
+
+### 2026-08-12 (shadow clip)
+
+- **The pill indicator carries its own clip layer.** The track cannot clip its
+  shadow: with 1px of padding, `overflow-hidden` on the track also cuts the
+  outer half of a focused trigger's ring, which is why it was set (2026-08-10,
+  track containment) and then taken back off. The indicator now sits in an
+  `absolute inset-0 overflow-hidden` layer rounded like the track, so
+  `shadow-base` stops at the track edge while the ring, which belongs to the
+  trigger outside that layer, still paints in full. `TabList` and
+  `TabButtons`, both orientations. The layer sets no `data-slot` — it is
+  presentational and must stay restructurable (P10).
 
 ### 2026-08-10 (iconRight removed)
 

--- a/src/components/TabButtons/TabButtons.cy.ts
+++ b/src/components/TabButtons/TabButtons.cy.ts
@@ -39,6 +39,30 @@ describe('<TabButtons />', () => {
     cy.get('[data-slot="tab-button"]').should('have.length', 2)
   })
 
+  it('clips the pill indicator so its shadow stops at the track', () => {
+    cy.mount(TabButtons, {
+      props: {
+        options: [
+          { label: 'Day', value: 'day' },
+          { label: 'Week', value: 'week' },
+        ],
+        modelValue: 'day',
+        variant: 'subtle',
+      },
+    })
+
+    // The track can't clip: it would cut a focused trigger's ring too. The
+    // layer holding the indicator does it instead.
+    cy.get('[data-slot="tab-buttons"]').should(
+      'not.have.css',
+      'overflow',
+      'hidden',
+    )
+    cy.get('[data-slot="tab-indicator"]')
+      .parent()
+      .should('have.css', 'overflow', 'hidden')
+  })
+
   it('does not double-call button click handlers', () => {
     const onClick = cy.spy().as('onClick')
 

--- a/src/components/TabButtons/TabButtons.cy.ts
+++ b/src/components/TabButtons/TabButtons.cy.ts
@@ -61,6 +61,16 @@ describe('<TabButtons />', () => {
     cy.get('[data-slot="tab-indicator"]')
       .parent()
       .should('have.css', 'overflow', 'hidden')
+
+    // Square corners would clip the edges and leave the corners bleeding,
+    // which is the bug. The layer has to round like the track.
+    cy.get('[data-slot="tab-buttons"]').then(($track) => {
+      const radius = getComputedStyle($track[0]).borderRadius
+      expect(radius, 'track radius').not.to.equal('0px')
+      cy.get('[data-slot="tab-indicator"]')
+        .parent()
+        .should('have.css', 'border-radius', radius)
+    })
   })
 
   it('does not double-call button click handlers', () => {

--- a/src/components/TabButtons/TabButtons.vue
+++ b/src/components/TabButtons/TabButtons.vue
@@ -313,12 +313,10 @@ function tabElementProps(button: (typeof resolvedButtons.value)[number]) {
     v-bind="$attrs"
   >
     <div ref="trackRef" data-slot="tab-buttons" :class="rootClasses">
-      <div
-        v-if="pillTrack"
-        aria-hidden="true"
-        data-slot="tab-indicator-clip"
-        :class="indicatorClipClasses"
-      >
+      <!-- Presentational clip layer, deliberately without a `data-slot`: it
+           carries no contract, it only stops the indicator's shadow at the
+           track edge. -->
+      <div v-if="pillTrack" aria-hidden="true" :class="indicatorClipClasses">
         <div
           data-slot="tab-indicator"
           :class="indicatorClasses"

--- a/src/components/TabButtons/TabButtons.vue
+++ b/src/components/TabButtons/TabButtons.vue
@@ -14,6 +14,7 @@ import Pill from '../shared/tabs/Pill.vue'
 import { NativeAnchor, NativeButton } from '../shared/nativeElements'
 import {
   browserTabCardClasses,
+  tabIndicatorClipClasses,
   tabIndicatorMotionClasses,
   tabIndicatorSurfaceClasses,
   tabRadiusClasses,
@@ -240,6 +241,11 @@ const browserCardBase = computed<BrowserTabBase>(() =>
   props.vertical ? props.side : 'default',
 )
 
+// Layer that clips the pill indicator's shadow to the track's rounded box.
+const indicatorClipClasses = computed(() =>
+  tabIndicatorClipClasses(props.variant, props.size),
+)
+
 const indicatorClasses = computed(() => [
   'pointer-events-none absolute left-0 top-0 motion-reduce:transition-none',
   indicatorAnimated.value &&
@@ -308,7 +314,19 @@ function tabElementProps(button: (typeof resolvedButtons.value)[number]) {
   >
     <div ref="trackRef" data-slot="tab-buttons" :class="rootClasses">
       <div
-        v-if="hasIndicator"
+        v-if="pillTrack"
+        aria-hidden="true"
+        data-slot="tab-indicator-clip"
+        :class="indicatorClipClasses"
+      >
+        <div
+          data-slot="tab-indicator"
+          :class="indicatorClasses"
+          :style="indicatorStyle"
+        />
+      </div>
+      <div
+        v-else-if="hasIndicator"
         aria-hidden="true"
         data-slot="tab-indicator"
         :class="indicatorClasses"

--- a/src/components/Tabs/TabList.vue
+++ b/src/components/Tabs/TabList.vue
@@ -3,6 +3,7 @@ import { computed, inject, provide } from 'vue'
 import { TabsIndicator, TabsList } from 'reka-ui'
 import {
   browserTabCardClasses,
+  tabIndicatorClipClasses,
   tabIndicatorInsetClasses,
   tabIndicatorMotionClasses,
   tabIndicatorSurfaceClasses,
@@ -65,6 +66,11 @@ const indicatorClasses = computed(() =>
     : 'left-0 bottom-0 h-px w-[--reka-tabs-indicator-size] translate-x-[--reka-tabs-indicator-position] translate-y-px transition-[width,transform]',
 )
 
+// Layer that clips the pill indicator's shadow to the track's rounded box.
+const indicatorClipClasses = computed(() =>
+  tabIndicatorClipClasses(props.variant, props.size),
+)
+
 // Sliding active-pill surface for subtle/ghost: rides behind the triggers,
 // which never paint an active background themselves, and carries the
 // background + shadow between selections.
@@ -118,13 +124,18 @@ defineSlots<{
       <div class="size-full bg-[var(--outline-gray-8)]" />
     </TabsIndicator>
 
-    <TabsIndicator
+    <div
       v-if="pillTrack"
       aria-hidden="true"
-      data-slot="tab-indicator"
-      class="pointer-events-none absolute -z-10 motion-reduce:transition-none"
-      :class="[pillIndicatorClasses, tabIndicatorMotionClasses]"
-    />
+      data-slot="tab-indicator-clip"
+      :class="indicatorClipClasses"
+    >
+      <TabsIndicator
+        data-slot="tab-indicator"
+        class="pointer-events-none absolute -z-10 motion-reduce:transition-none"
+        :class="[pillIndicatorClasses, tabIndicatorMotionClasses]"
+      />
+    </div>
 
     <TabsIndicator
       v-if="browserTrack"

--- a/src/components/Tabs/TabList.vue
+++ b/src/components/Tabs/TabList.vue
@@ -124,12 +124,10 @@ defineSlots<{
       <div class="size-full bg-[var(--outline-gray-8)]" />
     </TabsIndicator>
 
-    <div
-      v-if="pillTrack"
-      aria-hidden="true"
-      data-slot="tab-indicator-clip"
-      :class="indicatorClipClasses"
-    >
+    <!-- Presentational clip layer, deliberately without a `data-slot`: it
+         carries no contract, it only stops the indicator's shadow at the
+         track edge. -->
+    <div v-if="pillTrack" aria-hidden="true" :class="indicatorClipClasses">
       <TabsIndicator
         data-slot="tab-indicator"
         class="pointer-events-none absolute -z-10 motion-reduce:transition-none"

--- a/src/components/Tabs/Tabs.cy.ts
+++ b/src/components/Tabs/Tabs.cy.ts
@@ -37,8 +37,13 @@ describe('Tabs', () => {
       slots: {
         'tab-prefix': ({ tab }: { tab: (typeof items)[number] }) =>
           h('span', `[${tab.value}`),
-        'tab-label': ({ tab, selected }: { tab: (typeof items)[number]; selected: boolean }) =>
-          h('span', `${tab.label}${selected ? '*' : ''}`),
+        'tab-label': ({
+          tab,
+          selected,
+        }: {
+          tab: (typeof items)[number]
+          selected: boolean
+        }) => h('span', `${tab.label}${selected ? '*' : ''}`),
         'tab-suffix': () => h('span', ']'),
         'tab-panel': ({ tab }: { tab: (typeof items)[number] }) =>
           h('div', `${tab.label} content`),
@@ -55,6 +60,21 @@ describe('Tabs', () => {
     // must be able to target both with one selector (P10).
     cy.mount(Tabs, { props: { tabs: items, variant: 'subtle' } })
     cy.get('[data-slot="tab-list"] [data-slot="tab-indicator"]').should('exist')
+  })
+
+  it('clips the pill indicator so its shadow stops at the track', () => {
+    cy.mount(Tabs, { props: { tabs: items, variant: 'subtle' } })
+
+    // The track can't clip: it would cut a focused trigger's ring too. The
+    // layer holding the indicator does it instead.
+    cy.get('[data-slot="tab-list"]').should(
+      'not.have.css',
+      'overflow',
+      'hidden',
+    )
+    cy.get('[data-slot="tab-indicator"]')
+      .parent()
+      .should('have.css', 'overflow', 'hidden')
   })
 
   it('renders vertically', () => {
@@ -292,9 +312,7 @@ describe('Tabs', () => {
         {
           path: '/settings/billing',
           component: { template: '<router-view />' },
-          children: [
-            { path: 'history', component: { template: '<div />' } },
-          ],
+          children: [{ path: 'history', component: { template: '<div />' } }],
         },
       ],
     })
@@ -358,7 +376,11 @@ describe('Tabs', () => {
           },
           () => [
             h(TabList, { variant: 'underline' }, () => [
-              h(TabTrigger, { value: 'inbox', label: 'Inbox', route: '/inbox' }),
+              h(TabTrigger, {
+                value: 'inbox',
+                label: 'Inbox',
+                route: '/inbox',
+              }),
               h(TabTrigger, { value: 'sent', label: 'Sent', route: '/sent' }),
             ]),
           ],
@@ -966,9 +988,10 @@ describe('Tabs', () => {
       })
 
     cy.get('[data-slot="tab-list"]').should(($list) => {
-      expect(getComputedStyle($list[0]).overflow, 'track overflow').to.not.equal(
-        'hidden',
-      )
+      expect(
+        getComputedStyle($list[0]).overflow,
+        'track overflow',
+      ).to.not.equal('hidden')
     })
   })
 
@@ -994,7 +1017,11 @@ describe('Tabs', () => {
           { modelValue: 'inbox', 'onUpdate:modelValue': onUpdate },
           () => [
             h(TabList, { variant: 'underline' }, () => [
-              h(TabTrigger, { value: 'inbox', label: 'Inbox', route: '/inbox' }),
+              h(TabTrigger, {
+                value: 'inbox',
+                label: 'Inbox',
+                route: '/inbox',
+              }),
               h(TabTrigger, { value: 'sent', label: 'Sent', route: '/sent' }),
             ]),
           ],
@@ -1208,7 +1235,11 @@ describe('Tabs', () => {
           },
           () => [
             h(TabList, { variant: 'underline' }, () => [
-              h(TabTrigger, { value: 'inbox', label: 'Inbox', route: '/inbox' }),
+              h(TabTrigger, {
+                value: 'inbox',
+                label: 'Inbox',
+                route: '/inbox',
+              }),
               h(TabTrigger, { value: 'sent', label: 'Sent', route: '/sent' }),
             ]),
           ],
@@ -1238,9 +1269,10 @@ describe('Tabs', () => {
     })
 
     cy.get('[data-slot="tab-list"]').should(($list) => {
-      expect(getComputedStyle($list[0]).borderRightWidth, 'right rail').to.not.equal(
-        '0px',
-      )
+      expect(
+        getComputedStyle($list[0]).borderRightWidth,
+        'right rail',
+      ).to.not.equal('0px')
     })
   })
 })

--- a/src/components/Tabs/Tabs.cy.ts
+++ b/src/components/Tabs/Tabs.cy.ts
@@ -75,6 +75,16 @@ describe('Tabs', () => {
     cy.get('[data-slot="tab-indicator"]')
       .parent()
       .should('have.css', 'overflow', 'hidden')
+
+    // Square corners would clip the edges and leave the corners bleeding,
+    // which is the bug. The layer has to round like the track.
+    cy.get('[data-slot="tab-list"]').then(($track) => {
+      const radius = getComputedStyle($track[0]).borderRadius
+      expect(radius, 'track radius').not.to.equal('0px')
+      cy.get('[data-slot="tab-indicator"]')
+        .parent()
+        .should('have.css', 'border-radius', radius)
+    })
   })
 
   it('renders vertically', () => {
@@ -823,6 +833,33 @@ describe('Tabs', () => {
       })
     })
   }
+
+  it('slides the subtle pill onto the selected trigger', () => {
+    // The pill sits in a clip layer, so reka positions it from a containing
+    // block that is not the tablist. The layer's box matches the tablist's
+    // padding box, but a drift there would be invisible without this.
+    cy.mount(Tabs, { props: { tabs: shiftTabs, variant: 'subtle' } })
+
+    cy.get('[role=tab]').eq(2).click()
+    cy.get('[role=tab]').eq(2).should('have.attr', 'aria-selected', 'true')
+
+    // Retries until the 200ms slide settles. The indicator covers the
+    // trigger's box (reka measures integer offsets, so allow 1px).
+    cy.get('[role=tablist]').should(($list) => {
+      const indicator = $list[0].querySelector<HTMLElement>(
+        '[data-slot="tab-indicator"]',
+      )
+      expect(indicator, 'indicator').to.exist
+      const ir = indicator!.getBoundingClientRect()
+      const tr = $list[0]
+        .querySelectorAll<HTMLElement>('[role=tab]')[2]
+        .getBoundingClientRect()
+      expect(ir.x, 'x').to.be.closeTo(tr.x, 1)
+      expect(ir.width, 'width').to.be.closeTo(tr.width, 1)
+      expect(ir.y, 'y').to.be.closeTo(tr.y, 1)
+      expect(ir.height, 'height').to.be.closeTo(tr.height, 1)
+    })
+  })
 
   it('slides the browser-tab indicator card onto the selected trigger', () => {
     cy.mount(Tabs, {

--- a/src/components/shared/tabs/styles.ts
+++ b/src/components/shared/tabs/styles.ts
@@ -77,8 +77,9 @@ export function tabIndicatorSurfaceClasses(
 }
 
 /**
- * Track radius, one step outside the trigger radius: 8px at sm, 10px at md
- * (subtle) or 12px (`rounded-5`, ghost md). The track and the indicator's
+ * Track radius, one step outside the trigger radius: 8px at sm, 10px at md.
+ * Subtle md keeps its literal (a deliberate Figma override) where ghost md
+ * uses `rounded-5`; both land on 10px today. The track and the indicator's
  * clip layer both read it here, so the clip can't drift off the track's own
  * rounded box.
  */

--- a/src/components/shared/tabs/styles.ts
+++ b/src/components/shared/tabs/styles.ts
@@ -34,12 +34,14 @@ export function tabTrackClasses(opts: {
       // `tabIndicatorClipClasses`.
       return [
         'bg-surface-gray-2',
-        isSm ? 'gap-1 rounded-4 p-px' : 'gap-1.5 rounded-[10px] p-px',
+        isSm ? 'gap-1 p-px' : 'gap-1.5 p-px',
+        tabTrackRadiusClasses(variant, size),
       ]
     case 'ghost':
       return [
         'bg-surface-base',
-        isSm ? 'gap-1 rounded-4 p-px' : 'gap-1.5 rounded-5 p-0.5',
+        isSm ? 'gap-1 p-px' : 'gap-1.5 p-0.5',
+        tabTrackRadiusClasses(variant, size),
       ]
     case 'underline':
       return vertical
@@ -76,7 +78,9 @@ export function tabIndicatorSurfaceClasses(
 
 /**
  * Track radius, one step outside the trigger radius: 8px at sm, 10px at md
- * (subtle) or 12px (`rounded-5`, ghost md).
+ * (subtle) or 12px (`rounded-5`, ghost md). The track and the indicator's
+ * clip layer both read it here, so the clip can't drift off the track's own
+ * rounded box.
  */
 export function tabTrackRadiusClasses(
   variant: TabsVariant,

--- a/src/components/shared/tabs/styles.ts
+++ b/src/components/shared/tabs/styles.ts
@@ -28,10 +28,10 @@ export function tabTrackClasses(opts: {
     case 'subtle':
       // Shipped v1 geometry (overrides Figma): 1px padding at both sizes,
       // 10px radius at md.
-      // No `overflow-hidden`: with 1px of padding it also clipped the outer
-      // half of a focused trigger's 2px ring, and a clipped focus ring is a
-      // worse defect than the active pill's shadow spilling a pixel or two
-      // past the track edge.
+      // No `overflow-hidden` on the track itself: with 1px of padding it also
+      // clips the outer half of a focused trigger's 2px ring. The indicator's
+      // shadow is clipped one layer down instead — see
+      // `tabIndicatorClipClasses`.
       return [
         'bg-surface-gray-2',
         isSm ? 'gap-1 rounded-4 p-px' : 'gap-1.5 rounded-[10px] p-px',
@@ -71,6 +71,35 @@ export function tabIndicatorSurfaceClasses(
       ? 'bg-surface-gray-2'
       : 'bg-surface-elevation-3 shadow-base',
     tabRadiusClasses(variant, size),
+  ]
+}
+
+/**
+ * Track radius, one step outside the trigger radius: 8px at sm, 10px at md
+ * (subtle) or 12px (`rounded-5`, ghost md).
+ */
+export function tabTrackRadiusClasses(
+  variant: TabsVariant,
+  size: TabsSize,
+): string {
+  if (size === 'sm') return 'rounded-4'
+  return variant === 'ghost' ? 'rounded-5' : 'rounded-[10px]'
+}
+
+/**
+ * Clip layer for the sliding pill indicator (subtle/ghost). The track can't
+ * carry `overflow-hidden` itself — it would clip the outer half of a focused
+ * trigger's 2px ring too. A layer that holds only the indicator keeps both:
+ * the active pill's shadow stops at the track edge, the ring still paints.
+ * Matches the track's own box, so the shadow is cut on the same rounded rect.
+ */
+export function tabIndicatorClipClasses(
+  variant: TabsVariant,
+  size: TabsSize,
+): string[] {
+  return [
+    'pointer-events-none absolute inset-0 overflow-hidden',
+    tabTrackRadiusClasses(variant, size),
   ]
 }
 


### PR DESCRIPTION
The sliding pill indicator's `shadow-base` paints past the subtle track's rounded edges: 5px of blur in light, 14px in dark.

### Why the track can't just clip

`de61b6f5` removed `overflow-hidden` from the subtle track on purpose. With 1px of padding it also clipped the outer half of a focused trigger's 2px ring, and a clipped focus ring is the worse defect. Putting it back would trade one bug for the other.

### Fix

The indicator now rides in its own clip layer — `absolute inset-0 overflow-hidden`, rounded like the track. The shadow is cut on the track's own rounded rect. The focus ring belongs to the trigger, which sits outside that layer, so it still paints in full.

Both tracks in the family get it: `TabList` (Tabs) and `TabButtons`, horizontal and vertical. `underline` and `browser-tab` indicators are untouched — they paint outside the track by design.

### Before / after

Subtle track, light and dark, horizontal and vertical.

| Before | After |
| --- | --- |
| <img width="600" src="https://md.netchamp.dev/frappe-ui-pr-1075/before.png"> | <img width="600" src="https://md.netchamp.dev/frappe-ui-pr-1075/after.png"> |

Shadow bleeding past the track corner, 20x zoom. Light:

| Before | After |
| --- | --- |
| <img width="420" src="https://md.netchamp.dev/frappe-ui-pr-1075/zoom-before.png"> | <img width="420" src="https://md.netchamp.dev/frappe-ui-pr-1075/zoom-after.png"> |

Dark, where the blur is 14px:

| Before | After |
| --- | --- |
| <img width="420" src="https://md.netchamp.dev/frappe-ui-pr-1075/dark-before.png"> | <img width="420" src="https://md.netchamp.dev/frappe-ui-pr-1075/dark-after.png"> |

The focus ring the earlier commit protected, still unclipped on the middle trigger (TabButtons horizontal, TabButtons vertical, TabList):

<img width="420" src="https://md.netchamp.dev/frappe-ui-pr-1075/focus-ring.png">

### Testing

- `cypress run --component` on `TabButtons.cy.ts`, `Tabs.cy.ts`, `Tabs.resizeobserver.cy.ts` — 55 passing.
- `vitest --run src/components/Tabs` — 1 passing.
- `vue-tsc` reports no error in the three touched files.
- Visual sweep of all four variants in both orientations: no shift in `ghost`, `underline`, or `browser-tab`.

### Not done

- The shadow itself is paint-only and not assertable. The specs assert the structure that produces it — the track must not clip, the layer holding the indicator must, and its radius must equal the track's — and both assertions were checked to fail when the fix is removed. The screenshots are the evidence for the paint.
- The ghost track gets the same clip layer, though its indicator carries no shadow. One code path for both pill tracks.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1075/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.88% (-0.01% vs `main`)
<!-- coverage-report:end -->





