### PR TITLE
feat(Calendar): size month rows to their events instead of hiding them

### DIFF
--- a/docs/content/docs/changelog.md
+++ b/docs/content/docs/changelog.md
@@ -9,6 +9,25 @@ one-time dev-mode warning (unless noted). Removal is post-v1.
 
 ## Unreleased
 
+### Calendar — the Month view is a continuous strip that shows every event
+
+The Month view no longer draws a fixed 5- or 6-row grid that hid whatever
+did not fit behind an "n more" button. Its week rows grow to fit their
+events and the view scrolls when they outgrow it, and titles wrap instead of
+truncating. Below the `sm` breakpoint the days stack in a list instead of a
+grid.
+
+- **Behavior change:** `rangeChange` for the `Month` view now reports the
+  grid's extent — the padding days of its first and last weeks included —
+  rather than the first to the last of the month.
+- Days outside the month in view are no longer dimmed; the first of each
+  month is labelled with its month instead (`Sep 1`).
+- Event titles in the Week and Day views are `ink-gray-8`, as in the Month
+  view, rather than the event colour's text shade; the colour stays on the
+  bar and background.
+- `CalendarActions` (the `CALENDAR_ACTIONS_KEY` injection) gains
+  `setCalendarDate`.
+
 ### Calendar — `toDate` is honored, so events span the days they cover (breaking, silent)
 
 An event's `toDate` was ignored: everything rendered on `fromDate`. It now

