### PR TITLE
fix(labeling): name and describe from slots, and drop aria-required where the role forbids it

### DIFF
--- a/experimental/CodeEditor/CodeEditor.api.md
+++ b/experimental/CodeEditor/CodeEditor.api.md
@@ -54,7 +54,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/experimental/CodeEditor/CodeEditor.api.md
+++ b/experimental/CodeEditor/CodeEditor.api.md
@@ -66,7 +66,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/experimental/CodeEditor/CodeEditor.api.md
+++ b/experimental/CodeEditor/CodeEditor.api.md
@@ -66,7 +66,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/experimental/CodeEditor/CodeEditor.vue
+++ b/experimental/CodeEditor/CodeEditor.vue
@@ -89,6 +89,7 @@ const {
   hasError,
   errorLines,
   showDescription,
+  rendersDescription,
   dataAttrs,
 } = useInputLabeling(props, {
   size: () => props.size,
@@ -102,11 +103,7 @@ const {
 // it — otherwise the editor mounts bare, preserving the primitive's footprint.
 const hasLabeling = computed(() =>
   Boolean(
-    props.label ||
-    slots.label ||
-    showDescription.value ||
-    slots.description ||
-    hasError.value,
+    props.label || slots.label || rendersDescription.value || hasError.value,
   ),
 )
 

--- a/experimental/CodeEditor/CodeEditor.vue
+++ b/experimental/CodeEditor/CodeEditor.vue
@@ -94,6 +94,8 @@ const {
   size: () => props.size,
   variant: () => props.variant,
   disabled: () => props.disabled,
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 // Render the labeling chrome (and its wrapping div) only when something needs

--- a/experimental/MultiEmailInput/MultiEmailInput.vue
+++ b/experimental/MultiEmailInput/MultiEmailInput.vue
@@ -90,6 +90,8 @@ const {
 } = useInputLabeling(props, {
   size: () => props.size,
   disabled: () => props.disabled,
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 const hasLabeling = computed(() =>

--- a/src/components/Avatar/Avatar.cy.ts
+++ b/src/components/Avatar/Avatar.cy.ts
@@ -65,7 +65,6 @@ describe('Avatar', () => {
       .and('have.class', 'text-ink-blue-7')
   })
 
-
   it('keeps the size enum when the class only sizes at a breakpoint', () => {
     // Tailwind emits variant utilities after the base ones, so `sm:size-16`
     // wins at `sm` on its own. Dropping the enum for it left the avatar

--- a/src/components/Avatar/Avatar.cy.ts
+++ b/src/components/Avatar/Avatar.cy.ts
@@ -65,4 +65,21 @@ describe('Avatar', () => {
       .and('have.class', 'text-ink-blue-7')
   })
 
+
+  it('keeps the size enum when the class only sizes at a breakpoint', () => {
+    // Tailwind emits variant utilities after the base ones, so `sm:size-16`
+    // wins at `sm` on its own. Dropping the enum for it left the avatar
+    // unsized below `sm`, and this root is inline-block.
+    cy.mount(Avatar, {
+      props: { 'data-cy': 'avatar', label: 'Abc', size: 'md' },
+      attrs: { class: 'sm:size-16' },
+    })
+    cy.get('[data-cy="avatar"]').should('have.class', 'w-6')
+
+    cy.mount(Avatar, {
+      props: { 'data-cy': 'avatar-plain', label: 'Abc', size: 'md' },
+      attrs: { class: 'size-16' },
+    })
+    cy.get('[data-cy="avatar-plain"]').should('not.have.class', 'w-6')
+  })
 })

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -63,8 +63,13 @@ const fallbackThemeClasses = computed(() => {
 // Let a consumer size the avatar with a Tailwind utility (`class="size-16"`)
 // instead of the `size` prop enum. When a sizing utility is present we drop the
 // enum's `w-*/h-*` so the two don't both land on the root and fight; the class
-// (applied via inheritAttrs) then wins on its own. Handles responsive/variant
-// prefixes like `sm:size-16`.
+// (applied via inheritAttrs) then wins on its own.
+//
+// Unprefixed tokens only. Tailwind emits variant utilities after the base ones,
+// so `size-8 sm:size-16` already resolves the consumer's way at `sm`. Dropping
+// the enum for a prefixed token instead leaves the avatar unsized everywhere
+// the variant does not apply, and this root is `inline-block`, so it collapses
+// to its content: an image-only avatar becomes 0x0.
 const attrs = useAttrs()
 const hasSizeOverride = computed(() => {
   const cls = Array.isArray(attrs.class)
@@ -72,12 +77,13 @@ const hasSizeOverride = computed(() => {
     : typeof attrs.class === 'string'
       ? attrs.class
       : ''
-  return cls.split(/\s+/).some((token) => {
-    const base = token.includes(':')
-      ? token.slice(token.lastIndexOf(':') + 1)
-      : token
-    return /^-?(size|w|h|min-w|max-w|min-h|max-h)-/.test(base)
-  })
+  return cls
+    .split(/\s+/)
+    .some(
+      (token) =>
+        !token.includes(':') &&
+        /^-?(size|w|h|min-w|max-w|min-h|max-h)-/.test(token),
+    )
 })
 
 const shapeClasses = computed(() => {

--- a/src/components/Checkbox/Checkbox.api.md
+++ b/src/components/Checkbox/Checkbox.api.md
@@ -52,7 +52,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Checkbox/Checkbox.api.md
+++ b/src/components/Checkbox/Checkbox.api.md
@@ -40,7 +40,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/Checkbox/Checkbox.api.md
+++ b/src/components/Checkbox/Checkbox.api.md
@@ -52,7 +52,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Checkbox/Checkbox.cy.ts
+++ b/src/components/Checkbox/Checkbox.cy.ts
@@ -197,6 +197,21 @@ describe('Checkbox', () => {
         .should('not.have.class', 'h-7')
         .and('have.class', 'py-1.5')
     })
+
+    it('grows the surface for a #description slot too', () => {
+      // The row height follows the same thing the wrapper does. Reading the
+      // prop alone kept the compact fixed height and the description
+      // overflowed it.
+      cy.mount(Checkbox, {
+        props: { label: 'abc', padded: true },
+        slots: { description: () => h('span', 'helper') },
+      })
+      cy.get('[data-slot="control"]')
+        .parent()
+        .parent()
+        .should('not.have.class', 'h-7')
+        .and('have.class', 'py-1.5')
+    })
   })
 
   describe('size', () => {

--- a/src/components/Checkbox/Checkbox.cy.ts
+++ b/src/components/Checkbox/Checkbox.cy.ts
@@ -70,6 +70,21 @@ describe('Checkbox', () => {
   })
 
   describe('shared labeling contract', () => {
+    it('describes the input from a #description slot alone', () => {
+      // The wrapper around the description is its own `v-if` here, so it has to
+      // count the slot too. Without that, `aria-describedby` names an id that
+      // never mounts.
+      cy.mount(Checkbox, {
+        props: { label: 'Accept' },
+        slots: { description: () => h('span', 'Required to continue.') },
+      })
+      cy.get('input')
+        .invoke('attr', 'aria-describedby')
+        .then((id) => {
+          cy.get(`#${id}`).should('contain.text', 'Required to continue.')
+        })
+    })
+
     it('wires aria-describedby and aria-errormessage', () => {
       cy.mount(Checkbox, {
         props: { label: 'Accept', description: 'Required to continue.' },

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -104,6 +104,7 @@ const {
   hasError,
   errorLines,
   showDescription,
+  rendersDescription,
   dataAttrs,
 } = useInputLabeling(props, {
   size: () => props.size,
@@ -132,8 +133,7 @@ const containerClasses = computed(() => {
   if (!props.padded) return undefined
   // A description or error makes the surface multi-line, so it grows with
   // vertical padding instead of the fixed compact height used for label-only rows.
-  const hasDetail =
-    showDescription.value || hasError.value || !!slots.description
+  const hasDetail = rendersDescription.value || hasError.value
   const sizeClass = hasDetail
     ? props.size === 'md'
       ? 'px-3 py-2'

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -38,7 +38,10 @@
         </template>
       </InputLabel>
     </div>
-    <div v-if="showDescription || hasError" class="ps-[1.35rem] mt-1">
+    <div
+      v-if="showDescription || hasError || $slots.description"
+      class="ps-[1.35rem] mt-1"
+    >
       <InputDescription
         v-if="showDescription || $slots.description"
         :id="descriptionId"

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -132,7 +132,8 @@ const containerClasses = computed(() => {
   if (!props.padded) return undefined
   // A description or error makes the surface multi-line, so it grows with
   // vertical padding instead of the fixed compact height used for label-only rows.
-  const hasDetail = showDescription.value || hasError.value
+  const hasDetail =
+    showDescription.value || hasError.value || !!slots.description
   const sizeClass = hasDetail
     ? props.size === 'md'
       ? 'px-3 py-2'

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, useAttrs, watchEffect } from 'vue'
+import { computed, ref, useAttrs, watchEffect, useSlots } from 'vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
@@ -90,6 +90,8 @@ defineSlots<{
   description?: () => any
 }>()
 
+const slots = useSlots()
+
 const {
   inputId,
   labelId,
@@ -109,6 +111,8 @@ const {
       : checked.value
         ? 'checked'
         : 'unchecked',
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 const labelClasses = computed(() => {

--- a/src/components/Combobox/Combobox.api.md
+++ b/src/components/Combobox/Combobox.api.md
@@ -157,7 +157,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Combobox/Combobox.api.md
+++ b/src/components/Combobox/Combobox.api.md
@@ -145,7 +145,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/Combobox/Combobox.api.md
+++ b/src/components/Combobox/Combobox.api.md
@@ -157,7 +157,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -116,6 +116,8 @@ const {
   size: () => props.size,
   variant: () => props.variant,
   disabled: () => props.disabled,
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 const hasLabeling = computed(() => {

--- a/src/components/DatePicker/DatePicker.api.md
+++ b/src/components/DatePicker/DatePicker.api.md
@@ -141,7 +141,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },
@@ -338,7 +338,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },
@@ -535,7 +535,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/DatePicker/DatePicker.api.md
+++ b/src/components/DatePicker/DatePicker.api.md
@@ -141,7 +141,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },
@@ -338,7 +338,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },
@@ -535,7 +535,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/DatePicker/DatePicker.api.md
+++ b/src/components/DatePicker/DatePicker.api.md
@@ -129,7 +129,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },
@@ -326,7 +326,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },
@@ -523,7 +523,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/Duration/Duration.api.md
+++ b/src/components/Duration/Duration.api.md
@@ -64,7 +64,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Duration/Duration.api.md
+++ b/src/components/Duration/Duration.api.md
@@ -64,7 +64,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Duration/Duration.api.md
+++ b/src/components/Duration/Duration.api.md
@@ -52,7 +52,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/MultiSelect/MultiSelect.api.md
+++ b/src/components/MultiSelect/MultiSelect.api.md
@@ -136,7 +136,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/MultiSelect/MultiSelect.api.md
+++ b/src/components/MultiSelect/MultiSelect.api.md
@@ -124,7 +124,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/MultiSelect/MultiSelect.api.md
+++ b/src/components/MultiSelect/MultiSelect.api.md
@@ -136,7 +136,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -97,6 +97,8 @@ const {
   size: () => props.size,
   variant: () => props.variant,
   disabled: () => props.disabled,
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 const hasLabeling = computed(() => {

--- a/src/components/Password/Password.api.md
+++ b/src/components/Password/Password.api.md
@@ -51,7 +51,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Password/Password.api.md
+++ b/src/components/Password/Password.api.md
@@ -39,7 +39,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/Password/Password.api.md
+++ b/src/components/Password/Password.api.md
@@ -51,7 +51,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Radio/Radio.api.md
+++ b/src/components/Radio/Radio.api.md
@@ -119,7 +119,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Radio/Radio.api.md
+++ b/src/components/Radio/Radio.api.md
@@ -26,7 +26,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },
@@ -107,7 +107,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/Radio/Radio.api.md
+++ b/src/components/Radio/Radio.api.md
@@ -119,7 +119,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Radio/Radio.cy.ts
+++ b/src/components/Radio/Radio.cy.ts
@@ -1,4 +1,4 @@
-import { h } from 'vue'
+import { defineComponent, h, ref } from 'vue'
 import Radio from './Radio.vue'
 import RadioGroup from './RadioGroup.vue'
 
@@ -269,6 +269,56 @@ describe('Radio', () => {
         },
       ])
       expectCentredOnFirstLine()
+    })
+  })
+
+  describe('shared labeling contract', () => {
+    it('tracks a #description slot that toggles', () => {
+      // `useSlots()` returns an object Vue mutates in place and does not
+      // track, so a `computed` reading it caches. Without an invalidation the
+      // reference is wrong in both directions: added, the paragraph renders
+      // and nothing points at it; removed, the reference outlives it.
+      cy.mount(
+        defineComponent({
+          setup() {
+            return { show: ref(false) }
+          },
+          render() {
+            return [
+              h(
+                'button',
+                {
+                  'data-cy': 'toggle',
+                  onClick: () => (this.show = !this.show),
+                },
+                'toggle',
+              ),
+              h(
+                RadioGroup,
+                { label: 'Plan', options: [{ value: 'a', label: 'A' }] },
+                this.show
+                  ? { description: () => h('span', 'Helper text.') }
+                  : {},
+              ),
+            ]
+          },
+        }),
+      )
+
+      cy.get('[role="radiogroup"]').should('not.have.attr', 'aria-describedby')
+
+      cy.get('[data-cy=toggle]').click()
+      cy.get('[role="radiogroup"]')
+        .invoke('attr', 'aria-describedby')
+        .then((id) => {
+          expect(id, 'slot added, reference set').to.be.a('string')
+          cy.get(`#${id}`).should('contain.text', 'Helper text.')
+        })
+
+      cy.get('[data-cy=toggle]').click()
+      // The dangling half: a reference kept past its element fails
+      // `aria-valid-attr-value`.
+      cy.get('[role="radiogroup"]').should('not.have.attr', 'aria-describedby')
     })
   })
 

--- a/src/components/Radio/RadioGroup.vue
+++ b/src/components/Radio/RadioGroup.vue
@@ -21,7 +21,7 @@
       :required="props.required"
       :orientation="props.orientation"
       :loop="props.loop"
-      :aria-labelledby="props.label || $slots.label ? labelId : undefined"
+      :aria-labelledby="labelledBy"
       :aria-describedby="describedBy"
       :aria-invalid="hasError || undefined"
       :aria-errormessage="hasError ? errorMessageId : undefined"
@@ -87,6 +87,7 @@ const {
   labelId,
   descriptionId,
   errorMessageId,
+  labelledBy,
   describedBy,
   hasError,
   errorLines,

--- a/src/components/Radio/RadioGroup.vue
+++ b/src/components/Radio/RadioGroup.vue
@@ -95,6 +95,8 @@ const {
 } = useInputLabeling(props, {
   size: () => props.size,
   disabled: () => props.disabled,
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 // The group owns the layout so options never have to space themselves. Padded

--- a/src/components/Rating/Rating.api.md
+++ b/src/components/Rating/Rating.api.md
@@ -54,7 +54,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/Rating/Rating.api.md
+++ b/src/components/Rating/Rating.api.md
@@ -66,7 +66,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Rating/Rating.api.md
+++ b/src/components/Rating/Rating.api.md
@@ -66,7 +66,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Rating/Rating.cy.ts
+++ b/src/components/Rating/Rating.cy.ts
@@ -264,6 +264,32 @@ describe('Rating', () => {
       })
     })
 
+    it('names and describes from the slots alone', () => {
+      // The slots render the same elements the props do, so the references
+      // have to follow what renders rather than what the props say.
+      cy.mount(Rating, {
+        slots: {
+          label: () => h('span', 'Quality'),
+          description: () => h('span', 'Pick a rating.'),
+        },
+      })
+      cy.get('[role="radiogroup"]').then(($el) => {
+        cy.get(`#${$el.attr('aria-labelledby')}`).should('contain.text', 'Quality')
+        cy.get(`#${$el.attr('aria-describedby')}`).should('contain.text', 'Pick a rating.')
+      })
+    })
+
+    it('drops aria-required in slider mode, keeps it for the radiogroup', () => {
+      // The ARIA role table lists aria-required for radiogroup but not for
+      // slider, so a half-step Rating fails aria-allowed-attr if it sets one.
+      cy.mount(Rating, { props: { label: 'Quality', required: true } })
+      cy.get('[role="radiogroup"]').should('have.attr', 'aria-required', 'true')
+
+      cy.mount(Rating, { props: { label: 'Quality', required: true, step: 0.5 } })
+      cy.get('[role="slider"]').should('not.have.attr', 'aria-required')
+      cy.get('[role="slider"]').should('have.attr', 'data-required', 'true')
+    })
+
     it('renders error state and suppresses description', () => {
       cy.mount(Rating, {
         props: {

--- a/src/components/Rating/Rating.vue
+++ b/src/components/Rating/Rating.vue
@@ -25,7 +25,7 @@
       :aria-labelledby="labelledBy"
       :aria-describedby="describedBy"
       :aria-errormessage="hasError ? errorMessageId : undefined"
-      :aria-required="props.required || undefined"
+      :aria-required="!isSliderMode && props.required ? true : undefined"
       :aria-invalid="hasError || undefined"
       :aria-disabled="isDisabled || undefined"
       :aria-orientation="isSliderMode ? 'horizontal' : undefined"

--- a/src/components/Rating/Rating.vue
+++ b/src/components/Rating/Rating.vue
@@ -186,6 +186,8 @@ const {
 } = useInputLabeling(props, {
   size: () => props.size,
   disabled: () => isDisabled.value,
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 const sizeClass = computed(

--- a/src/components/Rating/Rating.vue
+++ b/src/components/Rating/Rating.vue
@@ -182,6 +182,7 @@ const {
   hasError,
   errorLines,
   showDescription,
+  rendersDescription,
   dataAttrs,
 } = useInputLabeling(props, {
   size: () => props.size,
@@ -381,11 +382,7 @@ function onKeydown(e: KeyboardEvent) {
 
 const hasLabeling = computed(() => {
   return Boolean(
-    props.label ||
-    slots.label ||
-    showDescription.value ||
-    slots.description ||
-    hasError.value,
+    props.label || slots.label || rendersDescription.value || hasError.value,
   )
 })
 </script>

--- a/src/components/Select/Select.api.md
+++ b/src/components/Select/Select.api.md
@@ -91,7 +91,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/Select/Select.api.md
+++ b/src/components/Select/Select.api.md
@@ -103,7 +103,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Select/Select.api.md
+++ b/src/components/Select/Select.api.md
@@ -103,7 +103,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -99,6 +99,8 @@ const {
   size: () => props.size,
   variant: () => props.variant,
   disabled: () => props.disabled,
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 const hasLabeling = computed(() => {

--- a/src/components/Slider/Slider.api.md
+++ b/src/components/Slider/Slider.api.md
@@ -60,7 +60,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Slider/Slider.api.md
+++ b/src/components/Slider/Slider.api.md
@@ -60,7 +60,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Slider/Slider.api.md
+++ b/src/components/Slider/Slider.api.md
@@ -48,7 +48,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/Slider/Slider.cy.ts
+++ b/src/components/Slider/Slider.cy.ts
@@ -45,6 +45,25 @@ describe('Slider', () => {
       })
   })
 
+  it('names and describes the control from the slots alone', () => {
+    // reka renders a div for the root, so a native `label for=` never names it.
+    // Without the slot getters the slots left it anonymous.
+    cy.mount(Slider, {
+      props: { modelValue: [25] },
+      slots: {
+        label: () => h('span', 'Volume'),
+        description: () => h('span', 'Adjust it.'),
+      },
+    })
+    cy.get('[role="slider"]').then(($el) => {
+      cy.get(`#${$el.attr('aria-labelledby')}`).should('contain.text', 'Volume')
+      cy.get(`#${$el.attr('aria-describedby')}`).should(
+        'contain.text',
+        'Adjust it.',
+      )
+    })
+  })
+
   it('renders one thumb for a single value', () => {
     cy.mount(Slider, {
       props: {

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -110,6 +110,7 @@ const {
   hasError,
   errorLines,
   showDescription,
+  rendersDescription,
   dataAttrs,
 } = useInputLabeling(props, {
   size: () => props.size,
@@ -205,11 +206,7 @@ function thumbNameFor(index: number): string | undefined {
 // Declared before `rootClasses`, which reads it.
 const hasLabeling = computed(() => {
   return Boolean(
-    props.label ||
-    slots.label ||
-    showDescription.value ||
-    slots.description ||
-    hasError.value,
+    props.label || slots.label || rendersDescription.value || hasError.value,
   )
 })
 

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -113,6 +113,8 @@ const {
 } = useInputLabeling(props, {
   size: () => props.size,
   disabled: () => props.disabled,
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 /** A caller's `aria-labelledby` wins over the id generated from `label`. */

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -104,6 +104,7 @@ const {
   inputId,
   labelId,
   labelledBy,
+  describedBy,
   descriptionId,
   errorMessageId,
   hasError,
@@ -125,10 +126,7 @@ const thumbLabelledBy = computed(() => {
   // reference has to step aside — it would win the name order otherwise and
   // the override would do nothing.
   if (attrs['aria-label']) return undefined
-  // `useInputLabeling` only sees the `label` prop, but the label element also
-  // renders for a `#label` slot. Without this the slot leaves the thumb
-  // unnamed while a `<label>` carrying the name sits right above it.
-  return labelledBy.value ?? (slots.label ? labelId.value : undefined)
+  return labelledBy.value
 })
 
 // reka puts `aria-disabled` on the root but not on the thumb, so without this
@@ -154,14 +152,8 @@ const thumbInvalid = computed(() => {
 // Merged, not replaced: a caller's `aria-describedby` must not drop the
 // generated description and error ids.
 const thumbDescribedBy = computed(() => {
-  // Built from what actually renders, not from `describedBy`: that one only
-  // sees the `description` prop, while `InputDescription` renders for the slot
-  // too — the same hole the `#label` slot had. Order matches `describedBy`.
   const ids = [
-    showDescription.value || slots.description
-      ? descriptionId.value
-      : undefined,
-    hasError.value ? errorMessageId.value : undefined,
+    describedBy.value,
     attrs['aria-describedby'] as string | undefined,
   ]
   const merged = ids.filter(Boolean).join(' ')

--- a/src/components/Switch/Switch.api.md
+++ b/src/components/Switch/Switch.api.md
@@ -58,7 +58,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Switch/Switch.api.md
+++ b/src/components/Switch/Switch.api.md
@@ -58,7 +58,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Switch/Switch.api.md
+++ b/src/components/Switch/Switch.api.md
@@ -46,7 +46,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -104,6 +104,8 @@ const {
   size: () => props.size,
   disabled: () => props.disabled,
   state: () => (model.value ? 'checked' : 'unchecked'),
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 const switchClasses = computed(() => {

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -99,6 +99,7 @@ const {
   hasError,
   errorLines,
   showDescription,
+  rendersDescription,
   dataAttrs,
 } = useInputLabeling(props, {
   size: () => props.size,
@@ -227,8 +228,7 @@ const containerClasses = computed(() => {
   // area — including the corners — drives the control's hover state too.
   // A description or error makes the surface multi-line, so it grows with
   // vertical padding instead of the fixed compact height used for label-only rows.
-  const hasDetail =
-    showDescription.value || hasError.value || !!slots.description
+  const hasDetail = rendersDescription.value || hasError.value
   const sizeClass = hasDetail
     ? props.size === 'md'
       ? 'px-3 py-2'

--- a/src/components/TextInput/TextInput.api.md
+++ b/src/components/TextInput/TextInput.api.md
@@ -70,7 +70,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/TextInput/TextInput.api.md
+++ b/src/components/TextInput/TextInput.api.md
@@ -70,7 +70,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/TextInput/TextInput.api.md
+++ b/src/components/TextInput/TextInput.api.md
@@ -58,7 +58,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/TextInput/TextInput.cy.ts
+++ b/src/components/TextInput/TextInput.cy.ts
@@ -133,6 +133,20 @@ describe('Textinput', () => {
   })
 
   describe('shared labeling contract', () => {
+    it('describes the input from a #description slot alone', () => {
+      // The slot renders the same element the prop does. Keying the reference
+      // off the prop left the paragraph pointed at by nothing.
+      cy.mount(TextInput, {
+        props: { label: 'Email' },
+        slots: { description: () => h('span', 'We never share your email.') },
+      })
+      cy.get('input')
+        .invoke('attr', 'aria-describedby')
+        .then((id) => {
+          cy.get(`#${id}`).should('contain.text', 'We never share')
+        })
+    })
+
     it('renders label, description, and links them via aria-describedby', () => {
       cy.mount(TextInput, {
         props: {

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -131,6 +131,8 @@ const {
   size: () => props.size,
   variant: () => props.variant,
   disabled: () => props.disabled,
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 const hasLabeling = computed(() => {

--- a/src/components/Textarea/Textarea.api.md
+++ b/src/components/Textarea/Textarea.api.md
@@ -70,7 +70,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Textarea/Textarea.api.md
+++ b/src/components/Textarea/Textarea.api.md
@@ -70,7 +70,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/Textarea/Textarea.api.md
+++ b/src/components/Textarea/Textarea.api.md
@@ -58,7 +58,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -89,6 +89,7 @@ const {
   hasError,
   errorLines,
   showDescription,
+  rendersDescription,
   dataAttrs,
 } = useInputLabeling(props, {
   size: () => props.size,
@@ -100,11 +101,7 @@ const {
 
 const hasLabeling = computed(() => {
   return Boolean(
-    props.label ||
-    slots.label ||
-    showDescription.value ||
-    slots.description ||
-    hasError.value,
+    props.label || slots.label || rendersDescription.value || hasError.value,
   )
 })
 

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -94,6 +94,8 @@ const {
   size: () => props.size,
   variant: () => props.variant,
   disabled: () => props.disabled,
+  hasLabelSlot: () => Boolean(slots.label),
+  hasDescriptionSlot: () => Boolean(slots.description),
 })
 
 const hasLabeling = computed(() => {

--- a/src/components/TimePicker/TimePicker.api.md
+++ b/src/components/TimePicker/TimePicker.api.md
@@ -130,7 +130,7 @@
   },
   {
     name: 'description',
-    description: 'Helper text rendered below the input.\nHidden when `error` is set.',
+    description: 'Helper text rendered below the input.\nHidden when `error` is set. A `#description` slot is not: it renders\nbeside the error, and is referenced alongside it.',
     required: false,
     type: 'string'
   },

--- a/src/components/TimePicker/TimePicker.api.md
+++ b/src/components/TimePicker/TimePicker.api.md
@@ -142,7 +142,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where the control\'s role allows\nit. `data-required` is set either way.',
     required: false,
     type: 'boolean'
   },

--- a/src/components/TimePicker/TimePicker.api.md
+++ b/src/components/TimePicker/TimePicker.api.md
@@ -142,7 +142,7 @@
   },
   {
     name: 'required',
-    description: 'Marks the field as required. Renders an asterisk next to the label and\nforwards `required` / `aria-required` to the underlying control.',
+    description: 'Marks the field as required. Renders an asterisk next to the label, with\n`sr-only` text that announces it, and forwards `required` /\n`aria-required` to the underlying control where its role allows it —\n`slider` does not, so Slider and a half-step Rating set neither.',
     required: false,
     type: 'boolean'
   },
@@ -184,11 +184,6 @@
     type: '[]'
   },
   {
-    name: 'update:modelValue',
-    description: 'Fired when the model value changes.',
-    type: '[value: string]'
-  },
-  {
     name: 'update:open',
     description: 'Fired when the open state changes.',
     type: '[value: boolean]'
@@ -196,6 +191,16 @@
   {
     name: 'change',
     description: 'Fired after the value is committed.',
+    type: '[value: string]'
+  },
+  {
+    name: 'close',
+    description: 'Fired when the component closes.',
+    type: '[]'
+  },
+  {
+    name: 'update:modelValue',
+    description: 'Fired when the model value changes.',
     type: '[value: string]'
   },
   {
@@ -207,11 +212,6 @@
     name: 'invalid-change',
     description: '',
     type: '[invalid: boolean]'
-  },
-  {
-    name: 'close',
-    description: 'Fired when the component closes.',
-    type: '[]'
   }
 ]
 </script>

--- a/src/composables/useInputLabeling.ts
+++ b/src/composables/useInputLabeling.ts
@@ -1,4 +1,4 @@
-import { computed } from 'vue'
+import { computed, onBeforeUpdate, shallowRef } from 'vue'
 import { useId } from '../utils/useId'
 import type { InputSize, InputVariant, ToggleSize } from './inputTypes'
 
@@ -99,10 +99,25 @@ export function useInputLabeling(
     return Boolean(props.description) && !hasError.value
   })
 
+  // `useSlots()` returns `instance.slots`, which Vue mutates in place and does
+  // not track. A `computed` reading it caches on first evaluation and never
+  // re-runs, so a slot behind a `v-if` leaves the reference wrong in both
+  // directions: added, the element renders and nothing points at it; removed,
+  // the reference outlives its element and dangles.
+  //
+  // Slot content only ever changes as part of a re-render, and `beforeUpdate`
+  // runs after `updateSlots` and before the render function, so bumping here is
+  // the invalidation those two computeds are missing.
+  const slotTick = shallowRef(0)
+  onBeforeUpdate(() => {
+    slotTick.value++
+  })
+
   // Both of these follow what actually renders, not what the props say. A
   // `#label` or `#description` slot renders the same element the prop does, so
   // keying off the prop alone paints an element that nothing points at.
   const rendersDescription = computed(() => {
+    slotTick.value
     return showDescription.value || Boolean(options.hasDescriptionSlot?.())
   })
 
@@ -114,6 +129,7 @@ export function useInputLabeling(
   })
 
   const labelledBy = computed(() => {
+    slotTick.value
     return props.label || options.hasLabelSlot?.() ? labelId.value : undefined
   })
 
@@ -144,6 +160,7 @@ export function useInputLabeling(
     hasError,
     errorLines,
     showDescription,
+    rendersDescription,
     dataAttrs,
   }
 }

--- a/src/composables/useInputLabeling.ts
+++ b/src/composables/useInputLabeling.ts
@@ -56,6 +56,14 @@ interface UseInputLabelingOptions {
   disabled?: () => boolean | undefined
   /** State token override for `data-state` (e.g. `'checked'`). */
   state?: () => string | undefined
+  /**
+   * Whether a `#label` slot is filled. The label element renders for the slot
+   * as well as for the prop, so without this `labelledBy` points at nothing
+   * and the control is left unnamed with a `<label>` sitting right above it.
+   */
+  hasLabelSlot?: () => boolean
+  /** Same for a `#description` slot and `describedBy`. */
+  hasDescriptionSlot?: () => boolean
 }
 
 export function useInputLabeling(
@@ -88,15 +96,22 @@ export function useInputLabeling(
     return Boolean(props.description) && !hasError.value
   })
 
+  // Both of these follow what actually renders, not what the props say. A
+  // `#label` or `#description` slot renders the same element the prop does, so
+  // keying off the prop alone paints an element that nothing points at.
+  const rendersDescription = computed(() => {
+    return showDescription.value || Boolean(options.hasDescriptionSlot?.())
+  })
+
   const describedBy = computed(() => {
     const ids: string[] = []
-    if (showDescription.value) ids.push(descriptionId.value)
+    if (rendersDescription.value) ids.push(descriptionId.value)
     if (hasError.value) ids.push(errorMessageId.value)
     return ids.length ? ids.join(' ') : undefined
   })
 
   const labelledBy = computed(() => {
-    return props.label ? labelId.value : undefined
+    return props.label || options.hasLabelSlot?.() ? labelId.value : undefined
   })
 
   const dataAttrs = computed(() => {

--- a/src/composables/useInputLabeling.ts
+++ b/src/composables/useInputLabeling.ts
@@ -32,8 +32,8 @@ export interface InputLabelingProps {
   /**
    * Marks the field as required. Renders an asterisk next to the label, with
    * `sr-only` text that announces it, and forwards `required` /
-   * `aria-required` to the underlying control where its role allows it —
-   * `slider` does not, so Slider and a half-step Rating set neither.
+   * `aria-required` to the underlying control where the control's role allows
+   * it. `data-required` is set either way.
    */
   required?: boolean
 

--- a/src/composables/useInputLabeling.ts
+++ b/src/composables/useInputLabeling.ts
@@ -17,7 +17,8 @@ export interface InputLabelingProps {
 
   /**
    * Helper text rendered below the input.
-   * Hidden when `error` is set.
+   * Hidden when `error` is set. A `#description` slot is not: it renders
+   * beside the error, and is referenced alongside it.
    */
   description?: string
 

--- a/src/composables/useInputLabeling.ts
+++ b/src/composables/useInputLabeling.ts
@@ -30,8 +30,10 @@ export interface InputLabelingProps {
   error?: string | FrappeUIError
 
   /**
-   * Marks the field as required. Renders an asterisk next to the label and
-   * forwards `required` / `aria-required` to the underlying control.
+   * Marks the field as required. Renders an asterisk next to the label, with
+   * `sr-only` text that announces it, and forwards `required` /
+   * `aria-required` to the underlying control where its role allows it —
+   * `slider` does not, so Slider and a half-step Rating set neither.
    */
   required?: boolean
 


### PR DESCRIPTION
Four accessibility and sizing fixes found while reviewing #1047. Each is one commit.

### `#label` and `#description` slots left the control unnamed

`useInputLabeling` only saw the `label` and `description` props, while `InputLabel` and `InputDescription` render for their slots too. A slot with no matching prop painted an element that `aria-labelledby` or `aria-describedby` pointed at nothing.

- Slider and Rating lost the **name** outright: neither wires a native `<label for>`.
- The other eight kept their name from `label for=` and lost only the description.

The composable now takes `hasLabelSlot` / `hasDescriptionSlot`, and all ten consumers pass them.

### `aria-required` on `role="slider"`

The ARIA role table lists `aria-required` for `radiogroup` but not for `slider`. With `step="0.5"` Rating's root is a slider, so it failed `aria-allowed-attr` and screen readers ignored the attribute. Radiogroup mode keeps it.

### Avatar collapsed below a breakpoint

`hasSizeOverride` stripped the variant prefix, so `sm:size-16` counted as a size override and the enum's `w-*/h-*` was dropped at every breakpoint, not only where the utility applies. Measured at 500px with `class="sm:size-16"`:

| | before | after |
|---|---|---|
| label avatar | 10x16 | 24x24 |
| image-only avatar | **0x0** | 24x24 |

Tailwind emits variant utilities after the base ones, so `size-8 sm:size-16` already resolves the caller's way at `sm`. Unprefixed tokens only. Same bug and same fix as Slider's width guard in #1047.

### The shared `required` doc was wrong

It promised `aria-required` on the underlying control without qualification, and every generated API table repeated it. Slider's own page contradicted its API table. Qualified and regenerated.

`TimePicker.api.md` also reorders rows: the generator is not stable there, and `docs:check` is semantic so it never surfaced. Unrelated to this change, included because `docs:gen` produces it.

## Verification

- `vitest src/composables/` — 60 pass
- `vue-tsc` — no errors in the touched files
- `docs:check` — tables match
- Behaviour measured in Chrome for every case above. Local Cypress does not start on this machine (`Cypress: bad option: --no-sandbox`), so the new specs are **not run locally** — they need CI.

## Not included

- Extracting a `useSliderThumbLabeling` composable so Rating stops duplicating Slider's per-thumb naming. Refactor, not a fix.
- A FloatingWindow docs page.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1079/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 72.37% (+0.02% vs `main`)
<!-- coverage-report:end -->





