### PR TITLE
fix(realtime): re-emit doctype_subscribe on socket (re)connect

### DIFF
--- a/src/resources/realtime.test.ts
+++ b/src/resources/realtime.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { onDocUpdate } from './realtime'
+import type { Socket } from 'socket.io-client'
+
+// Minimal socket.io-client Socket stub that captures emitted events and lets
+// tests fire `connect` manually, as socket.io does on (re)connect.
+function makeSocket() {
+  const handlers: Record<string, Array<(...args: any[]) => void>> = {}
+  const emits: Array<[string, ...any[]]> = []
+  const socket = {
+    emit: vi.fn((event: string, ...args: any[]) => {
+      emits.push([event, ...args])
+    }),
+    on: vi.fn((event: string, cb: (...args: any[]) => void) => {
+      ;(handlers[event] ||= []).push(cb)
+    }),
+    // test helper: fire a connect event
+    _connect() {
+      for (const cb of handlers['connect'] || []) cb()
+    },
+    _emits: emits,
+  }
+  return socket as unknown as Socket & {
+    _connect: () => void
+    _emits: Array<[string, ...any[]]>
+  }
+}
+
+describe('onDocUpdate', () => {
+  it('subscribes to a doctype once per socket', () => {
+    const socket = makeSocket()
+    const cb = vi.fn()
+    onDocUpdate(socket, 'CRM Deal', cb)
+    onDocUpdate(socket, 'CRM Deal', cb)
+
+    const subscribeEmits = socket._emits.filter(
+      ([ev]) => ev === 'doctype_subscribe',
+    )
+    expect(subscribeEmits).toHaveLength(1)
+    expect(subscribeEmits[0]).toEqual(['doctype_subscribe', 'CRM Deal'])
+  })
+
+  it('re-emits the full subscription set on reconnect', () => {
+    const socket = makeSocket()
+    const cb = vi.fn()
+    onDocUpdate(socket, 'CRM Deal', cb)
+    onDocUpdate(socket, 'ToDo', cb)
+
+    // Before reconnect: two distinct doctypes emitted once each.
+    expect(
+      socket._emits.filter(([ev]) => ev === 'doctype_subscribe'),
+    ).toHaveLength(2)
+
+    // Drop the "connection" and reconnect — socket.io drops server-side rooms.
+    socket._emits.length = 0
+    socket._connect()
+
+    const reEmits = socket._emits.filter(([ev]) => ev === 'doctype_subscribe')
+    expect(reEmits).toHaveLength(2)
+    expect(reEmits.map(([, dt]) => dt).sort()).toEqual(['CRM Deal', 'ToDo'])
+  })
+
+  it('does not re-subscribe a fresh socket to a doctype another socket joined', () => {
+    const socketA = makeSocket()
+    const socketB = makeSocket()
+    onDocUpdate(socketA, 'CRM Deal', vi.fn())
+
+    // A brand-new socket (re-login, second app instance) must emit its own
+    // subscribe even for the same doctype — it is a different server-side room.
+    onDocUpdate(socketB, 'CRM Deal', vi.fn())
+    expect(
+      socketB._emits.filter(([ev]) => ev === 'doctype_subscribe'),
+    ).toHaveLength(1)
+  })
+
+  it('fires the callback only for the matching doctype', () => {
+    const socket = makeSocket()
+    const cb = vi.fn()
+    onDocUpdate(socket, 'CRM Deal', cb)
+    onDocUpdate(socket, 'ToDo', vi.fn())
+
+    // Reach into the list_update handler registered by onDocUpdate
+    const handlers = (socket.on as ReturnType<typeof vi.fn>).mock.calls
+    const updateHandler = handlers.find(
+      ([ev]) => ev === 'list_update',
+    )![1] as any
+    updateHandler({ doctype: 'CRM Deal', name: 'DEAL-0002' })
+    expect(cb).toHaveBeenCalledWith('DEAL-0002')
+  })
+})

--- a/src/resources/realtime.ts
+++ b/src/resources/realtime.ts
@@ -17,9 +17,31 @@ export function onDocUpdate(
   })
 }
 
-let subscribed: Record<string, boolean> = {}
+// Track subscriptions per socket instance. Keying by the Socket (via WeakMap)
+// means a brand-new Socket (re-login, a second app on the same page) is never
+// assumed to already be subscribed to a doctype it has never joined. The set
+// holds the doctypes this socket has subscribed to, so they can be re-emitted
+// after the underlying connection drops and reconnects.
+const subscribed = new WeakMap<Socket, Set<string>>()
+
 function subscribe(socket: Socket, doctype: string): void {
-  if (subscribed[doctype]) return
+  let doctypes = subscribed.get(socket)
+  if (!doctypes) {
+    doctypes = new Set()
+    subscribed.set(socket, doctypes)
+    // Server-side rooms are per-socket and dropped on disconnect. Re-emit the
+    // full subscription set whenever the socket (re)connects, so a reconnected
+    // socket re-joins every room it had before. Listening on `connect` rather
+    // than socket.io's `reconnect` also covers the initial connect, and any
+    // subscribe() that ran while the socket was still connecting.
+    const current = doctypes
+    socket.on('connect', () => {
+      for (const type of current) {
+        socket.emit('doctype_subscribe', type)
+      }
+    })
+  }
+  if (doctypes.has(doctype)) return
+  doctypes.add(doctype)
   socket.emit('doctype_subscribe', doctype)
-  subscribed[doctype] = true
 }


### PR DESCRIPTION
Closes #1103

## What changed

`src/resources/realtime.ts` used a module-scoped `subscribed: Record<string, boolean>` guard, which caused two related staleness bugs:

1. **Reconnect staleness** — socket.io server-side rooms are dropped on disconnect, but `subscribed[doctype]` stays `true`, so `doctype_subscribe` is never re-emitted and `list_update` stops arriving. A `realtime: true` resource silently goes stale.
2. **Fresh-socket staleness** — the map was keyed only by doctype, not by socket, so a brand-new `Socket` (re-login, a second app on the same page) never emitted `doctype_subscribe` at all.

## The fix

- Replace `Record<string, boolean>` with a `WeakMap<Socket, Set<string>>` so each `Socket` owns its own subscription set.
- Listen for `socket.on('connect', ...)` — which fires on both the initial connect and every reconnect — and re-emit `doctype_subscribe` for every doctype in that socket's set.

## Tests

Added `src/resources/realtime.test.ts` (4 tests) covering:

- subscribes to a doctype once per socket
- re-emits the full subscription set on reconnect
- a fresh socket re-subscribes even for a doctype another socket joined
- the callback fires only for the matching doctype

All 4 new tests pass, plus the existing `documentResource` (3) and `listResource` (8) suites — 15/15 green. No new type errors (baseline tsc count unchanged at 201 pre-existing).

<!-- coverage-report:start -->
Coverage: 72.56% (+0.06% vs `main`)
<!-- coverage-report:end -->