--- a/experimental/Calendar/Calendar.cy.ts
+++ b/experimental/Calendar/Calendar.cy.ts
@@ -50,6 +50,10 @@ const events: CalendarEvent[] = [
 ]
 
 describe('Calendar', () => {
+  // Below the `sm` breakpoint the Month view stacks days instead of drawing
+  // week rows; the desktop specs want the rows.
+  beforeEach(() => cy.viewport(1024, 768))
+
   // Behavior 1: renders with default props
   it('renders the month view with the default header', () => {
     cy.mount(Calendar, { props: { events: [] } })
@@ -110,6 +114,65 @@ describe('Calendar', () => {
         const cellWidth = cell.width()! / 7
         expect($bar.width()!).to.be.greaterThan(cellWidth * 1.5)
       })
+  })
+
+  it('sizes a month row to its day and shows every event in it', () => {
+    const titles = [
+      'Standup',
+      'Design review',
+      'Interview',
+      'Team lunch',
+      'Retro',
+    ]
+    cy.mount(Calendar, {
+      props: {
+        events: titles.map((title, i) => ({
+          id: `EV-${i}`,
+          title,
+          fromDate: today,
+          toDate: today,
+          fromTime: `${9 + i}:00`,
+          toTime: `${10 + i}:00`,
+        })),
+      },
+    })
+
+    // Five events on one day: all five rendered, nothing folded behind a
+    // count.
+    for (const title of titles)
+      cy.contains('.event', title).should('be.visible')
+    cy.contains('more').should('not.exist')
+  })
+
+  it('names the month on its first day', () => {
+    // Today's own number is a bare pill, so on the 1st there is nothing to see.
+    if (new Date().getDate() === 1) return
+    cy.mount(Calendar, { props: { events: [] } })
+
+    const short = new Date().toLocaleString('en-US', { month: 'short' })
+    cy.get('[data-strip-date]').first().contains(`${short} 1`).should('exist')
+  })
+
+  it('stacks the days on a narrow screen', () => {
+    cy.viewport(390, 800)
+    cy.mount(Calendar, {
+      props: {
+        events: [
+          {
+            id: 'EV-STAY',
+            title: 'Offsite',
+            fromDate: thisWeek(1),
+            toDate: thisWeek(3),
+            isFullDay: true,
+          },
+        ],
+      },
+    })
+
+    // No week-row grid; a row per day, with a stay saying which day it is on.
+    cy.get('[data-week-row]').should('not.exist')
+    cy.contains('.event', 'Offsite').should('have.length.at.least', 1)
+    cy.contains('Day 1 of 3').should('exist')
   })
 
   it('puts a multi-day event in the all-day row and splits an overnight one', () => {

--- a/experimental/Calendar/Calendar.cy.ts
+++ b/experimental/Calendar/Calendar.cy.ts
@@ -145,12 +145,12 @@ describe('Calendar', () => {
   })
 
   it('names the month on its first day', () => {
-    // Today's own number is a bare pill, so on the 1st there is nothing to see.
-    if (new Date().getDate() === 1) return
+    // Pinned mid-month: today's own number is a bare pill, so on the 1st the
+    // label would not be there to find.
+    cy.clock(new Date(2026, 7, 15), ['Date'])
     cy.mount(Calendar, { props: { events: [] } })
 
-    const short = new Date().toLocaleString('en-US', { month: 'short' })
-    cy.get('[data-strip-date]').first().contains(`${short} 1`).should('exist')
+    cy.get('[data-strip-date]').first().contains('Aug 1').should('exist')
   })
 
   it('stacks the days on a narrow screen', () => {

--- a/experimental/Calendar/Calendar.md
+++ b/experimental/Calendar/Calendar.md
@@ -64,6 +64,25 @@ emits — persist them and refresh your source of truth from there.
 `cyan`, `blue`, `orange`, `green`) with the CSS variables used per state, for
 building matching UI such as a color picker.
 
+## Month view
+
+The Month view is a strip of week rows covering the month in view, and it
+scrolls when the rows outgrow the calendar's height. The arrows, Today, and
+the month picker move the month and scroll the strip to their date.
+
+Each row is as tall as its busiest day needs. Multi-day events run as bars
+across the top of the row; single-day events sit beneath them in their
+cells with the title wrapping to a second line, so every event is shown —
+there is no "n more".
+
+Below the `sm` breakpoint the days stack instead: a row per day, a heading
+where each month begins, and a week strip above to keep your place. Clicking a date number in either layout
+opens that day in the Day view.
+
+`rangeChange` reports the strip's full extent for the Month view — the
+padding days of the first and last weeks included — so a data source that
+fetches by range has events for every cell.
+
 ## Config
 
 The `config` prop takes a partial `CalendarConfig`; unset keys use these

--- a/experimental/Calendar/Calendar.vue
+++ b/experimental/Calendar/Calendar.vue
@@ -472,7 +472,6 @@ watch(currentDay, (newVal) => {
   setCalendarDate(target)
 })
 
-
 function increment() {
   incrementClickEvents[activeView.value]()
   syncSelectedMonth(currentYear.value, currentMonth.value)
@@ -489,8 +488,17 @@ const incrementClickEvents: Record<CalendarMode, () => void> = {
   Day: incrementDay,
 }
 
+// decrementMonth lands on the month's last day, which is right for stepping
+// back a day across a month edge but scrolls the Month strip to its bottom;
+// the Month view's own arrow lands on the first day, as the other arrow does.
+function decrementMonthView() {
+  decrementMonth()
+  date.value = findFirstDateOfMonth(currentMonth.value, currentYear.value)
+  week.value = findCurrentWeek(currentMonthDates.value[date.value])
+}
+
 const decrementClickEvents: Record<CalendarMode, () => void> = {
-  Month: decrementMonth,
+  Month: decrementMonthView,
   Week: decrementWeek,
   Day: decrementDay,
 }

--- a/experimental/Calendar/Calendar.vue
+++ b/experimental/Calendar/Calendar.vue
@@ -67,9 +67,10 @@
       v-if="activeView === 'Month'"
       :events="events"
       :currentMonth="currentMonth"
-      :currentMonthDates="currentMonthDates"
+      :currentYear="currentYear"
+      :currentDate="selectedDay"
+      :jumpDate="currentDate"
       :config="overrideConfig"
-      @setCurrentDate="(d) => updateCurrentDate(d)"
     >
       <template #event-popover-content="slotProps">
         <slot name="event-popover-content" v-bind="slotProps" />
@@ -143,6 +144,7 @@ import NewEventModal from './NewEventModal.vue'
 import useEventModal from './composables/useEventModal'
 import { isAnyPopoverOpen } from './useEventBase'
 import { stripPlacement } from './eventSpan'
+import { stripRange } from './monthStrip'
 import {
   ACTIVE_VIEW_KEY,
   CALENDAR_ACTIONS_KEY,
@@ -323,6 +325,7 @@ provide(CALENDAR_ACTIONS_KEY, {
   deleteEvent,
   handleCellClick,
   updateActiveView,
+  setCalendarDate,
   props,
 })
 
@@ -469,11 +472,6 @@ watch(currentDay, (newVal) => {
   setCalendarDate(target)
 })
 
-function updateCurrentDate(d: Date) {
-  activeView.value = 'Day'
-  date.value = findIndexOfDate(d)
-  week.value = findCurrentWeek(d)
-}
 
 function increment() {
   incrementClickEvents[activeView.value]()
@@ -715,15 +713,11 @@ function getVisibleRange() {
     }
   }
 
-  const start = dayjs(
-    new Date(currentYear.value, currentMonth.value, 1),
-  ).startOf('day')
-  const end = dayjs(
-    new Date(currentYear.value, currentMonth.value + 1, 0),
-  ).endOf('day')
+  // The Month strip's first and last weeks reach into the neighbouring months.
+  const range = stripRange(currentMonth.value, currentYear.value)
   return {
-    startDate: start.format('YYYY-MM-DD'),
-    endDate: end.format('YYYY-MM-DD'),
+    startDate: dayjs(range.start).format('YYYY-MM-DD'),
+    endDate: dayjs(range.end).format('YYYY-MM-DD'),
   }
 }
 

--- a/experimental/Calendar/CalendarMonthEvent.vue
+++ b/experimental/Calendar/CalendarMonthEvent.vue
@@ -38,17 +38,25 @@
           :style="eventBorderStyle"
         />
         <div
-          class="relative flex h-full select-none items-start gap-2 overflow-hidden"
+          class="relative flex h-full min-w-0 select-none items-start gap-2 overflow-hidden"
         >
           <div v-if="config.showIcon && eventIcon">
             <component :is="eventIcon" class="h-4 w-4 text-ink-gray-8" />
           </div>
-          <p
-            class="text-sm-medium truncate text-ink-gray-8"
-            :class="{ italic: !props.event.title }"
-          >
-            {{ props.event.title || '[No title]' }}
-          </p>
+          <div class="min-w-0">
+            <p
+              class="text-sm-medium text-ink-gray-8"
+              :class="[
+                wrap ? 'line-clamp-2 break-words' : 'truncate',
+                { italic: !props.event.title },
+              ]"
+            >
+              {{ props.event.title || '[No title]' }}
+            </p>
+            <p v-if="subtitle" class="event-subtitle mt-0.5 truncate text-xs">
+              {{ subtitle }}
+            </p>
+          </div>
         </div>
       </div>
     </template>
@@ -106,6 +114,14 @@ const props = defineProps<{
    * squared off, so a stay that began last week reads as continuing.
    */
   bar?: CalendarRowBar
+  /**
+   * Lets the title run to a second line instead of cutting it off. The
+   * Month strip sizes its rows to their content, so a pill there can afford
+   * to show its whole title.
+   */
+  wrap?: boolean
+  /** A second, quieter line under the title — a time, or "Day 2 of 3". */
+  subtitle?: string
 }>()
 
 defineOptions({ inheritAttrs: false })

--- a/experimental/Calendar/CalendarMonthEvent.vue
+++ b/experimental/Calendar/CalendarMonthEvent.vue
@@ -45,7 +45,7 @@
           </div>
           <div class="min-w-0">
             <p
-              class="text-sm-medium text-ink-gray-8"
+              class="event-title text-sm-medium text-ink-gray-8"
               :class="[
                 wrap ? 'line-clamp-2 break-words' : 'truncate',
                 { italic: !props.event.title },

--- a/experimental/Calendar/CalendarMonthStack.vue
+++ b/experimental/Calendar/CalendarMonthStack.vue
@@ -1,0 +1,182 @@
+<template>
+  <!--
+    The Month view on a phone. Seven columns do not fit, so the days stack:
+    one row per day with its events written out in full, and a heading where
+    each month begins. The week strip above keeps track of where in the month
+    the list is.
+  -->
+  <div class="flex min-h-0 flex-1 flex-col">
+    <div class="grid grid-cols-7 border-b border-outline-gray-1 px-2 pb-2">
+      <button
+        v-for="date in weekStripDays"
+        :key="parseDate(date)"
+        class="flex flex-col items-center text-xs text-ink-gray-4"
+        @click="scrollToDate(date)"
+      >
+        {{ daysList[date.getDay()]!.charAt(0) }}
+        <span
+          class="relative mt-0.5 flex size-7 items-center justify-center rounded-full text-sm"
+          :class="
+            isToday(date)
+              ? 'bg-surface-gray-10 text-ink-gray-2'
+              : 'text-ink-gray-8'
+          "
+        >
+          {{ date.getDate() }}
+          <span
+            v-if="eventsOn(events, date).length"
+            class="absolute -bottom-px left-1/2 size-[3px] -translate-x-1/2 rounded-full"
+            :class="isToday(date) ? 'bg-surface-white' : 'bg-ink-gray-5'"
+          />
+        </span>
+      </button>
+    </div>
+
+    <div ref="scroller" class="relative min-h-0 flex-1 overflow-y-auto">
+      <template v-for="row in rows" :key="row.key">
+        <div
+          v-if="row.seam"
+          class="flex items-center gap-2.5 px-4 pb-1.5 pt-3 text-sm font-medium text-ink-gray-8 after:flex-1 after:border-t after:border-outline-gray-2"
+          :data-strip-date="row.key"
+        >
+          {{ row.seam }}
+        </div>
+
+        <div
+          class="flex gap-3 border-b border-outline-gray-1 px-4 py-2.5"
+          :data-strip-date="row.key"
+        >
+          <button class="w-10 shrink-0 text-center" @click="openDay(row.date)">
+            <span class="block text-xs uppercase tracking-wide text-ink-gray-4">
+              {{ daysList[row.date.getDay()] }}
+            </span>
+            <span
+              class="mt-px inline-flex size-7 items-center justify-center rounded-full text-base font-medium"
+              :class="
+                isToday(row.date)
+                  ? 'bg-surface-gray-10 text-ink-gray-2'
+                  : 'text-ink-gray-8'
+              "
+            >
+              {{ row.date.getDate() }}
+            </span>
+          </button>
+
+          <div
+            class="flex min-w-0 flex-1 flex-col gap-1.5"
+            @click="calendarActions.handleCellClick($event, row.date)"
+          >
+            <CalendarMonthEvent
+              v-for="event in row.events"
+              :key="event.id"
+              :event="event"
+              :date="row.date"
+              wrap
+              :subtitle="subtitle(event, row.date)"
+              class="cursor-pointer"
+            >
+              <template #event-popover-content="slotProps">
+                <slot name="event-popover-content" v-bind="slotProps" />
+              </template>
+            </CalendarMonthEvent>
+            <p v-if="!row.events.length" class="py-1 text-sm text-ink-gray-4">
+              No events
+            </p>
+          </div>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref } from 'vue'
+import { daysList, formatTime, monthList, parseDate } from './calendarUtils'
+import { daysBetween, eventDays } from './eventSpan'
+import { eventsOn, isSpan, stripWeeks, weekStart } from './monthStrip'
+import { useNow } from './composables/useNow'
+import { useStripScroll } from './composables/useStripScroll'
+import CalendarMonthEvent from './CalendarMonthEvent.vue'
+import {
+  CALENDAR_ACTIONS_KEY,
+  type CalendarConfig,
+  type CalendarEvent,
+} from './types'
+
+const props = defineProps<{
+  events: CalendarEvent[]
+  currentMonth: number
+  currentYear: number
+  currentDate?: Date
+  jumpDate?: Date
+  config: CalendarConfig
+}>()
+
+interface StackRow {
+  key: string
+  date: Date
+  events: CalendarEvent[]
+  /** The month beginning here, written as a heading above the row. */
+  seam?: string
+}
+
+const now = useNow()
+
+function isToday(date: Date) {
+  return parseDate(date) === parseDate(now.value)
+}
+
+const rows = computed<StackRow[]>(() =>
+  stripWeeks(props.currentMonth, props.currentYear)
+    .flat()
+    .map((date) => ({
+      key: parseDate(date),
+      date,
+      events: eventsOn(props.events, date),
+      seam: date.getDate() === 1 ? monthList[date.getMonth()] : undefined,
+    })),
+)
+
+/** A time for a timed event; a stay says which of its days this is. */
+function subtitle(event: CalendarEvent, date: Date) {
+  if (isSpan(event)) {
+    const { start, end } = eventDays(event)
+    const day = daysBetween(start, parseDate(date)) + 1
+    const total = daysBetween(start, end) + 1
+    return `Day ${day} of ${total} · all day`
+  }
+  if (event.isFullDay || !event.fromTime) return 'All day'
+  const from = formatTime(event.fromTime, props.config.timeFormat)
+  if (!event.toTime) return from
+  return `${from} – ${formatTime(event.toTime, props.config.timeFormat)}`
+}
+
+const calendarActions = inject(CALENDAR_ACTIONS_KEY)
+
+if (!calendarActions) {
+  throw new Error('CalendarMonthStack must be rendered inside Calendar.')
+}
+
+function openDay(date: Date) {
+  calendarActions!.setCalendarDate(date)
+  calendarActions!.updateActiveView('Day', date)
+}
+
+const scroller = ref<HTMLElement | null>(null)
+
+const { topDate, scrollToDate } = useStripScroll(scroller, {
+  target: () => props.currentDate,
+  jump: () => props.jumpDate,
+})
+
+/** The week of the day at the top of the list. */
+const weekStripDays = computed(() => {
+  const top = topDate.value ? new Date(topDate.value + 'T00:00:00') : now.value
+  const start = weekStart(top)
+  return Array.from(
+    { length: 7 },
+    (_, i) =>
+      new Date(start.getFullYear(), start.getMonth(), start.getDate() + i),
+  )
+})
+</script>

--- a/experimental/Calendar/CalendarMonthly.vue
+++ b/experimental/Calendar/CalendarMonthly.vue
@@ -46,8 +46,12 @@
           ]"
           @click="calendarActions.handleCellClick($event, date)"
         >
+          <!-- The today pill is a 25px box around the number, so it gets a
+               tighter inset that keeps its digits in the same column as the
+               bare numbers on the other days. -->
           <div
-            class="flex w-full shrink-0 items-center justify-end px-2 text-xs"
+            class="flex w-full shrink-0 items-center justify-end text-xs"
+            :class="isToday(date) ? 'px-[3px]' : 'px-2'"
             :style="{ height: `${HEADER_HEIGHT}px` }"
           >
             <div

--- a/experimental/Calendar/CalendarMonthly.vue
+++ b/experimental/Calendar/CalendarMonthly.vue
@@ -80,9 +80,9 @@
 
             <!-- Room for the lanes of bars laid over this column. -->
             <div
-              v-if="spanLanes(row, col)"
+              v-if="row.lanes[col]"
               class="shrink-0"
-              :style="{ height: `${spanLanes(row, col) * LANE_PITCH}px` }"
+              :style="{ height: `${row.lanes[col]! * LANE_PITCH}px` }"
             />
 
             <div
@@ -177,23 +177,28 @@ interface StripRow {
   bars: CalendarRowBar[]
   /** Single-day events per column. */
   days: CalendarEvent[][]
+  /** Lanes of bars each column has to leave room for. */
+  lanes: number[]
 }
 
 const rows = computed<StripRow[]>(() => {
   const spans = props.events.filter(isSpan)
-  return stripWeeks(props.currentMonth, props.currentYear).map((week) => ({
-    key: parseDate(week[0]!),
-    week,
-    bars: layoutRow(spans, week).bars,
-    days: week.map((date) => dayEvents(props.events, date)),
-  }))
+  return stripWeeks(props.currentMonth, props.currentYear).map((week) => {
+    const { bars } = layoutRow(spans, week)
+    return {
+      key: parseDate(week[0]!),
+      week,
+      bars,
+      days: week.map((date) => dayEvents(props.events, date)),
+      lanes: week.map((_, col) => {
+        const inColumn = barsInColumn(bars, col)
+        return inColumn.length
+          ? Math.max(...inColumn.map((bar) => bar.lane)) + 1
+          : 0
+      }),
+    }
+  })
 })
-
-/** Lanes of bars a column has to leave room for. */
-function spanLanes(row: StripRow, col: number) {
-  const bars = barsInColumn(row.bars, col)
-  return bars.length ? Math.max(...bars.map((bar) => bar.lane)) + 1 : 0
-}
 
 function barStyle(bar: CalendarRowBar) {
   const span = bar.endCol - bar.startCol + 1

--- a/experimental/Calendar/CalendarMonthly.vue
+++ b/experimental/Calendar/CalendarMonthly.vue
@@ -1,5 +1,19 @@
 <template>
-  <div class="flex flex-1 flex-col overflow-scroll">
+  <CalendarMonthStack
+    v-if="isNarrow"
+    :events="events"
+    :currentMonth="currentMonth"
+    :currentYear="currentYear"
+    :currentDate="currentDate"
+    :jumpDate="jumpDate"
+    :config="config"
+  >
+    <template #event-popover-content="slotProps">
+      <slot name="event-popover-content" v-bind="slotProps" />
+    </template>
+  </CalendarMonthStack>
+
+  <div v-else class="flex min-h-0 flex-1 flex-col">
     <!-- Day List -->
     <div class="grid w-full grid-cols-7">
       <span
@@ -11,102 +25,105 @@
     </div>
 
     <!--
-      Date Grid. Each week is a row of seven cells with the row's events laid
-      over it as bars: an event covering several days is one bar across them,
-      packed into a lane it keeps for the whole row, and a single-day event is
-      a one-column bar in the same lane system. The cells beneath take clicks
-      and drops, and show how many lanes did not fit.
+      The strip. One row per week of the month, each at least as tall as its
+      busiest day needs: a stay across several days is a bar in a lane at the
+      top of the row, single-day events flow beneath it in their cells. Rows
+      share whatever height is left over, and the strip scrolls once they
+      outgrow it.
     -->
     <div
-      class="grid w-full flex-1 border-outline-gray-1"
-      :class="[
-        weeks.length > 5 ? 'grid-rows-6' : 'grid-rows-5',
-        !config.noBorder && 'border-[0.5px]',
-      ]"
+      ref="scroller"
+      class="relative min-h-0 flex-1 overflow-y-auto border-outline-gray-1"
+      :class="!config.noBorder && 'border-[0.5px]'"
     >
-      <div
-        v-for="(week, weekIdx) in weeks"
-        :key="parseDate(week[0])"
-        :ref="(el) => weekIdx === 0 && (firstRow = el as HTMLElement)"
-        class="relative grid grid-cols-7"
-        :style="{ minHeight: `${rowMinHeight(weekIdx)}px` }"
-        data-week-row
-        @dragover.prevent
-        @dragenter.prevent
-        @drop="onDrop($event, week)"
-      >
+      <div class="flex min-h-full flex-col">
         <div
-          v-for="(date, col) in week"
-          :key="parseDate(date)"
-          class="flex flex-col overflow-hidden"
-          :class="[
-            config.noBorder ? 'border-l border-t border-0' : 'border-[0.5px]',
-            config.noBorder && col === 0 && 'border-l-0',
-            isWeekend(date, config) && 'bg-surface-gray-1',
-          ]"
-          @click="calendarActions.handleCellClick($event, date)"
+          v-for="row in rows"
+          :key="row.key"
+          class="relative grid flex-auto grid-cols-7 border-b border-outline-gray-1 last:border-b-0"
+          :data-strip-date="row.key"
+          data-week-row
+          @dragover.prevent
+          @dragenter.prevent
+          @drop="onDrop($event, row.week)"
         >
-          <!-- The today pill is a 25px box around the number, so it gets a
-               tighter inset that keeps its digits in the same column as the
-               bare numbers on the other days. -->
           <div
-            class="flex w-full shrink-0 items-center justify-end text-xs"
-            :class="isToday(date) ? 'px-[3px]' : 'px-2'"
-            :style="{ height: `${HEADER_HEIGHT}px` }"
+            v-for="(date, col) in row.week"
+            :key="parseDate(date)"
+            class="flex min-w-0 flex-col border-outline-gray-1"
+            :class="[
+              col > 0 && 'border-l',
+              isWeekend(date, config) && 'bg-surface-gray-1',
+            ]"
+            @click="calendarActions.handleCellClick($event, date)"
           >
+            <!-- The today pill is a 25px box around the number, so it gets a
+                 tighter inset that keeps its digits in the same column as the
+                 bare numbers on the other days. -->
             <div
-              class="cursor-pointer"
-              :class="[
-                !isCurrentMonth(date)
-                  ? 'text-ink-gray-4'
-                  : isToday(date)
+              class="flex shrink-0 items-center justify-end text-xs"
+              :class="isToday(date) ? 'px-[3px]' : 'px-2'"
+              :style="{ height: `${HEADER_HEIGHT}px` }"
+            >
+              <button
+                class="cursor-pointer whitespace-nowrap"
+                :class="[
+                  isToday(date)
                     ? 'flex items-center justify-center bg-surface-gray-10 text-ink-gray-2 rounded-4 size-[25px]'
                     : 'text-ink-gray-8',
-              ]"
-              @click.stop="
-                isCurrentMonth(date)
-                  ? calendarActions.updateActiveView('Day', date)
-                  : calendarActions.updateActiveView(
-                      'Day',
-                      date,
-                      isPreviousMonth(date),
-                      isNextMonth(date),
-                    )
-              "
+                ]"
+                @click.stop="openDay(date)"
+              >
+                {{ dayLabel(date) }}
+              </button>
+            </div>
+
+            <!-- Room for the lanes of bars laid over this column. -->
+            <div
+              v-if="spanLanes(row, col)"
+              class="shrink-0"
+              :style="{ height: `${spanLanes(row, col) * LANE_PITCH}px` }"
+            />
+
+            <div
+              v-if="row.days[col]!.length"
+              class="flex flex-col gap-1 px-0.5 pb-1.5"
             >
