### PR TITLE
feat(charts): number card target and delta prefix

### DIFF
--- a/experimental/FloatingWindow/FloatingWindow.vue
+++ b/experimental/FloatingWindow/FloatingWindow.vue
@@ -14,7 +14,7 @@
       ref="panel"
       v-bind="$attrs"
       :data-state="mode"
-      class="floating-window relative flex flex-col rounded-6 border border-outline-gray-2 bg-surface-elevation-1"
+      class="floating-window relative flex flex-col rounded-6 bg-surface-elevation-1"
       :class="isDocked ? '' : 'shadow-2xl'"
       :style="style"
     >

--- a/src/charts/AreaChart.vue
+++ b/src/charts/AreaChart.vue
@@ -52,7 +52,6 @@
       <ChartLegend
         :items="legendItems"
         @change="toggleSeries"
-        @highlight="hoverSeries"
       />
     </template>
   </ChartContainer>
@@ -124,7 +123,6 @@ const {
   tooltip,
   legendItems,
   toggleSeries,
-  hoverSeries,
   plotAttrs,
   reading,
 } = useAxisChart({

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -53,7 +53,6 @@
       <ChartLegend
         :items="legendItems"
         @change="toggleSeries"
-        @highlight="hoverSeries"
       />
     </template>
   </ChartContainer>
@@ -127,7 +126,6 @@ const {
   tooltip,
   legendItems,
   toggleSeries,
-  hoverSeries,
   plotAttrs,
   reading,
 } = useAxisChart({

--- a/src/charts/LineChart.cy.ts
+++ b/src/charts/LineChart.cy.ts
@@ -163,14 +163,16 @@ describe('LineChart', () => {
         .and('contain.text', 'Refund cap')
     })
 
-    it('leaves the rule in place while every series is switched off', () => {
+    // The legend refuses to hide the last visible series, so one series off is
+    // as empty as the plot gets from here. An all-hidden plot has no scale to
+    // place the rule on, which is its own question.
+    it('leaves the rule in place while a series is switched off', () => {
       // Inside refunds' own range, so the rule stays on the scale the plot
       // settles at: a line off the end of the axis is not drawn, which would
       // pass this test for the wrong reason.
       mountChart({ referenceLines: [{ value: 5, label: 'Target' }] })
       cy.get('[aria-label="Hide Sales"]').click()
-      cy.get('[aria-label="Hide Refunds"]').click()
-      lines().should('not.exist')
+      lines().should('have.length', 1)
       cy.get('[data-slot="chart-plot"] svg text').should(
         'contain.text',
         'Target',

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -52,7 +52,6 @@
       <ChartLegend
         :items="legendItems"
         @change="toggleSeries"
-        @highlight="hoverSeries"
       />
     </template>
   </ChartContainer>
@@ -124,7 +123,6 @@ const {
   tooltip,
   legendItems,
   toggleSeries,
-  hoverSeries,
   plotAttrs,
   reading,
 } = useAxisChart({

--- a/src/charts/NumberCard.vue
+++ b/src/charts/NumberCard.vue
@@ -108,11 +108,19 @@
         <!-- The ink is the caller's on a reading that carries one, the way a
              series' color is: a card standing for a series is read against it. -->
         <div
-          class="relative truncate text-3xl-semibold tabular-nums"
+          class="relative flex min-w-0 items-baseline gap-1.5 text-3xl-semibold tabular-nums"
           :class="isEmpty ? 'text-ink-gray-4' : 'text-ink-gray-9'"
           :style="valueStyle"
         >
-          {{ valueText }}
+          <span class="shrink-0">{{ valueText }}</span>
+          <!-- The target is the part that gives way: the reading clips only if
+               it alone overflows the card. -->
+          <span
+            v-if="targetText"
+            class="min-w-0 truncate text-base text-ink-gray-4"
+          >
+            / {{ targetText }}
+          </span>
         </div>
 
         <div v-if="isEmpty" class="text-sm text-ink-gray-5">No data</div>
@@ -280,6 +288,12 @@ const formattedValue = computed(() =>
 // Never empty: this line sets the height of the card's top block, and an empty
 // one would collapse it and take the block's other variants with it.
 const valueText = computed(() => formattedValue.value || '—')
+
+// Not counted up, and never printed beside the em dash: nothing measured
+// against a target reads as a target of its own.
+const targetText = computed(() =>
+  isEmpty.value ? '' : formatCardValue(props, props.target),
+)
 
 let frame: number | undefined
 

--- a/src/charts/NumberCard.vue
+++ b/src/charts/NumberCard.vue
@@ -144,7 +144,7 @@
           />
           <span
             v-if="formattedDelta"
-            class="text-sm-medium tabular-nums"
+            class="shrink-0 whitespace-nowrap text-sm-medium tabular-nums"
             :class="toneClass"
           >
             {{ formattedDelta }}
@@ -152,7 +152,13 @@
           <!-- The card states the comparison but does not own it: an app that
                lets the reader change the period puts its own Dropdown here. -->
           <slot name="caption" :caption="deltaCaption">
-            <span v-if="deltaCaption" class="truncate text-ink-gray-5">
+            <!-- Titled because it is the part that clips: a caption too long
+                 for the card is still readable on hover. -->
+            <span
+              v-if="deltaCaption"
+              :title="deltaCaption"
+              class="truncate text-ink-gray-5"
+            >
               {{ deltaCaption }}
             </span>
           </slot>

--- a/src/charts/areaChartOptions.test.ts
+++ b/src/charts/areaChartOptions.test.ts
@@ -182,10 +182,8 @@ describe('area chart option', () => {
     })
   })
 
-  it('dims the fill relative to its own opacity when blurred', () => {
-    expect(build().series[0].blur.areaStyle.opacity).toBeLessThan(
-      DEFAULT_FILL_OPACITY,
-    )
+  it('never blurs the fill: no series emphasis to blur against', () => {
+    expect(build().series[0].blur).toBeUndefined()
   })
 
   it('drops hidden series', () => {

--- a/src/charts/axisChartOptions.ts
+++ b/src/charts/axisChartOptions.ts
@@ -12,7 +12,6 @@ import {
   resolveXAxis,
   toNumber,
   valueAxisIndex,
-  BLUR_OPACITY,
   DATA_LABEL_FONT_SIZE,
   type AxisChartOptionContext,
 } from './axisChartCommon'
@@ -500,14 +499,10 @@ function buildBarSeries(entry: PlottedSeries, ctx: SeriesContext) {
     barMaxWidth: BAR_MAX_WIDTH,
     barCategoryGap: BAR_CATEGORY_GAP,
     itemStyle: { color },
-    // A whole series lifts at a time, never a single bar: isolating the bar
-    // under the pointer turns every mouse move into a flicker, and the axis
-    // pointer and tooltip already say which category is being read.
-    emphasis: { focus: 'series', blurScope: 'coordinateSystem' },
-    blur: {
-      itemStyle: { opacity: BLUR_OPACITY },
-      label: { opacity: BLUR_OPACITY },
-    },
+    // No per-series emphasis: fading the other series to read one of them costs
+    // more than it says, and the axis pointer and tooltip already read out the
+    // category under the pointer.
+    emphasis: { disabled: true },
     label: {
       show: Boolean(series.showDataLabels),
       position,
@@ -560,14 +555,8 @@ function buildLineSeries(
       width: series.lineWidth ?? DEFAULT_LINE_WIDTH,
       type: series.lineType ?? 'solid',
     },
-    // 'series' rather than the bar chart's 'self': fading every point of a line
-    // except the hovered one breaks the line up, so a whole line lifts instead.
-    emphasis: { focus: 'series', blurScope: 'coordinateSystem' },
-    blur: {
-      lineStyle: { opacity: BLUR_OPACITY },
-      itemStyle: { opacity: BLUR_OPACITY },
-      label: { opacity: BLUR_OPACITY },
-    },
+    // No per-series emphasis, as on bars: hovering one line never fades the rest.
+    emphasis: { disabled: true },
     label: {
       show: Boolean(series.showDataLabels),
       position: 'top',
@@ -584,13 +573,6 @@ function buildLineSeries(
   return {
     ...base,
     areaStyle: fillStyle(series, config, color, banded),
-    blur: {
-      ...base.blur,
-      // The blur state has to dim the fill relative to its own opacity, not to 1.
-      areaStyle: {
-        opacity: fillOpacityOf(series, config, banded) * BLUR_OPACITY,
-      },
-    },
   }
 }
 

--- a/src/charts/barChartOptions.test.ts
+++ b/src/charts/barChartOptions.test.ts
@@ -447,15 +447,10 @@ describe('bar chart option series', () => {
     expect(option.series[1].itemStyle.color).toBe('#000033')
   })
 
-  it('emphasises a whole series at a time, and only gently', () => {
+  it('never emphasises a series, so nothing else fades', () => {
     const option = build()
-    expect(option.series[0].emphasis).toEqual({
-      focus: 'series',
-      blurScope: 'coordinateSystem',
-    })
-    // Legend hover is the only thing that blurs, so it has to stay readable.
-    expect(option.series[0].blur.itemStyle.opacity).toBeGreaterThan(0.5)
-    expect(option.series[0].blur.itemStyle.opacity).toBeLessThan(1)
+    expect(option.series[0].emphasis).toEqual({ disabled: true })
+    expect(option.series[0].blur).toBeUndefined()
   })
 
   it('hides data labels unless asked, and formats them compactly', () => {

--- a/src/charts/core/useAxisChart.ts
+++ b/src/charts/core/useAxisChart.ts
@@ -119,11 +119,7 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
 
   const renderError = computed(() => built.value.error)
 
-  const {
-    chart,
-    dispatch,
-    width: plotWidth,
-  } = useChart({
+  const { chart, width: plotWidth } = useChart({
     container: plotEl,
     option: () => built.value.option,
     events: {
@@ -175,21 +171,6 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
       config.value.series.length,
     )
   }
-
-  // Legend hover is the only thing that emphasises a series. Pointing at the
-  // plot deliberately does not — the axis pointer and tooltip already read out
-  // the category, and dimming on every mouse move costs more than it says.
-  const hoveredSeries = ref<string | null>(null)
-  function hoverSeries(name: string | null) {
-    hoveredSeries.value = name
-  }
-
-  watch(hoveredSeries, (name, previous) => {
-    if (previous) dispatch({ type: 'downplay', seriesName: previous })
-    if (name && !hiddenSeries.value.includes(name)) {
-      dispatch({ type: 'highlight', seriesName: name })
-    }
-  })
 
   const tooltip = reactive({
     open: false,
@@ -440,7 +421,6 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
     tooltip,
     legendItems,
     toggleSeries,
-    hoverSeries,
     /** `v-bind` onto the plot element: the tab stop and its arrow keys. */
     plotAttrs: keyboard.attrs,
     /** What the live region announces while the cursor walks the plot. */

--- a/src/charts/docs/NumberCard.api.md
+++ b/src/charts/docs/NumberCard.api.md
@@ -54,10 +54,22 @@
     type: 'string'
   },
   {
+    name: 'target',
+    description: 'What the reading is measured against, printed as a muted ` / target` in the value\'s own formatting.',
+    required: false,
+    type: 'number | string'
+  },
+  {
     name: 'delta',
     description: 'Change against the comparison period. Sign drives the arrow.',
     required: false,
     type: 'number | null'
+  },
+  {
+    name: 'deltaPrefix',
+    description: 'Unit printed before the delta, e.g. `\'$\'`.',
+    required: false,
+    type: 'string'
   },
   {
     name: 'deltaSuffix',

--- a/src/charts/lineChartOptions.test.ts
+++ b/src/charts/lineChartOptions.test.ts
@@ -178,13 +178,10 @@ describe('line chart option series', () => {
     expect(build({ connectNulls: true }).series[0].connectNulls).toBe(true)
   })
 
-  it('lifts a whole line on hover and fades the others', () => {
+  it('never emphasises a line, so the others keep their opacity', () => {
     const option = build()
-    expect(option.series[0].emphasis).toEqual({
-      focus: 'series',
-      blurScope: 'coordinateSystem',
-    })
-    expect(option.series[0].blur.lineStyle.opacity).toBeLessThan(1)
+    expect(option.series[0].emphasis).toEqual({ disabled: true })
+    expect(option.series[0].blur).toBeUndefined()
   })
 
   it('hides data labels unless asked, and formats them compactly', () => {

--- a/src/charts/numberCardFormat.ts
+++ b/src/charts/numberCardFormat.ts
@@ -48,13 +48,15 @@ export function formatCardValue(
  * `-3.1%` next to a down arrow would say it twice.
  */
 export function formatCardDelta(
-  config: Pick<NumberCardConfig, 'deltaSuffix'>,
+  config: Pick<NumberCardConfig, 'deltaPrefix' | 'deltaSuffix'>,
   delta: number | null | undefined,
 ): string {
   if (!isPresent(delta)) return ''
-  return `${formatValue(Math.abs(delta), undefined, true)}${
-    config.deltaSuffix ?? ''
-  }`
+  return `${config.deltaPrefix ?? ''}${formatValue(
+    Math.abs(delta),
+    undefined,
+    true,
+  )}${config.deltaSuffix ?? ''}`
 }
 
 function isPresent(value: number | null | undefined): value is number {

--- a/src/charts/stories/NumberKpis.vue
+++ b/src/charts/stories/NumberKpis.vue
@@ -13,6 +13,7 @@ const cards: NumberCardProps[] = [
   {
     title: 'Net revenue',
     value: 220200,
+    target: 250000,
     prefix: '$',
     compact: true,
     delta: 5.1,

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -376,8 +376,12 @@ export type NumberCardConfig = {
   value: number | null
   prefix?: string
   suffix?: string
+  /** What the reading is measured against, printed as a muted ` / target` in the value's own formatting. */
+  target?: number | string
   /** Change against the comparison period. Sign drives the arrow. */
   delta?: number | null
+  /** Unit printed before the delta, e.g. `'$'`. */
+  deltaPrefix?: string
   /** Unit printed after the delta, e.g. `'%'`. */
   deltaSuffix?: string
   /** What the delta is measured against, e.g. `'vs last month'`. */
@@ -925,8 +929,12 @@ export type NumberCardProps = Omit<ChartBaseProps, 'subtitle'> &
     prefix?: string
     /** Printed after the number, e.g. a unit. */
     suffix?: string
+    /** What the reading is measured against, printed as a muted ` / target` in the value's own formatting. */
+    target?: number | string
     /** Change against the comparison period. Sign drives the arrow. */
     delta?: number | null
+    /** Unit printed before the delta, e.g. `'$'`. */
+    deltaPrefix?: string
     /** Unit printed after the delta, e.g. `'%'`. */
     deltaSuffix?: string
     /** What the delta is measured against, e.g. `'vs last month'`. */


### PR DESCRIPTION
Four changes to the charts family and `FloatingWindow`.

**NumberCard — `target` and `deltaPrefix`**

`target` prints a muted ` / target` after the value, in the value's own formatting. `deltaPrefix` puts a unit before the delta, next to the existing `deltaSuffix`. Both are optional, so nothing changes for a card that does not set them. The delta row now stays on one line instead of wrapping.

**Axis charts — no per-series emphasis**

Hovering one series no longer fades the others. `emphasis: { focus: 'series' }` and the `blur` states are gone from the bar, line and area builders, and `useAxisChart` no longer returns `hoverSeries`. The axis pointer and the tooltip already name the category under the pointer, so the fade cost more than it said.

Scatter, sankey and donut keep their own blur behavior — worth a follow-up if we want one rule across the family.

**FloatingWindow — no border**

The floating panel drops its border. The shadow already separates it from the page.

---

`yarn test`, `yarn type-check` and `yarn docs:check` pass.

<!-- coverage-report:start -->
Coverage: 72.43% (-0.01% vs `main`)
<!-- coverage-report:end -->
