### PR TITLE
fix: remove duplicate update:open / update:query emit declarations (Fixes #1096)

### DIFF
--- a/src/components/Combobox/Combobox.vue
+++ b/src/components/Combobox/Combobox.vue
@@ -90,7 +90,15 @@ const attrs = useAttrs()
 const slots = useSlots()
 
 const model = defineModel<ComboboxOptionValue | null>({ default: null })
+/**
+ * Controls the popover visibility. Fires `update:open` when toggled.
+ */
 const open = defineModel<boolean>('open', { default: false })
+/**
+ * Controls the search query. Fires `update:query` when the user types.
+ * Optional — the component owns the query when not bound, so `v-model:query`
+ * is never required.
+ */
 const query = defineModel<string>('query', { default: '' })
 // Bound, the query is the consumer's — the component never resets it on its
 // own (see `skipInitialDisplaySync` and the open watcher below).

--- a/src/components/Combobox/types.ts
+++ b/src/components/Combobox/types.ts
@@ -311,12 +311,6 @@ export interface ComboboxEmits {
   /** Fired when the committed value changes. */
   'update:modelValue': [value: ComboboxOptionValue | null]
 
-  /** Fired when the open state changes. */
-  'update:open': [value: boolean]
-
-  /** Fired when the query changes. */
-  'update:query': [value: string]
-
   /** Fired when the resolved selected option changes. */
   'update:selectedOption': [
     option: ComboboxSelectableOption | ComboboxCustomOption | null,

--- a/src/components/MultiSelect/MultiSelect.vue
+++ b/src/components/MultiSelect/MultiSelect.vue
@@ -71,9 +71,15 @@ const attrs = useAttrs()
 const slots = useSlots()
 
 const model = defineModel<Array<string | number>>({ default: () => [] })
+/**
+ * Controls the popover visibility. Fires `update:open` when toggled.
+ */
 const open = defineModel<boolean>('open', { default: false })
-// Optional outside-in control of the search box. Unbound, `defineModel`
-// keeps the value local, so `v-model:query` is never required.
+/**
+ * Controls the search query. Fires `update:query` when the user types.
+ * Optional — the component owns the query when not bound, so `v-model:query`
+ * is never required.
+ */
 const query = defineModel<string>('query', { default: '' })
 // Bound, the query is the consumer's — the component never resets it (see the
 // open watcher at the bottom of this block).

--- a/src/components/MultiSelect/types.ts
+++ b/src/components/MultiSelect/types.ts
@@ -308,10 +308,4 @@ export interface MultiSelectEmits {
    * resolved out of `options`, so custom fields on an option survive.
    */
   'update:selectedOptions': [value: MultiSelectOption[]]
-
-  /** Fired when the open state changes. */
-  'update:open': [value: boolean]
-
-  /** Fired when the search query changes. */
-  'update:query': [value: string]
 }


### PR DESCRIPTION
## Description

Fixes #1096

**Combobox** and **MultiSelect** declare `update:open` / `update:query` twice — once through `defineModel` and once in their `*Emits` interface (which is passed to `defineEmits`). The merged type signature makes `$event: unknown` for consumers using `@update:open`.

### Fix

- **Combobox** (`types.ts`, `Combobox.vue`): Removed `'update:open'` and `'update:query'` from `ComboboxEmits`; moved their JSDoc onto the `defineModel` calls
- **MultiSelect** (`types.ts`, `MultiSelect.vue`): Same pattern

### Precedent

`Tree.vue:103-109` — `TreeEmits` has no `update:expanded`, and the JSDoc sits on the `defineModel` call.

### Call sites that resolve automatically

- `CodeBlockComponent.vue:20` — `@update:open="languageMenuOpen = $event"` (no cast needed)
- `ServerSearch.vue:129` — typed handler
- `AsyncOptions.vue:89` — typed handler

### Not in scope

`DropdownEmits`, `SelectEmits`, `SettingsDialogEmits` are dead type surface (never applied via `defineEmits`). barista-for-frappe[bot] suggested folding them into #1070.

## Verification

- [x] `ComboboxEmits.update:open` and `update:query` removed
- [x] `MultiSelectEmits.update:open` and `update:query` removed
- [x] JSDoc moved to `defineModel` calls in both components
- [x] Docs descriptions preserved via `defineModel` JSDoc
- [x] Public API surface preserved (emits still work at runtime — `defineModel` handles the emit)