-              {{ date.getDate() }}
+              <CalendarMonthEvent
+                v-for="event in row.days[col]"
+                :key="event.id"
+                :event="event"
+                :date="date"
+                wrap
+                class="cursor-pointer"
+                :draggable="config.isEditMode"
+                @dragstart="onDragStart($event, event, row.week)"
+                @dragend="$event.target.style.opacity = '1'"
+              >
+                <template #event-popover-content="slotProps">
+                  <slot name="event-popover-content" v-bind="slotProps" />
+                </template>
+              </CalendarMonthEvent>
             </div>
           </div>
 
-          <button
-            v-if="hiddenCount(weekIdx, col)"
-            class="mx-1 w-fit rounded-1 px-1.5 text-base-medium text-ink-gray-6 hover:bg-surface-gray-1"
-            :style="{
-              marginTop: `${visibleLanes(weekIdx) * LANE_PITCH}px`,
-              height: `${MORE_HEIGHT}px`,
-            }"
-            @click.stop="emit('setCurrentDate', date)"
+          <CalendarMonthEvent
+            v-for="bar in row.bars"
+            :key="bar.event.id"
+            :event="bar.event"
+            :date="row.week[bar.startCol]!"
+            :bar="bar"
+            class="absolute cursor-pointer"
+            :style="barStyle(bar)"
+            :draggable="config.isEditMode"
+            @dragstart="onDragStart($event, bar.event, row.week)"
+            @dragend="$event.target.style.opacity = '1'"
           >
