### PR TITLE
feat(Calendar): draft and declined events, plus follow-up fixes

### DIFF
--- a/docs/content/docs/changelog.md
+++ b/docs/content/docs/changelog.md
@@ -27,6 +27,9 @@ grid.
   bar and background.
 - `CalendarActions` (the `CALENDAR_ACTIONS_KEY` injection) gains
   `setCalendarDate`.
+- **Behavior change:** `reloadEvents()` on the template ref now re-reads the
+  `events` prop and discards edits made in the calendar since (a drag or
+  resize not yet persisted), where it used to hand the edited objects back.
 
 ### Calendar — `toDate` is honored, so events span the days they cover (breaking, silent)
 

--- a/docs/content/docs/changelog.md
+++ b/docs/content/docs/changelog.md
@@ -27,6 +27,11 @@ grid.
   bar and background.
 - `CalendarActions` (the `CALENDAR_ACTIONS_KEY` injection) gains
   `setCalendarDate`.
+- An event with `isDraft: true` draws as a dashed outline in the event's
+  colour, without the colour bar, rather than a filled pill, in every view.
+- An event with `isDeclined: true` keeps its fill and bar but its title is
+  struck through and muted; in the Week and Day views it no longer takes a
+  column of its own, so overlapping events lay out as if it were not there.
 - **Behavior change:** `reloadEvents()` on the template ref now re-reads the
   `events` prop and discards edits made in the calendar since (a drag or
   resize not yet persisted), where it used to hand the edited objects back.

--- a/experimental/Calendar/Calendar.cy.ts
+++ b/experimental/Calendar/Calendar.cy.ts
@@ -264,6 +264,26 @@ describe('Calendar', () => {
     cy.contains('All day').should('not.exist')
   })
 
