### PR TITLE
fix(Menu): raise danger item ink to red-7 for dark-mode contrast

### DIFF
--- a/src/components/Dropdown/Dropdown.cy.ts
+++ b/src/components/Dropdown/Dropdown.cy.ts
@@ -78,7 +78,7 @@ describe('Dropdown', () => {
       .within(() => {
         // Danger rows use the same ink as the ghost red Button; ink-red-5
         // is too dim against the dark-mode menu surface.
-        cy.get('.text-ink-red-7').should('exist')
+        cy.contains('Delete').should('have.class', 'text-ink-red-7')
         cy.get('.lucide-trash-2').should('have.class', 'text-ink-red-7')
       })
 

--- a/src/components/Dropdown/Dropdown.cy.ts
+++ b/src/components/Dropdown/Dropdown.cy.ts
@@ -72,7 +72,17 @@ describe('Dropdown', () => {
     cy.get('[aria-haspopup=menu]').click()
     cy.get('[role=menu]').should('exist')
 
-    cy.get('[role=menuitem]').eq(1).should('contain.text', 'Delete').click()
+    cy.get('[role=menuitem]')
+      .eq(1)
+      .should('contain.text', 'Delete')
+      .within(() => {
+        // Danger rows use the same ink as the ghost red Button; ink-red-5
+        // is too dim against the dark-mode menu surface.
+        cy.get('.text-ink-red-7').should('exist')
+        cy.get('.lucide-trash-2').should('have.class', 'text-ink-red-7')
+      })
+
+    cy.get('[role=menuitem]').eq(1).click()
 
     cy.get('[role=menu]').should('not.exist')
   })

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -153,7 +153,7 @@ export function getMenuIconColor(item: {
   theme?: MenuTheme
 }) {
   if (item.disabled) return 'text-ink-gray-4'
-  return item.theme === 'red' ? 'text-ink-red-5' : 'text-ink-gray-6'
+  return item.theme === 'red' ? 'text-ink-red-7' : 'text-ink-gray-6'
 }
 
 export function getMenuTextColor(item: {
@@ -161,7 +161,7 @@ export function getMenuTextColor(item: {
   theme?: MenuTheme
 }) {
   if (item.disabled) return 'text-ink-gray-4'
-  return item.theme === 'red' ? 'text-ink-red-5' : 'text-ink-gray-7'
+  return item.theme === 'red' ? 'text-ink-red-7' : 'text-ink-gray-7'
 }
 
 export function getMenuBackgroundColor(item: { theme?: MenuTheme }) {


### PR DESCRIPTION
## What was broken

Danger (red) options in Dropdown and ContextMenu were hard to read in dark mode. This came from a bug report in the Raven-frappe-ui channel.

## Root cause

Menu rows with \`theme: 'red'\` use \`text-ink-red-5\`. In dark mode that token resolves to a dim red (dark \`red/400\`). Measured contrast:

| State | Dark | Light |
|---|---|---|
| At rest, on \`surface-elevation-2\` | 2.89:1 | 4.47:1 |
| Hovered, on \`surface-red-3\` | 1.85:1 | 3.41:1 |

WCAG AA needs 4.5:1. The hover state in dark mode was near-invisible.

## What changed

\`getMenuTextColor\` and \`getMenuIconColor\` in \`src/components/Menu/utils.ts\` now return \`text-ink-red-7\`. This matches the ghost red Button, which already pairs \`text-ink-red-7\` with \`hover:bg-surface-red-3\`. New contrast:

| State | Dark | Light |
|---|---|---|
| At rest | 5.96:1 | 6.69:1 |
| Hovered | 3.82:1 | 5.11:1 |

The dark hover state is still below 4.5:1, but it now matches the ghost red Button exactly. Raising it further would need a hover-surface change in both components.

## How it was verified

- Contrast ratios computed from \`tailwind/generated/colors.json\` (oklch to relative luminance).
- Cypress component tests, including a new assertion that danger rows render \`text-ink-red-7\`:

\`\`\`
✔  Dropdown/Dropdown.cy.ts      17 passing
✔  ContextMenu/ContextMenu.cy.ts 14 passing
\`\`\`

- \`yarn type-check\`: 78 errors, all pre-existing on main, none in the changed files.


## Screenshots

Before and after, at rest and with the item highlighted.

| Dark | Light |
|---|---|
| ![Dark mode before/after](https://gist.githubusercontent.com/netchampfaris/cde7c2fa44b2c4544272b9536566753a/raw/dark-before-after.png) | ![Light mode before/after](https://gist.githubusercontent.com/netchampfaris/cde7c2fa44b2c4544272b9536566753a/raw/light-before-after.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1080/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 71.88% (±0.00% vs `main`)
<!-- coverage-report:end -->


