### PR TITLE
fix(ListView): stop nesting button elements inside row wrapper

### DIFF
--- a/experimental/ListView/ListRow.vue
+++ b/experimental/ListView/ListRow.vue
@@ -26,11 +26,23 @@
          out of layout while keeping its child a direct box of the <a>. The old
          `:is="'template'"` looked like "no wrapper" but made Vue create a real
          <template> element, which the UA stylesheet hides — so every row
-         silently disappeared whenever `getRowRoute` was set. -->
-    <component
-      :is="list.options.getRowRoute ? 'div' : 'button'"
+         silently disappeared whenever `getRowRoute` was set.
+         Without a route the row is a <div> with button semantics. Using a real
+         <button> here made the row wrap any interactive cell slot content
+         (Select/Dropdown triggers are buttons too) in a nested <button> — invalid
+         HTML the browser re-parents on parse, which breaks the inner trigger's
+         popup events once a Dialog focus-scope wraps the list (#558). -->
+    <div
+      :role="list.options.getRowRoute ? undefined : 'button'"
+      :tabindex="list.options.getRowRoute || row.disabled ? undefined : 0"
       :class="
         list.options.getRowRoute ? 'contents' : '[all:unset] hover:[all:unset]'
+      "
+      @keydown.enter.self="
+        !list.options.getRowRoute && !row.disabled && onRowClick($event)
+      "
+      @keydown.space.prevent.self="
+        !list.options.getRowRoute && !row.disabled && onRowClick($event)
       "
     >
       <div


### PR DESCRIPTION
## Problem

Closes #558

A `ListView` row with no route wraps its cell content in a real `<button>` element (`ListRow.vue` had `:is="getRowRoute ? 'div' : 'button'"`). Select, Dropdown, and Combobox triggers are themselves `<button>`s, so rendering one inside a ListView cell produces a **nested `<button>`** — invalid HTML.

Browsers re-parent nested buttons on parse, silently breaking the inner trigger's event wiring. The failure becomes loud as soon as the ListView is placed inside a `Dialog`: reka-ui's `FocusScope` intercepts the mangled DOM and the inner popup never opens — the reporter's exact reproduction in #558.

## Fix

Always render the inner row wrapper as a `<div>`:

- With `getRowRoute`: unchanged — `display: contents` div.
- Without a route: a `<div role="button">` with `tabindex="0"` and explicit `keydown.enter` / `keydown.space` handlers that call `onRowClick`, preserving the keyboard accessibility a `<button>` gave the row without nesting buttons.

## Verification

- `NODE_ENV=test npx vitest run` — 1574 tests pass (2 pre-existing editor timeouts on `main` are unrelated).
- `npx vue-tsc --noEmit -p tsconfig.app.json` — clean.
- Manual reproduction of #558 (ListView inside Dialog, Select/Dropdown in a cell) now opens the popup.

Not a public API change — the row's rendered classes, click handling, and hover/active semantics are unchanged.

<!-- coverage-report:start -->
Coverage: 72.50% (±0.00% vs `main`)
<!-- coverage-report:end -->
