### PR TITLE
fix: export defineModel props, add ContextMenuEmits, TabButtonsSlots, remove dead #target (Closes #1070)

### DIFF
--- a/src/components/ContextMenu/index.ts
+++ b/src/components/ContextMenu/index.ts
@@ -9,6 +9,7 @@ export type {
   ContextMenuItemSlots,
   ContextMenuOption,
   ContextMenuOptions,
+  ContextMenuEmits,
   ContextMenuProps,
   ContextMenuSlotFn,
   ContextMenuSlotProps,

--- a/src/components/ContextMenu/types.ts
+++ b/src/components/ContextMenu/types.ts
@@ -30,6 +30,10 @@ export interface ContextMenuProps {
   open?: boolean
 }
 
+export interface ContextMenuEmits {
+  'update:open': [open: boolean]
+}
+
 export type ContextMenuSlots = Omit<MenuSlots, 'default' | 'trigger'> & {
   /** The right-clickable region that opens the menu. */
   default?: (props: ContextMenuTriggerSlotProps) => any

--- a/src/components/HoverCard/types.ts
+++ b/src/components/HoverCard/types.ts
@@ -44,6 +44,9 @@ export interface HoverCardProps {
    * surface.
    */
   arrow?: boolean
+
+  /** Controls the visibility of the hover card. */
+  open?: boolean
 }
 
 /** Slot props passed to the `#trigger` slot. */

--- a/src/components/KeyboardShortcutsDialog/types.ts
+++ b/src/components/KeyboardShortcutsDialog/types.ts
@@ -11,4 +11,7 @@ export interface KeyboardShortcutsDialogProps {
    * Rows, not registrations: shortcuts that merge count once (default: 20).
    */
   searchThreshold?: number
+
+  /** Controls the visibility of the dialog. */
+  open?: boolean
 }

--- a/src/components/TabButtons/TabButtons.vue
+++ b/src/components/TabButtons/TabButtons.vue
@@ -27,6 +27,7 @@ import type {
   TabButton,
   TabButtonsEmits,
   TabButtonsProps,
+  TabButtonsSlots,
   TabButtonValue,
 } from './types'
 
@@ -44,6 +45,8 @@ const props = withDefaults(defineProps<TabButtonsProps>(), {
 })
 
 const emit = defineEmits<TabButtonsEmits>()
+
+defineSlots<TabButtonsSlots>()
 
 const options = computed(() => props.options ?? [])
 

--- a/src/components/TabButtons/types.ts
+++ b/src/components/TabButtons/types.ts
@@ -51,3 +51,10 @@ export interface TabButtonsProps {
 export interface TabButtonsEmits {
   'update:modelValue': [value: TabButtonValue]
 }
+
+export interface TabButtonsSlots {
+  /** Slot before the tab button label. */
+  prefix?: (props: { button: TabButton; checked: boolean; disabled: boolean }) => any
+  /** Slot after the tab button label. */
+  suffix?: (props: { button: TabButton; checked: boolean; disabled: boolean }) => any
+}

--- a/src/components/Tree/types.ts
+++ b/src/components/Tree/types.ts
@@ -90,6 +90,9 @@ export interface TreeProps {
    * @default false
    */
   disabled?: boolean
+
+  /** Controls whether the whole tree is expanded. */
+  expanded?: boolean
 }
 
 /** State + callbacks shared from `Tree` down to every recursive `TreeItem`. */

--- a/src/components/shared/picker/PickerShell.vue
+++ b/src/components/shared/picker/PickerShell.vue
@@ -3,7 +3,6 @@
     <PopoverAnchor :reference="anchorEl" as-child>
       <div v-bind="$attrs" @keydown.down.prevent="onArrowDown">
         <slot name="trigger" v-bind="triggerSlotProps">
-          <slot name="target" v-bind="triggerSlotProps">
             <TextInput
               ref="textInputRef"
               v-model="inputValue"
@@ -135,7 +134,6 @@ const emit = defineEmits<{
 
 const slots = defineSlots<{
   trigger?: (props: TriggerSlotProps) => any
-  target?: (props: TriggerSlotProps) => any
   prefix?: (props: TriggerSlotProps) => any
   suffix?: (props: TriggerSlotProps) => any
   default?: (props: { close: () => void }) => any
@@ -167,7 +165,7 @@ const popoverPanelRef = ref<{ $el: HTMLElement } | null>(null)
 const panelEl = computed(() => popoverPanelRef.value?.$el ?? null)
 
 const anchorEl = computed(() => {
-  if (slots.trigger || slots.target) return undefined
+  if (slots.trigger) return undefined
   return textInputRef.value?.inputElement ?? undefined
 })
 
@@ -233,7 +231,7 @@ const triggerSlotProps = computed<TriggerSlotProps>(() => ({
   inputValue: inputValue.value,
 }))
 
-const hasCustomTrigger = computed(() => !!(slots.trigger || slots.target))
+const hasCustomTrigger = computed(() => !!slots.trigger)
 
 watch(open, (val, prev) => {
   if (val === prev) return


### PR DESCRIPTION
Closes #1070

Four findings from the cross-family vocabulary pass, all confirmed by barista:

1. **`open` / `expanded` via `defineModel` only** — HoverCard, KeyboardShortcutsDialog, and Tree now declare their `open`/`expanded` prop in the exported `*Props` interface. Consumers can see and type-check these props.

2. **`ContextMenuEmits`** — added and exported the missing `ContextMenuEmits` type with the `update:open` event, matching the precedent set by `ContextMenuProps` which already declares `open`.

3. **`TabButtons` `defineSlots`** — added `TabButtonsSlots` type with `prefix` and `suffix` slot declarations, and wired `defineSlots<TabButtonsSlots>()` in the component. The generated API table will no longer show a truncated type blob.

4. **`#target` fallback slot removed from `PickerShell`** — the `#target` slot was the last place in the repo still spelling the retired name. None of the three pickers forward it, and the slot was unreachable from the public surface. Removed the template slot, the type declaration, and the two `slots.target` checks that treated it as a valid custom trigger.