### PR TITLE
feat(charts): print a heatmap's categories, and stand its scale beside the plot

### DIFF
--- a/src/charts/HeatmapChart.cy.ts
+++ b/src/charts/HeatmapChart.cy.ts
@@ -82,6 +82,16 @@ describe('HeatmapChart', () => {
       .and('contain.text', '10')
   })
 
+  it('prints the categories through the axis formatters', () => {
+    mountChart({
+      xAxis: { format: (hour: string) => hour.toUpperCase() },
+      yAxis: { format: (day: string) => day.slice(0, 1) },
+    })
+    cy.get('[data-slot="chart-plot"] svg text')
+      .should('contain.text', '9AM')
+      .and('contain.text', 'M')
+  })
+
   it('prints the values in the cells on request', () => {
     mountChart({ showValues: true })
     cy.get('[data-slot="chart-plot"] svg text').should('contain.text', '8')

--- a/src/charts/HeatmapChart.cy.ts
+++ b/src/charts/HeatmapChart.cy.ts
@@ -49,6 +49,19 @@ const plot = () => cy.get('[data-slot="chart-plot"] [role="img"]')
 /** Cells carry a computed rgb() fill; nothing else in the plot is filled. */
 const cells = () => cy.get('[data-slot="chart-plot"] svg path[fill^="rgb"]')
 
+/** The scale is DOM beside a canvas grid, so checking the two agree means
+ *  measuring both. */
+const box = (selector: string) =>
+  cy.get(selector).then(($el) => $el[0].getBoundingClientRect())
+
+/** One x-axis label, as echarts drew it into the plot. */
+const axisLabel = (text: string) =>
+  cy
+    .get('[data-slot="chart-plot"] svg text')
+    .filter((_, el) => el.textContent === text)
+    .first()
+    .then(($el) => ($el[0] as unknown as SVGGraphicsElement).getBoundingClientRect())
+
 describe('HeatmapChart', () => {
   it('draws a cell per row, on axes taken from the data', () => {
     mountChart()
@@ -67,12 +80,47 @@ describe('HeatmapChart', () => {
     })
   })
 
-  it('stands the scale in for a legend, ends labelled', () => {
+  it('stands the scale beside the plot, ends labelled', () => {
     mountChart()
-    cy.get('[data-slot="chart-container"]')
+    // A continuous ramp has no entries to switch on and off, so the scale
+    // stands in for the legend.
+    cy.get('[data-slot="chart-legend"]').should('not.exist')
+    cy.get('[data-slot="chart-scale"]')
       .should('contain.text', '2')
       .and('contain.text', '8')
-    cy.get('[data-slot="chart-legend"] button').should('not.exist')
+
+    box('[data-slot="chart-scale"]').then((scale) => {
+      box('[data-slot="chart-plot"] [role="img"]').then((plot) => {
+        expect(scale.left, 'scale sits after the plot').to.be.at.least(
+          plot.right - 1,
+        )
+      })
+    })
+  })
+
+  it('lines the low end up with the row of x-axis labels', () => {
+    mountChart()
+    // `min` reads as one of the axis labels, so it starts where they start —
+    // which is a number only the laid-out chart knows.
+    axisLabel('9am').then((label) => {
+      box('[data-slot="chart-scale-min"]').then((min) => {
+        expect(min.top, 'min starts on the x-label row').to.be.closeTo(
+          label.top,
+          3,
+        )
+      })
+    })
+  })
+
+  it('stands the scale opposite the category axis in RTL', () => {
+    mountChart({ dir: 'rtl' })
+    box('[data-slot="chart-scale"]').then((scale) => {
+      box('[data-slot="chart-plot"] [role="img"]').then((plot) => {
+        expect(scale.right, 'scale sits before the plot').to.be.at.most(
+          plot.left + 1,
+        )
+      })
+    })
   })
 
   it('takes the ends of the scale from the props', () => {

--- a/src/charts/HeatmapChart.vue
+++ b/src/charts/HeatmapChart.vue
@@ -75,6 +75,7 @@ import { usePlotKeyboard } from './core/usePlotKeyboard'
 import {
   buildHeatmapMatrix,
   buildHeatmapOption,
+  heatmapCategoryLabel,
   sampleRamp,
 } from './heatmapOptions'
 import { formatLabel, formatValue } from './format'
@@ -138,6 +139,8 @@ const built = computed(() => {
       option: buildHeatmapOption(config.value, {
         tokens: tokens.value,
         format: props.format,
+        xFormat: props.xAxis?.format,
+        yFormat: props.yAxis?.format,
       }),
       error: null as string | null,
     }
@@ -193,6 +196,15 @@ const { chart, dispatch } = useChart({
   },
 })
 
+/** One category as its own axis prints it. */
+function printX(label: string) {
+  return heatmapCategoryLabel(props.xAxis?.format, matrix.value.xValues, label)
+}
+
+function printY(label: string) {
+  return heatmapCategoryLabel(props.yAxis?.format, matrix.value.yValues, label)
+}
+
 function showTooltip(dataIndex: number) {
   const cell = matrix.value.cells[dataIndex]
   if (!cell) {
@@ -201,8 +213,9 @@ function showTooltip(dataIndex: number) {
   }
 
   // The two categories head the tooltip, the way the x value heads an axis
-  // chart's; the measure is the one line under it.
-  tooltip.label = `${cell.y} · ${cell.x}`
+  // chart's. The measure is the one line under it. Printed the way the axes
+  // print them, or a reader meets two spellings of one category.
+  tooltip.label = `${printY(cell.y)} · ${printX(cell.x)}`
   tooltip.items = [
     {
       name: `${cell.yIndex}:${cell.xIndex}`,

--- a/src/charts/HeatmapChart.vue
+++ b/src/charts/HeatmapChart.vue
@@ -19,14 +19,52 @@
     <template v-if="$slots.empty" #empty><slot name="empty" /></template>
 
     <template #default>
-      <div
-        ref="plotEl"
-        class="h-full w-full rounded-2 focus-visible:focus-ring"
-        dir="ltr"
-        role="img"
-        :aria-label="chartAriaLabel(title, subtitle)"
-        v-bind="plotAttrs"
-      />
+      <!-- Beside the plot, not under it: a continuous ramp is a scale, and it
+           reads down the side the way an axis chart's value axis does. The
+           container's `dir` puts it on the far side either way, so nothing is
+           reversed here. The plot's own `dir="ltr"` governs only its contents. -->
+      <div class="flex h-full w-full">
+        <div
+          ref="plotEl"
+          class="min-w-0 flex-1 rounded-2 focus-visible:focus-ring"
+          dir="ltr"
+          role="img"
+          :aria-label="chartAriaLabel(title, subtitle)"
+          v-bind="plotAttrs"
+        />
+
+        <!-- `text-2xs` is `AXIS_LABEL_FONT_SIZE` as a class: 11px and tight,
+             because these read as axis labels rather than as captions. -->
+        <div
+          data-slot="chart-scale"
+          class="ms-2 flex shrink-0 flex-col items-center justify-end"
+        >
+          <span class="text-2xs tabular-nums text-ink-gray-5">
+            {{ scale.max }}
+          </span>
+          <!-- Grows into the room it has and stops: a ramp as tall as the card
+               reads as a second column of data rather than as a key to one. -->
+          <span
+            class="mt-2 min-h-8 max-h-20 w-2 flex-1 rounded-1"
+            :style="{ backgroundImage: scale.gradient }"
+          />
+          <!-- Holds the whole label row, so `min` starts where an x-axis label
+               starts. Its own height until the first layout, or the first frame
+               would draw a collapsed box. -->
+          <span
+            data-slot="chart-scale-min"
+            class="text-2xs tabular-nums text-ink-gray-5"
+            :style="{
+              marginTop: `${AXIS_LABEL_MARGIN}px`,
+              height: xLabelRowHeight
+                ? `${Math.max(xLabelRowHeight - AXIS_LABEL_MARGIN, 0)}px`
+                : undefined,
+            }"
+          >
+            {{ scale.min }}
+          </span>
+        </div>
+      </div>
 
       <!-- The tooltip hangs off the pointer, which a reader walking the grid
            with the arrow keys has not got. The same reading in text. -->
@@ -45,23 +83,6 @@
         </template>
       </ChartTooltip>
     </template>
-
-    <!-- A continuous ramp has no entries to switch on and off, so the scale
-         itself stands in for the legend. -->
-    <template #legend>
-      <div class="flex items-center justify-end gap-2">
-        <span class="text-p-xs tabular-nums text-ink-gray-5">
-          {{ scale.min }}
-        </span>
-        <span
-          class="h-2 w-20 rounded-1"
-          :style="{ backgroundImage: scale.gradient }"
-        />
-        <span class="text-p-xs tabular-nums text-ink-gray-5">
-          {{ scale.max }}
-        </span>
-      </div>
-    </template>
   </ChartContainer>
 </template>
 
@@ -72,6 +93,7 @@ import { GridComponent, VisualMapContinuousComponent } from 'echarts/components'
 import { LabelLayout } from 'echarts/features'
 import { registerChartModules, useChart } from './core/useChart'
 import { usePlotKeyboard } from './core/usePlotKeyboard'
+import { AXIS_LABEL_MARGIN } from './axisChartCommon'
 import {
   buildHeatmapMatrix,
   buildHeatmapOption,
@@ -166,10 +188,40 @@ const tooltip = reactive({
   items: [] as ChartTooltipItem[],
 })
 
+/**
+ * How much of the plot box sits below the axis line: the row echarts reserved
+ * for the x-axis labels, in px.
+ *
+ * DOM beside a canvas grid, so the number that ties the two together has to be
+ * read off the laid-out chart. echarts sizes that row from the labels, which
+ * change with the text, the font and the width — hence a read per render.
+ *
+ * The grid rect is echarts internals: read through `any`, and given up on when
+ * missing. A version that moves it leaves `min` a few px out, not a dead chart.
+ */
+const xLabelRowHeight = ref(0)
+
+function measureXLabelRow() {
+  const grid = (chart.value as any)
+    ?.getModel?.()
+    ?.getComponent?.('grid', 0)
+    ?.coordinateSystem?.getRect?.()
+  if (!grid || !chart.value) return
+
+  const below = chart.value.getHeight() - (grid.y + grid.height)
+  // Sub-pixel churn across resizes would otherwise rewrite this every frame.
+  if (Number.isFinite(below) && Math.abs(below - xLabelRowHeight.value) > 0.5) {
+    xLabelRowHeight.value = below
+  }
+}
+
 const { chart, dispatch } = useChart({
   container: plotEl,
   option: () => built.value.option,
   events: {
+    // Fires once the plot has finished laying out, which is the first moment
+    // the grid rect means anything, and again after every resize and re-render.
+    finished: () => measureXLabelRow(),
     mouseover: (params: any) => showTooltip(params.dataIndex),
     mouseout: () => (tooltip.open = false),
     click: (params: any) => {
@@ -324,14 +376,13 @@ const plotAttrs = keyboard.attrs
 /** The ramp scale in the chrome, painted from the stops the cells came from. */
 const scale = computed(() => {
   const { min, max, stops } = matrix.value
-  const sampled = sampleRamp(stops)
-  // The labels swap sides with the flex row in RTL, so the ramp has to swap
-  // with them — otherwise the low end would sit against the high label.
-  const towards = dir.value === 'rtl' ? 'left' : 'right'
   return {
     min: shorten(min),
     max: shorten(max),
-    gradient: `linear-gradient(to ${towards}, ${sampled.join(', ')})`,
+    // Upright, low end at the foot. The labels sit above and below the ramp
+    // rather than either side of it, so this reads the same in both directions
+    // and RTL has nothing to flip.
+    gradient: `linear-gradient(to top, ${sampleRamp(stops).join(', ')})`,
   }
 })
 

--- a/src/charts/axisChartCommon.ts
+++ b/src/charts/axisChartCommon.ts
@@ -61,7 +61,7 @@ const TILTED_LABEL_EXTENT = 72
 /** A label's own line box, which turns into reach of its own once rotated. */
 const LABEL_LINE_HEIGHT = 13
 /** The gap every axis here keeps between a label and the plot. */
-const AXIS_LABEL_MARGIN = 8
+export const AXIS_LABEL_MARGIN = 8
 
 const DEFAULT_PALETTE: ChartPaletteName = 'sequential'
 

--- a/src/charts/docs/HeatmapChart.api.md
+++ b/src/charts/docs/HeatmapChart.api.md
@@ -72,6 +72,18 @@
     type: 'number'
   },
   {
+    name: 'xAxis',
+    description: 'The columns of the grid: the axis under it, and the tooltip head.',
+    required: false,
+    type: 'HeatmapAxisOptions'
+  },
+  {
+    name: 'yAxis',
+    description: 'The rows of the grid: the axis beside it, and the tooltip head.',
+    required: false,
+    type: 'HeatmapAxisOptions'
+  },
+  {
     name: 'showValues',
     description: 'Prints each cell\'s value inside it. A label that would collide with its\nneighbour is dropped, so a grid too fine to carry numbers shows none.',
     required: false,

--- a/src/charts/docs/HeatmapChart.md
+++ b/src/charts/docs/HeatmapChart.md
@@ -10,6 +10,17 @@ that would collide with its neighbour.
 
 <ComponentPreview name="Charts-HeatmapTickets" csr="true" self-layout />
 
+## Printing the categories
+
+`xAxis.format` and `yAxis.format` print one cut each, on the axis and in the
+tooltip. Each is given the value the row carried rather than the string the
+category reads as, so a date column can read as `Mar`.
+
+They change how a category prints, not what it is: two categories that print
+alike stay two cells, and `select` still names the raw value.
+
+<ComponentPreview name="Charts-HeatmapSignups" csr="true" self-layout />
+
 ## Signed data
 
 Signed data reads on the `diverging` ramp, centered on zero. `min` and `max` pin

--- a/src/charts/heatmapOptions.test.ts
+++ b/src/charts/heatmapOptions.test.ts
@@ -6,6 +6,7 @@ import {
   hoverCellColor,
   sampleRamp,
   HEATMAP_RAMP_SAMPLES,
+  type HeatmapOptionContext,
 } from './heatmapOptions'
 import { hexToOklch } from './colorMath'
 import type { ChartTokens } from './tokens'
@@ -56,8 +57,11 @@ function matrix(overrides: Partial<HeatmapChartConfig> = {}) {
   return buildHeatmapMatrix(config(overrides), { tokens })
 }
 
-function build(overrides: Partial<HeatmapChartConfig> = {}) {
-  return buildHeatmapOption(config(overrides), { tokens }) as any
+function build(
+  overrides: Partial<HeatmapChartConfig> = {},
+  context: Partial<HeatmapOptionContext> = {},
+) {
+  return buildHeatmapOption(config(overrides), { tokens, ...context }) as any
 }
 
 describe('buildHeatmapMatrix', () => {
@@ -410,5 +414,84 @@ describe('hoverCellColor', () => {
 
     expect(option.grid.top).toBe(40)
     expect(option.grid.outerBoundsContain).toBe('all')
+  })
+})
+
+describe('printing the categories', () => {
+  const months = [
+    { month: new Date('2024-03-01'), team: 'Sales', deals: 4 },
+    { month: new Date('2024-01-01'), team: 'Sales', deals: 7 },
+  ]
+  const monthName = (value: Date) =>
+    value.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })
+
+  const byMonth = { data: months, xColumn: 'month', yColumn: 'team' }
+
+  it('keeps the value each category was registered from, keyed by its label', () => {
+    const built = matrix(byMonth)
+
+    expect([...built.xValues]).toEqual([
+      [String(months[0].month), months[0].month],
+      [String(months[1].month), months[1].month],
+    ])
+    expect([...built.yValues]).toEqual([['Sales', 'Sales']])
+  })
+
+  it('prints an axis label from the value, not from the string it reads as', () => {
+    const printed = build(byMonth, { xFormat: monthName }).xAxis.axisLabel
+      .formatter
+
+    // The category itself is a stringified Date. The formatter never sees it.
+    expect(printed(String(months[0].month))).toBe('Mar')
+    expect(printed(String(months[1].month))).toBe('Jan')
+  })
+
+  // Pins the label-keyed lookup: echarts numbers a category formatter's ticks
+  // from the visible extent, so position alone would slide under a `dataZoom`.
+  it('prints a category the axis asks for out of order', () => {
+    const printed = build(byMonth, { xFormat: monthName }).xAxis.axisLabel
+      .formatter
+
+    expect(printed(String(months[1].month))).toBe('Jan')
+    expect(printed(String(months[0].month))).toBe('Mar')
+  })
+
+  it('leaves echarts to print the category when no formatter is given', () => {
+    expect(build().xAxis.axisLabel.formatter).toBeUndefined()
+    expect(build().yAxis.axisLabel.formatter).toBeUndefined()
+  })
+
+  it('prints each axis through its own formatter', () => {
+    const option = build(
+      {},
+      {
+        xFormat: (value: string) => `at ${value}`,
+        yFormat: (value: string) => `on ${value}`,
+      },
+    )
+
+    expect(option.xAxis.axisLabel.formatter('8am')).toBe('at 8am')
+    expect(option.yAxis.axisLabel.formatter('Mon')).toBe('on Mon')
+  })
+
+  it('leaves the blank marker alone, whatever the formatter would make of it', () => {
+    const option = build(
+      { data: [{ day: 'Mon', hour: null, orders: 3 }] },
+      { xFormat: (value: any) => `hour ${value}` },
+    )
+
+    expect(option.xAxis.axisLabel.formatter('(Blank)')).toBe('(Blank)')
+  })
+
+  it('does not merge two categories that print alike', () => {
+    const built = matrix({
+      data: [
+        { day: 'Mon', hour: new Date('2024-03-01'), orders: 1 },
+        { day: 'Mon', hour: new Date('2025-03-01'), orders: 2 },
+      ],
+    })
+
+    expect(built.xCategories).toHaveLength(2)
+    expect(built.cells).toHaveLength(2)
   })
 })

--- a/src/charts/heatmapOptions.ts
+++ b/src/charts/heatmapOptions.ts
@@ -1,6 +1,7 @@
 import type { EChartsCoreOption } from 'echarts/core'
 import {
   AXIS_LABEL_FONT_SIZE,
+  AXIS_LABEL_MARGIN,
   DATA_LABEL_FONT_SIZE,
   toNumber,
 } from './axisChartCommon'
@@ -317,7 +318,7 @@ export function buildHeatmapOption(
       axisTick: { show: false },
       axisLabel: {
         hideOverlap: true,
-        margin: 8,
+        margin: AXIS_LABEL_MARGIN,
         color: tokens.axisLabel,
         fontSize: AXIS_LABEL_FONT_SIZE,
         ...categoryLabelFormatter(xFormat, matrix.xValues),
@@ -336,7 +337,7 @@ export function buildHeatmapOption(
       axisTick: { show: false },
       axisLabel: {
         hideOverlap: true,
-        margin: 8,
+        margin: AXIS_LABEL_MARGIN,
         color: tokens.axisLabel,
         fontSize: AXIS_LABEL_FONT_SIZE,
         ...categoryLabelFormatter(yFormat, matrix.yValues),

--- a/src/charts/heatmapOptions.ts
+++ b/src/charts/heatmapOptions.ts
@@ -10,6 +10,7 @@ import { CHART_FONT_FAMILY } from './measureText'
 import { chartColors, insideLabelColor, type ChartTokens } from './tokens'
 import { mergeDeep } from './utils'
 import type {
+  ChartCategoryFormatter,
   ChartPaletteName,
   ChartValueFormatter,
   HeatmapCell,
@@ -20,10 +21,18 @@ import type {
 // Plot, tooltip and the ramp scale in the chrome all read the same
 // `HeatmapMatrix`, so the scale in the corner can't disagree with the fills.
 
+/**
+ * Formatters travel beside the config rather than inside it, as they do for the
+ * axis charts (see `AxisChartFormatters`): the builder takes plain data.
+ */
 export type HeatmapOptionContext = {
   tokens: ChartTokens
   /** Prints the value inside a cell. Defaults to a shortened number. */
   format?: ChartValueFormatter
+  /** Prints the columns of the grid. Left out, echarts prints the category. */
+  xFormat?: ChartCategoryFormatter
+  /** Prints the rows of the grid. */
+  yFormat?: ChartCategoryFormatter
 }
 
 /**
@@ -83,23 +92,8 @@ export function buildHeatmapMatrix(
   { tokens }: HeatmapOptionContext,
 ): HeatmapMatrix {
   const rows = config.data ?? []
-  const xCategories: string[] = []
-  const yCategories: string[] = []
-  const xIndexes = new Map<string, number>()
-  const yIndexes = new Map<string, number>()
-
-  const index = (
-    label: string,
-    categories: string[],
-    indexes: Map<string, number>,
-  ) => {
-    const existing = indexes.get(label)
-    if (existing !== undefined) return existing
-    const next = categories.length
-    categories.push(label)
-    indexes.set(label, next)
-    return next
-  }
+  const x = categoryAxis()
+  const y = categoryAxis()
 
   // Keyed by coordinate, so two rows landing on the same cell leave one cell
   // rather than two stacked ones. The later row wins: a caller that pre-
@@ -108,12 +102,12 @@ export function buildHeatmapMatrix(
   const placed = new Map<string, Omit<HeatmapCell, 'color'>>()
 
   for (const row of rows) {
-    const x = categoryLabel(row[config.xColumn])
-    const y = categoryLabel(row[config.yColumn])
     // Categories are registered even when the value is missing: an hour with no
     // orders is still an hour, and dropping its column would close the gap.
-    const xIndex = index(x, xCategories, xIndexes)
-    const yIndex = index(y, yCategories, yIndexes)
+    const xIndex = x.register(row[config.xColumn])
+    const yIndex = y.register(row[config.yColumn])
+    const xLabel = x.labels[xIndex]
+    const yLabel = y.labels[yIndex]
 
     const value = toNumber(row[config.valueColumn])
     if (value === null) continue
@@ -121,10 +115,10 @@ export function buildHeatmapMatrix(
     const key = `${xIndex}:${yIndex}`
     if (import.meta.env.DEV && placed.has(key)) {
       console.warn(
-        `[frappe-ui] Two rows land on the heatmap cell x="${x}", y="${y}". The last one is drawn; pre-aggregate the data to choose yourself.`,
+        `[frappe-ui] Two rows land on the heatmap cell x="${xLabel}", y="${yLabel}". The last one is drawn; pre-aggregate the data to choose yourself.`,
       )
     }
-    placed.set(key, { x, y, xIndex, yIndex, value, row })
+    placed.set(key, { x: xLabel, y: yLabel, xIndex, yIndex, value, row })
   }
 
   const unsized = [...placed.values()]
@@ -139,7 +133,42 @@ export function buildHeatmapMatrix(
     color: rampColor(stops, span > 0 ? (cell.value - min) / span : 1),
   }))
 
-  return { xCategories, yCategories, cells, min, max, stops }
+  return {
+    xCategories: x.labels,
+    yCategories: y.labels,
+    xValues: x.values,
+    yValues: y.values,
+    cells,
+    min,
+    max,
+    stops,
+  }
+}
+
+/**
+ * One cut of the grid, collected as the rows are read.
+ *
+ * Values are keyed by label rather than held in a parallel array: the label is
+ * all an echarts axis-label formatter is handed. Its index counts from the
+ * visible extent, so a `dataZoom` would slide a positional lookup by one.
+ */
+function categoryAxis() {
+  const labels: string[] = []
+  const values = new Map<string, any>()
+  const indexes = new Map<string, number>()
+
+  return {
+    labels,
+    values,
+    register(value: any) {
+      const label = categoryLabel(value)
+      const existing = indexes.get(label)
+      if (existing !== undefined) return existing
+      indexes.set(label, labels.length)
+      values.set(label, value)
+      return labels.push(label) - 1
+    },
+  }
 }
 
 /**
@@ -217,11 +246,42 @@ function categoryLabel(value: any) {
     : String(value)
 }
 
+/**
+ * How one category reads. The formatter is handed the value the row carried,
+ * because the label the category is keyed by has already lost a Date.
+ *
+ * A blank category prints as the blank marker whatever the formatter does with
+ * it: `(Blank)` says the rows named no category, and a formatter reading a date
+ * out of `undefined` would say something worse.
+ */
+export function heatmapCategoryLabel(
+  format: ChartCategoryFormatter | undefined,
+  values: Map<string, any>,
+  label: string,
+): string {
+  if (!format || label === BLANK_CATEGORY) return label
+  return format(values.get(label))
+}
+
+/**
+ * The `axisLabel` keys that print a category, or none when no formatter was
+ * given — echarts then prints the category itself.
+ */
+function categoryLabelFormatter(
+  format: ChartCategoryFormatter | undefined,
+  values: Map<string, any>,
+) {
+  if (!format) return {}
+  return {
+    formatter: (label: string) => heatmapCategoryLabel(format, values, label),
+  }
+}
+
 export function buildHeatmapOption(
   config: HeatmapChartConfig,
   context: HeatmapOptionContext,
 ): EChartsCoreOption {
-  const { tokens, format } = context
+  const { tokens, format, xFormat, yFormat } = context
   const isRTL = config.dir === 'rtl'
   const matrix = buildHeatmapMatrix(config, context)
   const showValues = Boolean(config.showValues)
@@ -260,6 +320,7 @@ export function buildHeatmapOption(
         margin: 8,
         color: tokens.axisLabel,
         fontSize: AXIS_LABEL_FONT_SIZE,
+        ...categoryLabelFormatter(xFormat, matrix.xValues),
       },
     },
     yAxis: {
@@ -278,6 +339,7 @@ export function buildHeatmapOption(
         margin: 8,
         color: tokens.axisLabel,
         fontSize: AXIS_LABEL_FONT_SIZE,
+        ...categoryLabelFormatter(yFormat, matrix.yValues),
       },
     },
     // Hidden: the ramp is explained by an HTML scale next to the plot. This one

--- a/src/charts/index.ts
+++ b/src/charts/index.ts
@@ -105,6 +105,7 @@ export type {
   EchartOptionsOverride,
   FunnelStage,
   FunnelStageEvent,
+  HeatmapAxisOptions,
   HeatmapCellEvent,
   HeatmapPalette,
   NumberCardSparkline,

--- a/src/charts/stories/HeatmapSignups.vue
+++ b/src/charts/stories/HeatmapSignups.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { HeatmapChart } from 'frappe-ui/charts'
+
+const PLANS = ['Free', 'Pro', 'Team']
+const COUNTS = [
+  [420, 455, 512, 498, 540, 601],
+  [86, 92, 104, 118, 131, 147],
+  [12, 15, 14, 21, 26, 33],
+]
+
+// A real date column: the axis would otherwise print the whole timestamp.
+const signups = PLANS.flatMap((plan, planIndex) =>
+  COUNTS[planIndex].map((signups, month) => ({
+    plan,
+    month: new Date(Date.UTC(2024, month, 1)),
+    signups,
+  })),
+)
+
+const monthName = (month: Date) =>
+  month.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })
+</script>
+
+<template>
+  <div class="h-72 w-full">
+    <HeatmapChart
+      :data="signups"
+      x="month"
+      y="plan"
+      value="signups"
+      :x-axis="{ format: monthName }"
+      show-values
+      title="Signups by plan"
+      subtitle="First half of 2024"
+    />
+  </div>
+</template>

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -289,6 +289,17 @@ export type FunnelStageEvent = {
  */
 export type HeatmapPalette = 'sequential' | 'diverging' | string[]
 
+/** One cut of the grid. Both are category axes, so both read the same way. */
+export type HeatmapAxisOptions = {
+  /**
+   * Prints each category. Takes the value the row carried, not the string it
+   * reads as: a date column arrives as a Date, and `Mar 2024` needs the value.
+   *
+   * Display only. Two categories printing alike stay two categories.
+   */
+  format?: ChartCategoryFormatter
+}
+
 export type HeatmapChartConfig = {
   /** One row per cell. Rows with no numeric value leave their cell undrawn. */
   data: Record<string, any>[]
@@ -339,6 +350,10 @@ export type HeatmapMatrix = {
   xCategories: string[]
   /** Rows, in the order the rows first mention them. Drawn top to bottom. */
   yCategories: string[]
+  /** The value each x category was first named by, keyed by the category. */
+  xValues: Map<string, any>
+  /** As `xValues`, for the rows of the grid. */
+  yValues: Map<string, any>
   cells: HeatmapCell[]
   /** Bottom of the color scale, config or data. */
   min: number
@@ -802,6 +817,10 @@ export type HeatmapChartProps = ChartBaseProps & {
   min?: number
   /** Top of the color scale. Defaults to the largest value in the data. */
   max?: number
+  /** The columns of the grid: the axis under it, and the tooltip head. */
+  xAxis?: HeatmapAxisOptions
+  /** The rows of the grid: the axis beside it, and the tooltip head. */
+  yAxis?: HeatmapAxisOptions
   /**
    * Prints each cell's value inside it. A label that would collide with its
    * neighbour is dropped, so a grid too fine to carry numbers shows none.


### PR DESCRIPTION
Both cuts of a grid are category axes. A date column drew
`2024-03-01 00:00:00` under every column, and no prop could reach the label.

### Printing the categories

`xAxis.format` and `yAxis.format` print one cut each, on the axis and in the
tooltip. Named the way the axis charts and the scatter name theirs.

- Each takes the value the row carried, not the string the category is keyed
  by. A Date has already lost its type by then.
- Display only. Two values printing alike stay two categories, and `select`
  still names the raw value.
- Values are held against their label, not their position: echarts numbers a
  category formatter's ticks from the visible extent.

### The scale beside the plot

A continuous ramp has no entries to switch on and off, so the scale stands in
for the legend. It now stands beside the plot, lined up with the grid — foot of
the ramp on the axis line, `min` in the row of x-axis labels.

- That row's height is measured off the laid-out chart. echarts sizes it from
  the labels themselves, so CSS cannot know it.
- The gradient runs upright, its ends above and below rather than either side.
- Nothing reverses the row for RTL. The container's own `dir` already lays it
  out from the far side.

<!-- coverage-report:start -->
Coverage: 72.50% (+0.04% vs `main`)
<!-- coverage-report:end -->

