### PR TITLE
fix: remove Google Docs/Drive from iframe allowlist to prevent silent link loss (Fixes #1082)

### DIFF
--- a/src/molecules/editor/extensions/iframe/iframe-allowlist.ts
+++ b/src/molecules/editor/extensions/iframe/iframe-allowlist.ts
@@ -31,8 +31,6 @@ export const IFRAME_ALLOWLIST: readonly string[] = [
   'codesandbox.io',
   'figma.com',
   'embed.figma.com',
-  'docs.google.com',
-  'drive.google.com',
   'notion.so',
 ]
 

--- a/src/molecules/editor/extensions/iframe/iframe-embed-utils.ts
+++ b/src/molecules/editor/extensions/iframe/iframe-embed-utils.ts
@@ -84,14 +84,6 @@ export const PLATFORM_CONFIGS: readonly PlatformConfig[] = [
     example: 'https://figma.com/design/…',
   },
   {
-    name: 'Google Docs',
-    ratio: 4 / 3,
-    defaultWidth: 600,
-    hosts: ['docs.google.com', 'drive.google.com'],
-    icon: 'lucide-file-text',
-    example: 'https://docs.google.com/document/d/…',
-  },
-  {
     name: 'Notion',
     ratio: 4 / 3,
     defaultWidth: 600,


### PR DESCRIPTION
## Problem

Pasting a Google Drive/Docs share link into the editor and clicking Send loses the link entirely — the saved reply contains no trace of it, with no error shown. Inserting the URL via the link toolbar button works as a workaround.

## Root cause

`RichTextKit` ships the `Iframe` extension by default. The iframe paste plugin's bare-URL branch validates pasted plain text against `IFRAME_ALLOWLIST`, which includes `docs.google.com` and `drive.google.com`. A pasted Drive link is silently replaced with an `<iframe>` embed node — no confirmation and no way to paste it as a plain link. When the content is saved, server-side sanitization strips the iframe, leaving nothing.

## Fix

Remove `docs.google.com` and `drive.google.com` from:
- `IFRAME_ALLOWLIST` in `iframe-allowlist.ts` — the paste handler and dialog won't auto-convert these URLs to iframe embeds
- `PLATFORM_CONFIGS` in `iframe-embed-utils.ts` — the corresponding platform entry is no longer needed

Users can still paste Google Drive links as plain text links (via the link toolbar button), and the `<iframe>` embed snippet in HTML paste still works for those who intentionally want to embed a Google Doc.

## Related

Fixes #1082

<!-- coverage-report:start -->
Coverage: 72.34% (-0.01% vs `main`)
<!-- coverage-report:end -->
