### PR TITLE
fix(Progress): expose an accessible name on the progressbar

### DIFF
--- a/src/components/Progress/Progress.cy.ts
+++ b/src/components/Progress/Progress.cy.ts
@@ -29,6 +29,12 @@ describe('Progress', () => {
       .and('have.attr', 'data-state', 'loading')
   })
 
+  it('gives unlabeled bars a generic accessible name', () => {
+    cy.mount(Progress, { props: { value: 40 } })
+
+    cy.get('[role=progressbar]').should('have.attr', 'aria-label', 'Progress')
+  })
+
   it('clamps the fill to the ends of the track', () => {
     for (const [value, offset] of [
       [150, 0],

--- a/src/components/Progress/Progress.vue
+++ b/src/components/Progress/Progress.vue
@@ -26,6 +26,7 @@
       :model-value="clampedValue"
       :max="MAX_VALUE"
       :get-value-label="() => valueLabel"
+      :aria-label="props.label || 'Progress'"
       class="transform-gpu overflow-hidden rounded-7"
       :class="indicatorContainerClasses"
     >


### PR DESCRIPTION
## Summary
`Progress` already had a Cypress assertion that `[role=progressbar]` exposes `aria-label` from the visible `label` prop. The label was rendered in a sibling `<span>`, so Reka UI's `ProgressRoot` stayed unnamed (Lighthouse: progressbar elements do not have accessible names).

This sets `aria-label` on `ProgressRoot` from `props.label`, with a generic `"Progress"` fallback when no label is passed.

## Test plan
- [ ] `Progress.cy.ts` — existing assistive-tech example still expects `aria-label="Uploading"`
- [ ] New case: unlabeled bar has `aria-label="Progress"`