### PR TITLE
docs: sort emits by name in propsgen for stable output

### DIFF
--- a/docs/scripts/propsgen.ts
+++ b/docs/scripts/propsgen.ts
@@ -309,8 +309,9 @@ function extractTableData(name: string, data: any, vuePath: string) {
       }),
     )
 
-  const emits = sourceOrder
-    .sortByDeclaration(data.events.filter((x: any) => !x.global))
+  const emits = data.events
+    .filter((x: any) => !x.global)
+    .sort((a: any, b: any) => a.name.localeCompare(b.name))
     .map((x: any) =>
       withOptional({
         name: x.name,


### PR DESCRIPTION
`sortByDeclaration` cannot order emits reliably. Vue's `$emit` types are synthesized from `__VLS_ModelEmit` and `__VLS_Emit` type aliases, which the TypeScript checker iterates in a non-deterministic order. This causes the emitted rows in `.api.md` files to swap positions between runs with no source change behind it.

**Problem**: `TimePicker.api.md` emits (`update:modelValue`, `update:open`) swap positions between runs. The same instability affects other multi-component families (DatePicker).

**Fix**: Replace `sortByDeclaration` with a stable sort by emit name. The emit name is defined in the source, so sorting by name is still a function of the source — not of checker traversal.

Closes #1081

<!-- coverage-report:start -->
Coverage: 72.37% (±0.00% vs `main`)
<!-- coverage-report:end -->