-            {{ hiddenCount(weekIdx, col) }} more
-          </button>
+            <template #event-popover-content="slotProps">
+              <slot name="event-popover-content" v-bind="slotProps" />
+            </template>
+          </CalendarMonthEvent>
         </div>
-
-        <CalendarMonthEvent
-          v-for="bar in visibleBars(weekIdx)"
-          :key="bar.event.id"
-          :event="bar.event"
-          :date="week[bar.startCol]"
-          :bar="bar"
-          class="absolute cursor-pointer"
-          :style="barStyle(bar)"
-          :draggable="config.isEditMode"
-          @dragstart="onDragStart($event, bar.event, week)"
-          @dragend="$event.target.style.opacity = '1'"
-        >
-          <template #event-popover-content="slotProps">
-            <slot name="event-popover-content" v-bind="slotProps" />
-          </template>
-        </CalendarMonthEvent>
       </div>
     </div>
   </div>
@@ -114,8 +131,8 @@
 
 <script setup lang="ts">
 import { computed, inject, ref } from 'vue'
-import { useElementSize } from '@vueuse/core'
-import { daysList, parseDate, isWeekend } from './calendarUtils'
+import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
+import { daysList, isWeekend, parseDate } from './calendarUtils'
 import {
   LANE_HEIGHT,
   LANE_PITCH,
@@ -124,8 +141,11 @@ import {
   layoutRow,
   shiftEventDays,
 } from './eventSpan'
+import { dayEvents, isSpan, shortMonth, stripWeeks } from './monthStrip'
 import { useNow } from './composables/useNow'
+import { useStripScroll } from './composables/useStripScroll'
 import CalendarMonthEvent from './CalendarMonthEvent.vue'
+import CalendarMonthStack from './CalendarMonthStack.vue'
 import {
   CALENDAR_ACTIONS_KEY,
   type CalendarConfig,
@@ -135,71 +155,44 @@ import {
 
 const props = defineProps<{
   events: CalendarEvent[]
-  currentMonthDates: Date[]
   currentMonth: number
+  currentYear: number
+  /** The day navigation last landed on; the strip scrolls to its row. */
+  currentDate?: Date
+  /** Set by Today and the month picker; scrolls there even if it is the same day. */
+  jumpDate?: Date
   config: CalendarConfig
-}>()
-
-const emit = defineEmits<{
-  setCurrentDate: [date: Date]
 }>()
 
 /** The date-number strip at the top of every cell. */
 const HEADER_HEIGHT = 32
-/** The "n more" button that stands in for the lanes that did not fit. */
-const MORE_HEIGHT = 20
 
-/**
- * Lanes every row makes room for whatever the calendar's height. A row grows
- * past this when the grid has height to spare, and the outer scroll takes
- * over when it has too little.
- */
-const DEFAULT_LANES = 2
+// Seven columns do not survive a phone's width; the days stack instead.
+const isNarrow = useBreakpoints(breakpointsTailwind).smaller('sm')
 
-const weeks = computed(() => {
-  const dates = [...props.currentMonthDates]
-  const rows: Date[][] = []
-  while (dates.length) rows.push(dates.splice(0, 7))
-  return rows
+interface StripRow {
+  key: string
+  week: Date[]
+  /** Multi-day events, packed into lanes across the row. */
+  bars: CalendarRowBar[]
+  /** Single-day events per column. */
+  days: CalendarEvent[][]
+}
+
+const rows = computed<StripRow[]>(() => {
+  const spans = props.events.filter(isSpan)
+  return stripWeeks(props.currentMonth, props.currentYear).map((week) => ({
+    key: parseDate(week[0]!),
+    week,
+    bars: layoutRow(spans, week).bars,
+    days: week.map((date) => dayEvents(props.events, date)),
+  }))
 })
 
-const rows = computed(() =>
-  weeks.value.map((week) => layoutRow(props.events, week)),
-)
-
-// All rows share a height, so measuring the first is measuring every one.
-const firstRow = ref<HTMLElement | null>(null)
-const { height: rowHeight } = useElementSize(firstRow)
-
-function rowMinHeight(weekIdx: number) {
-  const laneCount = rows.value[weekIdx]?.laneCount ?? 0
-  const lanes = Math.min(laneCount, DEFAULT_LANES)
-  const more = laneCount > lanes ? MORE_HEIGHT : 0
-  return HEADER_HEIGHT + lanes * LANE_PITCH + more
-}
-
-/**
- * Lanes a row can show. When they all fit, every lane; otherwise as many as
- * leave room for the "n more" button beneath them. Before the first measure
- * the default allowance keeps the grid from flashing empty.
- */
-function visibleLanes(weekIdx: number) {
-  const laneCount = rows.value[weekIdx]?.laneCount ?? 0
-  if (!rowHeight.value) return Math.min(laneCount, DEFAULT_LANES)
-  const room = rowHeight.value - HEADER_HEIGHT
-  if (laneCount * LANE_PITCH <= room) return laneCount
-  return Math.max(0, Math.floor((room - MORE_HEIGHT) / LANE_PITCH))
-}
-
-function visibleBars(weekIdx: number) {
-  const visible = visibleLanes(weekIdx)
-  return rows.value[weekIdx]?.bars.filter((bar) => bar.lane < visible) ?? []
-}
-
-function hiddenCount(weekIdx: number, col: number) {
-  const visible = visibleLanes(weekIdx)
-  const bars = rows.value[weekIdx]?.bars ?? []
-  return barsInColumn(bars, col).filter((bar) => bar.lane >= visible).length
+/** Lanes of bars a column has to leave room for. */
+function spanLanes(row: StripRow, col: number) {
+  const bars = barsInColumn(row.bars, col)
+  return bars.length ? Math.max(...bars.map((bar) => bar.lane)) + 1 : 0
 }
 
 function barStyle(bar: CalendarRowBar) {
@@ -218,16 +211,12 @@ function isToday(date: Date) {
   return parseDate(date) === parseDate(now.value)
 }
 
-function isCurrentMonth(date: Date) {
-  return date.getMonth() === props.currentMonth
-}
-
-function isPreviousMonth(date: Date) {
-  return date.getMonth() === props.currentMonth - 1
-}
-
-function isNextMonth(date: Date) {
-  return date.getMonth() === props.currentMonth + 1
+/** The first of a month says which month, since the strip runs across them. */
+function dayLabel(date: Date) {
+  if (date.getDate() === 1 && !isToday(date)) {
+    return `${shortMonth(date)} 1`
+  }
+  return date.getDate()
 }
 
 const calendarActions = inject(CALENDAR_ACTIONS_KEY)
@@ -236,11 +225,23 @@ if (!calendarActions) {
   throw new Error('CalendarMonthly must be rendered inside Calendar.')
 }
 
+function openDay(date: Date) {
+  calendarActions!.setCalendarDate(date)
+  calendarActions!.updateActiveView('Day', date)
+}
+
+const scroller = ref<HTMLElement | null>(null)
+
+useStripScroll(scroller, {
+  target: () => props.currentDate,
+  jump: () => props.jumpDate,
+})
+
 /** The day under a pointer, from its position across a week row. */
 function dateAtPointer(row: HTMLElement, clientX: number, week: Date[]) {
   const rect = row.getBoundingClientRect()
   const col = Math.floor(((clientX - rect.left) / rect.width) * 7)
-  return parseDate(week[Math.max(0, Math.min(6, col))])
+  return parseDate(week[Math.max(0, Math.min(6, col))]!)
 }
 
 // A drag carries the event and the day it was picked up on, so that a drop
@@ -265,7 +266,7 @@ const onDragStart = (
   event.dataTransfer.setData('calendarEventID', String(calendarEvent.id))
   event.dataTransfer.setData(
     'calendarGrabDate',
-    row ? dateAtPointer(row, event.clientX, week) : parseDate(week[0]),
+    row ? dateAtPointer(row, event.clientX, week) : parseDate(week[0]!),
   )
 }
 
@@ -287,6 +288,6 @@ const onDrop = (event: DragEvent, week: Date[]) => {
   const shift = daysBetween(grabDate, dropDate)
   if (!shift) return
   shiftEventDays(calendarEvent, shift)
-  calendarActions.updateEventState(calendarEvent)
+  calendarActions!.updateEventState(calendarEvent)
 }
 </script>

--- a/experimental/Calendar/CalendarWeekDayEvent.vue
+++ b/experimental/Calendar/CalendarWeekDayEvent.vue
@@ -59,7 +59,7 @@
               <div class="flex w-fit flex-col gap-0.5 overflow-hidden">
                 <p
                   ref="eventTitleRef"
-                  class="text-sm-medium text-ink-gray-8"
+                  class="event-title text-sm-medium text-ink-gray-8"
                   :class="lineClampClass"
                 >
                   {{ props.event.title || '[No title]' }}

--- a/experimental/Calendar/CalendarWeekDayEvent.vue
+++ b/experimental/Calendar/CalendarWeekDayEvent.vue
@@ -59,7 +59,7 @@
               <div class="flex w-fit flex-col gap-0.5 overflow-hidden">
                 <p
                   ref="eventTitleRef"
-                  class="text-sm-medium event-title"
+                  class="text-sm-medium text-ink-gray-8"
                   :class="lineClampClass"
                 >
                   {{ props.event.title || '[No title]' }}

--- a/experimental/Calendar/composables/useStripScroll.ts
+++ b/experimental/Calendar/composables/useStripScroll.ts
@@ -1,0 +1,121 @@
+import {
+  nextTick,
+  onBeforeUpdate,
+  onMounted,
+  onScopeDispose,
+  onUpdated,
+  ref,
+  watch,
+  type Ref,
+} from 'vue'
+import { parseDate } from '../calendarUtils'
+
+/**
+ * Keeps a scrolling strip of dated rows in step with the calendar's
+ * navigation.
+ *
+ * Rows carry `data-strip-date`, their first day as `YYYY-MM-DD`. When the
+ * calendar's date changes — the arrows, Today, the month picker — the strip
+ * scrolls to the row holding the new `target`. Whenever the rows re-render
+ * (the strip's window moving with the month, or events arriving), the row
+ * that was at the top stays where it was. Scrolling itself changes nothing
+ * in the calendar; it only reports which row is at the top.
+ */
+export function useStripScroll(
+  scroller: Ref<HTMLElement | null>,
+  opts: {
+    /** The date to scroll to when navigation changes it. */
+    target: () => Date | undefined
+    /** A second date that jumps the strip whenever it is set, even to the same day. */
+    jump?: () => Date | undefined
+  },
+) {
+  /** First day of the row at the top of the viewport. */
+  const topDate = ref<string>()
+
+  let anchor: { date: string; offset: number } | null = null
+
+  const rows = () =>
+    Array.from(
+      scroller.value?.querySelectorAll<HTMLElement>('[data-strip-date]') ?? [],
+    )
+
+  function topRow(): HTMLElement | undefined {
+    const el = scroller.value
+    if (!el) return
+    const top = el.scrollTop + 1
+    return rows().find((row) => row.offsetTop + row.offsetHeight > top)
+  }
+
+  /**
+   * The row holding `date`: the first that starts on it, or else the last
+   * that starts before it.
+   */
+  function rowFor(date: string): HTMLElement | undefined {
+    let found: HTMLElement | undefined
+    for (const row of rows()) {
+      const start = row.dataset.stripDate!
+      if (start === date) return row
+      if (start < date) found = row
+      else break
+    }
+    return found
+  }
+
+  function scrollToDate(date: Date | string) {
+    const row = rowFor(parseDate(date))
+    const el = scroller.value
+    if (row && el) el.scrollTop = row.offsetTop
+  }
+
+  let frame = 0
+  function onScroll() {
+    if (frame) return
+    frame = requestAnimationFrame(() => {
+      frame = 0
+      topDate.value = topRow()?.dataset.stripDate
+    })
+  }
+
+  onBeforeUpdate(() => {
+    const el = scroller.value
+    const row = topRow()
+    if (!el || !row) return
+    anchor = {
+      date: row.dataset.stripDate!,
+      offset: row.offsetTop - el.scrollTop,
+    }
+  })
+
+  onUpdated(() => {
+    const el = scroller.value
+    if (!el || !anchor) return
+    const row =
+      rows().find((r) => r.dataset.stripDate === anchor!.date) ??
+      rowFor(anchor.date)
+    if (row) el.scrollTop = row.offsetTop - anchor.offset
+    anchor = null
+  })
+
+  async function follow(date?: Date) {
+    if (!date) return
+    await nextTick()
+    scrollToDate(date)
+  }
+
+  watch(() => opts.target(), follow)
+  if (opts.jump) watch(() => opts.jump!(), follow)
+
+  onMounted(() => {
+    scroller.value?.addEventListener('scroll', onScroll, { passive: true })
+    scrollToDate(opts.target() ?? new Date())
+    topDate.value = topRow()?.dataset.stripDate
+  })
+
+  onScopeDispose(() => {
+    scroller.value?.removeEventListener('scroll', onScroll)
+    if (frame) cancelAnimationFrame(frame)
+  })
+
+  return { topDate, scrollToDate }
+}

--- a/experimental/Calendar/composables/useStripScroll.ts
+++ b/experimental/Calendar/composables/useStripScroll.ts
@@ -1,7 +1,6 @@
 import {
   nextTick,
   onBeforeUpdate,
-  onMounted,
   onScopeDispose,
   onUpdated,
   ref,
@@ -106,11 +105,20 @@ export function useStripScroll(
   watch(() => opts.target(), follow)
   if (opts.jump) watch(() => opts.jump!(), follow)
 
-  onMounted(() => {
-    scroller.value?.addEventListener('scroll', onScroll, { passive: true })
-    scrollToDate(opts.target() ?? new Date())
-    topDate.value = topRow()?.dataset.stripDate
-  })
+  // The scroller may not exist at mount — the narrow layout has none — and
+  // appear later when the viewport widens, so it is watched rather than read
+  // once.
+  watch(
+    scroller,
+    (el, previous) => {
+      previous?.removeEventListener('scroll', onScroll)
+      if (!el) return
+      el.addEventListener('scroll', onScroll, { passive: true })
+      scrollToDate(opts.target() ?? new Date())
+      topDate.value = topRow()?.dataset.stripDate
+    },
+    { immediate: true, flush: 'post' },
+  )
 
   onScopeDispose(() => {
     scroller.value?.removeEventListener('scroll', onScroll)

--- a/experimental/Calendar/monthStrip.spec.ts
+++ b/experimental/Calendar/monthStrip.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { parseDate } from './calendarUtils'
+import {
+  dayEvents,
+  eventsOn,
+  isSpan,
+  sortByStart,
+  stripRange,
+  stripWeeks,
+  weekStart,
+} from './monthStrip'
+import type { CalendarEvent } from './types'
+
+const d = (iso: string) => new Date(iso + 'T00:00:00')
+
+describe('weekStart', () => {
+  it('goes back to the Sunday of the week', () => {
+    expect(parseDate(weekStart(d('2026-08-27')))).toBe('2026-08-23')
+    expect(parseDate(weekStart(d('2026-08-23')))).toBe('2026-08-23')
+  })
+})
+
+describe('stripWeeks', () => {
+  // August 2026 runs Saturday the 1st to Monday the 31st.
+  const weeks = stripWeeks(7, 2026)
+
+  it('starts on the Sunday before the first and ends on the Saturday after the last', () => {
+    expect(weeks).toHaveLength(6)
+    expect(parseDate(weeks[0]![0]!)).toBe('2026-07-26')
+    expect(parseDate(weeks[weeks.length - 1]![6]!)).toBe('2026-09-05')
+  })
+
+  it('runs in whole weeks without gaps', () => {
+    expect(weeks.every((week) => week.length === 7)).toBe(true)
+    for (let i = 1; i < weeks.length; i++) {
+      const prevEnd = weeks[i - 1]![6]!.getTime()
+      const nextStart = weeks[i]![0]!.getTime()
+      expect(nextStart - prevEnd).toBe(24 * 60 * 60 * 1000)
+    }
+  })
+
+  it('pads across a year boundary', () => {
+    const jan = stripWeeks(0, 2027)
+    expect(parseDate(jan[0]![0]!)).toBe('2026-12-27')
+    expect(parseDate(jan[jan.length - 1]![6]!)).toBe('2027-02-06')
+  })
+
+  it('stripRange reports the same first and last day', () => {
+    const range = stripRange(7, 2026)
+    expect(parseDate(range.start)).toBe('2026-07-26')
+    expect(parseDate(range.end)).toBe('2026-09-05')
+  })
+})
+
+describe('events on the strip', () => {
+  const events: CalendarEvent[] = [
+    {
+      id: 'late',
+      title: 'Late',
+      fromDate: '2026-08-27',
+      toDate: '2026-08-27',
+      fromTime: '15:00',
+      toTime: '16:00',
+    },
+    {
+      id: 'early',
+      title: 'Early',
+      fromDate: '2026-08-27',
+      toDate: '2026-08-27',
+      fromTime: '09:30',
+      toTime: '10:00',
+    },
+    {
+      id: 'allday',
+      title: 'All day',
+      fromDate: '2026-08-27',
+      toDate: '2026-08-27',
+      isFullDay: true,
+    },
+    {
+      id: 'stay',
+      title: 'Stay',
+      fromDate: '2026-08-31',
+      toDate: '2026-09-02',
+      isFullDay: true,
+    },
+  ]
+
+  it('tells spans from single days', () => {
+    expect(isSpan(events[3]!)).toBe(true)
+    expect(isSpan(events[0]!)).toBe(false)
+  })
+
+  it('orders a day full-day first, then by start time', () => {
+    expect(sortByStart(events.slice(0, 3)).map((e) => e.id)).toEqual([
+      'allday',
+      'early',
+      'late',
+    ])
+    expect(dayEvents(events, d('2026-08-27')).map((e) => e.id)).toEqual([
+      'allday',
+      'early',
+      'late',
+    ])
+  })
+
+  it('leaves spans out of a day and puts them in eventsOn', () => {
+    expect(dayEvents(events, d('2026-09-01'))).toEqual([])
+    expect(eventsOn(events, d('2026-09-01')).map((e) => e.id)).toEqual(['stay'])
+  })
+})

--- a/experimental/Calendar/monthStrip.ts
+++ b/experimental/Calendar/monthStrip.ts
@@ -1,0 +1,89 @@
+import { monthList, parseDate } from './calendarUtils'
+import { eventDayCount, eventDays } from './eventSpan'
+import type { CalendarEvent } from './types'
+
+/**
+ * The Month view is a strip of week rows, each as tall as it needs to be.
+ * These helpers describe that strip: which weeks make up a month, what a row
+ * is called, and which events land where.
+ */
+
+function addDays(date: Date, days: number): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days)
+}
+
+/** The Sunday that starts the week holding `date`. */
+export function weekStart(date: Date): Date {
+  return addDays(date, -date.getDay())
+}
+
+/**
+ * The week rows of a month: seven dates each, Sunday to Saturday, from the
+ * week holding the first of the month to the week holding its last day.
+ */
+export function stripWeeks(month: number, year: number): Date[][] {
+  const first = weekStart(new Date(year, month, 1))
+  const last = weekStart(new Date(year, month + 1, 0))
+  const weeks: Date[][] = []
+  for (let d = first; d <= last; d = addDays(d, 7)) {
+    weeks.push(Array.from({ length: 7 }, (_, i) => addDays(d, i)))
+  }
+  return weeks
+}
+
+/** First and last day the strip of a month shows, padding days included. */
+export function stripRange(month: number, year: number) {
+  const weeks = stripWeeks(month, year)
+  const lastWeek = weeks[weeks.length - 1]!
+  return { start: weeks[0]![0]!, end: lastWeek[lastWeek.length - 1]! }
+}
+
+export function shortMonth(date: Date): string {
+  return monthList[date.getMonth()]!.slice(0, 3)
+}
+
+/** Whether the event covers more than one day, and so draws as a bar. */
+export function isSpan(event: CalendarEvent): boolean {
+  return eventDayCount(event) > 1
+}
+
+function minutes(time?: string): number {
+  if (!time) return 0
+  const [h, m] = time.split(':')
+  return parseInt(h!) * 60 + parseInt(m || '0')
+}
+
+/** Full-day events first, then by start time, then a stable tiebreak. */
+export function sortByStart(events: CalendarEvent[]): CalendarEvent[] {
+  return [...events].sort((a, b) => {
+    const fullA = a.isFullDay ? 0 : 1
+    const fullB = b.isFullDay ? 0 : 1
+    if (fullA !== fullB) return fullA - fullB
+    const timeA = minutes(a.fromTime)
+    const timeB = minutes(b.fromTime)
+    if (timeA !== timeB) return timeA - timeB
+    return String(a.id ?? '').localeCompare(String(b.id ?? ''))
+  })
+}
+
+/** Single-day events that fall on `date`. */
+export function dayEvents(
+  events: CalendarEvent[],
+  date: Date,
+): CalendarEvent[] {
+  const key = parseDate(date)
+  return sortByStart(
+    events.filter((e) => !isSpan(e) && eventDays(e).start === key),
+  )
+}
+
+/** Every event that occupies `date`, spans included. */
+export function eventsOn(events: CalendarEvent[], date: Date): CalendarEvent[] {
+  const key = parseDate(date)
+  return sortByStart(
+    events.filter((e) => {
+      const { start, end } = eventDays(e)
+      return start <= key && key <= end
+    }),
+  )
+}

--- a/experimental/Calendar/style.css
+++ b/experimental/Calendar/style.css
@@ -14,9 +14,6 @@
 .event {
   background-color: var(--bg);
 }
-.event .event-title {
-  color: var(--text);
-}
 .event .event-subtitle {
   color: var(--subtext);
 }
@@ -25,9 +22,6 @@
 }
 .event.active {
   background-color: var(--bg-active);
-}
-.event.active .event-title {
-  color: var(--text-active, var(--ink-base));
 }
 .event.active .event-subtitle {
   color: var(--subtext-active);

--- a/experimental/Calendar/style.css
+++ b/experimental/Calendar/style.css
@@ -23,6 +23,11 @@
 .event.active {
   background-color: var(--bg-active);
 }
+/* A selected event may sit on a dark surface (violet, pink, cyan), where the
+   ink-gray-8 title the pills wear otherwise would vanish. */
+.event.active .event-title {
+  color: var(--text-active, var(--ink-base));
+}
 .event.active .event-subtitle {
   color: var(--subtext-active);
 }

--- a/experimental/Calendar/types.ts
+++ b/experimental/Calendar/types.ts
@@ -171,6 +171,8 @@ export interface CalendarActions {
     isPreviousMonth?: boolean,
     isNextMonth?: boolean,
   ) => void
+  /** Moves the calendar to a date, or to today when none is given. */
+  setCalendarDate: (date?: Date | string) => void
   props: CalendarPublicProps
 }
 

--- a/experimental/Calendar/useEventBase.ts
+++ b/experimental/Calendar/useEventBase.ts
@@ -73,7 +73,6 @@ export function useEventBase(props: { event: CalendarEvent; date: Date }) {
     const _color = color(props.event.color || 'green')
     return {
       '--bg': _color.bg,
-      '--text': _color.text,
       '--subtext': _color.subtext,
       '--text-active': _color.textActive,
       '--subtext-active': _color.subtextActive,


### PR DESCRIPTION

<img width="1074" height="893" alt="image" src="https://github.com/user-attachments/assets/b866f2da-e322-44ba-880f-5203fdda07ab" />

The Month view drew a fixed 5- or 6-row grid and hid whatever did not fit behind an "n more" button, with every title truncated. Both complaints came from the same choice: space was allocated by convention, not by content.

**Month rows grow to fit.** Each week row is as tall as its busiest day needs. Multi-day events run as bars in lanes at the top of the row; single-day events flow beneath them in their cells, titles wrapping to a second line. Rows share leftover height so a sparse month still fills the calendar, and the view scrolls once rows outgrow it. No more "n more".

**Phones stack the days.** Below `sm` the seven columns give way to a row per day, a heading where each month begins, and a week strip above to keep your place.

**Navigation scrolls the strip.** Arrows, Today and the month picker land on their date's row; a re-render (events arriving) keeps the top row where it was.

Smaller things in the same area, as separate commits:
- Today's pill had drifted 5px right of the other day numbers after the multi-day rewrite — fixed.
- Week/Day pill titles are `ink-gray-8` like the Month pill; the colour stays on the bar and background.

Behaviour changes (also in the changelog):
- `rangeChange` for the Month view reports the grid's extent, padding days included, rather than the first to the last of the month.
- Days outside the month are no longer dimmed; the first of a month is labelled `Sep 1`.
- `CalendarActions` gains `setCalendarDate`.

Tests: `monthStrip.spec.ts` for the strip helpers; Cypress specs for the elastic rows, the first-of-month label, and the narrow-screen stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1108/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 72.50% (±0.00% vs `main`)
<!-- coverage-report:end -->

