### PR TITLE
docs(combobox): gray the invite row in the member picker story

### DIFF
--- a/src/components/Combobox/stories/MemberPicker.vue
+++ b/src/components/Combobox/stories/MemberPicker.vue
@@ -96,7 +96,7 @@ const selected = computed(
         />
         <div
           v-else
-          class="flex size-6 items-center justify-center rounded-full bg-surface-blue-2 text-ink-blue-6"
+          class="flex size-6 items-center justify-center rounded-full bg-surface-gray-2 text-ink-gray-6"
         >
           <span class="lucide-user-plus size-3.5" />
         </div>
@@ -112,7 +112,7 @@ const selected = computed(
       </template>
 
       <template #item-invite="{ query }">
-        <span class="truncate text-ink-blue-6">
+        <span class="truncate">
           {{ query ? `Invite "${query}"` : 'Invite new member' }}
         </span>
       </template>


### PR DESCRIPTION
Originates from a bug report in the Raven `Raven-frappe-ui` channel: the Combobox docs example did not look espresso.

## What was broken

On the Combobox docs page, the **Member Picker** example rendered its "Invite new member" row in blue — a blue circle behind the icon and blue label text — inside a list where every other row was gray.

## Root cause

The story hard-coded `bg-surface-blue-2 text-ink-blue-6` on the invite icon and `text-ink-blue-6` on the invite label. Blue encoded nothing there: the row is a plain action, not a state, a sign, a severity, or an unread marker. The design rule is gray unless the color carries meaning, so the row read as a link and pulled attention off the member rows. The sibling **Create New** story already renders the same kind of custom action row in gray.

## Change

`src/components/Combobox/stories/MemberPicker.vue`:

- icon circle `bg-surface-blue-2 text-ink-blue-6` -> `bg-surface-gray-2 text-ink-gray-6` (the `Avatar` gray theme surface, since the circle stands in for an avatar)
- invite label: dropped `text-ink-blue-6` so it inherits the row ink like every other option label

Story markup only. No component or token change.

## Verification

Rendered the docs page in a headless browser, opened the Member Picker, and scrolled the list to the invite row. Before: blue circle + blue label. After: gray circle + default row ink, in both light and dark mode.

```
$ yarn type-check
$ vue-tsc --noEmit -p tsconfig.app.json && vue-tsc --noEmit -p tsconfig.node.json
Done in 15.74s.

$ yarn test
 Test Files  93 passed (93)
      Tests  1550 passed (1550)
   Duration  28.76s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1102/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 72.50% (±0.00% vs `main`)
<!-- coverage-report:end -->