+  // Anything layered over the calendar owns the keyboard. The shortcuts are bare
+  // letters, so without this they reached straight through an open dialog and
+  // switched the view behind it.
+  it('ignores shortcuts while an overlay is open', () => {
+    cy.mount(Calendar, { props: { events: [] } })
+
+    // The month/year button is the header's first control; its picker is a dialog.
+    cy.get('button').first().click()
+    cy.get('[role=dialog]').should('exist')
+
+    cy.get('body').type('w')
+    cy.contains('All day').should('not.exist')
+
+    // Closed again, the same key does what it always did.
+    cy.get('body').type('{esc}')
+    cy.get('[role=dialog]').should('not.exist')
+    cy.get('body').type('w')
+    cy.contains('All day').should('exist')
+  })
+
   // Behavior 5: every documented slot renders
   it('renders the #header slot with its props', () => {
     cy.mount(Calendar, {

--- a/experimental/Calendar/Calendar.md
+++ b/experimental/Calendar/Calendar.md
@@ -112,6 +112,9 @@ With `enableShortcuts` on: `m` / `w` / `d` switch views, `t` jumps to today,
 `←` / `→` navigate, and `Delete` removes the event whose popover is open
 (edit mode only).
 
+They stay out of the way of whatever is on top: nothing fires while a field has
+focus, or while a dialog, popover, menu or select is open anywhere on the page.
+
 ## Click handling
 
 By default, a single click on an event opens its detail popover and a double

--- a/experimental/Calendar/Calendar.vue
+++ b/experimental/Calendar/Calendar.vue
@@ -300,28 +300,31 @@ watch(activeView, (value) => {
   }
 })
 
-const parseEvents = computed(() => {
+/**
+ * A fresh internal copy of the events prop. A function rather than a computed
+ * on purpose: the views edit the copy in place (a drag shifts its dates), and
+ * `reloadEvents` must hand back the prop's values, not the edited objects a
+ * cached computed would return again.
+ */
+function parseEvents(): CalendarEvent[] {
   return (
     props.events?.map((event) => {
       const { fromDate, toDate, fromTime, toTime, ...rest } = event
-      const date = fromDate
-      const fromDateTime = fromDate + ' ' + fromTime
-      const toDateTime = toDate + ' ' + toTime
-
+      const timed = !!(fromTime && toTime)
       return {
         ...rest,
-        date,
-        fromDateTime,
-        toDateTime,
+        date: fromDate,
+        fromDateTime: fromDate + ' ' + fromTime,
+        toDateTime: toDate + ' ' + toTime,
         fromDate,
         toDate,
-        fromTime,
-        toTime,
+        fromTime: timed ? handleSeconds(fromTime) : fromTime,
+        toTime: timed ? handleSeconds(toTime) : toTime,
       }
     }) || []
   )
-})
-const events = ref<CalendarEvent[]>(parseEvents.value)
+}
+const events = ref<CalendarEvent[]>(parseEvents())
 
 watch(
   () => props.events,
@@ -330,15 +333,8 @@ watch(
 )
 
 function reloadEvents() {
-  events.value = parseEvents.value
+  events.value = parseEvents()
 }
-
-events.value.forEach((event) => {
-  if (!event.fromTime || !event.toTime) return
-
-  event.fromTime = handleSeconds(event.fromTime)
-  event.toTime = handleSeconds(event.toTime)
-})
 
 const { showEventModal, newEvent, openNewEventModal } = useEventModal()
 

--- a/experimental/Calendar/Calendar.vue
+++ b/experimental/Calendar/Calendar.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="flex h-full flex-col overflow-hidden">
+  <!-- No overflow-hidden here: each view scrolls itself, and clipping at the
+       root only cut the focus outline off the header's buttons. -->
+  <div class="flex h-full flex-col">
     <slot
       name="header"
       v-bind="{

--- a/experimental/Calendar/Calendar.vue
+++ b/experimental/Calendar/Calendar.vue
@@ -230,6 +230,27 @@ function syncSelectedMonth(year: number, month: number) {
   }
 }
 
+// Anything layered over the calendar owns the keyboard while it is up — a modal,
+// a dropdown, an event's own popover, the header's month picker. The shortcuts are
+// bare letters, so a press meant for the thing on top switched the view behind it,
+// and an arrow key moved the month under an open picker.
+//
+// Asked of the document rather than of the event's ancestors: an overlay is
+// portalled to <body>, a sibling of the calendar rather than a descendant, and a
+// press with nothing focused reports <body> itself as the target — `closest()`
+// from there would see neither.
+//
+// By role, which is what tells an overlay apart from the rest of the page: reka
+// gives dialogs and popovers `dialog`, menus `menu`, selects `listbox`, and each
+// is in the DOM only while open. Tooltips are `tooltip` and so are left out — one
+// showing under the pointer is not something the keyboard is talking to.
+const OVERLAY_SELECTOR =
+  '[role="dialog"], [role="alertdialog"], [role="menu"], [role="listbox"]'
+
+function isOverlayOpen() {
+  return !!document.querySelector(OVERLAY_SELECTOR)
+}
+
 // shortcuts for changing the active view and navigating through the calendar
 onMounted(() => {
   if (!overrideConfig.enableShortcuts) return
@@ -239,6 +260,8 @@ onUnmounted(() => {
   window.removeEventListener('keydown', handleShortcuts)
 })
 function handleShortcuts(e: KeyboardEvent) {
+  if (isOverlayOpen()) return
+
   const target = e.target as HTMLElement | null
   if (
     target?.tagName === 'INPUT' ||

--- a/experimental/Calendar/CalendarMonthEvent.vue
+++ b/experimental/Calendar/CalendarMonthEvent.vue
@@ -21,6 +21,7 @@
           active: activeEvent == (props.event?.id || props.event?.name),
           'rounded-l-none': bar && !bar.isStart,
           'rounded-r-none': bar && !bar.isEnd,
+          'event-draft': !!props.event.isDraft,
         }"
         :style="eventBgStyle"
         @click.stop="
@@ -33,9 +34,8 @@
         @dblclick.prevent="handleEventEdit($event)"
       >
         <div
-          v-if="props.event.fromTime"
+          v-if="props.event.fromTime && !props.event.isDraft"
           class="event-border w-[2px] rounded-4 shrink-0"
-          :style="eventBorderStyle"
         />
         <div
           class="relative flex h-full min-w-0 select-none items-start gap-2 overflow-hidden"
@@ -45,9 +45,12 @@
           </div>
           <div class="min-w-0">
             <p
-              class="event-title text-sm-medium text-ink-gray-8"
+              class="event-title text-sm-medium"
               :class="[
                 wrap ? 'line-clamp-2 break-words' : 'truncate',
+                props.event.isDeclined
+                  ? 'line-through text-ink-gray-5'
+                  : 'text-ink-gray-8',
                 { italic: !props.event.title },
               ]"
             >
@@ -134,7 +137,6 @@ const {
   eventIcons,
   showEventModal,
   eventBgStyle,
-  eventBorderStyle,
   handleEventClick,
   handleEventEdit,
   handleEventDelete,

--- a/experimental/Calendar/CalendarMonthly.vue
+++ b/experimental/Calendar/CalendarMonthly.vue
@@ -96,9 +96,10 @@
                 :date="date"
                 wrap
                 class="cursor-pointer"
+                :class="draggingId === event.id && 'opacity-50'"
                 :draggable="config.isEditMode"
                 @dragstart="onDragStart($event, event, row.week)"
-                @dragend="$event.target.style.opacity = '1'"
+                @dragend="draggingId = null"
               >
                 <template #event-popover-content="slotProps">
                   <slot name="event-popover-content" v-bind="slotProps" />
@@ -114,10 +115,11 @@
             :date="row.week[bar.startCol]!"
             :bar="bar"
             class="absolute cursor-pointer"
+            :class="draggingId === bar.event.id && 'opacity-50'"
             :style="barStyle(bar)"
             :draggable="config.isEditMode"
             @dragstart="onDragStart($event, bar.event, row.week)"
-            @dragend="$event.target.style.opacity = '1'"
+            @dragend="draggingId = null"
           >
             <template #event-popover-content="slotProps">
               <slot name="event-popover-content" v-bind="slotProps" />
@@ -253,17 +255,21 @@ function dateAtPointer(row: HTMLElement, clientX: number, week: Date[]) {
 // moves the event by the distance dragged rather than snapping its start to
 // wherever it landed — grabbing the third day of a stay and moving it one
 // cell right should move the stay one day, not three.
+/**
+ * The event being dragged. A stay across several weeks is a bar per row, so
+ * the fade is keyed on the event rather than on the piece that was grabbed.
+ */
+const draggingId = ref<CalendarEvent['id'] | null>(null)
+
 const onDragStart = (
   event: DragEvent,
   calendarEvent: CalendarEvent,
   week: Date[],
 ) => {
   if (!calendarEvent.id) return
+  draggingId.value = calendarEvent.id
   const target = event.target as HTMLElement | null
-  if (target) {
-    target.style.opacity = '0.5'
-    target.style.cursor = 'move'
-  }
+  if (target) target.style.cursor = 'move'
   if (!event.dataTransfer) return
   const row = target?.closest('[data-week-row]') as HTMLElement | null
   event.dataTransfer.dropEffect = 'move'

--- a/experimental/Calendar/CalendarWeekDayEvent.vue
+++ b/experimental/Calendar/CalendarWeekDayEvent.vue
@@ -30,6 +30,7 @@
             'rounded-r-none': bar && !bar.isEnd,
             'rounded-b-none': !isAllDay && props.event.segIsEnd === false,
             'rounded-t-none': !isAllDay && props.event.segIsStart === false,
+            'event-draft': !!props.event.isDraft,
           }"
           :style="innerStyle"
           @click.prevent="
@@ -46,9 +47,8 @@
         >
           <div class="flex gap-1.5 h-full p-[5px]">
             <div
-              v-if="props.event.fromTime"
+              v-if="props.event.fromTime && !props.event.isDraft"
               class="event-border h-full w-[2px] rounded-4 shrink-0"
-              :style="eventBorderStyle"
             />
             <div
               class="relative flex h-full select-none items-start gap-2 overflow-hidden"
@@ -67,10 +67,17 @@
                     : 'w-fit flex-col gap-0.5'
                 "
               >
+                <!-- Declined: struck through and muted; the fill and bar stay,
+                     so the event still reads as the one you said no to. -->
                 <p
                   ref="eventTitleRef"
-                  class="event-title text-sm-medium text-ink-gray-8"
-                  :class="isCompact ? 'truncate' : lineClampClass"
+                  class="event-title text-sm-medium"
+                  :class="[
+                    isCompact ? 'truncate' : lineClampClass,
+                    props.event.isDeclined
+                      ? 'line-through text-ink-gray-5'
+                      : 'text-ink-gray-8',
+                  ]"
                 >
                   {{ props.event.title || '[No title]' }}
                 </p>
@@ -188,7 +195,6 @@ const {
   eventIcons,
   showEventModal,
   eventBgStyle,
-  eventBorderStyle,
   preventClick,
   handleEventClick,
   handleEventEdit,

--- a/experimental/Calendar/CalendarWeekDayEvent.vue
+++ b/experimental/Calendar/CalendarWeekDayEvent.vue
@@ -56,11 +56,21 @@
               <div v-if="config.showIcon && eventIcon">
                 <component :is="eventIcon" class="h-4 w-4" />
               </div>
-              <div class="flex w-fit flex-col gap-0.5 overflow-hidden">
+              <!-- A short event has one line's worth of height, so the time
+                   sits beside the title there instead of under it, where it
+                   would be cut off. -->
+              <div
+                class="flex min-w-0 overflow-hidden"
+                :class="
+                  isCompact
+                    ? 'items-baseline gap-1.5'
+                    : 'w-fit flex-col gap-0.5'
+                "
+              >
                 <p
                   ref="eventTitleRef"
                   class="event-title text-sm-medium text-ink-gray-8"
-                  :class="lineClampClass"
+                  :class="isCompact ? 'truncate' : lineClampClass"
                 >
                   {{ props.event.title || '[No title]' }}
                 </p>
@@ -68,6 +78,7 @@
                   ref="eventTimeRef"
                   v-if="!isAllDay"
                   class="text-xs event-subtitle"
+                  :class="isCompact && 'shrink-0 whitespace-nowrap'"
                 >
                   {{
                     formattedDuration(
@@ -291,6 +302,19 @@ const innerStyle = computed(() => ({
 }))
 
 // ── Line clamp ────────────────────────────────────────────────────────────
+
+/**
+ * Whether the event's slot is too short for a title line and a time line:
+ * below the threshold the pill is held at its minimum height, which fits
+ * one line, so the two go side by side.
+ */
+const isCompact = computed(() => {
+  if (isAllDay.value) return false
+  return (
+    calculateDiff(placedFromTime(), placedToTime()) * minuteHeight <
+    heightThreshold
+  )
+})
 
 const lineClampClass = computed(() => {
   if (isAllDay.value) return 'line-clamp-1'

--- a/experimental/Calendar/CalendarWeekly.vue
+++ b/experimental/Calendar/CalendarWeekly.vue
@@ -111,10 +111,6 @@
         <!-- Grid -->
         <div class="relative z-0 flex w-full flex-col">
           <!-- time events => not full day events => overflow-scroll here -->
-          <div
-            class="w-[calc(100%-4px)] h-px z-[2] left-0.5 mt-[0.5px] bg-[#F79596] absolute"
-            :style="currentTime"
-          />
           <div class="grid w-full grid-cols-7" data-day-columns="7">
             <!-- 7 Columns -->
             <div
@@ -253,13 +249,6 @@ const allDayHeight = computed(
 const now = useNow()
 
 const isToday = (date: Date) => parseDate(date) === parseDate(now.value)
-
-const currentTime = computed(() => {
-  let hour = now.value.getHours()
-  let minutes = now.value.getMinutes()
-  let top = (hour * 60 + minutes) * minuteHeight + 'px'
-  return { top }
-})
 
 const calendarActions = inject(CALENDAR_ACTIONS_KEY)
 

--- a/experimental/Calendar/calendarUtils.ts
+++ b/experimental/Calendar/calendarUtils.ts
@@ -159,6 +159,13 @@ export function handleSeconds(time: string): string {
 export function findOverlappingEventsCount(
   events: CalendarEvent[],
 ): CalendarEvent[] {
+  // A declined event claims no room: the others lay out as if it were not
+  // there, and it sits full width beneath them.
+  const declined = events
+    .filter((event) => event.isDeclined)
+    .map((event) => ({ ...event, hallNumber: 0, idx: -1 }))
+  events = events.filter((event) => !event.isDeclined)
+
   // Sort events based on start time
   events = events.sort((a, b) => (a.startTime || 0) - (b.startTime || 0))
 
@@ -188,6 +195,7 @@ export function findOverlappingEventsCount(
       })),
     )
     .flat()
+    .concat(declined)
 }
 
 // Helpers

--- a/experimental/Calendar/calendarUtils.ts
+++ b/experimental/Calendar/calendarUtils.ts
@@ -160,7 +160,9 @@ export function findOverlappingEventsCount(
   events: CalendarEvent[],
 ): CalendarEvent[] {
   // A declined event claims no room: the others lay out as if it were not
-  // there, and it sits full width beneath them.
+  // there, and it sits full width beneath them. Grid events all carry the same
+  // z-index, so "beneath" is DOM order — the declined go first, before the
+  // events they underlie.
   const declined = events
     .filter((event) => event.isDeclined)
     .map((event) => ({ ...event, hallNumber: 0, idx: -1 }))
@@ -186,16 +188,17 @@ export function findOverlappingEventsCount(
   }
 
   // flattening halls and events
-  return result
-    .map((hall, idx) =>
-      hall.map((event, eventIdx) => ({
-        ...event,
-        hallNumber: idx,
-        idx: eventIdx,
-      })),
-    )
-    .flat()
-    .concat(declined)
+  return declined.concat(
+    result
+      .map((hall, idx) =>
+        hall.map((event, eventIdx) => ({
+          ...event,
+          hallNumber: idx,
+          idx: eventIdx,
+        })),
+      )
+      .flat(),
+  )
 }
 
 // Helpers

--- a/experimental/Calendar/style.css
+++ b/experimental/Calendar/style.css
@@ -37,6 +37,14 @@
 .event:not(.active):hover {
   background-color: var(--bg-hover);
 }
+/* A draft: saved, but nothing sent. An outline in the event's colour rather
+   than a fill, so it reads as not yet real. */
+.event.event-draft:not(.active),
+.event.event-draft:not(.active):hover {
+  background-color: transparent;
+  outline: 1px dashed var(--border);
+  outline-offset: -1px;
+}
 .event:not(.active) .past,
 .event.past:not(.active) {
   opacity: 0.5;

--- a/experimental/Calendar/types.ts
+++ b/experimental/Calendar/types.ts
@@ -40,6 +40,14 @@ export interface CalendarEvent {
   type?: string
   /** Ignores the times and covers `fromDate`..`toDate` whole. */
   isFullDay?: boolean
+  /** Saved but not sent: drawn as a dashed outline instead of a filled pill. */
+  isDraft?: boolean
+  /**
+   * The viewer said no. The title is struck through, and in the Week and Day
+   * views the event claims no room: overlapping events lay out as if it were
+   * not there and it sits full width beneath them.
+   */
+  isDeclined?: boolean
   startTime?: number
   endTime?: number
   hallNumber?: number

--- a/experimental/Calendar/useEventBase.ts
+++ b/experimental/Calendar/useEventBase.ts
@@ -78,12 +78,11 @@ export function useEventBase(props: { event: CalendarEvent; date: Date }) {
       '--subtext-active': _color.subtextActive,
       '--bg-hover': _color.bgHover,
       '--bg-active': _color.bgActive,
+      // On the root, not only the colour bar: a draft's dashed outline reads
+      // it there, and a draft has no bar.
+      '--border': _color.border,
+      '--border-active': _color.borderActive,
     }
-  })
-
-  const eventBorderStyle = computed(() => {
-    const _color = color(props.event.color || 'green')
-    return { '--border': _color.border, '--border-active': _color.borderActive }
   })
 
   // ── Delete shortcut ──────────────────────────────────────────────────────
@@ -163,7 +162,6 @@ export function useEventBase(props: { event: CalendarEvent; date: Date }) {
     eventIcons: config.eventIcons,
     showEventModal,
     eventBgStyle,
-    eventBorderStyle,
     preventClick,
     handleEventClick,
     handleEventEdit,

--- a/src/components/Sidebar/SidebarHeader.vue
+++ b/src/components/Sidebar/SidebarHeader.vue
@@ -46,15 +46,16 @@
                   : 'ml-0 w-auto opacity-100'
             "
           >
-            <div class="leading-none">
-              <span class="text-base-medium text-ink-gray-8">
-                {{ props.title }}
-              </span>
+            <!-- The size sits on the line itself, not on a span inside a
+                 leading-none div: a line box built from a strut at the
+                 inherited size and text at another puts the baseline at a
+                 different offset in an app whose layout sets a smaller base
+                 size, and the header text sat a px lower there. -->
+            <div class="truncate text-base-medium text-ink-gray-8">
+              {{ props.title }}
             </div>
-            <div class="mt-0.5 leading-none">
-              <span class="text-sm text-ink-gray-6">
-                {{ props.subtitle }}
-              </span>
+            <div class="mt-0.5 truncate text-sm text-ink-gray-6">
+              {{ props.subtitle }}
             </div>
           </div>
           <div


### PR DESCRIPTION
Follow-ups to #1108 on the experimental Calendar, plus one Sidebar fix.

## Draft and declined events

Two new optional flags on `CalendarEvent`, drawn in opposite ways:

- `isDraft` — saved but nothing sent. A dashed outline in the event's colour, no fill and no colour bar, hover included.
- `isDeclined` — the viewer said no. Fill and bar stay, the title is struck through and muted, and in the Week and Day views the event claims no room: the others lay out as if it were not there and it sits full width beneath them.

## Calendar fixes

- An event too short for two lines now reads title then time on one row. It used to drop the time, which was the line that got cut.
- Dragging a multi-day event fades every row of it, not only the piece that was grabbed.
- Dropped the week-wide current-time hairline. The per-day marker already shows the time in today's column.
- The root no longer clips the header. Every view scrolls itself, so `overflow-hidden` there only ever cut the focus outline off the header's buttons.
- `reloadEvents()` re-reads the `events` prop instead of handing back the same objects the views edit in place, so an app can use it to undo an unconfirmed drag. **Behavior change**, noted in the changelog.
- The view shortcuts are bare letters, so they reached through an open dialog, popover, menu or select and switched the view behind it. Nothing fires while an overlay is up.

## Sidebar

- The header's lines carry their own font size, so the header is one height whatever base size the app's layout sets. Each line was a `leading-none` div around a sized span, so the line box depended on the inherited size and an app with a smaller base got a header a pixel tighter.

Cypress covers the shortcut fix. The draft and declined visuals are not covered yet.

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1109/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 72.49% (-0.01% vs `main`)
<!-- coverage-report:end -->
