### PR TITLE
fix(slots): re-evaluate slot-derived computeds when a slot toggles

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,7 +25,9 @@ live in `src/components/` or a domain dir (e.g. `frappe/` for Frappe-integrated 
 A component that reads its own slots outside the template takes them from
 `useReactiveSlots()`, never `useSlots()`. Vue mutates `instance.slots` in place
 and does not track it, so a `computed` over `useSlots()` caches whichever slots
-were filled at mount. Reading `$slots` in a template is already correct.
+were filled at mount. Reading `$slots` in your own template is already correct;
+handing the object to a child (as a prop, or through `provide`) is not, because
+the child re-reads it only when something else re-renders the child.
 
 ## Lifecycle & control
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,6 +21,12 @@ A component that composes atoms into a higher-level control — e.g. `Link` (com
 `Combobox`). Follows the same design rules as atoms (P5 labeling, P10 styling, …). May
 live in `src/components/` or a domain dir (e.g. `frappe/` for Frappe-integrated controls).
 
+**slots (reading your own)**:
+A component that reads its own slots outside the template takes them from
+`useReactiveSlots()`, never `useSlots()`. Vue mutates `instance.slots` in place
+and does not track it, so a `computed` over `useSlots()` caches whichever slots
+were filled at mount. Reading `$slots` in a template is already correct.
+
 ## Lifecycle & control
 
 **open**:

--- a/experimental/CodeEditor/CodeEditor.vue
+++ b/experimental/CodeEditor/CodeEditor.vue
@@ -46,13 +46,12 @@ import {
   onMounted,
   ref,
   useAttrs,
-  useSlots,
   watch,
 } from 'vue'
 import type { EditorView } from '@codemirror/view'
 import type { Compartment, Extension } from '@codemirror/state'
 import { useInputLabeling } from '../../src/composables/useInputLabeling'
-import { useSlotTick } from '../../src/composables/useSlotTick'
+import { useReactiveSlots } from '../../src/composables/useReactiveSlots'
 import InputLabel from '../../src/components/InputLabeling/InputLabel.vue'
 import InputDescription from '../../src/components/InputLabeling/InputDescription.vue'
 import InputError from '../../src/components/InputLabeling/InputError.vue'
@@ -79,8 +78,7 @@ defineSlots<{
 }>()
 
 const attrs = useAttrs()
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 const {
   labelId,
@@ -103,12 +101,11 @@ const {
 
 // Render the labeling chrome (and its wrapping div) only when something needs
 // it — otherwise the editor mounts bare, preserving the primitive's footprint.
-const hasLabeling = computed(() => {
-  slotTick.value
-  return Boolean(
+const hasLabeling = computed(() =>
+  Boolean(
     props.label || slots.label || rendersDescription.value || hasError.value,
-  )
-})
+  ),
+)
 
 const el = ref<HTMLElement | null>(null)
 

--- a/experimental/CodeEditor/CodeEditor.vue
+++ b/experimental/CodeEditor/CodeEditor.vue
@@ -52,6 +52,7 @@ import {
 import type { EditorView } from '@codemirror/view'
 import type { Compartment, Extension } from '@codemirror/state'
 import { useInputLabeling } from '../../src/composables/useInputLabeling'
+import { useSlotTick } from '../../src/composables/useSlotTick'
 import InputLabel from '../../src/components/InputLabeling/InputLabel.vue'
 import InputDescription from '../../src/components/InputLabeling/InputDescription.vue'
 import InputError from '../../src/components/InputLabeling/InputError.vue'
@@ -79,6 +80,7 @@ defineSlots<{
 
 const attrs = useAttrs()
 const slots = useSlots()
+const slotTick = useSlotTick()
 
 const {
   labelId,
@@ -101,11 +103,12 @@ const {
 
 // Render the labeling chrome (and its wrapping div) only when something needs
 // it — otherwise the editor mounts bare, preserving the primitive's footprint.
-const hasLabeling = computed(() =>
-  Boolean(
+const hasLabeling = computed(() => {
+  slotTick.value
+  return Boolean(
     props.label || slots.label || rendersDescription.value || hasError.value,
-  ),
-)
+  )
+})
 
 const el = ref<HTMLElement | null>(null)
 

--- a/experimental/CodeEditor/CodeEditor.vue
+++ b/experimental/CodeEditor/CodeEditor.vue
@@ -40,14 +40,7 @@
 // tree-shakes into its own async chunk — apps that never render a code field pay
 // no runtime cost (importing `frappe-ui/experimental` pulls in no editor code
 // until a field actually mounts).
-import {
-  computed,
-  onBeforeUnmount,
-  onMounted,
-  ref,
-  useAttrs,
-  watch,
-} from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, useAttrs, watch } from 'vue'
 import type { EditorView } from '@codemirror/view'
 import type { Compartment, Extension } from '@codemirror/state'
 import { useInputLabeling } from '../../src/composables/useInputLabeling'

--- a/experimental/CodeEditor/CodeEditor.vue
+++ b/experimental/CodeEditor/CodeEditor.vue
@@ -63,7 +63,7 @@ const props = withDefaults(defineProps<CodeEditorProps>(), {
   size: 'md',
 })
 const emit = defineEmits<CodeEditorEmits>()
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
   label?: (props: { required: boolean }) => any
   /** Overrides the rendered description content. */
@@ -71,7 +71,7 @@ defineSlots<{
 }>()
 
 const attrs = useAttrs()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
 const {
   labelId,

--- a/experimental/ListView/ListView.vue
+++ b/experimental/ListView/ListView.vue
@@ -24,7 +24,8 @@ import ListHeader from './ListHeader.vue'
 import ListRows from './ListRows.vue'
 import ListGroups from './ListGroups.vue'
 import ListSelectBanner from './ListSelectBanner.vue'
-import { ref, reactive, computed, provide, watch, useSlots } from 'vue'
+import { ref, reactive, computed, provide, watch } from 'vue'
+import { useReactiveSlots } from '../../src/composables/useReactiveSlots'
 
 defineOptions({
   inheritAttrs: false,
@@ -60,7 +61,7 @@ const props = defineProps({
   },
 })
 
-const slots = useSlots()
+const slots = useReactiveSlots()
 
 let selections = reactive(new Set())
 let activeRow = ref(null)

--- a/experimental/MultiEmailInput/MultiEmailInput.vue
+++ b/experimental/MultiEmailInput/MultiEmailInput.vue
@@ -31,6 +31,7 @@ import {
   LabelingWrapper,
 } from '../../src/components/InputLabeling'
 import { useInputLabeling } from '../../src/composables/useInputLabeling'
+import { useSlotTick } from '../../src/composables/useSlotTick'
 import { usePortalTarget } from '../../src/composables/usePortalTarget'
 import {
   inputFontSizeClasses,
@@ -66,6 +67,7 @@ const props = withDefaults(defineProps<MultiEmailInputProps>(), {
 
 const emit = defineEmits<MultiEmailInputEmits>()
 const slots = useSlots()
+const slotTick = useSlotTick()
 const attrs = useAttrs()
 
 // `portalTo` stays undefaulted on purpose: a `'body'` default outranks the
@@ -94,15 +96,16 @@ const {
   hasDescriptionSlot: () => Boolean(slots.description),
 })
 
-const hasLabeling = computed(() =>
-  Boolean(
+const hasLabeling = computed(() => {
+  slotTick.value
+  return Boolean(
     props.label ||
     props.description ||
     hasError.value ||
     slots.label ||
     slots.description,
-  ),
-)
+  )
+})
 
 const inputAriaAttrs = computed(() => ({
   'aria-invalid': hasError.value || undefined,

--- a/experimental/MultiEmailInput/MultiEmailInput.vue
+++ b/experimental/MultiEmailInput/MultiEmailInput.vue
@@ -58,7 +58,7 @@ const props = withDefaults(defineProps<MultiEmailInputProps>(), {
 })
 
 const emit = defineEmits<MultiEmailInputEmits>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<MultiEmailInputSlots>()
 const attrs = useAttrs()
 
 // `portalTo` stays undefaulted on purpose: a `'body'` default outranks the

--- a/experimental/MultiEmailInput/MultiEmailInput.vue
+++ b/experimental/MultiEmailInput/MultiEmailInput.vue
@@ -1,12 +1,5 @@
 <script setup lang="ts">
-import {
-  computed,
-  nextTick,
-  reactive,
-  ref,
-  useAttrs,
-  watch,
-} from 'vue'
+import { computed, nextTick, reactive, ref, useAttrs, watch } from 'vue'
 import {
   ComboboxAnchor,
   ComboboxContent,

--- a/experimental/MultiEmailInput/MultiEmailInput.vue
+++ b/experimental/MultiEmailInput/MultiEmailInput.vue
@@ -5,7 +5,6 @@ import {
   reactive,
   ref,
   useAttrs,
-  useSlots,
   watch,
 } from 'vue'
 import {
@@ -31,7 +30,7 @@ import {
   LabelingWrapper,
 } from '../../src/components/InputLabeling'
 import { useInputLabeling } from '../../src/composables/useInputLabeling'
-import { useSlotTick } from '../../src/composables/useSlotTick'
+import { useReactiveSlots } from '../../src/composables/useReactiveSlots'
 import { usePortalTarget } from '../../src/composables/usePortalTarget'
 import {
   inputFontSizeClasses,
@@ -66,8 +65,7 @@ const props = withDefaults(defineProps<MultiEmailInputProps>(), {
 })
 
 const emit = defineEmits<MultiEmailInputEmits>()
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 const attrs = useAttrs()
 
 // `portalTo` stays undefaulted on purpose: a `'body'` default outranks the
@@ -96,16 +94,15 @@ const {
   hasDescriptionSlot: () => Boolean(slots.description),
 })
 
-const hasLabeling = computed(() => {
-  slotTick.value
-  return Boolean(
+const hasLabeling = computed(() =>
+  Boolean(
     props.label ||
     props.description ||
     hasError.value ||
     slots.label ||
     slots.description,
-  )
-})
+  ),
+)
 
 const inputAriaAttrs = computed(() => ({
   'aria-invalid': hasError.value || undefined,

--- a/experimental/ThemeSwitcher/ThemeSwitcher.vue
+++ b/experimental/ThemeSwitcher/ThemeSwitcher.vue
@@ -69,8 +69,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useId, useSlots } from 'vue'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { computed, useId } from 'vue'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { RadioGroupItem, RadioGroupRoot } from 'reka-ui'
 import {
   useColorScheme,
@@ -133,17 +133,12 @@ const selected = computed<ColorScheme>({
   },
 })
 
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 const headingId = useId()
-const showLabel = computed(() => {
-  slotTick.value
-  return Boolean(props.label || slots.label)
-})
-const showDescription = computed(() => {
-  slotTick.value
-  return Boolean(props.description || slots.description)
-})
+const showLabel = computed(() => Boolean(props.label || slots.label))
+const showDescription = computed(() =>
+  Boolean(props.description || slots.description),
+)
 const logoIsImage = computed(
   () => typeof props.logo === 'string' && props.logo.length > 0,
 )

--- a/experimental/ThemeSwitcher/ThemeSwitcher.vue
+++ b/experimental/ThemeSwitcher/ThemeSwitcher.vue
@@ -106,7 +106,7 @@ const emit = defineEmits<{
   'update:modelValue': [theme: ColorScheme]
 }>()
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Overrides the heading content. */
   label?: () => any
   /** Overrides the helper-text content. */
@@ -133,7 +133,7 @@ const selected = computed<ColorScheme>({
   },
 })
 
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 const headingId = useId()
 const showLabel = computed(() => Boolean(props.label || slots.label))
 const showDescription = computed(() =>

--- a/experimental/ThemeSwitcher/ThemeSwitcher.vue
+++ b/experimental/ThemeSwitcher/ThemeSwitcher.vue
@@ -70,6 +70,7 @@
 
 <script setup lang="ts">
 import { computed, useId, useSlots } from 'vue'
+import { useSlotTick } from '../../composables/useSlotTick'
 import { RadioGroupItem, RadioGroupRoot } from 'reka-ui'
 import {
   useColorScheme,
@@ -133,11 +134,16 @@ const selected = computed<ColorScheme>({
 })
 
 const slots = useSlots()
+const slotTick = useSlotTick()
 const headingId = useId()
-const showLabel = computed(() => Boolean(props.label || slots.label))
-const showDescription = computed(() =>
-  Boolean(props.description || slots.description),
-)
+const showLabel = computed(() => {
+  slotTick.value
+  return Boolean(props.label || slots.label)
+})
+const showDescription = computed(() => {
+  slotTick.value
+  return Boolean(props.description || slots.description)
+})
 const logoIsImage = computed(
   () => typeof props.logo === 'string' && props.logo.length > 0,
 )

--- a/experimental/ThemeSwitcher/ThemeSwitcher.vue
+++ b/experimental/ThemeSwitcher/ThemeSwitcher.vue
@@ -70,12 +70,12 @@
 
 <script setup lang="ts">
 import { computed, useId } from 'vue'
-import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { RadioGroupItem, RadioGroupRoot } from 'reka-ui'
 import {
   useColorScheme,
   type ColorScheme,
 } from '#composables/useColorScheme'
+import { useReactiveSlots } from '#composables/useReactiveSlots'
 import { warnDeprecated } from '#utils/warnDeprecated'
 import ThemePreview from './ThemePreview.vue'
 import type { ThemeSwitcherProps } from './types'

--- a/src/charts/NumberCard.vue
+++ b/src/charts/NumberCard.vue
@@ -186,7 +186,7 @@ import type { NumberCardProps, NumberCardSlots } from './types'
 const props = withDefaults(defineProps<NumberCardProps>(), { card: true })
 
 defineSlots<NumberCardSlots>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<NumberCardSlots>()
 
 const root = ref<HTMLElement>()
 const dir = computed(() => props.dir ?? documentDir())

--- a/src/charts/NumberCard.vue
+++ b/src/charts/NumberCard.vue
@@ -170,6 +170,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useSlotTick } from '../composables/useSlotTick'
 import {
   deltaDirection,
   deltaTone,
@@ -199,6 +200,7 @@ import type { NumberCardProps, NumberCardSlots } from './types'
 const props = withDefaults(defineProps<NumberCardProps>(), { card: true })
 
 const slots = defineSlots<NumberCardSlots>()
+const slotTick = useSlotTick()
 
 const root = ref<HTMLElement>()
 const dir = computed(() => props.dir ?? documentDir())
@@ -219,18 +221,23 @@ const toneClass = computed(
   () => TONE_CLASSES[deltaTone(props.delta, props.negativeIsBetter)],
 )
 const formattedDelta = computed(() => formatCardDelta(props, props.delta))
-const showEmptySlot = computed(() => isEmpty.value && Boolean(slots.empty))
+const showEmptySlot = computed(() => {
+  slotTick.value
+  return isEmpty.value && Boolean(slots.empty)
+})
 // Only over a reading. The em dash a card with no value prints is not a number
 // the color says anything about, and the loading skeleton is not one either.
 const valueStyle = computed(() =>
   props.color && !isEmpty.value ? { color: props.color } : undefined,
 )
-const showDeltaRow = computed(
-  () =>
+const showDeltaRow = computed(() => {
+  slotTick.value
+  return (
     Boolean(formattedDelta.value) ||
     Boolean(props.deltaCaption) ||
-    Boolean(slots.caption),
-)
+    Boolean(slots.caption)
+  )
+})
 
 // `preserveAspectRatio="none"` makes the horizontal unit meaningless — fine for
 // a line with no axis — so the geometry is computed once at any card width.

--- a/src/charts/NumberCard.vue
+++ b/src/charts/NumberCard.vue
@@ -156,6 +156,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useSlotTick } from '../composables/useSlotTick'
 import {
   deltaDirection,
   deltaTone,
@@ -185,6 +186,7 @@ import type { NumberCardProps, NumberCardSlots } from './types'
 const props = withDefaults(defineProps<NumberCardProps>(), { card: true })
 
 const slots = defineSlots<NumberCardSlots>()
+const slotTick = useSlotTick()
 
 const root = ref<HTMLElement>()
 const dir = computed(() => props.dir ?? documentDir())
@@ -205,18 +207,23 @@ const toneClass = computed(
   () => TONE_CLASSES[deltaTone(props.delta, props.negativeIsBetter)],
 )
 const formattedDelta = computed(() => formatCardDelta(props, props.delta))
-const showEmptySlot = computed(() => isEmpty.value && Boolean(slots.empty))
+const showEmptySlot = computed(() => {
+  slotTick.value
+  return isEmpty.value && Boolean(slots.empty)
+})
 // Only over a reading. The em dash a card with no value prints is not a number
 // the color says anything about, and the loading skeleton is not one either.
 const valueStyle = computed(() =>
   props.color && !isEmpty.value ? { color: props.color } : undefined,
 )
-const showDeltaRow = computed(
-  () =>
+const showDeltaRow = computed(() => {
+  slotTick.value
+  return (
     Boolean(formattedDelta.value) ||
     Boolean(props.deltaCaption) ||
-    Boolean(slots.caption),
-)
+    Boolean(slots.caption)
+  )
+})
 
 // `preserveAspectRatio="none"` makes the horizontal unit meaningless — fine for
 // a line with no axis — so the geometry is computed once at any card width.

--- a/src/charts/NumberCard.vue
+++ b/src/charts/NumberCard.vue
@@ -170,7 +170,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
-import { useSlotTick } from '../composables/useSlotTick'
+import { useReactiveSlots } from '../composables/useReactiveSlots'
 import {
   deltaDirection,
   deltaTone,
@@ -199,8 +199,8 @@ import type { NumberCardProps, NumberCardSlots } from './types'
 // NumberCard forwards a definite `false` and the surface never draws.
 const props = withDefaults(defineProps<NumberCardProps>(), { card: true })
 
-const slots = defineSlots<NumberCardSlots>()
-const slotTick = useSlotTick()
+defineSlots<NumberCardSlots>()
+const slots = useReactiveSlots()
 
 const root = ref<HTMLElement>()
 const dir = computed(() => props.dir ?? documentDir())
@@ -221,23 +221,18 @@ const toneClass = computed(
   () => TONE_CLASSES[deltaTone(props.delta, props.negativeIsBetter)],
 )
 const formattedDelta = computed(() => formatCardDelta(props, props.delta))
-const showEmptySlot = computed(() => {
-  slotTick.value
-  return isEmpty.value && Boolean(slots.empty)
-})
+const showEmptySlot = computed(() => isEmpty.value && Boolean(slots.empty))
 // Only over a reading. The em dash a card with no value prints is not a number
 // the color says anything about, and the loading skeleton is not one either.
 const valueStyle = computed(() =>
   props.color && !isEmpty.value ? { color: props.color } : undefined,
 )
-const showDeltaRow = computed(() => {
-  slotTick.value
-  return (
+const showDeltaRow = computed(
+  () =>
     Boolean(formattedDelta.value) ||
     Boolean(props.deltaCaption) ||
-    Boolean(slots.caption)
-  )
-})
+    Boolean(slots.caption),
+)
 
 // `preserveAspectRatio="none"` makes the horizontal unit meaningless — fine for
 // a line with no axis — so the geometry is computed once at any card width.

--- a/src/charts/NumberCard.vue
+++ b/src/charts/NumberCard.vue
@@ -156,7 +156,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
-import { useSlotTick } from '../composables/useSlotTick'
+import { useReactiveSlots } from '../composables/useReactiveSlots'
 import {
   deltaDirection,
   deltaTone,
@@ -185,8 +185,8 @@ import type { NumberCardProps, NumberCardSlots } from './types'
 // NumberCard forwards a definite `false` and the surface never draws.
 const props = withDefaults(defineProps<NumberCardProps>(), { card: true })
 
-const slots = defineSlots<NumberCardSlots>()
-const slotTick = useSlotTick()
+defineSlots<NumberCardSlots>()
+const slots = useReactiveSlots()
 
 const root = ref<HTMLElement>()
 const dir = computed(() => props.dir ?? documentDir())
@@ -207,23 +207,18 @@ const toneClass = computed(
   () => TONE_CLASSES[deltaTone(props.delta, props.negativeIsBetter)],
 )
 const formattedDelta = computed(() => formatCardDelta(props, props.delta))
-const showEmptySlot = computed(() => {
-  slotTick.value
-  return isEmpty.value && Boolean(slots.empty)
-})
+const showEmptySlot = computed(() => isEmpty.value && Boolean(slots.empty))
 // Only over a reading. The em dash a card with no value prints is not a number
 // the color says anything about, and the loading skeleton is not one either.
 const valueStyle = computed(() =>
   props.color && !isEmpty.value ? { color: props.color } : undefined,
 )
-const showDeltaRow = computed(() => {
-  slotTick.value
-  return (
+const showDeltaRow = computed(
+  () =>
     Boolean(formattedDelta.value) ||
     Boolean(props.deltaCaption) ||
-    Boolean(slots.caption)
-  )
-})
+    Boolean(slots.caption),
+)
 
 // `preserveAspectRatio="none"` makes the horizontal unit meaningless — fine for
 // a line with no axis — so the geometry is computed once at any card width.

--- a/src/charts/NumberCard.vue
+++ b/src/charts/NumberCard.vue
@@ -200,7 +200,7 @@ import type { NumberCardProps, NumberCardSlots } from './types'
 const props = withDefaults(defineProps<NumberCardProps>(), { card: true })
 
 defineSlots<NumberCardSlots>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<NumberCardSlots>()
 
 const root = ref<HTMLElement>()
 const dir = computed(() => props.dir ?? documentDir())

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -17,7 +17,7 @@ const props = defineProps(alertProps)
 const emit = defineEmits<AlertEmits>()
 
 defineSlots<AlertSlots>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<AlertSlots>()
 
 watchEffect(() => {
   if (typeof props.icon === 'string') {

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive, watchEffect } from 'vue'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import Button from '../Button/Button.vue'
 import { warnUnsupportedIconString } from '../../utils/iconString'
 import { mergeActionProps } from '../shared/action'
@@ -16,8 +16,8 @@ const props = defineProps(alertProps)
 
 const emit = defineEmits<AlertEmits>()
 
-const slots = defineSlots<AlertSlots>()
-const slotTick = useSlotTick()
+defineSlots<AlertSlots>()
+const slots = useReactiveSlots()
 
 watchEffect(() => {
   if (typeof props.icon === 'string') {
@@ -33,12 +33,11 @@ watchEffect(() => {
 // Row when the content fits one line; banner when a description or a second
 // action needs the stacked layout. There is no layout prop — the computed
 // result is stamped as `data-layout`.
-const layout = computed(() => {
-  slotTick.value
-  return props.description || slots.description || props.secondaryAction
+const layout = computed(() =>
+  props.description || slots.description || props.secondaryAction
     ? 'banner'
-    : 'row'
-})
+    : 'row',
+)
 
 // Urgent themes interrupt assistive tech; the rest announce politely.
 const role = computed(() =>
@@ -60,27 +59,21 @@ const { lucideIcon, componentIcon } = useStatusIcon({
   icons: solidStatusIcons,
 })
 
-const showPrefix = computed(() => {
-  slotTick.value
-  return Boolean(slots.prefix || lucideIcon.value || componentIcon.value)
-})
+const showPrefix = computed(() =>
+  Boolean(slots.prefix || lucideIcon.value || componentIcon.value),
+)
 
 const iconColorClass = computed(() => iconColorClasses[props.theme])
 
-const showTitle = computed(() => {
-  slotTick.value
-  return Boolean(props.title || slots.title)
-})
+const showTitle = computed(() => Boolean(props.title || slots.title))
 
-const showDescription = computed(() => {
-  slotTick.value
-  return Boolean(props.description || slots.description)
-})
+const showDescription = computed(() =>
+  Boolean(props.description || slots.description),
+)
 
-const showBannerActions = computed(() => {
-  slotTick.value
-  return Boolean(slots.actions || props.primaryAction || props.secondaryAction)
-})
+const showBannerActions = computed(() =>
+  Boolean(slots.actions || props.primaryAction || props.secondaryAction),
+)
 
 function dismiss() {
   emit('dismiss')

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive, watchEffect } from 'vue'
+import { useSlotTick } from '../../composables/useSlotTick'
 import Button from '../Button/Button.vue'
 import { warnUnsupportedIconString } from '../../utils/iconString'
 import { mergeActionProps } from '../shared/action'
@@ -16,6 +17,7 @@ const props = defineProps(alertProps)
 const emit = defineEmits<AlertEmits>()
 
 const slots = defineSlots<AlertSlots>()
+const slotTick = useSlotTick()
 
 watchEffect(() => {
   if (typeof props.icon === 'string') {
@@ -31,11 +33,12 @@ watchEffect(() => {
 // Row when the content fits one line; banner when a description or a second
 // action needs the stacked layout. There is no layout prop — the computed
 // result is stamped as `data-layout`.
-const layout = computed(() =>
-  props.description || slots.description || props.secondaryAction
+const layout = computed(() => {
+  slotTick.value
+  return props.description || slots.description || props.secondaryAction
     ? 'banner'
-    : 'row',
-)
+    : 'row'
+})
 
 // Urgent themes interrupt assistive tech; the rest announce politely.
 const role = computed(() =>
@@ -57,21 +60,27 @@ const { lucideIcon, componentIcon } = useStatusIcon({
   icons: solidStatusIcons,
 })
 
-const showPrefix = computed(() =>
-  Boolean(slots.prefix || lucideIcon.value || componentIcon.value),
-)
+const showPrefix = computed(() => {
+  slotTick.value
+  return Boolean(slots.prefix || lucideIcon.value || componentIcon.value)
+})
 
 const iconColorClass = computed(() => iconColorClasses[props.theme])
 
-const showTitle = computed(() => Boolean(props.title || slots.title))
+const showTitle = computed(() => {
+  slotTick.value
+  return Boolean(props.title || slots.title)
+})
 
-const showDescription = computed(() =>
-  Boolean(props.description || slots.description),
-)
+const showDescription = computed(() => {
+  slotTick.value
+  return Boolean(props.description || slots.description)
+})
 
-const showBannerActions = computed(() =>
-  Boolean(slots.actions || props.primaryAction || props.secondaryAction),
-)
+const showBannerActions = computed(() => {
+  slotTick.value
+  return Boolean(slots.actions || props.primaryAction || props.secondaryAction)
+})
 
 function dismiss() {
   emit('dismiss')

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -18,7 +18,7 @@ import { RouterLink } from 'vue-router'
 import Spinner from '../Spinner/Spinner.vue'
 import TooltipBubble from '../Tooltip/TooltipBubble.vue'
 import { warnUnsupportedIconString } from '../../utils/iconString'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { buttonProps, type ThemeVariant } from './types'
 
 export default defineComponent({
@@ -35,8 +35,11 @@ export default defineComponent({
     /** Content shown after the button label (right icon / custom content) */
     suffix: void
   }>,
-  setup(props, { attrs, slots }) {
-    const slotTick = useSlotTick()
+  setup(props, { attrs, slots: rawSlots }) {
+    // The computeds below read the slots, and the object Vue hands to `setup`
+    // is mutated in place and never tracked. `typeof rawSlots` keeps the
+    // typing `slots: Object as SlotsType<...>` above declares.
+    const slots = useReactiveSlots<typeof rawSlots>()
 
     watchEffect(() => {
       warnUnsupportedIconString('Button', 'icon', props.icon)
@@ -51,14 +54,11 @@ export default defineComponent({
     // group's skip-delay applies to this button instead of a private provider.
     const parentTooltipProvider = injectTooltipProviderContext(null)
 
-    // Re-reads the tick on every update, but its value is the slot function
+    // Re-reads the slots on every update, but its value is the slot function
     // itself, so it only propagates when the slot actually changes. Without
     // this gate the check below would materialize a throwaway vnode tree on
     // every render of every text button.
-    const defaultSlot = computed(() => {
-      slotTick.value
-      return slots.default
-    })
+    const defaultSlot = computed(() => slots.default)
 
     // Render as an icon button when the default slot is exactly one lucide-* icon.
     const hasLucideIconInDefaultSlot = computed(() => {
@@ -68,14 +68,12 @@ export default defineComponent({
       return typeof name === 'string' && name.startsWith('lucide-')
     })
 
-    const isIconButton = computed(() => {
-      slotTick.value
-      return (
+    const isIconButton = computed(
+      () =>
         Boolean(props.icon) ||
         Boolean(slots.icon) ||
-        hasLucideIconInDefaultSlot.value
-      )
-    })
+        hasLucideIconInDefaultSlot.value,
+    )
 
     const slotClasses = computed(
       () => ({ xs: 'h-3.5', sm: 'h-4', md: 'h-4.5', lg: 'h-5' })[props.size],

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -19,6 +19,7 @@ import { RouterLink } from 'vue-router'
 import Spinner from '../Spinner/Spinner.vue'
 import TooltipBubble from '../Tooltip/TooltipBubble.vue'
 import { warnUnsupportedIconString } from '../../utils/iconString'
+import { useSlotTick } from '../../composables/useSlotTick'
 import { buttonProps, type ThemeVariant } from './types'
 
 export default defineComponent({
@@ -36,6 +37,8 @@ export default defineComponent({
     suffix: void
   }>,
   setup(props, { attrs, slots, expose }) {
+    const slotTick = useSlotTick()
+
     watchEffect(() => {
       warnUnsupportedIconString('Button', 'icon', props.icon)
       warnUnsupportedIconString('Button', 'iconLeft', props.iconLeft)
@@ -51,18 +54,21 @@ export default defineComponent({
 
     // Render as an icon button when the default slot is exactly one lucide-* icon.
     const hasLucideIconInDefaultSlot = computed(() => {
+      slotTick.value
       const content = slots.default?.()
       if (!Array.isArray(content)) return false
       const name = (content[0]?.type as { name?: string })?.name
       return typeof name === 'string' && name.startsWith('lucide-')
     })
 
-    const isIconButton = computed(
-      () =>
+    const isIconButton = computed(() => {
+      slotTick.value
+      return (
         Boolean(props.icon) ||
         Boolean(slots.icon) ||
-        hasLucideIconInDefaultSlot.value,
-    )
+        hasLucideIconInDefaultSlot.value
+      )
+    })
 
     const slotClasses = computed(
       () => ({ xs: 'h-3.5', sm: 'h-4', md: 'h-4.5', lg: 'h-5' })[props.size],

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -18,6 +18,7 @@ import { RouterLink } from 'vue-router'
 import Spinner from '../Spinner/Spinner.vue'
 import TooltipBubble from '../Tooltip/TooltipBubble.vue'
 import { warnUnsupportedIconString } from '../../utils/iconString'
+import { useSlotTick } from '../../composables/useSlotTick'
 import { buttonProps, type ThemeVariant } from './types'
 
 export default defineComponent({
@@ -35,6 +36,8 @@ export default defineComponent({
     suffix: void
   }>,
   setup(props, { attrs, slots }) {
+    const slotTick = useSlotTick()
+
     watchEffect(() => {
       warnUnsupportedIconString('Button', 'icon', props.icon)
       warnUnsupportedIconString('Button', 'iconLeft', props.iconLeft)
@@ -50,18 +53,21 @@ export default defineComponent({
 
     // Render as an icon button when the default slot is exactly one lucide-* icon.
     const hasLucideIconInDefaultSlot = computed(() => {
+      slotTick.value
       const content = slots.default?.()
       if (!Array.isArray(content)) return false
       const name = (content[0]?.type as { name?: string })?.name
       return typeof name === 'string' && name.startsWith('lucide-')
     })
 
-    const isIconButton = computed(
-      () =>
+    const isIconButton = computed(() => {
+      slotTick.value
+      return (
         Boolean(props.icon) ||
         Boolean(slots.icon) ||
-        hasLucideIconInDefaultSlot.value,
-    )
+        hasLucideIconInDefaultSlot.value
+      )
+    })
 
     const slotClasses = computed(
       () => ({ xs: 'h-3.5', sm: 'h-4', md: 'h-4.5', lg: 'h-5' })[props.size],

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -19,7 +19,7 @@ import { RouterLink } from 'vue-router'
 import Spinner from '../Spinner/Spinner.vue'
 import TooltipBubble from '../Tooltip/TooltipBubble.vue'
 import { warnUnsupportedIconString } from '../../utils/iconString'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { buttonProps, type ThemeVariant } from './types'
 
 export default defineComponent({
@@ -36,8 +36,11 @@ export default defineComponent({
     /** Content shown after the button label (right icon / custom content) */
     suffix: void
   }>,
-  setup(props, { attrs, slots, expose }) {
-    const slotTick = useSlotTick()
+  setup(props, { attrs, slots: rawSlots, expose }) {
+    // The computeds below read the slots, and the object Vue hands to `setup`
+    // is mutated in place and never tracked. `typeof rawSlots` keeps the
+    // typing `slots: Object as SlotsType<...>` above declares.
+    const slots = useReactiveSlots<typeof rawSlots>()
 
     watchEffect(() => {
       warnUnsupportedIconString('Button', 'icon', props.icon)
@@ -52,14 +55,11 @@ export default defineComponent({
     // group's skip-delay applies to this button instead of a private provider.
     const parentTooltipProvider = injectTooltipProviderContext(null)
 
-    // Re-reads the tick on every update, but its value is the slot function
+    // Re-reads the slots on every update, but its value is the slot function
     // itself, so it only propagates when the slot actually changes. Without
     // this gate the check below would materialize a throwaway vnode tree on
     // every render of every text button.
-    const defaultSlot = computed(() => {
-      slotTick.value
-      return slots.default
-    })
+    const defaultSlot = computed(() => slots.default)
 
     // Render as an icon button when the default slot is exactly one lucide-* icon.
     const hasLucideIconInDefaultSlot = computed(() => {
@@ -69,14 +69,12 @@ export default defineComponent({
       return typeof name === 'string' && name.startsWith('lucide-')
     })
 
-    const isIconButton = computed(() => {
-      slotTick.value
-      return (
+    const isIconButton = computed(
+      () =>
         Boolean(props.icon) ||
         Boolean(slots.icon) ||
-        hasLucideIconInDefaultSlot.value
-      )
-    })
+        hasLucideIconInDefaultSlot.value,
+    )
 
     const slotClasses = computed(
       () => ({ xs: 'h-3.5', sm: 'h-4', md: 'h-4.5', lg: 'h-5' })[props.size],

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -52,10 +52,18 @@ export default defineComponent({
     // group's skip-delay applies to this button instead of a private provider.
     const parentTooltipProvider = injectTooltipProviderContext(null)
 
+    // Re-reads the tick on every update, but its value is the slot function
+    // itself, so it only propagates when the slot actually changes. Without
+    // this gate the check below would materialize a throwaway vnode tree on
+    // every render of every text button.
+    const defaultSlot = computed(() => {
+      slotTick.value
+      return slots.default
+    })
+
     // Render as an icon button when the default slot is exactly one lucide-* icon.
     const hasLucideIconInDefaultSlot = computed(() => {
-      slotTick.value
-      const content = slots.default?.()
+      const content = defaultSlot.value?.()
       if (!Array.isArray(content)) return false
       const name = (content[0]?.type as { name?: string })?.name
       return typeof name === 'string' && name.startsWith('lucide-')

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -51,10 +51,18 @@ export default defineComponent({
     // group's skip-delay applies to this button instead of a private provider.
     const parentTooltipProvider = injectTooltipProviderContext(null)
 
+    // Re-reads the tick on every update, but its value is the slot function
+    // itself, so it only propagates when the slot actually changes. Without
+    // this gate the check below would materialize a throwaway vnode tree on
+    // every render of every text button.
+    const defaultSlot = computed(() => {
+      slotTick.value
+      return slots.default
+    })
+
     // Render as an icon button when the default slot is exactly one lucide-* icon.
     const hasLucideIconInDefaultSlot = computed(() => {
-      slotTick.value
-      const content = slots.default?.()
+      const content = defaultSlot.value?.()
       if (!Array.isArray(content)) return false
       const name = (content[0]?.type as { name?: string })?.name
       return typeof name === 'string' && name.startsWith('lucide-')

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -56,8 +56,9 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, useAttrs, watchEffect, useSlots } from 'vue'
+import { computed, ref, useAttrs, watchEffect } from 'vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -86,14 +87,14 @@ function onChange(e: Event) {
   model.value = (e.target as HTMLInputElement).checked
 }
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
   label?: (props: { required: boolean }) => any
   /** Overrides the rendered description content. */
   description?: () => any
 }>()
 
-const slots = useSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
 const {
   inputId,

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -1,12 +1,5 @@
 <script setup lang="ts">
-import {
-  computed,
-  nextTick,
-  ref,
-  useAttrs,
-  useTemplateRef,
-  watch,
-} from 'vue'
+import { computed, nextTick, ref, useAttrs, useTemplateRef, watch } from 'vue'
 import {
   ComboboxAnchor,
   ComboboxContent,

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -4,7 +4,6 @@ import {
   nextTick,
   ref,
   useAttrs,
-  useSlots,
   useTemplateRef,
   watch,
 } from 'vue'
@@ -21,7 +20,7 @@ import OptionIcon from '../shared/selection/OptionIcon.vue'
 import PopoverPanel from '../shared/popover/PopoverPanel.vue'
 import ComboboxResults from './ComboboxResults.vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { usePortalTarget } from '../../composables/usePortalTarget'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
@@ -88,8 +87,7 @@ const portalTarget = usePortalTarget(() => props.portalTo)
 
 const emit = defineEmits<ComboboxEmits>()
 const attrs = useAttrs()
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 const model = defineModel<ComboboxOptionValue | null>({ default: null })
 const open = defineModel<boolean>('open', { default: false })
@@ -123,7 +121,6 @@ const {
 })
 
 const hasLabeling = computed(() => {
-  slotTick.value
   return Boolean(
     props.label ||
     props.description ||
@@ -206,10 +203,9 @@ const typedQuery = computed(() => (hasTypedSinceOpen.value ? query.value : ''))
 // Button mode covers two paths: caller-provided `#trigger` slot, or the
 // built-in button trigger selected via `trigger="button"`. In both cases
 // the search input moves into the popover.
-const isButtonMode = computed(() => {
-  slotTick.value
-  return Boolean(slots.trigger) || props.trigger === 'button'
-})
+const isButtonMode = computed(
+  () => Boolean(slots.trigger) || props.trigger === 'button',
+)
 
 const filteredGroups = useFilteredGroups<NormalizedItem, NormalizedGroup>({
   groups: normalizedGroups,

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -80,7 +80,12 @@ const portalTarget = usePortalTarget(() => props.portalTo)
 
 const emit = defineEmits<ComboboxEmits>()
 const attrs = useAttrs()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<ComboboxSlots>()
+
+// `ComboboxResults` dispatches on dynamic names (`item-${slot}`), which the
+// enumerated `ComboboxSlots` cannot express. Same object, so reads still go
+// through the proxy.
+const slotFns = slots as Record<string, ((props?: any) => any) | undefined>
 
 const model = defineModel<ComboboxOptionValue | null>({ default: null })
 const open = defineModel<boolean>('open', { default: false })
@@ -729,7 +734,7 @@ defineSlots<ComboboxSlots>()
                   :loading="loading"
                   :empty-text="emptyText"
                   :show-empty="showEmpty"
-                  :slot-fns="slots"
+                  :slot-fns="slotFns"
                   :all-selectable-options="allSelectableOptions"
                   @select-custom="handleCustomItemSelect"
                 />

--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -21,6 +21,7 @@ import OptionIcon from '../shared/selection/OptionIcon.vue'
 import PopoverPanel from '../shared/popover/PopoverPanel.vue'
 import ComboboxResults from './ComboboxResults.vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { useSlotTick } from '../../composables/useSlotTick'
 import { usePortalTarget } from '../../composables/usePortalTarget'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
@@ -88,6 +89,7 @@ const portalTarget = usePortalTarget(() => props.portalTo)
 const emit = defineEmits<ComboboxEmits>()
 const attrs = useAttrs()
 const slots = useSlots()
+const slotTick = useSlotTick()
 
 const model = defineModel<ComboboxOptionValue | null>({ default: null })
 const open = defineModel<boolean>('open', { default: false })
@@ -121,6 +123,7 @@ const {
 })
 
 const hasLabeling = computed(() => {
+  slotTick.value
   return Boolean(
     props.label ||
     props.description ||
@@ -203,9 +206,10 @@ const typedQuery = computed(() => (hasTypedSinceOpen.value ? query.value : ''))
 // Button mode covers two paths: caller-provided `#trigger` slot, or the
 // built-in button trigger selected via `trigger="button"`. In both cases
 // the search input moves into the popover.
-const isButtonMode = computed(
-  () => Boolean(slots.trigger) || props.trigger === 'button',
-)
+const isButtonMode = computed(() => {
+  slotTick.value
+  return Boolean(slots.trigger) || props.trigger === 'button'
+})
 
 const filteredGroups = useFilteredGroups<NormalizedItem, NormalizedGroup>({
   groups: normalizedGroups,

--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -49,7 +49,7 @@ const props = withDefaults(defineProps<ContextMenuProps>(), {
 
 defineSlots<ContextMenuSlots>()
 
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<ContextMenuSlots>()
 
 const portalTarget = usePortalTarget()
 

--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onUnmounted, useSlots, watch } from 'vue'
+import { computed, onUnmounted, watch } from 'vue'
 import {
   ContextMenuContent,
   ContextMenuItem,
@@ -39,6 +39,7 @@ import Menu from '../Menu/Menu.vue'
 import { menuClasses, normalizeMenuOptions } from '../Menu/utils'
 import type { ContextMenuProps, ContextMenuSlots } from './types'
 import { usePortalTarget } from '../../composables/usePortalTarget'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 
 const openModel = defineModel<boolean>('open', { default: false })
 
@@ -48,7 +49,7 @@ const props = withDefaults(defineProps<ContextMenuProps>(), {
 
 defineSlots<ContextMenuSlots>()
 
-const slots = useSlots()
+const slots = useReactiveSlots()
 
 const portalTarget = usePortalTarget()
 

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -78,6 +78,7 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from 'vue'
+import { useSlotTick } from '../../composables/useSlotTick'
 import { dayjs, dayjsLocal } from '../../utils/dayjs'
 import { generateWeeks } from './utils'
 import CalendarPanel, { type CalendarPanelCell } from './CalendarPanel.vue'
@@ -110,10 +111,14 @@ const props = withDefaults(defineProps<DatePickerProps>(), {
 const emit = defineEmits<DatePickerEmits>()
 
 const slots = defineSlots<DatePickerSlots>()
+const slotTick = useSlotTick()
 
 // Layout only — the elevated shell (rounded/bg/shadow/ring) is owned by
 // PopoverPanel inside PickerShell.
-const contentClass = computed(() => (slots.actions ? 'w-fit' : 'w-56'))
+const contentClass = computed(() => {
+  slotTick.value
+  return slots.actions ? 'w-fit' : 'w-56'
+})
 
 // ── Popover open state ───────────────────────────────────────────────────────
 

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -111,7 +111,7 @@ const props = withDefaults(defineProps<DatePickerProps>(), {
 const emit = defineEmits<DatePickerEmits>()
 
 defineSlots<DatePickerSlots>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<DatePickerSlots>()
 
 // Layout only — the elevated shell (rounded/bg/shadow/ring) is owned by
 // PopoverPanel inside PickerShell.

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -78,7 +78,7 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from 'vue'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { dayjs, dayjsLocal } from '../../utils/dayjs'
 import { generateWeeks } from './utils'
 import CalendarPanel, { type CalendarPanelCell } from './CalendarPanel.vue'
@@ -110,15 +110,12 @@ const props = withDefaults(defineProps<DatePickerProps>(), {
 })
 const emit = defineEmits<DatePickerEmits>()
 
-const slots = defineSlots<DatePickerSlots>()
-const slotTick = useSlotTick()
+defineSlots<DatePickerSlots>()
+const slots = useReactiveSlots()
 
 // Layout only — the elevated shell (rounded/bg/shadow/ring) is owned by
 // PopoverPanel inside PickerShell.
-const contentClass = computed(() => {
-  slotTick.value
-  return slots.actions ? 'w-fit' : 'w-56'
-})
+const contentClass = computed(() => (slots.actions ? 'w-fit' : 'w-56'))
 
 // ── Popover open state ───────────────────────────────────────────────────────
 

--- a/src/components/DatePicker/DateRangePicker.vue
+++ b/src/components/DatePicker/DateRangePicker.vue
@@ -142,7 +142,7 @@ const props = withDefaults(defineProps<DateRangePickerProps>(), {
 })
 const emit = defineEmits<DateRangePickerEmits>()
 
-const slots = defineSlots<DateRangePickerSlots>()
+defineSlots<DateRangePickerSlots>()
 
 // ── Popover open state ───────────────────────────────────────────────────────
 

--- a/src/components/DatePicker/DateTimePicker.vue
+++ b/src/components/DatePicker/DateTimePicker.vue
@@ -94,6 +94,7 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from 'vue'
+import { useSlotTick } from '../../composables/useSlotTick'
 import TimePicker from '../TimePicker/TimePicker.vue'
 import { dayjs, dayjsLocal, dayjsSystem } from '../../utils/dayjs'
 import { generateWeeks } from './utils'
@@ -127,10 +128,14 @@ const props = withDefaults(defineProps<DateTimePickerProps>(), {
 const emit = defineEmits<DateTimePickerEmits>()
 
 const slots = defineSlots<DateTimePickerSlots>()
+const slotTick = useSlotTick()
 
 // Layout only — the elevated shell (rounded/bg/shadow/ring) is owned by
 // PopoverPanel inside PickerShell.
-const contentClass = computed(() => (slots.actions ? 'w-fit' : 'w-56'))
+const contentClass = computed(() => {
+  slotTick.value
+  return slots.actions ? 'w-fit' : 'w-56'
+})
 
 // ── Popover open state ───────────────────────────────────────────────────────
 

--- a/src/components/DatePicker/DateTimePicker.vue
+++ b/src/components/DatePicker/DateTimePicker.vue
@@ -94,7 +94,7 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from 'vue'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import TimePicker from '../TimePicker/TimePicker.vue'
 import { dayjs, dayjsLocal, dayjsSystem } from '../../utils/dayjs'
 import { generateWeeks } from './utils'
@@ -127,15 +127,12 @@ const props = withDefaults(defineProps<DateTimePickerProps>(), {
 })
 const emit = defineEmits<DateTimePickerEmits>()
 
-const slots = defineSlots<DateTimePickerSlots>()
-const slotTick = useSlotTick()
+defineSlots<DateTimePickerSlots>()
+const slots = useReactiveSlots()
 
 // Layout only — the elevated shell (rounded/bg/shadow/ring) is owned by
 // PopoverPanel inside PickerShell.
-const contentClass = computed(() => {
-  slotTick.value
-  return slots.actions ? 'w-fit' : 'w-56'
-})
+const contentClass = computed(() => (slots.actions ? 'w-fit' : 'w-56'))
 
 // ── Popover open state ───────────────────────────────────────────────────────
 

--- a/src/components/DatePicker/DateTimePicker.vue
+++ b/src/components/DatePicker/DateTimePicker.vue
@@ -128,7 +128,7 @@ const props = withDefaults(defineProps<DateTimePickerProps>(), {
 const emit = defineEmits<DateTimePickerEmits>()
 
 defineSlots<DateTimePickerSlots>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<DateTimePickerSlots>()
 
 // Layout only — the elevated shell (rounded/bg/shadow/ring) is owned by
 // PopoverPanel inside PickerShell.

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -193,11 +193,11 @@ const props = withDefaults(defineProps<DialogProps>(), {
 
 const emit = defineEmits<DialogEmits>()
 
-const slots = defineSlots<DialogSlots>()
+defineSlots<DialogSlots>()
 
 const portalTarget = usePortalTarget()
 
-const allSlots = useReactiveSlots()
+const slots = useReactiveSlots<DialogSlots>()
 
 const isDismissible = computed(() => props.dismissible !== false)
 
@@ -345,7 +345,7 @@ const isSingleActionFullWidth = computed(() => {
 // is title/slot-driven only — the close button lives independently.
 const showHeader = computed(() => {
   if (props.bare) return false
-  if (allSlots.title) return true
+  if (slots.title) return true
   if (props.title) return true
   return false
 })

--- a/src/components/Dialog/Dialog.vue
+++ b/src/components/Dialog/Dialog.vue
@@ -159,11 +159,12 @@ import {
   DialogDescription,
   DialogClose,
 } from 'reka-ui'
-import { computed, reactive, ref, useSlots, watchEffect } from 'vue'
+import { computed, reactive, ref, watchEffect } from 'vue'
 import type { ComponentPublicInstance } from 'vue'
 import { useAutofocusOnOpen } from '../../composables/useAutofocusOnOpen'
 import { usePortalTarget } from '../../composables/usePortalTarget'
 import { Button } from '../Button'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import {
   warnUnsupportedIconString,
   isLucideIconString,
@@ -196,7 +197,7 @@ const slots = defineSlots<DialogSlots>()
 
 const portalTarget = usePortalTarget()
 
-const allSlots = useSlots()
+const allSlots = useReactiveSlots()
 
 const isDismissible = computed(() => props.dismissible !== false)
 

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -73,7 +73,7 @@ defineOptions({
 
 const openModel = defineModel<boolean>('open', { default: false })
 const attrs = useAttrs()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<DropdownSlots>()
 
 const props = withDefaults(defineProps<DropdownProps>(), {
   options: () => [],

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onScopeDispose, useAttrs, useSlots } from 'vue'
+import { computed, onScopeDispose, useAttrs } from 'vue'
 import {
   DropdownMenuContent,
   DropdownMenuItem,
@@ -65,6 +65,7 @@ import Menu from '../Menu/Menu.vue'
 import type { DropdownProps, DropdownSlots } from './types'
 import { menuClasses, normalizeMenuOptions, warnRemoved } from '../Menu/utils'
 import { usePortalTarget } from '../../composables/usePortalTarget'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 
 defineOptions({
   inheritAttrs: false,
@@ -72,7 +73,7 @@ defineOptions({
 
 const openModel = defineModel<boolean>('open', { default: false })
 const attrs = useAttrs()
-const slots = useSlots()
+const slots = useReactiveSlots()
 
 const props = withDefaults(defineProps<DropdownProps>(), {
   options: () => [],

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -12,6 +12,7 @@ import Button from '../Button/Button.vue'
 import { LoadingIndicator } from '../LoadingIndicator'
 import MultiSelectResults from './MultiSelectResults.vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { useSlotTick } from '../../composables/useSlotTick'
 import { usePortalTarget } from '../../composables/usePortalTarget'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
@@ -69,6 +70,7 @@ const portalTarget = usePortalTarget(() => props.portalTo)
 const emit = defineEmits<MultiSelectEmits>()
 const attrs = useAttrs()
 const slots = useSlots()
+const slotTick = useSlotTick()
 
 const model = defineModel<Array<string | number>>({ default: () => [] })
 const open = defineModel<boolean>('open', { default: false })
@@ -102,6 +104,7 @@ const {
 })
 
 const hasLabeling = computed(() => {
+  slotTick.value
   return Boolean(
     props.label ||
     props.description ||

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, useAttrs, useSlots, useTemplateRef, watch } from 'vue'
+import { computed, ref, useAttrs, useTemplateRef, watch } from 'vue'
 import {
   ComboboxAnchor,
   ComboboxContent,
@@ -12,7 +12,7 @@ import Button from '../Button/Button.vue'
 import { LoadingIndicator } from '../LoadingIndicator'
 import MultiSelectResults from './MultiSelectResults.vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { usePortalTarget } from '../../composables/usePortalTarget'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import { useFilteredGroups } from '../shared/selection/useFilteredGroups'
@@ -69,8 +69,7 @@ const portalTarget = usePortalTarget(() => props.portalTo)
 
 const emit = defineEmits<MultiSelectEmits>()
 const attrs = useAttrs()
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 const model = defineModel<Array<string | number>>({ default: () => [] })
 const open = defineModel<boolean>('open', { default: false })
@@ -104,7 +103,6 @@ const {
 })
 
 const hasLabeling = computed(() => {
-  slotTick.value
   return Boolean(
     props.label ||
     props.description ||

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -69,7 +69,12 @@ const portalTarget = usePortalTarget(() => props.portalTo)
 
 const emit = defineEmits<MultiSelectEmits>()
 const attrs = useAttrs()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<MultiSelectSlots>()
+
+// `MultiSelectResults` dispatches on dynamic names (`item-${slot}`), which the
+// enumerated `MultiSelectSlots` cannot express. Same object, so reads still go
+// through the proxy.
+const slotFns = slots as Record<string, ((props?: any) => any) | undefined>
 
 const model = defineModel<Array<string | number>>({ default: () => [] })
 const open = defineModel<boolean>('open', { default: false })
@@ -533,7 +538,7 @@ defineSlots<MultiSelectSlots>()
                 :hide-search="hideSearch"
                 :empty-text="emptyText"
                 :show-empty="showEmpty"
-                :slot-fns="slots"
+                :slot-fns="slotFns"
                 :all-options="allOptions"
               />
 

--- a/src/components/PageHeader/PageHeaderMobile.vue
+++ b/src/components/PageHeader/PageHeaderMobile.vue
@@ -36,8 +36,8 @@
 
 <script setup lang="ts">
 import { useElementSize } from '@vueuse/core'
-import { computed, useSlots, useTemplateRef, type CSSProperties } from 'vue'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { computed, useTemplateRef, type CSSProperties } from 'vue'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import PageHeaderBase from './PageHeaderBase.vue'
 import type { PageHeaderMobileProps } from './types'
 
@@ -52,16 +52,9 @@ defineSlots<{
   suffix?: () => any
 }>()
 
-const slots = useSlots()
-const slotTick = useSlotTick()
-const hasPrefixSlot = computed(() => {
-  slotTick.value
-  return Boolean(slots.prefix)
-})
-const hasSuffixSlot = computed(() => {
-  slotTick.value
-  return Boolean(slots.suffix)
-})
+const slots = useReactiveSlots()
+const hasPrefixSlot = computed(() => Boolean(slots.prefix))
+const hasSuffixSlot = computed(() => Boolean(slots.suffix))
 
 // The title stays visually centered regardless of how wide the prefix/suffix
 // controls are: inset it symmetrically by the widest control.

--- a/src/components/PageHeader/PageHeaderMobile.vue
+++ b/src/components/PageHeader/PageHeaderMobile.vue
@@ -43,7 +43,7 @@ import type { PageHeaderMobileProps } from './types'
 
 defineProps<PageHeaderMobileProps>()
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** A control leading the centered title — usually a `PageHeaderBackButton`. */
   prefix?: () => any
   /** The centered title. Overrides `title`; usually a `PageHeaderMobileTitle`. */
@@ -52,7 +52,7 @@ defineSlots<{
   suffix?: () => any
 }>()
 
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 const hasPrefixSlot = computed(() => Boolean(slots.prefix))
 const hasSuffixSlot = computed(() => Boolean(slots.suffix))
 

--- a/src/components/PageHeader/PageHeaderMobile.vue
+++ b/src/components/PageHeader/PageHeaderMobile.vue
@@ -37,6 +37,7 @@
 <script setup lang="ts">
 import { useElementSize } from '@vueuse/core'
 import { computed, useSlots, useTemplateRef, type CSSProperties } from 'vue'
+import { useSlotTick } from '../../composables/useSlotTick'
 import PageHeaderBase from './PageHeaderBase.vue'
 import type { PageHeaderMobileProps } from './types'
 
@@ -52,8 +53,15 @@ defineSlots<{
 }>()
 
 const slots = useSlots()
-const hasPrefixSlot = computed(() => Boolean(slots.prefix))
-const hasSuffixSlot = computed(() => Boolean(slots.suffix))
+const slotTick = useSlotTick()
+const hasPrefixSlot = computed(() => {
+  slotTick.value
+  return Boolean(slots.prefix)
+})
+const hasSuffixSlot = computed(() => {
+  slotTick.value
+  return Boolean(slots.suffix)
+})
 
 // The title stays visually centered regardless of how wide the prefix/suffix
 // controls are: inset it symmetrically by the widest control.

--- a/src/components/Radio/Radio.vue
+++ b/src/components/Radio/Radio.vue
@@ -33,6 +33,7 @@
 
 <script lang="ts" setup>
 import { computed, inject, useSlots } from 'vue'
+import { useSlotTick } from '../../composables/useSlotTick'
 // See RadioGroup.vue — AcceptableValue omits `boolean` at the type level only.
 import { RadioGroupItem, type AcceptableValue } from 'reka-ui'
 import { useId } from '../../utils/useId'
@@ -44,6 +45,7 @@ const props = withDefaults(defineProps<RadioProps>(), {
 })
 
 const slots = useSlots()
+const slotTick = useSlotTick()
 
 defineSlots<{
   /** Overrides the rendered label content. */
@@ -69,9 +71,10 @@ const fallbackId = useId()
 const inputId = computed(() => props.id ?? fallbackId)
 const labelId = computed(() => `${inputId.value}-label`)
 const descriptionId = computed(() => `${inputId.value}-description`)
-const hasDescription = computed(() =>
-  Boolean(props.description || slots.description),
-)
+const hasDescription = computed(() => {
+  slotTick.value
+  return Boolean(props.description || slots.description)
+})
 
 // The whole row is the control: reka-ui renders it as a `role="radio"` button,
 // so hover, focus and the click target cover the label and description without

--- a/src/components/Radio/Radio.vue
+++ b/src/components/Radio/Radio.vue
@@ -32,8 +32,8 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, useSlots } from 'vue'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { computed, inject } from 'vue'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 // See RadioGroup.vue — AcceptableValue omits `boolean` at the type level only.
 import { RadioGroupItem, type AcceptableValue } from 'reka-ui'
 import { useId } from '../../utils/useId'
@@ -44,8 +44,7 @@ const props = withDefaults(defineProps<RadioProps>(), {
   disabled: false,
 })
 
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 defineSlots<{
   /** Overrides the rendered label content. */
@@ -71,10 +70,9 @@ const fallbackId = useId()
 const inputId = computed(() => props.id ?? fallbackId)
 const labelId = computed(() => `${inputId.value}-label`)
 const descriptionId = computed(() => `${inputId.value}-description`)
-const hasDescription = computed(() => {
-  slotTick.value
-  return Boolean(props.description || slots.description)
-})
+const hasDescription = computed(() =>
+  Boolean(props.description || slots.description),
+)
 
 // The whole row is the control: reka-ui renders it as a `role="radio"` button,
 // so hover, focus and the click target cover the label and description without

--- a/src/components/Radio/Radio.vue
+++ b/src/components/Radio/Radio.vue
@@ -44,9 +44,9 @@ const props = withDefaults(defineProps<RadioProps>(), {
   disabled: false,
 })
 
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Overrides the rendered label content. */
   label?: () => any
   /** Overrides the rendered description content. */

--- a/src/components/Radio/RadioGroup.vue
+++ b/src/components/Radio/RadioGroup.vue
@@ -52,6 +52,7 @@ import { computed, provide, useSlots } from 'vue'
 import { RadioGroupRoot, type AcceptableValue } from 'reka-ui'
 import { useId } from '../../utils/useId'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { useSlotTick } from '../../composables/useSlotTick'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -68,6 +69,7 @@ const props = withDefaults(defineProps<RadioGroupProps>(), {
 
 const model = defineModel<RadioValue>()
 const slots = useSlots()
+const slotTick = useSlotTick()
 
 defineSlots<{
   /** The `<Radio>` options. */
@@ -104,6 +106,7 @@ const {
 // rows sit flush (the surface itself provides the separation); default rows get
 // a small gap.
 const rootClasses = computed(() => {
+  slotTick.value
   const stacked = props.orientation === 'vertical'
   const gap = props.padded ? '' : stacked ? 'gap-y-1.5' : 'gap-x-4'
   return [

--- a/src/components/Radio/RadioGroup.vue
+++ b/src/components/Radio/RadioGroup.vue
@@ -68,9 +68,9 @@ const props = withDefaults(defineProps<RadioGroupProps>(), {
 })
 
 const model = defineModel<RadioValue>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** The `<Radio>` options. */
   default?: () => any
   /** Overrides the rendered group heading. Receives `{ required }`. */

--- a/src/components/Radio/RadioGroup.vue
+++ b/src/components/Radio/RadioGroup.vue
@@ -45,14 +45,14 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, provide, useSlots } from 'vue'
+import { computed, provide } from 'vue'
 // reka-ui's AcceptableValue omits `boolean`, but the runtime never touches the
 // declared type — the prop is untyped and values are compared with ohash's
 // isEqual — so a yes/no radio works. Cast at the boundary to keep it.
 import { RadioGroupRoot, type AcceptableValue } from 'reka-ui'
 import { useId } from '../../utils/useId'
 import { useInputLabeling } from '../../composables/useInputLabeling'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -68,8 +68,7 @@ const props = withDefaults(defineProps<RadioGroupProps>(), {
 })
 
 const model = defineModel<RadioValue>()
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 defineSlots<{
   /** The `<Radio>` options. */
@@ -106,7 +105,6 @@ const {
 // rows sit flush (the surface itself provides the separation); default rows get
 // a small gap.
 const rootClasses = computed(() => {
-  slotTick.value
   const stacked = props.orientation === 'vertical'
   const gap = props.padded ? '' : stacked ? 'gap-y-1.5' : 'gap-x-4'
   return [

--- a/src/components/Rating/Rating.vue
+++ b/src/components/Rating/Rating.vue
@@ -132,6 +132,7 @@
 import { computed, ref, useAttrs, useSlots, nextTick } from 'vue'
 import type { StyleValue } from 'vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { useSlotTick } from '../../composables/useSlotTick'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -148,6 +149,7 @@ const props = withDefaults(defineProps<RatingProps>(), {
 
 const model = defineModel<number>({ default: 0 })
 const slots = useSlots()
+const slotTick = useSlotTick()
 const attrs = useAttrs()
 
 const isDisabled = computed(() => props.disabled)
@@ -381,6 +383,7 @@ function onKeydown(e: KeyboardEvent) {
 }
 
 const hasLabeling = computed(() => {
+  slotTick.value
   return Boolean(
     props.label || slots.label || rendersDescription.value || hasError.value,
   )

--- a/src/components/Rating/Rating.vue
+++ b/src/components/Rating/Rating.vue
@@ -148,12 +148,12 @@ const props = withDefaults(defineProps<RatingProps>(), {
 })
 
 const model = defineModel<number>({ default: 0 })
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 const attrs = useAttrs()
 
 const isDisabled = computed(() => props.disabled)
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
   label?: (props: { required: boolean }) => any
   /** Overrides the rendered description content. */

--- a/src/components/Rating/Rating.vue
+++ b/src/components/Rating/Rating.vue
@@ -129,10 +129,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, useAttrs, useSlots, nextTick } from 'vue'
+import { computed, ref, useAttrs, nextTick } from 'vue'
 import type { StyleValue } from 'vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -148,8 +148,7 @@ const props = withDefaults(defineProps<RatingProps>(), {
 })
 
 const model = defineModel<number>({ default: 0 })
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 const attrs = useAttrs()
 
 const isDisabled = computed(() => props.disabled)
@@ -383,7 +382,6 @@ function onKeydown(e: KeyboardEvent) {
 }
 
 const hasLabeling = computed(() => {
-  slotTick.value
   return Boolean(
     props.label || slots.label || rendersDescription.value || hasError.value,
   )

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, useAttrs, useSlots, useTemplateRef } from 'vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { useSlotTick } from '../../composables/useSlotTick'
 import { usePortalTarget } from '../../composables/usePortalTarget'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import type { SelectionExposed } from '../shared/selection/types'
@@ -64,6 +65,7 @@ const portalTarget = usePortalTarget(() => props.portalTo)
 
 const attrs = useAttrs()
 const slots = useSlots()
+const slotTick = useSlotTick()
 
 const triggerRef = useTemplateRef<{ $el?: HTMLElement } | null>('trigger')
 
@@ -104,6 +106,7 @@ const {
 })
 
 const hasLabeling = computed(() => {
+  slotTick.value
   return Boolean(
     props.label ||
     props.description ||

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, useAttrs, useSlots, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useInputLabeling } from '../../composables/useInputLabeling'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { usePortalTarget } from '../../composables/usePortalTarget'
 import { useEmptyValueMapping } from '../shared/selection/useEmptyValueMapping'
 import type { SelectionExposed } from '../shared/selection/types'
@@ -64,8 +64,7 @@ const props = withDefaults(defineProps<SelectProps>(), {
 const portalTarget = usePortalTarget(() => props.portalTo)
 
 const attrs = useAttrs()
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 const triggerRef = useTemplateRef<{ $el?: HTMLElement } | null>('trigger')
 
@@ -106,7 +105,6 @@ const {
 })
 
 const hasLabeling = computed(() => {
-  slotTick.value
   return Boolean(
     props.label ||
     props.description ||

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -64,7 +64,7 @@ const props = withDefaults(defineProps<SelectProps>(), {
 const portalTarget = usePortalTarget(() => props.portalTo)
 
 const attrs = useAttrs()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<SelectSlots>()
 
 const triggerRef = useTemplateRef<{ $el?: HTMLElement } | null>('trigger')
 

--- a/src/components/Sidebar/SidebarCard.vue
+++ b/src/components/Sidebar/SidebarCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watchEffect } from 'vue'
+import { useSlotTick } from '../../composables/useSlotTick'
 import Button from '../Button/Button.vue'
 import { warnUnsupportedIconString } from '../../utils/iconString'
 import { mergeActionProps } from '../shared/action'
@@ -27,6 +28,7 @@ const props = withDefaults(defineProps<SidebarCardProps>(), {
 const emit = defineEmits<SidebarCardEmits>()
 
 const slots = defineSlots<SidebarCardSlots>()
+const slotTick = useSlotTick()
 
 watchEffect(() => {
   if (typeof props.icon === 'string') {
@@ -51,19 +53,27 @@ const { lucideIcon, componentIcon } = useStatusIcon({
   icons: lineStatusIcons,
 })
 
-const showPrefix = computed(() =>
-  Boolean(slots.prefix || lucideIcon.value || componentIcon.value),
-)
+const showPrefix = computed(() => {
+  slotTick.value
+  return Boolean(slots.prefix || lucideIcon.value || componentIcon.value)
+})
 
 const iconColorClass = computed(() => iconColorClasses[props.theme])
 
-const showTitle = computed(() => Boolean(props.title || slots.title))
+const showTitle = computed(() => {
+  slotTick.value
+  return Boolean(props.title || slots.title)
+})
 
-const showDescription = computed(() =>
-  Boolean(props.description || slots.description),
-)
+const showDescription = computed(() => {
+  slotTick.value
+  return Boolean(props.description || slots.description)
+})
 
-const showActions = computed(() => Boolean(slots.actions || props.action))
+const showActions = computed(() => {
+  slotTick.value
+  return Boolean(slots.actions || props.action)
+})
 
 function dismiss() {
   emit('dismiss')

--- a/src/components/Sidebar/SidebarCard.vue
+++ b/src/components/Sidebar/SidebarCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watchEffect } from 'vue'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import Button from '../Button/Button.vue'
 import { warnUnsupportedIconString } from '../../utils/iconString'
 import { mergeActionProps } from '../shared/action'
@@ -27,8 +27,8 @@ const props = withDefaults(defineProps<SidebarCardProps>(), {
 
 const emit = defineEmits<SidebarCardEmits>()
 
-const slots = defineSlots<SidebarCardSlots>()
-const slotTick = useSlotTick()
+defineSlots<SidebarCardSlots>()
+const slots = useReactiveSlots()
 
 watchEffect(() => {
   if (typeof props.icon === 'string') {
@@ -53,27 +53,19 @@ const { lucideIcon, componentIcon } = useStatusIcon({
   icons: lineStatusIcons,
 })
 
-const showPrefix = computed(() => {
-  slotTick.value
-  return Boolean(slots.prefix || lucideIcon.value || componentIcon.value)
-})
+const showPrefix = computed(() =>
+  Boolean(slots.prefix || lucideIcon.value || componentIcon.value),
+)
 
 const iconColorClass = computed(() => iconColorClasses[props.theme])
 
-const showTitle = computed(() => {
-  slotTick.value
-  return Boolean(props.title || slots.title)
-})
+const showTitle = computed(() => Boolean(props.title || slots.title))
 
-const showDescription = computed(() => {
-  slotTick.value
-  return Boolean(props.description || slots.description)
-})
+const showDescription = computed(() =>
+  Boolean(props.description || slots.description),
+)
 
-const showActions = computed(() => {
-  slotTick.value
-  return Boolean(slots.actions || props.action)
-})
+const showActions = computed(() => Boolean(slots.actions || props.action))
 
 function dismiss() {
   emit('dismiss')

--- a/src/components/Sidebar/SidebarCard.vue
+++ b/src/components/Sidebar/SidebarCard.vue
@@ -28,7 +28,7 @@ const props = withDefaults(defineProps<SidebarCardProps>(), {
 const emit = defineEmits<SidebarCardEmits>()
 
 defineSlots<SidebarCardSlots>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<SidebarCardSlots>()
 
 watchEffect(() => {
   if (typeof props.icon === 'string') {

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -3,6 +3,7 @@ import { computed, normalizeClass, useSlots, useAttrs } from 'vue'
 import type { StyleValue } from 'vue'
 import { SliderRange, SliderRoot, SliderThumb, SliderTrack } from 'reka-ui'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { useSlotTick } from '../../composables/useSlotTick'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -21,6 +22,7 @@ const emit = defineEmits<SliderEmits>()
 /** The current slider value (controlled). */
 const model = defineModel<SliderValue>()
 const slots = useSlots()
+const slotTick = useSlotTick()
 
 const attrs = useAttrs()
 
@@ -205,6 +207,7 @@ function thumbNameFor(index: number): string | undefined {
 
 // Declared before `rootClasses`, which reads it.
 const hasLabeling = computed(() => {
+  slotTick.value
   return Boolean(
     props.label || slots.label || rendersDescription.value || hasError.value,
   )

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, normalizeClass, useSlots, useAttrs } from 'vue'
+import { computed, normalizeClass, useAttrs } from 'vue'
 import type { StyleValue } from 'vue'
 import { SliderRange, SliderRoot, SliderThumb, SliderTrack } from 'reka-ui'
 import { useInputLabeling } from '../../composables/useInputLabeling'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -21,8 +21,7 @@ const props = withDefaults(defineProps<SliderProps>(), {
 const emit = defineEmits<SliderEmits>()
 /** The current slider value (controlled). */
 const model = defineModel<SliderValue>()
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 const attrs = useAttrs()
 
@@ -207,7 +206,6 @@ function thumbNameFor(index: number): string | undefined {
 
 // Declared before `rootClasses`, which reads it.
 const hasLabeling = computed(() => {
-  slotTick.value
   return Boolean(
     props.label || slots.label || rendersDescription.value || hasError.value,
   )

--- a/src/components/Slider/Slider.vue
+++ b/src/components/Slider/Slider.vue
@@ -21,7 +21,7 @@ const props = withDefaults(defineProps<SliderProps>(), {
 const emit = defineEmits<SliderEmits>()
 /** The current slider value (controlled). */
 const model = defineModel<SliderValue>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
 const attrs = useAttrs()
 
@@ -85,7 +85,7 @@ const rootAttrs = computed(() => {
   )
 })
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
   label?: (props: { required: boolean }) => any
   /** Overrides the rendered description content. */

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -69,6 +69,7 @@
 import { computed, useSlots } from 'vue'
 import { SwitchRoot, SwitchThumb } from 'reka-ui'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { useSlotTick } from '../../composables/useSlotTick'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -82,6 +83,7 @@ const props = withDefaults(defineProps<SwitchProps>(), {
 
 const model = defineModel<boolean>({ default: false })
 const slots = useSlots()
+const slotTick = useSlotTick()
 
 defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
@@ -164,6 +166,7 @@ const switchLabelClasses = computed(() => {
 const controlPosition = computed(() => props.controlPosition ?? 'end')
 
 const switchGroupClasses = computed(() => {
+  slotTick.value
   const hasLabel = props.label || slots.label
   const hasDescription = props.description || slots.description
   if (!hasLabel && !hasDescription) return undefined
@@ -213,6 +216,7 @@ const errorIndentClasses = computed(() => {
 // so the total gap matches the other components (~4 px).
 // Settings-style rows (hasDescription) have no inner padding so keep mt-1.
 const errorSpacingClass = computed(() => {
+  slotTick.value
   const hasDescription = props.description || slots.description
   // A description sits tight under the label; error-only rows keep a small gap.
   if (hasDescription) return 'mt-0.5'

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -82,9 +82,9 @@ const props = withDefaults(defineProps<SwitchProps>(), {
 })
 
 const model = defineModel<boolean>({ default: false })
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
   label?: (props: { required: boolean }) => any
   /** Overrides the rendered description content. */

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -66,10 +66,10 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, useSlots } from 'vue'
+import { computed } from 'vue'
 import { SwitchRoot, SwitchThumb } from 'reka-ui'
 import { useInputLabeling } from '../../composables/useInputLabeling'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -82,8 +82,7 @@ const props = withDefaults(defineProps<SwitchProps>(), {
 })
 
 const model = defineModel<boolean>({ default: false })
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
@@ -166,7 +165,6 @@ const switchLabelClasses = computed(() => {
 const controlPosition = computed(() => props.controlPosition ?? 'end')
 
 const switchGroupClasses = computed(() => {
-  slotTick.value
   const hasLabel = props.label || slots.label
   const hasDescription = props.description || slots.description
   if (!hasLabel && !hasDescription) return undefined
@@ -216,7 +214,6 @@ const errorIndentClasses = computed(() => {
 // so the total gap matches the other components (~4 px).
 // Settings-style rows (hasDescription) have no inner padding so keep mt-1.
 const errorSpacingClass = computed(() => {
-  slotTick.value
   const hasDescription = props.description || slots.description
   // A description sits tight under the label; error-only rows keep a small gap.
   if (hasDescription) return 'mt-0.5'

--- a/src/components/Tabs/TabTrigger.vue
+++ b/src/components/Tabs/TabTrigger.vue
@@ -20,7 +20,7 @@ import type { TabTriggerProps, TabTriggerSlotProps } from './types'
 
 const props = defineProps<TabTriggerProps>()
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Leading content, after `iconLeft`. */
   prefix?: (props: TabTriggerSlotProps) => any
   /** Replaces the label region. */
@@ -28,7 +28,7 @@ defineSlots<{
   /** Trailing content (badges, counts). */
   suffix?: (props: TabTriggerSlotProps) => any
 }>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
 const root = inject(tabsRootKey, null)
 const list = inject(tabListKey, null)

--- a/src/components/Tabs/TabTrigger.vue
+++ b/src/components/Tabs/TabTrigger.vue
@@ -13,6 +13,7 @@ import Pill from '../shared/tabs/Pill.vue'
 import { NativeButton } from '../shared/nativeElements'
 import { tabRadiusClasses, tabShellClasses } from '../shared/tabs/styles'
 import { warnUnsupportedIconString } from '../../utils/iconString'
+import { useSlotTick } from '../../composables/useSlotTick'
 import { tabListKey, tabsRootKey } from './context'
 import type { BrowserTabBase } from '../shared/tabs/pillTypes'
 import type { TabTriggerProps, TabTriggerSlotProps } from './types'
@@ -27,6 +28,7 @@ const slots = defineSlots<{
   /** Trailing content (badges, counts). */
   suffix?: (props: TabTriggerSlotProps) => any
 }>()
+const slotTick = useSlotTick()
 
 const root = inject(tabsRootKey, null)
 const list = inject(tabListKey, null)
@@ -84,7 +86,10 @@ const slotProps = computed<TabTriggerSlotProps>(() => ({
   disabled: !!props.disabled,
 }))
 
-const isIconOnly = computed(() => Boolean(props.icon) && !slots.default)
+const isIconOnly = computed(() => {
+  slotTick.value
+  return Boolean(props.icon) && !slots.default
+})
 
 const browserTabBase = computed<BrowserTabBase>(() => {
   if (variant.value !== 'browser-tab') return 'none'

--- a/src/components/Tabs/TabTrigger.vue
+++ b/src/components/Tabs/TabTrigger.vue
@@ -13,14 +13,14 @@ import Pill from '../shared/tabs/Pill.vue'
 import { NativeButton } from '../shared/nativeElements'
 import { tabRadiusClasses, tabShellClasses } from '../shared/tabs/styles'
 import { warnUnsupportedIconString } from '../../utils/iconString'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { tabListKey, tabsRootKey } from './context'
 import type { BrowserTabBase } from '../shared/tabs/pillTypes'
 import type { TabTriggerProps, TabTriggerSlotProps } from './types'
 
 const props = defineProps<TabTriggerProps>()
 
-const slots = defineSlots<{
+defineSlots<{
   /** Leading content, after `iconLeft`. */
   prefix?: (props: TabTriggerSlotProps) => any
   /** Replaces the label region. */
@@ -28,7 +28,7 @@ const slots = defineSlots<{
   /** Trailing content (badges, counts). */
   suffix?: (props: TabTriggerSlotProps) => any
 }>()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 const root = inject(tabsRootKey, null)
 const list = inject(tabListKey, null)
@@ -86,10 +86,7 @@ const slotProps = computed<TabTriggerSlotProps>(() => ({
   disabled: !!props.disabled,
 }))
 
-const isIconOnly = computed(() => {
-  slotTick.value
-  return Boolean(props.icon) && !slots.default
-})
+const isIconOnly = computed(() => Boolean(props.icon) && !slots.default)
 
 const browserTabBase = computed<BrowserTabBase>(() => {
   if (variant.value !== 'browser-tab') return 'none'

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -11,6 +11,7 @@ import { TabsRoot } from 'reka-ui'
 import TabList from './TabList.vue'
 import TabTrigger from './TabTrigger.vue'
 import TabPanel from './TabPanel.vue'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { tabsRootKey, type TabTriggerRegistration } from './context'
 import type {
   TabItem,
@@ -28,7 +29,7 @@ const props = withDefaults(defineProps<TabsProps>(), {
 
 const emit = defineEmits<TabsEmits>()
 
-const slots = defineSlots<{
+const declaredSlots = defineSlots<{
   /** Composed mode: `TabList` / `TabPanel` children. */
   default?: () => any
   /** Shorthand mode: leading content in every generated trigger. */
@@ -40,6 +41,7 @@ const slots = defineSlots<{
   /** Shorthand mode: panel body for the selected tab. */
   'tab-panel'?: (props: { tab: TabItem }) => any
 }>()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
 if (import.meta.env.DEV) {
   let warned = false

--- a/src/components/TextInput/TextInput.cy.ts
+++ b/src/components/TextInput/TextInput.cy.ts
@@ -281,7 +281,10 @@ describe('Textinput', () => {
           h('div', [
             h(
               'button',
-              { 'data-cy': 'toggle', onClick: () => (show.value = !show.value) },
+              {
+                'data-cy': 'toggle',
+                onClick: () => (show.value = !show.value),
+              },
               'Toggle',
             ),
             h(

--- a/src/components/TextInput/TextInput.cy.ts
+++ b/src/components/TextInput/TextInput.cy.ts
@@ -258,4 +258,53 @@ describe('Textinput', () => {
     cy.get('[data-cy="prefix"]').should('exist').and('have.text', '$')
     cy.get('[data-cy="suffix"]').should('exist').and('have.text', '.00')
   })
+
+  it('reserves room for #prefix and #suffix', () => {
+    cy.mount(TextInput, {
+      slots: { prefix: '<span>$</span>', suffix: '<span>.00</span>' },
+    })
+    cy.get('input').should('have.class', 'ps-8').and('have.class', 'pe-8')
+
+    cy.mount(TextInput)
+    cy.get('input').should('have.class', 'ps-2').and('have.class', 'pe-2')
+  })
+
+  // The docs playground toggles both slots at runtime. The padding is read
+  // from `useSlots()`, which is not reactive, so a cached value used to leave
+  // the input at `ps-2` and the prefix painted over the text.
+  it('repads when a slot appears or disappears after mount', () => {
+    const Harness = defineComponent({
+      setup() {
+        const show = ref(false)
+
+        return () =>
+          h('div', [
+            h(
+              'button',
+              { 'data-cy': 'toggle', onClick: () => (show.value = !show.value) },
+              'Toggle',
+            ),
+            h(
+              TextInput,
+              null,
+              show.value
+                ? {
+                    prefix: () => h('span', '$'),
+                    suffix: () => h('span', '.00'),
+                  }
+                : {},
+            ),
+          ])
+      },
+    })
+
+    cy.mount(Harness)
+    cy.get('input').should('have.class', 'ps-2').and('have.class', 'pe-2')
+
+    cy.get('[data-cy="toggle"]').click()
+    cy.get('input').should('have.class', 'ps-8').and('have.class', 'pe-8')
+
+    cy.get('[data-cy="toggle"]').click()
+    cy.get('input').should('have.class', 'ps-2').and('have.class', 'pe-2')
+  })
 })

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -72,11 +72,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, useAttrs, useSlots } from 'vue'
+import { computed, ref, useAttrs } from 'vue'
 import type { StyleValue } from 'vue'
 import debounce from '../../utils/debounce'
 import { useInputLabeling } from '../../composables/useInputLabeling'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -94,7 +94,7 @@ const props = withDefaults(defineProps<TextInputProps>(), {
 })
 
 const emit = defineEmits<TextInputEmits>()
-const slots = useSlots()
+const slots = useReactiveSlots()
 
 defineSlots<{
   /** Content rendered before the input (left side) */
@@ -111,11 +111,6 @@ defineSlots<{
 }>()
 
 const attrs = useAttrs()
-
-// The padding and the wrapper below are read off `slots`, which is not
-// reactive. See `useSlotTick`: a `#prefix` behind a `v-if` renders over the
-// text without this, because the input keeps its slot-less padding.
-const slotTick = useSlotTick()
 
 const attrsWithoutClassStyle = computed(() => {
   return Object.fromEntries(
@@ -142,7 +137,6 @@ const {
 })
 
 const hasLabeling = computed(() => {
-  slotTick.value
   return Boolean(
     props.label ||
     props.description ||
@@ -174,8 +168,6 @@ const textColor = computed(() => {
 })
 
 const inputClasses = computed(() => {
-  slotTick.value
-
   let sizeClasses = {
     sm: 'text-base rounded-4 h-7',
     md: 'text-base rounded-4 h-8',

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -94,9 +94,9 @@ const props = withDefaults(defineProps<TextInputProps>(), {
 })
 
 const emit = defineEmits<TextInputEmits>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Content rendered before the input (left side) */
   prefix?: () => any
 

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -76,6 +76,7 @@ import { computed, ref, useAttrs, useSlots } from 'vue'
 import type { StyleValue } from 'vue'
 import debounce from '../../utils/debounce'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { useSlotTick } from '../../composables/useSlotTick'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -111,6 +112,11 @@ defineSlots<{
 
 const attrs = useAttrs()
 
+// The padding and the wrapper below are read off `slots`, which is not
+// reactive. See `useSlotTick`: a `#prefix` behind a `v-if` renders over the
+// text without this, because the input keeps its slot-less padding.
+const slotTick = useSlotTick()
+
 const attrsWithoutClassStyle = computed(() => {
   return Object.fromEntries(
     Object.entries(attrs).filter(([key]) => key !== 'class' && key !== 'style'),
@@ -136,6 +142,7 @@ const {
 })
 
 const hasLabeling = computed(() => {
+  slotTick.value
   return Boolean(
     props.label ||
     props.description ||
@@ -167,6 +174,8 @@ const textColor = computed(() => {
 })
 
 const inputClasses = computed(() => {
+  slotTick.value
+
   let sizeClasses = {
     sm: 'text-base rounded-4 h-7',
     md: 'text-base rounded-4 h-8',

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -50,6 +50,7 @@ import { computed, ref, useAttrs, useSlots } from 'vue'
 import type { StyleValue } from 'vue'
 import debounce from '../../utils/debounce'
 import { useInputLabeling } from '../../composables/useInputLabeling'
+import { useSlotTick } from '../../composables/useSlotTick'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -70,6 +71,7 @@ const props = withDefaults(defineProps<TextareaProps>(), {
 const emit = defineEmits<TextareaEmits>()
 const attrs = useAttrs()
 const slots = useSlots()
+const slotTick = useSlotTick()
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 
 defineSlots<{
@@ -100,6 +102,7 @@ const {
 })
 
 const hasLabeling = computed(() => {
+  slotTick.value
   return Boolean(
     props.label || slots.label || rendersDescription.value || hasError.value,
   )

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -46,11 +46,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, useAttrs, useSlots } from 'vue'
+import { computed, ref, useAttrs } from 'vue'
 import type { StyleValue } from 'vue'
 import debounce from '../../utils/debounce'
 import { useInputLabeling } from '../../composables/useInputLabeling'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import InputLabel from '../InputLabeling/InputLabel.vue'
 import InputDescription from '../InputLabeling/InputDescription.vue'
 import InputError from '../InputLabeling/InputError.vue'
@@ -70,8 +70,7 @@ const props = withDefaults(defineProps<TextareaProps>(), {
 
 const emit = defineEmits<TextareaEmits>()
 const attrs = useAttrs()
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 
 defineSlots<{
@@ -102,7 +101,6 @@ const {
 })
 
 const hasLabeling = computed(() => {
-  slotTick.value
   return Boolean(
     props.label || slots.label || rendersDescription.value || hasError.value,
   )

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -70,10 +70,10 @@ const props = withDefaults(defineProps<TextareaProps>(), {
 
 const emit = defineEmits<TextareaEmits>()
 const attrs = useAttrs()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Overrides the rendered label content. Receives `{ required }`. */
   label?: (props: { required: boolean }) => any
 

--- a/src/components/ThemeSwitcher/ThemeSwitcher.vue
+++ b/src/components/ThemeSwitcher/ThemeSwitcher.vue
@@ -69,8 +69,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useId, useSlots } from 'vue'
-import { useSlotTick } from '../../composables/useSlotTick'
+import { computed, useId } from 'vue'
+import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { RadioGroupItem, RadioGroupRoot } from 'reka-ui'
 import {
   useColorScheme,
@@ -133,17 +133,12 @@ const selected = computed<ColorScheme>({
   },
 })
 
-const slots = useSlots()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 const headingId = useId()
-const showLabel = computed(() => {
-  slotTick.value
-  return Boolean(props.label || slots.label)
-})
-const showDescription = computed(() => {
-  slotTick.value
-  return Boolean(props.description || slots.description)
-})
+const showLabel = computed(() => Boolean(props.label || slots.label))
+const showDescription = computed(() =>
+  Boolean(props.description || slots.description),
+)
 const logoIsImage = computed(
   () => typeof props.logo === 'string' && props.logo.length > 0,
 )

--- a/src/components/ThemeSwitcher/ThemeSwitcher.vue
+++ b/src/components/ThemeSwitcher/ThemeSwitcher.vue
@@ -106,7 +106,7 @@ const emit = defineEmits<{
   'update:modelValue': [theme: ColorScheme]
 }>()
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   /** Overrides the heading content. */
   label?: () => any
   /** Overrides the helper-text content. */
@@ -133,7 +133,7 @@ const selected = computed<ColorScheme>({
   },
 })
 
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 const headingId = useId()
 const showLabel = computed(() => Boolean(props.label || slots.label))
 const showDescription = computed(() =>

--- a/src/components/ThemeSwitcher/ThemeSwitcher.vue
+++ b/src/components/ThemeSwitcher/ThemeSwitcher.vue
@@ -70,6 +70,7 @@
 
 <script setup lang="ts">
 import { computed, useId, useSlots } from 'vue'
+import { useSlotTick } from '../../composables/useSlotTick'
 import { RadioGroupItem, RadioGroupRoot } from 'reka-ui'
 import {
   useColorScheme,
@@ -133,11 +134,16 @@ const selected = computed<ColorScheme>({
 })
 
 const slots = useSlots()
+const slotTick = useSlotTick()
 const headingId = useId()
-const showLabel = computed(() => Boolean(props.label || slots.label))
-const showDescription = computed(() =>
-  Boolean(props.description || slots.description),
-)
+const showLabel = computed(() => {
+  slotTick.value
+  return Boolean(props.label || slots.label)
+})
+const showDescription = computed(() => {
+  slotTick.value
+  return Boolean(props.description || slots.description)
+})
 const logoIsImage = computed(
   () => typeof props.logo === 'string' && props.logo.length > 0,
 )

--- a/src/components/shared/picker/PickerShell.vue
+++ b/src/components/shared/picker/PickerShell.vue
@@ -70,7 +70,7 @@ import { TextInput } from '../../TextInput'
 import LucideChevronDown from '~icons/lucide/chevron-down'
 import PopoverPanel from '../popover/PopoverPanel.vue'
 import { usePortalTarget } from '../../../composables/usePortalTarget'
-import { useSlotTick } from '../../../composables/useSlotTick'
+import { useReactiveSlots } from '../../../composables/useReactiveSlots'
 import type { InputSize, InputVariant } from '../../../composables/inputTypes'
 import type { FrappeUIError } from '../../../composables/useInputLabeling'
 
@@ -134,14 +134,14 @@ const emit = defineEmits<{
   (e: 'requestFocus'): void
 }>()
 
-const slots = defineSlots<{
+defineSlots<{
   trigger?: (props: TriggerSlotProps) => any
   target?: (props: TriggerSlotProps) => any
   prefix?: (props: TriggerSlotProps) => any
   suffix?: (props: TriggerSlotProps) => any
   default?: (props: { close: () => void }) => any
 }>()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 defineOptions({ inheritAttrs: false })
 
@@ -169,7 +169,6 @@ const popoverPanelRef = ref<{ $el: HTMLElement } | null>(null)
 const panelEl = computed(() => popoverPanelRef.value?.$el ?? null)
 
 const anchorEl = computed(() => {
-  slotTick.value
   if (slots.trigger || slots.target) return undefined
   return textInputRef.value?.inputElement ?? undefined
 })
@@ -236,10 +235,7 @@ const triggerSlotProps = computed<TriggerSlotProps>(() => ({
   inputValue: inputValue.value,
 }))
 
-const hasCustomTrigger = computed(() => {
-  slotTick.value
-  return !!(slots.trigger || slots.target)
-})
+const hasCustomTrigger = computed(() => !!(slots.trigger || slots.target))
 
 watch(open, (val, prev) => {
   if (val === prev) return

--- a/src/components/shared/picker/PickerShell.vue
+++ b/src/components/shared/picker/PickerShell.vue
@@ -70,6 +70,7 @@ import { TextInput } from '../../TextInput'
 import LucideChevronDown from '~icons/lucide/chevron-down'
 import PopoverPanel from '../popover/PopoverPanel.vue'
 import { usePortalTarget } from '../../../composables/usePortalTarget'
+import { useSlotTick } from '../../../composables/useSlotTick'
 import type { InputSize, InputVariant } from '../../../composables/inputTypes'
 import type { FrappeUIError } from '../../../composables/useInputLabeling'
 
@@ -140,6 +141,7 @@ const slots = defineSlots<{
   suffix?: (props: TriggerSlotProps) => any
   default?: (props: { close: () => void }) => any
 }>()
+const slotTick = useSlotTick()
 
 defineOptions({ inheritAttrs: false })
 
@@ -167,6 +169,7 @@ const popoverPanelRef = ref<{ $el: HTMLElement } | null>(null)
 const panelEl = computed(() => popoverPanelRef.value?.$el ?? null)
 
 const anchorEl = computed(() => {
+  slotTick.value
   if (slots.trigger || slots.target) return undefined
   return textInputRef.value?.inputElement ?? undefined
 })
@@ -233,7 +236,10 @@ const triggerSlotProps = computed<TriggerSlotProps>(() => ({
   inputValue: inputValue.value,
 }))
 
-const hasCustomTrigger = computed(() => !!(slots.trigger || slots.target))
+const hasCustomTrigger = computed(() => {
+  slotTick.value
+  return !!(slots.trigger || slots.target)
+})
 
 watch(open, (val, prev) => {
   if (val === prev) return

--- a/src/components/shared/picker/PickerShell.vue
+++ b/src/components/shared/picker/PickerShell.vue
@@ -134,14 +134,14 @@ const emit = defineEmits<{
   (e: 'requestFocus'): void
 }>()
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   trigger?: (props: TriggerSlotProps) => any
   target?: (props: TriggerSlotProps) => any
   prefix?: (props: TriggerSlotProps) => any
   suffix?: (props: TriggerSlotProps) => any
   default?: (props: { close: () => void }) => any
 }>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
 defineOptions({ inheritAttrs: false })
 

--- a/src/components/shared/slotReactivity.cy.ts
+++ b/src/components/shared/slotReactivity.cy.ts
@@ -3,6 +3,8 @@ import type { Component } from 'vue'
 import Alert from '../Alert/Alert.vue'
 import Button from '../Button/Button.vue'
 import Combobox from '../Combobox/Combobox.vue'
+import Dialog from '../Dialog/Dialog.vue'
+import Dropdown from '../Dropdown/Dropdown.vue'
 import PageHeaderMobile from '../PageHeader/PageHeaderMobile.vue'
 import PickerShell from './picker/PickerShell.vue'
 import Pill from './tabs/Pill.vue'
@@ -237,5 +239,77 @@ describe('slot-derived computeds follow the slots', () => {
     cy.get('[data-cy="toggle"]').click()
     cy.get('[data-cy="open"]').click()
     cy.get('@requestFocus').should('have.been.calledOnce')
+  })
+
+  // `showHeader` gates the whole header row, and its inverse gates the
+  // standalone close button. A `#title` behind a `v-if` left both wrong at
+  // once: no header, and a floating close button in its place.
+  it('Dialog brings in the header once #title fills', () => {
+    const Harness = defineComponent({
+      setup() {
+        const show = ref(false)
+
+        return () =>
+          h('div', [
+            h(
+              'button',
+              {
+                'data-cy': 'toggle',
+                onClick: () => (show.value = !show.value),
+              },
+              'Toggle',
+            ),
+            h(
+              Dialog,
+              { modelValue: true },
+              show.value
+                ? { title: () => h('h3', { 'data-cy': 'mark' }, 'Confirm') }
+                : {},
+            ),
+          ])
+      },
+    })
+
+    cy.mount(Harness)
+    cy.get('[data-cy="mark"]').should('not.exist')
+
+    cy.get('[data-cy="toggle"]').click({ force: true })
+    cy.get('[data-cy="mark"]').should('exist')
+
+    cy.get('[data-cy="toggle"]').click({ force: true })
+    cy.get('[data-cy="mark"]').should('not.exist')
+  })
+
+  // Dropdown forwards its slots object to `MenuItemContent`, which builds four
+  // computeds off it. The chain is only as reactive as its source.
+  it('Dropdown renders #item-prefix added after mount', () => {
+    // The slot is toggled from a ref, not a button. The menu must stay open
+    // across the toggle — closing it remounts `MenuItemContent` and rebuilds
+    // its computeds, which passes either way — and any click outside the open
+    // menu dismisses it.
+    const show = ref(false)
+
+    const Harness = defineComponent({
+      setup() {
+        return () =>
+          h(
+            Dropdown,
+            { options: [{ label: 'Edit' }] },
+            show.value
+              ? { 'item-prefix': () => h('span', { 'data-cy': 'mark' }, '>') }
+              : {},
+          )
+      },
+    })
+
+    cy.mount(Harness)
+    cy.get('[aria-haspopup="menu"]').click()
+    cy.get('[data-cy="mark"]').should('not.exist')
+
+    cy.then(() => (show.value = true))
+    cy.get('[data-cy="mark"]').should('exist')
+
+    cy.then(() => (show.value = false))
+    cy.get('[data-cy="mark"]').should('not.exist')
   })
 })

--- a/src/components/shared/slotReactivity.cy.ts
+++ b/src/components/shared/slotReactivity.cy.ts
@@ -5,6 +5,7 @@ import Button from '../Button/Button.vue'
 import Combobox from '../Combobox/Combobox.vue'
 import Dialog from '../Dialog/Dialog.vue'
 import Dropdown from '../Dropdown/Dropdown.vue'
+import ListView from '../../../experimental/ListView/ListView.vue'
 import PageHeaderMobile from '../PageHeader/PageHeaderMobile.vue'
 import PickerShell from './picker/PickerShell.vue'
 import Pill from './tabs/Pill.vue'
@@ -310,6 +311,52 @@ describe('slot-derived computeds follow the slots', () => {
     cy.get('[data-cy="mark"]').should('exist')
 
     cy.then(() => (show.value = false))
+    cy.get('[data-cy="mark"]').should('not.exist')
+  })
+
+  // ListView hands its slots to descendants through `provide`. `ListRow` reads
+  // `list.slots.cell` in its own template, and nothing re-renders it when the
+  // slot toggles: `ListRows` takes no props, so `shouldUpdateComponent` says
+  // no, and the provided computed's deps are rows/columns/options. The proxy
+  // puts the read inside `ListRow`'s render effect, where the tick reaches it.
+  it('ListView reaches descendants with #cell added after mount', () => {
+    const show = ref(false)
+    // Hoisted: fresh array literals per render would change the provided
+    // computed's deps and re-render the descendants anyway, which passes with
+    // the bug present. The slot toggle has to be the only thing that moves.
+    const columns = [{ label: 'Name', key: 'name' }]
+    const rows = [{ id: 1, name: 'John Doe' }]
+
+    const Harness = defineComponent({
+      setup() {
+        return () =>
+          h('div', [
+            h(
+              'button',
+              {
+                'data-cy': 'toggle',
+                onClick: () => (show.value = !show.value),
+              },
+              'Toggle',
+            ),
+            h(
+              ListView,
+              { class: 'h-[250px]', columns, rows, rowKey: 'id' },
+              show.value
+                ? { cell: () => h('span', { 'data-cy': 'mark' }, 'Custom') }
+                : {},
+            ),
+          ])
+      },
+    })
+
+    cy.mount(Harness)
+    cy.get('[data-cy="mark"]').should('not.exist')
+
+    cy.get('[data-cy="toggle"]').click()
+    cy.get('[data-cy="mark"]').should('exist')
+
+    cy.get('[data-cy="toggle"]').click()
     cy.get('[data-cy="mark"]').should('not.exist')
   })
 })

--- a/src/components/shared/slotReactivity.cy.ts
+++ b/src/components/shared/slotReactivity.cy.ts
@@ -12,7 +12,7 @@ import Textarea from '../Textarea/Textarea.vue'
 /**
  * `useSlots()` returns `instance.slots`, which Vue mutates in place and does
  * not track. Every component here derives something from it inside a
- * `computed`, so without `useSlotTick()` the computed keeps whatever was
+ * `computed`, so without `useReactiveSlots()` the computed keeps whatever was
  * filled at mount — a slot behind a `v-if` never takes effect.
  *
  * Each case mounts with the slot empty, fills it, and empties it again.

--- a/src/components/shared/slotReactivity.cy.ts
+++ b/src/components/shared/slotReactivity.cy.ts
@@ -2,7 +2,9 @@ import { defineComponent, h, ref } from 'vue'
 import type { Component } from 'vue'
 import Alert from '../Alert/Alert.vue'
 import Button from '../Button/Button.vue'
+import Combobox from '../Combobox/Combobox.vue'
 import PageHeaderMobile from '../PageHeader/PageHeaderMobile.vue'
+import PickerShell from './picker/PickerShell.vue'
 import Pill from './tabs/Pill.vue'
 import SidebarCard from '../Sidebar/SidebarCard.vue'
 import Textarea from '../Textarea/Textarea.vue'
@@ -113,6 +115,23 @@ const cases: Case[] = [
     },
   },
   {
+    // Button mode moves the search input into the popover, so at rest there
+    // is no `role="combobox"` input to type into.
+    name: 'Combobox switches to button mode on #trigger',
+    component: Combobox,
+    props: { options: ['Apple', 'Mango'] },
+    slot: 'trigger',
+    content: () => h('button', { 'data-cy': 'mark' }, 'Pick'),
+    filled: () => {
+      cy.get('[data-cy="mark"]').should('exist')
+      cy.get('[role="combobox"]').should('not.exist')
+    },
+    empty: () => {
+      cy.get('[data-cy="mark"]').should('not.exist')
+      cy.get('[role="combobox"]').should('exist')
+    },
+  },
+  {
     name: 'PageHeaderMobile reserves the prefix inset on #prefix',
     component: PageHeaderMobile,
     props: { title: 'Inbox' },
@@ -161,4 +180,58 @@ describe('slot-derived computeds follow the slots', () => {
       c.empty()
     })
   }
+
+  // `hasCustomTrigger` is not observable in the DOM — the trigger itself
+  // renders from `$slots` in the template, which was always reactive. What it
+  // gates is the `requestFocus` emit: a custom trigger has no typing context,
+  // so focus should jump into the popover content on open.
+  it('PickerShell asks for content focus once #trigger fills', () => {
+    const Harness = defineComponent({
+      props: { onRequestFocus: { type: Function, required: true } },
+      setup(props) {
+        const show = ref(false)
+        const open = ref(false)
+
+        return () =>
+          h('div', [
+            h(
+              'button',
+              {
+                'data-cy': 'toggle',
+                onClick: () => (show.value = !show.value),
+              },
+              'Toggle',
+            ),
+            h(
+              'button',
+              { 'data-cy': 'open', onClick: () => (open.value = !open.value) },
+              'Open',
+            ),
+            h(
+              PickerShell,
+              {
+                open: open.value,
+                'onUpdate:open': (v: boolean) => (open.value = v),
+                onRequestFocus: () => props.onRequestFocus(),
+              },
+              show.value
+                ? { trigger: () => h('button', { 'data-cy': 'mark' }, 'Pick') }
+                : {},
+            ),
+          ])
+      },
+    })
+
+    cy.mount(Harness, { props: { onRequestFocus: cy.spy().as('requestFocus') } })
+
+    // Default trigger: opening keeps focus on the TextInput for typing.
+    cy.get('[data-cy="open"]').click()
+    cy.get('@requestFocus').should('not.have.been.called')
+    cy.get('[data-cy="open"]').click()
+
+    // Custom trigger added after mount.
+    cy.get('[data-cy="toggle"]').click()
+    cy.get('[data-cy="open"]').click()
+    cy.get('@requestFocus').should('have.been.calledOnce')
+  })
 })

--- a/src/components/shared/slotReactivity.cy.ts
+++ b/src/components/shared/slotReactivity.cy.ts
@@ -1,0 +1,164 @@
+import { defineComponent, h, ref } from 'vue'
+import type { Component } from 'vue'
+import Alert from '../Alert/Alert.vue'
+import Button from '../Button/Button.vue'
+import PageHeaderMobile from '../PageHeader/PageHeaderMobile.vue'
+import Pill from './tabs/Pill.vue'
+import SidebarCard from '../Sidebar/SidebarCard.vue'
+import Textarea from '../Textarea/Textarea.vue'
+
+/**
+ * `useSlots()` returns `instance.slots`, which Vue mutates in place and does
+ * not track. Every component here derives something from it inside a
+ * `computed`, so without `useSlotTick()` the computed keeps whatever was
+ * filled at mount — a slot behind a `v-if` never takes effect.
+ *
+ * Each case mounts with the slot empty, fills it, and empties it again.
+ */
+interface Case {
+  /** Spec name. */
+  name: string
+  component: Component
+  props?: Record<string, unknown>
+  /** Slot the case toggles. */
+  slot: string
+  content: () => unknown
+  /** Runs while the slot is filled. */
+  filled: () => void
+  /** Runs while the slot is empty. */
+  empty: () => void
+}
+
+const cases: Case[] = [
+  {
+    // `icon: false` drops the automatic theme glyph, so `showPrefix` depends
+    // on the slot alone.
+    name: 'Alert gates its prefix region on #prefix',
+    component: Alert,
+    props: { title: 'Heads up', icon: false },
+    slot: 'prefix',
+    content: () => h('span', { 'data-cy': 'mark' }, '!'),
+    filled: () => cy.get('[data-slot="prefix"]').should('exist'),
+    empty: () => cy.get('[data-slot="prefix"]').should('not.exist'),
+  },
+  {
+    name: 'Alert switches to the banner layout on #description',
+    component: Alert,
+    props: { title: 'Heads up', icon: false },
+    slot: 'description',
+    content: () => h('span', 'More detail'),
+    filled: () => cy.get('[data-layout]').should('have.attr', 'data-layout', 'banner'),
+    empty: () => cy.get('[data-layout]').should('have.attr', 'data-layout', 'row'),
+  },
+  {
+    name: 'SidebarCard gates its prefix region on #prefix',
+    component: SidebarCard,
+    props: { title: 'Storage', icon: false },
+    slot: 'prefix',
+    content: () => h('span', { 'data-cy': 'mark' }, '!'),
+    filled: () => cy.get('[data-slot="prefix"]').should('exist'),
+    empty: () => cy.get('[data-slot="prefix"]').should('not.exist'),
+  },
+  {
+    name: 'SidebarCard gates its actions region on #actions',
+    component: SidebarCard,
+    props: { title: 'Storage', icon: false },
+    slot: 'actions',
+    content: () => h('span', 'Upgrade'),
+    filled: () => cy.get('[data-slot="actions"]').should('exist'),
+    empty: () => cy.get('[data-slot="actions"]').should('not.exist'),
+  },
+  {
+    // An `#icon` slot turns the button into an icon button, which replaces the
+    // label region outright.
+    name: 'Button becomes an icon button when #icon fills',
+    component: Button,
+    props: { label: 'Close' },
+    slot: 'icon',
+    content: () => h('span', { 'data-cy': 'mark' }, '×'),
+    filled: () => {
+      cy.get('[data-cy="mark"]').should('exist')
+      cy.get('button').should('not.contain.text', 'Close')
+    },
+    empty: () => {
+      cy.get('[data-cy="mark"]').should('not.exist')
+      cy.get('button').should('contain.text', 'Close')
+    },
+  },
+  {
+    name: 'Pill drops icon-only intent when the default slot fills',
+    component: Pill,
+    props: { icon: 'lucide-x', label: 'Close' },
+    slot: 'default',
+    content: () => 'Close',
+    filled: () => cy.get('.sr-only').should('not.exist'),
+    empty: () => cy.get('.sr-only').should('exist'),
+  },
+  {
+    // `hasLabeling` decides whether the labeling wrapper exists, and the
+    // wrapper is what a caller's `class` lands on. Without it the control
+    // keeps the class and the wrapper never appears.
+    name: 'Textarea moves the caller class onto the labeling wrapper on #label',
+    component: Textarea,
+    props: { class: 'probe' },
+    slot: 'label',
+    content: () => 'Notes',
+    filled: () => {
+      cy.get('div.probe').should('exist')
+      cy.get('textarea').should('not.have.class', 'probe')
+    },
+    empty: () => {
+      cy.get('div.probe').should('not.exist')
+      cy.get('textarea').should('have.class', 'probe')
+    },
+  },
+  {
+    name: 'PageHeaderMobile reserves the prefix inset on #prefix',
+    component: PageHeaderMobile,
+    props: { title: 'Inbox' },
+    slot: 'prefix',
+    content: () => h('button', { 'data-cy': 'mark' }, 'Back'),
+    filled: () => cy.get('[data-cy="mark"]').should('exist'),
+    empty: () => cy.get('[data-cy="mark"]').should('not.exist'),
+  },
+]
+
+function harness(c: Case) {
+  return defineComponent({
+    setup() {
+      const show = ref(false)
+
+      return () =>
+        h('div', [
+          h(
+            'button',
+            {
+              'data-cy': 'toggle',
+              onClick: () => (show.value = !show.value),
+            },
+            'Toggle',
+          ),
+          h(
+            c.component,
+            { ...c.props },
+            show.value ? { [c.slot]: () => c.content() } : {},
+          ),
+        ])
+    },
+  })
+}
+
+describe('slot-derived computeds follow the slots', () => {
+  for (const c of cases) {
+    it(c.name, () => {
+      cy.mount(harness(c))
+      c.empty()
+
+      cy.get('[data-cy="toggle"]').click()
+      c.filled()
+
+      cy.get('[data-cy="toggle"]').click()
+      c.empty()
+    })
+  }
+})

--- a/src/components/shared/slotReactivity.cy.ts
+++ b/src/components/shared/slotReactivity.cy.ts
@@ -49,8 +49,10 @@ const cases: Case[] = [
     props: { title: 'Heads up', icon: false },
     slot: 'description',
     content: () => h('span', 'More detail'),
-    filled: () => cy.get('[data-layout]').should('have.attr', 'data-layout', 'banner'),
-    empty: () => cy.get('[data-layout]').should('have.attr', 'data-layout', 'row'),
+    filled: () =>
+      cy.get('[data-layout]').should('have.attr', 'data-layout', 'banner'),
+    empty: () =>
+      cy.get('[data-layout]').should('have.attr', 'data-layout', 'row'),
   },
   {
     name: 'SidebarCard gates its prefix region on #prefix',
@@ -222,7 +224,9 @@ describe('slot-derived computeds follow the slots', () => {
       },
     })
 
-    cy.mount(Harness, { props: { onRequestFocus: cy.spy().as('requestFocus') } })
+    cy.mount(Harness, {
+      props: { onRequestFocus: cy.spy().as('requestFocus') },
+    })
 
     // Default trigger: opening keeps focus on the TextInput for typing.
     cy.get('[data-cy="open"]').click()

--- a/src/components/shared/tabs/Pill.vue
+++ b/src/components/shared/tabs/Pill.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useSlotTick } from '../../../composables/useSlotTick'
+import { useReactiveSlots } from '../../../composables/useReactiveSlots'
 import { Icon } from '../../Icon'
 import { browserTabCardClasses, tabRadiusClasses } from './styles'
 import type { PillProps } from './pillTypes'
@@ -13,12 +13,12 @@ const props = withDefaults(defineProps<PillProps>(), {
   orientation: 'horizontal',
 })
 
-const slots = defineSlots<{
+defineSlots<{
   prefix?: () => any
   default?: () => any
   suffix?: () => any
 }>()
-const slotTick = useSlotTick()
+const slots = useReactiveSlots()
 
 // `icon` means icon-only intent (label, if provided, is rendered as
 // sr-only). `iconLeft` is an accent icon next to a visible label. Trailing
@@ -26,10 +26,7 @@ const slotTick = useSlotTick()
 // A default slot cancels icon-only intent: the caller is supplying visible
 // label content, so hiding it would drop what they passed. `TabTrigger` reads
 // the same rule for the `aria-label`/`title` it derives from `label`.
-const isIconOnly = computed(() => {
-  slotTick.value
-  return Boolean(props.icon) && !slots.default
-})
+const isIconOnly = computed(() => Boolean(props.icon) && !slots.default)
 
 const sizeClasses = computed(() => {
   const isSm = props.size === 'sm'

--- a/src/components/shared/tabs/Pill.vue
+++ b/src/components/shared/tabs/Pill.vue
@@ -13,12 +13,12 @@ const props = withDefaults(defineProps<PillProps>(), {
   orientation: 'horizontal',
 })
 
-defineSlots<{
+const declaredSlots = defineSlots<{
   prefix?: () => any
   default?: () => any
   suffix?: () => any
 }>()
-const slots = useReactiveSlots()
+const slots = useReactiveSlots<typeof declaredSlots>()
 
 // `icon` means icon-only intent (label, if provided, is rendered as
 // sr-only). `iconLeft` is an accent icon next to a visible label. Trailing

--- a/src/components/shared/tabs/Pill.vue
+++ b/src/components/shared/tabs/Pill.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useSlotTick } from '../../../composables/useSlotTick'
 import { Icon } from '../../Icon'
 import { browserTabCardClasses, tabRadiusClasses } from './styles'
 import type { PillProps } from './pillTypes'
@@ -17,6 +18,7 @@ const slots = defineSlots<{
   default?: () => any
   suffix?: () => any
 }>()
+const slotTick = useSlotTick()
 
 // `icon` means icon-only intent (label, if provided, is rendered as
 // sr-only). `iconLeft` is an accent icon next to a visible label. Trailing
@@ -24,7 +26,10 @@ const slots = defineSlots<{
 // A default slot cancels icon-only intent: the caller is supplying visible
 // label content, so hiding it would drop what they passed. `TabTrigger` reads
 // the same rule for the `aria-label`/`title` it derives from `label`.
-const isIconOnly = computed(() => Boolean(props.icon) && !slots.default)
+const isIconOnly = computed(() => {
+  slotTick.value
+  return Boolean(props.icon) && !slots.default
+})
 
 const sizeClasses = computed(() => {
   const isSm = props.size === 'sm'

--- a/src/composables/useInputLabeling.ts
+++ b/src/composables/useInputLabeling.ts
@@ -1,5 +1,6 @@
-import { computed, onBeforeUpdate, shallowRef } from 'vue'
+import { computed } from 'vue'
 import { useId } from '../utils/useId'
+import { useSlotTick } from './useSlotTick'
 import type { InputSize, InputVariant, ToggleSize } from './inputTypes'
 
 /**
@@ -99,19 +100,10 @@ export function useInputLabeling(
     return Boolean(props.description) && !hasError.value
   })
 
-  // `useSlots()` returns `instance.slots`, which Vue mutates in place and does
-  // not track. A `computed` reading it caches on first evaluation and never
-  // re-runs, so a slot behind a `v-if` leaves the reference wrong in both
+  // Without this, a slot behind a `v-if` leaves the reference wrong in both
   // directions: added, the element renders and nothing points at it; removed,
   // the reference outlives its element and dangles.
-  //
-  // Slot content only ever changes as part of a re-render, and `beforeUpdate`
-  // runs after `updateSlots` and before the render function, so bumping here is
-  // the invalidation those two computeds are missing.
-  const slotTick = shallowRef(0)
-  onBeforeUpdate(() => {
-    slotTick.value++
-  })
+  const slotTick = useSlotTick()
 
   // Both of these follow what actually renders, not what the props say. A
   // `#label` or `#description` slot renders the same element the prop does, so

--- a/src/composables/useReactiveSlots.ts
+++ b/src/composables/useReactiveSlots.ts
@@ -12,9 +12,11 @@ import { useSlotTick } from './useSlotTick'
  * subscribes the caller to the slot tick on every read, so the deriving
  * `computed` re-runs when the slots change.
  *
- * Use it anywhere a component reads its own slots outside the template.
- * Reading `$slots` in the template is already correct — the render function
- * re-runs on its own — so this changes nothing there.
+ * Use it anywhere a component reads its own slots outside the template, and
+ * anywhere the object is handed on, as a prop or through `provide`. Reading
+ * `$slots` in your own template is already correct, because the render
+ * function re-runs on its own; a child reading the same object is not, because
+ * nothing re-renders the child when a slot toggles.
  */
 export function useReactiveSlots<T extends object = Slots>(): T {
   const slots = useSlots()

--- a/src/composables/useReactiveSlots.ts
+++ b/src/composables/useReactiveSlots.ts
@@ -1,0 +1,37 @@
+import { useSlots } from 'vue'
+import type { Slots } from 'vue'
+import { useSlotTick } from './useSlotTick'
+
+/**
+ * `useSlots()`, but safe to read inside a `computed`.
+ *
+ * The object Vue hands back is mutated in place and never tracked, so a
+ * `computed` that reads it caches the slots filled at mount: a `#prefix`
+ * behind a `v-if` renders while the padding reserved for it does not, a gated
+ * region never appears at all. This wraps the same object in a proxy that
+ * subscribes the caller to the slot tick on every read, so the deriving
+ * `computed` re-runs when the slots change.
+ *
+ * Use it anywhere a component reads its own slots outside the template.
+ * Reading `$slots` in the template is already correct — the render function
+ * re-runs on its own — so this changes nothing there.
+ */
+export function useReactiveSlots<T extends object = Slots>(): T {
+  const slots = useSlots()
+  const slotTick = useSlotTick()
+
+  return new Proxy(slots, {
+    get(target, key, receiver) {
+      slotTick.value
+      return Reflect.get(target, key, receiver)
+    },
+    has(target, key) {
+      slotTick.value
+      return Reflect.has(target, key)
+    },
+    ownKeys(target) {
+      slotTick.value
+      return Reflect.ownKeys(target)
+    },
+  }) as T
+}

--- a/src/composables/useSlotTick.ts
+++ b/src/composables/useSlotTick.ts
@@ -1,5 +1,5 @@
-import { onBeforeUpdate, shallowRef } from 'vue'
-import type { ShallowRef } from 'vue'
+import { getCurrentInstance, onBeforeUpdate, shallowRef } from 'vue'
+import type { ComponentInternalInstance, ShallowRef } from 'vue'
 
 /**
  * Reactive invalidation for anything derived from `useSlots()`.
@@ -11,13 +11,31 @@ import type { ShallowRef } from 'vue'
  *
  * Slot content only ever changes as part of a re-render, and `beforeUpdate`
  * runs after `updateSlots` and before the render function, so bumping here is
- * the invalidation those computeds are missing. Read `slotTick.value` inside
- * the computed to subscribe to it.
+ * the invalidation those computeds are missing.
+ *
+ * Components should reach for `useReactiveSlots()` instead — it reads this tick
+ * for them. This is the low-level piece, for composables that take slot state
+ * as getters rather than reading a slots object.
  */
+
+// One tick per component, however many callers ask for it. `useReactiveSlots`
+// and `useInputLabeling` both want it, and a component using the two would
+// otherwise register the hook twice and keep two refs in step for nothing.
+const ticks = new WeakMap<ComponentInternalInstance, ShallowRef<number>>()
+
 export function useSlotTick(): ShallowRef<number> {
+  const instance = getCurrentInstance()
+  // Outside a component there is no update to invalidate on. A constant ref
+  // saves every caller a branch.
+  if (!instance) return shallowRef(0)
+
+  const existing = ticks.get(instance)
+  if (existing) return existing
+
   const slotTick = shallowRef(0)
   onBeforeUpdate(() => {
     slotTick.value++
   })
+  ticks.set(instance, slotTick)
   return slotTick
 }

--- a/src/composables/useSlotTick.ts
+++ b/src/composables/useSlotTick.ts
@@ -1,0 +1,23 @@
+import { onBeforeUpdate, shallowRef } from 'vue'
+import type { ShallowRef } from 'vue'
+
+/**
+ * Reactive invalidation for anything derived from `useSlots()`.
+ *
+ * `useSlots()` returns `instance.slots`, which Vue mutates in place and does
+ * not track. A `computed` reading it caches on first evaluation and never
+ * re-runs, so a slot behind a `v-if` leaves the derived value stuck at whatever
+ * was filled at mount.
+ *
+ * Slot content only ever changes as part of a re-render, and `beforeUpdate`
+ * runs after `updateSlots` and before the render function, so bumping here is
+ * the invalidation those computeds are missing. Read `slotTick.value` inside
+ * the computed to subscribe to it.
+ */
+export function useSlotTick(): ShallowRef<number> {
+  const slotTick = shallowRef(0)
+  onBeforeUpdate(() => {
+    slotTick.value++
+  })
+  return slotTick
+}

--- a/vitepress/components/Docs/PropsTable.vue
+++ b/vitepress/components/Docs/PropsTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useSlots } from 'vue'
+import { computed } from 'vue'
 
 interface ItemProp {
   name: string
@@ -16,9 +16,6 @@ interface Props {
 }
 
 const props = defineProps<Props>()
-const slots = useSlots()
-
-const hasCustomCodeSlot = computed(() => Boolean(slots.code))
 
 const typeDefinition = computed(() => {
   const typeName = props.name ? `${props.name}Props` : 'ComponentProps'
@@ -52,7 +49,7 @@ const typeDefinition = computed(() => {
       </summary>
 
       <div class="mt-1 overflow-hidden rounded-7 border bg-surface-gray-1">
-        <slot v-if="hasCustomCodeSlot" name="code" />
+        <slot v-if="$slots.code" name="code" />
         <pre
           v-else
           class="overflow-x-auto whitespace-pre px-4 py-3 font-mono text-xs leading-6 text-ink-gray-7"


### PR DESCRIPTION
Reported in the Raven `Raven-frappe-ui` channel: the prefix story on the TextInput docs page is broken. That turned out to be one instance of a defect that runs through the library, so this fixes all of them.

## What was broken

On https://ui.frappe.io/docs/components/textinput, turning on the playground's `prefix` switch paints the icon on top of the input text. The same happens for `suffix`. Any consumer that puts a `#prefix` behind a `v-if` hits it.

The static "Prefix and suffix slots" preview looks right, because those slots are filled at mount.

## Root cause

`TextInput` builds its padding classes in a `computed` that reads `useSlots()`:

```ts
slots.prefix ? 'ps-8' : 'ps-2'
```

`useSlots()` returns `instance.slots`. Vue mutates that object in place and does not track it, so the computed caches whichever slots were filled at mount and never re-runs. The prefix element itself renders (the template reads `$slots` at render time), but the input keeps its slot-less `ps-2` and the two overlap.

`hasLabeling` in the same file had the same defect for the `#label` and `#description` slots.

`useInputLabeling` already fixed this for `labelledBy` / `describedBy` in #1079, with a ref bumped in `beforeUpdate`. `beforeUpdate` runs after `updateSlots` and before the render function, so it is the invalidation the computeds are missing.

## Not a docs-only problem

The playground toggles the slot the ordinary way, `<template v-if="values.prefix" #prefix>`. Consumers do the same. Gameplan's `Page.vue` toggles `#suffix` on `PageHeaderMobile` when the page document arrives from the server, and the more-options menu never appears.

Two other Vue libraries shipped the same defect in the same shape: Element Plus (element-plus#18978, fixed by moving the check into the template) and Nuxt UI (still present in `Input.vue` at v4.11.0).

## Why this shape

Vue's own docs prescribe the trigger:

> the properties of `attrs` and `slots` are **not** reactive. If you intend to apply side effects based on changes to `attrs` or `slots`, you should do so inside an `onBeforeUpdate` lifecycle hook.

Nuxt UI ships exactly that in `Page.vue` (`shallowRef` seeded from the slots, refreshed in `onBeforeUpdate`), after nuxt/ui#4947 and nuxt/ui#4969. They applied it to one component and left three others broken in two incompatible shapes. Factoring it once avoids that.

Vue core wraps `instance.slots` in the same kind of proxy in `getSlotsProxy`, but only in dev builds, and only HMR triggers the matching dep. The behaviour is still open upstream as vuejs/core#11227.

Libraries that author in render functions (Vuetify, Naive UI, Ant Design Vue, reka-ui, Headless UI) never hit this, because a render function re-reads the slots on every update. frappe-ui is `<script setup>` SFCs, so that escape is not available.

## What changed

- New `useSlotTick()`: the invalidation, lifted out of `useInputLabeling` so it
  has one home. It memoizes one ref per component instance, so a component
  reading it from two places registers one `beforeUpdate` hook.
- New `useReactiveSlots()`: `useSlots()` wrapped in a proxy that reads the tick
  on every access. A `computed` that reads the returned object subscribes by
  itself. Both stay internal, neither is exported from `src/index.ts`.
- 28 components take their slots from it, with the declared slot names kept on
  the handle so a typo still fails to compile.
- `PropsTable.vue` in `vitepress/` reads its `#code` slot in the template
  instead, which needs no composable.
- `CONTEXT.md` states the rule.

Three distinct shapes needed fixing, not one:

1. a `computed` or `watch` getter in the same file (most components),
2. the slots object handed to a child as a prop (`Dropdown` to `MenuItemContent`),
3. the slots object handed to descendants through `provide` (`ListView`).

No prop, slot or event changed.

## Verification

`src/components/shared/slotReactivity.cy.ts` covers 13 components. Every case mounts with the slot empty, fills it, and empties it again.

With the tick reads stripped out of the proxy, all 13 fail. That red proof caught three cases that passed for the wrong reason and were rewritten.

```
TextInput.cy.ts        19 passing
slotReactivity.cy.ts   13 passing
```

Local run on the rebased head: full Cypress component suite, `yarn test` 1585 passing across 95 files, `yarn type-check` clean, `yarn docs:check` clean.

## Known limitation

`<template #prefix><span v-if="show" /></template>` still reserves the prefix region when `show` is false. The slot key never disappears, so no presence check catches it. Naive UI and Ant Design Vue solve that by invoking the slot and filtering `Comment` vnodes. Different defect, present before this PR, not addressed here.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1093/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 72.52% (+0.09% vs `main`)
<!-- coverage-report:end -->
