### PR TITLE
fix(editor): keep native drag payload in read-only editors

### DIFF
--- a/experimental/TextEditor/TextEditor.vue
+++ b/experimental/TextEditor/TextEditor.vue
@@ -43,6 +43,7 @@ import {
 } from 'vue'
 
 import { Editor, EditorContent } from '@tiptap/vue-3'
+import type { EditorView } from '@tiptap/pm/view'
 import StarterKit from '@tiptap/starter-kit'
 import { Placeholder } from '@tiptap/extensions'
 import Typography from '@tiptap/extension-typography'
@@ -125,6 +126,9 @@ const editorProps = computed(() => {
   return {
     attributes: {
       class: normalizeClass(['prose', props.editorClass]),
+    },
+    handleDOMEvents: {
+      dragstart: (view: EditorView) => !view.editable,
     },
   }
 })

--- a/src/molecules/editor/useEditor.ts
+++ b/src/molecules/editor/useEditor.ts
@@ -84,6 +84,11 @@ export function useEditor(
     extensions,
     editable: toValue(options.editable) ?? true,
     autofocus: options.autofocus,
+    editorProps: {
+      handleDOMEvents: {
+        dragstart: (view) => !view.editable,
+      },
+    },
     onUpdate: ({ editor: tiptapEditor }) => {
       if (!isCollaborationMode && options.content && !applyingExternalUpdate) {
         const value = serialize(tiptapEditor)


### PR DESCRIPTION
Links inside a read-only editor can't be dragged out. Drag one onto another field and nothing lands, so anywhere saved content is shown through the editor (Helpdesk ticket comments, CRM notes) the URL has to be copied by hand. The same link in plain rendered HTML drags fine.

ProseMirror takes over the drag even when the editor isn't editable and replaces the browser's payload with the current selection, which in a read-only editor is empty. Leaving its handler out when the editor isn't editable keeps the browser's own behaviour. Editable editors are unchanged. Applied to both `TextEditor` and `useEditor`.

<!-- coverage-report:start -->
Coverage: 72.50% (±0.00% vs `main`)
<!-- coverage-report:end -->
