### PR TITLE
fix(editor): ignore a file dropped on a read-only editor

### DIFF
--- a/spec/editor.md
+++ b/spec/editor.md
@@ -276,7 +276,7 @@ defineProps<{ editor?: Editor | null }>()
 
 ### `EditorDropZone`
 
-File-drop target that wraps the editor surface (toolbar + content). A file dropped on the chrome uploads and inserts at the document end; drops on the prose stay with the media plugin. The `#overlay` scoped slot replaces the overlay look.
+File-drop target that wraps the editor surface (toolbar + content). A file dropped on the chrome uploads and inserts at the document end; drops on the prose stay with the media plugin. The `#overlay` scoped slot replaces the overlay look. The overlay appears only when the zone would accept the drop, so a `disabled`, `null`, destroyed, or read-only editor shows nothing.
 
 ```ts
 defineProps<{ editor: Editor | null; disabled?: boolean; label?: string }>()

--- a/src/molecules/editor/components/EditorDropZone.test.ts
+++ b/src/molecules/editor/components/EditorDropZone.test.ts
@@ -10,13 +10,15 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { createApp, h } from 'vue'
 import EditorDropZone from './EditorDropZone.vue'
 import { CommentKit } from '../kits'
-import { flush, mount as mountEditor } from '../test-helpers'
+import {
+  cleanupMounted,
+  flush,
+  mount as mountEditor,
+  registerCleanup,
+} from '../test-helpers'
 import type { Editor as TiptapEditor } from '../useEditor'
 
 const LABEL = 'Drop files to upload'
-
-type Teardown = () => void
-const teardowns: Teardown[] = []
 
 /**
  * Mounts the zone on its own, with a real tiptap instance from the shared
@@ -31,7 +33,7 @@ function mountZone(props: {
   document.body.appendChild(root)
   const app = createApp({ render: () => h(EditorDropZone, props) })
   app.mount(root)
-  teardowns.push(() => {
+  registerCleanup(() => {
     app.unmount()
     root.remove()
   })
@@ -39,9 +41,7 @@ function mountZone(props: {
 }
 
 function editorFor(options: { editable?: boolean }): TiptapEditor {
-  const ctx = mountEditor({ extensions: [CommentKit], ...options })
-  teardowns.push(() => ctx.app.unmount())
-  return ctx.getEditor()
+  return mountEditor({ extensions: [CommentKit], ...options }).getEditor()
 }
 
 /** jsdom has no DataTransfer, and the drag signal only reads `types`. */
@@ -51,11 +51,13 @@ function startWindowDrag() {
   window.dispatchEvent(event)
 }
 
+// One hook, so the order is explicit rather than a guess about how vitest
+// sequences two of them: end the drag first, then unmount.
 afterEach(() => {
   // The window drag signal is module-level and reference-counted: end the drag
   // and unmount, or the next test starts mid-drag.
   window.dispatchEvent(new Event('dragend'))
-  while (teardowns.length) teardowns.pop()!()
+  cleanupMounted()
 })
 
 describe('EditorDropZone overlay', () => {

--- a/src/molecules/editor/components/EditorDropZone.test.ts
+++ b/src/molecules/editor/components/EditorDropZone.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The overlay is a promise: "drop files here". A read-only editor refuses every
+ * drop, so it must not make that promise. `editable: false` alone — without the
+ * `disabled` prop — is the ordinary way to render a read-only editor, so the
+ * overlay has to read the editor, not just the prop.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { createApp, h } from 'vue'
+import EditorDropZone from './EditorDropZone.vue'
+import { CommentKit } from '../kits'
+import { flush, mount as mountEditor } from '../test-helpers'
+import type { Editor as TiptapEditor } from '../useEditor'
+
+const LABEL = 'Drop files to upload'
+
+type Teardown = () => void
+const teardowns: Teardown[] = []
+
+/**
+ * Mounts the zone on its own, with a real tiptap instance from the shared
+ * helper: the shared `mount` renders `Editor`, which does not wrap itself in a
+ * drop zone.
+ */
+function mountZone(props: {
+  editor: TiptapEditor | null
+  disabled?: boolean
+}): HTMLElement {
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  const app = createApp({ render: () => h(EditorDropZone, props) })
+  app.mount(root)
+  teardowns.push(() => {
+    app.unmount()
+    root.remove()
+  })
+  return root
+}
+
+function editorFor(options: { editable?: boolean }): TiptapEditor {
+  const ctx = mountEditor({ extensions: [CommentKit], ...options })
+  teardowns.push(() => ctx.app.unmount())
+  return ctx.getEditor()
+}
+
+/** jsdom has no DataTransfer, and the drag signal only reads `types`. */
+function startWindowDrag() {
+  const event: any = new Event('dragenter', { bubbles: true })
+  event.dataTransfer = { types: ['Files'], items: [] }
+  window.dispatchEvent(event)
+}
+
+afterEach(() => {
+  // The window drag signal is module-level and reference-counted: end the drag
+  // and unmount, or the next test starts mid-drag.
+  window.dispatchEvent(new Event('dragend'))
+  while (teardowns.length) teardowns.pop()!()
+})
+
+describe('EditorDropZone overlay', () => {
+  it('stays hidden for a read-only editor that was never passed `disabled`', async () => {
+    const editor = editorFor({ editable: false })
+    expect(editor.isEditable).toBe(false)
+    const root = mountZone({ editor })
+
+    startWindowDrag()
+    await flush()
+
+    expect(root.textContent).not.toContain(LABEL)
+  })
+
+  it('appears for an editable editor', async () => {
+    const editor = editorFor({ editable: true })
+    expect(editor.isEditable).toBe(true)
+    const root = mountZone({ editor })
+
+    startWindowDrag()
+    await flush()
+
+    expect(root.textContent).toContain(LABEL)
+  })
+
+  it('stays hidden when `disabled` is set on an editable editor', async () => {
+    const root = mountZone({
+      editor: editorFor({ editable: true }),
+      disabled: true,
+    })
+
+    startWindowDrag()
+    await flush()
+
+    expect(root.textContent).not.toContain(LABEL)
+  })
+
+  it('stays hidden while the editor is still null', async () => {
+    const root = mountZone({ editor: null })
+
+    startWindowDrag()
+    await flush()
+
+    expect(root.textContent).not.toContain(LABEL)
+  })
+})

--- a/src/molecules/editor/components/EditorDropZone.vue
+++ b/src/molecules/editor/components/EditorDropZone.vue
@@ -36,19 +36,27 @@ const props = withDefaults(
 
 const root = useTemplateRef<HTMLElement>('root')
 
+// One rule for both the drop handler and the overlay, so the zone never offers
+// a drop it would refuse. A function, not a computed: `isEditable` and
+// `isDestroyed` are plain tiptap state that never notifies Vue, so a cached
+// answer would survive a `setEditable()` call. Read fresh, every drag.
+function acceptsFiles(editor: Editor | null): editor is Editor {
+  return !props.disabled && !!editor && !editor.isDestroyed && editor.isEditable
+}
+
 const { isWindowDragging, isOverZone, draggedTypes } = useEditorFileDrop(
   root,
   (files) => {
     const editor = props.editor
-    if (props.disabled || !editor || editor.isDestroyed || !editor.isEditable) {
-      return
-    }
+    if (!acceptsFiles(editor)) return
     // The single drop pipeline decides single-image vs group dialog vs video.
     editor.commands.dropFiles(files)
   },
 )
 
-const showOverlay = computed(() => isWindowDragging.value && !props.disabled)
+const showOverlay = computed(
+  () => isWindowDragging.value && acceptsFiles(props.editor),
+)
 const overlayLabel = computed(() => {
   const imageCount = draggedTypes.value.filter((type) =>
     /^image\//i.test(type),

--- a/src/molecules/editor/extensions/attachment/attachment.flow.test.ts
+++ b/src/molecules/editor/extensions/attachment/attachment.flow.test.ts
@@ -7,31 +7,17 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { CommentKit } from '../../kits'
-import { flush, mount } from '../../test-helpers'
+import { cleanupMounted, flush, mount } from '../../test-helpers'
 import type { Editor as TiptapEditor } from '../../useEditor'
 
-type Teardown = () => void
-const teardowns: Teardown[] = []
-
-/** Mounts through the shared helper and records how to take it back down. */
-function mountEditor(props: Parameters<typeof mount>[0]) {
-  const ctx = mount(props)
-  teardowns.push(() => ctx.app.unmount())
-  return ctx
-}
-
-afterEach(() => {
-  // Cleanup lives here, not at the end of a test body: a failed assertion
-  // skips the rest of the test and would leak a mounted editor into the next.
-  while (teardowns.length) teardowns.pop()!()
-})
+afterEach(cleanupMounted)
 
 describe('attachment drop flow (CommentKit)', () => {
   it('inserts a chip node when a non-media file is uploaded', async () => {
     const upload = vi.fn(async (file: File) => ({
       file_url: `/files/${file.name}`,
     }))
-    const ctx = mountEditor({
+    const ctx = mount({
       extensions: [CommentKit],
       uploadFunction: upload,
     })

--- a/src/molecules/editor/extensions/attachment/attachment.flow.test.ts
+++ b/src/molecules/editor/extensions/attachment/attachment.flow.test.ts
@@ -5,17 +5,36 @@
  * upload function, then `uploadAttachmentFiles` (what media-drop / EditorDropZone
  * call). Asserts a chip node is actually inserted and the NodeView mounts.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { CommentKit } from '../../kits'
 import { flush, mount } from '../../test-helpers'
 import type { Editor as TiptapEditor } from '../../useEditor'
+
+type Teardown = () => void
+const teardowns: Teardown[] = []
+
+/** Mounts through the shared helper and records how to take it back down. */
+function mountEditor(props: Parameters<typeof mount>[0]) {
+  const ctx = mount(props)
+  teardowns.push(() => ctx.app.unmount())
+  return ctx
+}
+
+afterEach(() => {
+  // Cleanup lives here, not at the end of a test body: a failed assertion
+  // skips the rest of the test and would leak a mounted editor into the next.
+  while (teardowns.length) teardowns.pop()!()
+})
 
 describe('attachment drop flow (CommentKit)', () => {
   it('inserts a chip node when a non-media file is uploaded', async () => {
     const upload = vi.fn(async (file: File) => ({
       file_url: `/files/${file.name}`,
     }))
-    const ctx = mount({ extensions: [CommentKit], uploadFunction: upload })
+    const ctx = mountEditor({
+      extensions: [CommentKit],
+      uploadFunction: upload,
+    })
     // tiptap's `Storage` interface is empty and nothing here augments it, so
     // the storage diagnostic below reads through a widened handle. Same cast
     // `resolveUploadOptions` makes.
@@ -47,7 +66,5 @@ describe('attachment drop flow (CommentKit)', () => {
     expect(node, 'attachment node should be inserted').toBeTruthy()
     expect(node.attrs.src).toBe('/files/report.pdf')
     expect(node.attrs.fileName).toBe('report.pdf')
-
-    ctx.app.unmount()
   })
 })

--- a/src/molecules/editor/extensions/attachment/attachment.flow.test.ts
+++ b/src/molecules/editor/extensions/attachment/attachment.flow.test.ts
@@ -5,50 +5,23 @@
  * upload function, then `uploadAttachmentFiles` (what media-drop / EditorDropZone
  * call). Asserts a chip node is actually inserted and the NodeView mounts.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { createApp, h, nextTick, reactive } from 'vue'
-
-let Editor: any
-let EditorContent: any
-let CommentKit: any
-
-beforeEach(async () => {
-  ;({ default: Editor } = await import('../../Editor.vue'))
-  ;({ default: EditorContent } = await import('../../EditorContent.vue'))
-  ;({ CommentKit } = await import('../../kits'))
-})
-
-function mount(staticProps: Record<string, any>) {
-  const state = reactive<Record<string, any>>({ modelValue: '' })
-  let editor: any = null
-  const root = document.createElement('div')
-  document.body.appendChild(root)
-  const app = createApp({
-    render() {
-      return h(Editor, { ...staticProps, ...state }, {
-        default: ({ editor: e }: any) => {
-          editor = e
-          return h(EditorContent, { editor: e })
-        },
-      })
-    },
-  })
-  app.mount(root)
-  return { getEditor: () => editor, app, root }
-}
-
-const flush = async () => {
-  for (let i = 0; i < 5; i++) {
-    await Promise.resolve()
-    await nextTick()
-  }
-}
+import { describe, it, expect, vi } from 'vitest'
+import { CommentKit } from '../../kits'
+import { flush, mount } from '../../test-helpers'
+import type { Editor as TiptapEditor } from '../../useEditor'
 
 describe('attachment drop flow (CommentKit)', () => {
   it('inserts a chip node when a non-media file is uploaded', async () => {
-    const upload = vi.fn(async (file: File) => ({ file_url: `/files/${file.name}` }))
+    const upload = vi.fn(async (file: File) => ({
+      file_url: `/files/${file.name}`,
+    }))
     const ctx = mount({ extensions: [CommentKit], uploadFunction: upload })
-    const editor = ctx.getEditor()
+    // tiptap's `Storage` interface is empty and nothing here augments it, so
+    // the storage diagnostic below reads through a widened handle. Same cast
+    // `resolveUploadOptions` makes.
+    const editor = ctx.getEditor() as TiptapEditor & {
+      storage: Record<string, any>
+    }
 
     // diagnostics: does the editor expose the command + upload storage?
     expect(typeof editor.commands.uploadAttachmentFiles).toBe('function')

--- a/src/molecules/editor/extensions/media-drop/media-drop-extension.test.ts
+++ b/src/molecules/editor/extensions/media-drop/media-drop-extension.test.ts
@@ -6,10 +6,26 @@
  * on a read-only editor too. Unguarded, dropping an image on a post you can only
  * read uploads the file and inserts it into the document you are reading.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { CommentKit } from '../../kits'
 import { flush, mount } from '../../test-helpers'
 import type { Editor as TiptapEditor } from '../../useEditor'
+
+type Teardown = () => void
+const teardowns: Teardown[] = []
+
+/** Mounts through the shared helper and records how to take it back down. */
+function mountEditor(props: Parameters<typeof mount>[0]) {
+  const ctx = mount(props)
+  teardowns.push(() => ctx.app.unmount())
+  return ctx
+}
+
+afterEach(() => {
+  // Cleanup lives here, not at the end of a test body: a failed assertion
+  // skips the rest of the test and would leak a mounted editor into the next.
+  while (teardowns.length) teardowns.pop()!()
+})
 
 const image = () =>
   new File([new Uint8Array([1, 2, 3])], 'shot.png', { type: 'image/png' })
@@ -47,7 +63,7 @@ function nodeCount(editor: TiptapEditor, typeName: string): number {
 describe('MediaDrop on a read-only editor', () => {
   it('does not upload or insert a dropped file', async () => {
     const upload = uploadSpy()
-    const ctx = mount({
+    const ctx = mountEditor({
       extensions: [CommentKit],
       uploadFunction: upload,
       editable: false,
@@ -60,13 +76,11 @@ describe('MediaDrop on a read-only editor', () => {
 
     expect(upload).not.toHaveBeenCalled()
     expect(nodeCount(editor, 'attachment')).toBe(0)
-
-    ctx.app.unmount()
   })
 
   it('claims the drop so the browser does not navigate to the file', async () => {
     const upload = uploadSpy()
-    const ctx = mount({
+    const ctx = mountEditor({
       extensions: [CommentKit],
       uploadFunction: upload,
       editable: false,
@@ -76,13 +90,11 @@ describe('MediaDrop on a read-only editor', () => {
     await flush()
 
     expect(event.defaultPrevented).toBe(true)
-
-    ctx.app.unmount()
   })
 
   it('rejects dropFiles called directly, whatever the entry point', async () => {
     const upload = uploadSpy()
-    const ctx = mount({
+    const ctx = mountEditor({
       extensions: [CommentKit],
       uploadFunction: upload,
       editable: false,
@@ -94,15 +106,16 @@ describe('MediaDrop on a read-only editor', () => {
 
     expect(upload).not.toHaveBeenCalled()
     expect(nodeCount(editor, 'attachment')).toBe(0)
-
-    ctx.app.unmount()
   })
 })
 
 describe('MediaDrop on an editable editor', () => {
   it('still uploads and inserts a dropped file', async () => {
     const upload = uploadSpy()
-    const ctx = mount({ extensions: [CommentKit], uploadFunction: upload })
+    const ctx = mountEditor({
+      extensions: [CommentKit],
+      uploadFunction: upload,
+    })
     const editor = ctx.getEditor()
     expect(editor.isEditable).toBe(true)
 
@@ -111,7 +124,5 @@ describe('MediaDrop on an editable editor', () => {
 
     expect(upload).toHaveBeenCalledOnce()
     expect(nodeCount(editor, 'attachment')).toBe(1)
-
-    ctx.app.unmount()
   })
 })

--- a/src/molecules/editor/extensions/media-drop/media-drop-extension.test.ts
+++ b/src/molecules/editor/extensions/media-drop/media-drop-extension.test.ts
@@ -7,43 +7,9 @@
  * read uploads the file and inserts it into the document you are reading.
  */
 import { describe, it, expect, vi } from 'vitest'
-import { createApp, h, nextTick, reactive } from 'vue'
-import Editor from '../../Editor.vue'
-import EditorContent from '../../EditorContent.vue'
 import { CommentKit } from '../../kits'
+import { flush, mount } from '../../test-helpers'
 import type { Editor as TiptapEditor } from '../../useEditor'
-
-type EditorProps = InstanceType<typeof Editor>['$props']
-
-function mount(staticProps: EditorProps) {
-  const state = reactive({ modelValue: '' })
-  let editor: TiptapEditor | null = null
-  const root = document.createElement('div')
-  document.body.appendChild(root)
-  const app = createApp({
-    render() {
-      return h(
-        Editor,
-        { ...staticProps, ...state },
-        {
-          default: ({ editor: e }: { editor: TiptapEditor | null }) => {
-            editor = e
-            return h(EditorContent, { editor: e })
-          },
-        },
-      )
-    },
-  })
-  app.mount(root)
-  return { getEditor: () => editor!, app }
-}
-
-const flush = async () => {
-  for (let i = 0; i < 5; i++) {
-    await Promise.resolve()
-    await nextTick()
-  }
-}
 
 const image = () =>
   new File([new Uint8Array([1, 2, 3])], 'shot.png', { type: 'image/png' })

--- a/src/molecules/editor/extensions/media-drop/media-drop-extension.test.ts
+++ b/src/molecules/editor/extensions/media-drop/media-drop-extension.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * ProseMirror runs `props.handleDOMEvents` before its own editable check
+ * (`runCustomHandler` in prosemirror-view's input.ts), so the drop handler fires
+ * on a read-only editor too. Unguarded, dropping an image on a post you can only
+ * read uploads the file and inserts it into the document you are reading.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createApp, h, nextTick, reactive } from 'vue'
+
+let Editor: any
+let EditorContent: any
+let CommentKit: any
+
+beforeEach(async () => {
+  ;({ default: Editor } = await import('../../Editor.vue'))
+  ;({ default: EditorContent } = await import('../../EditorContent.vue'))
+  ;({ CommentKit } = await import('../../kits'))
+})
+
+function mount(staticProps: Record<string, any>) {
+  const state = reactive<Record<string, any>>({ modelValue: '' })
+  let editor: any = null
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  const app = createApp({
+    render() {
+      return h(
+        Editor,
+        { ...staticProps, ...state },
+        {
+          default: ({ editor: e }: any) => {
+            editor = e
+            return h(EditorContent, { editor: e })
+          },
+        },
+      )
+    },
+  })
+  app.mount(root)
+  return { getEditor: () => editor, app }
+}
+
+const flush = async () => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+const image = () =>
+  new File([new Uint8Array([1, 2, 3])], 'shot.png', { type: 'image/png' })
+
+// Attachments, not images, carry the "did it upload?" assertions: `uploadImage`
+// probes the file's dimensions first, which jsdom cannot decode, so an image
+// never reaches `uploadFunction` here either way.
+const pdf = () =>
+  new File([new Uint8Array([1, 2, 3])], 'report.pdf', {
+    type: 'application/pdf',
+  })
+
+/** jsdom has no DataTransfer, and `collectFiles` only reads `items`. */
+function drop(editor: any, file: File) {
+  const event: any = new Event('drop', { bubbles: true, cancelable: true })
+  event.dataTransfer = { items: [{ kind: 'file', getAsFile: () => file }] }
+  event.clientX = 0
+  event.clientY = 0
+  editor.view.dom.dispatchEvent(event)
+  return event
+}
+
+function nodeCount(editor: any, typeName: string): number {
+  let count = 0
+  editor.state.doc.descendants((node: any) => {
+    if (node.type.name === typeName) count++
+  })
+  return count
+}
+
+describe('MediaDrop on a read-only editor', () => {
+  it('does not upload or insert a dropped file', async () => {
+    const upload = vi.fn(async (file: File) => ({
+      file_url: `/files/${file.name}`,
+    }))
+    const ctx = mount({
+      extensions: [CommentKit],
+      uploadFunction: upload,
+      editable: false,
+    })
+    const editor = ctx.getEditor()
+    expect(editor.isEditable).toBe(false)
+
+    drop(editor, pdf())
+    await flush()
+
+    expect(upload).not.toHaveBeenCalled()
+    expect(nodeCount(editor, 'attachment')).toBe(0)
+
+    ctx.app.unmount()
+  })
+
+  it('claims the drop so the browser does not navigate to the file', async () => {
+    const upload = vi.fn(async (file: File) => ({
+      file_url: `/files/${file.name}`,
+    }))
+    const ctx = mount({
+      extensions: [CommentKit],
+      uploadFunction: upload,
+      editable: false,
+    })
+
+    const event = drop(ctx.getEditor(), image())
+    await flush()
+
+    expect(event.defaultPrevented).toBe(true)
+
+    ctx.app.unmount()
+  })
+
+  it('rejects dropFiles called directly, whatever the entry point', async () => {
+    const upload = vi.fn(async (file: File) => ({
+      file_url: `/files/${file.name}`,
+    }))
+    const ctx = mount({
+      extensions: [CommentKit],
+      uploadFunction: upload,
+      editable: false,
+    })
+    const editor = ctx.getEditor()
+
+    expect(editor.commands.dropFiles([pdf()])).toBe(false)
+    await flush()
+
+    expect(upload).not.toHaveBeenCalled()
+    expect(nodeCount(editor, 'attachment')).toBe(0)
+
+    ctx.app.unmount()
+  })
+})
+
+describe('MediaDrop on an editable editor', () => {
+  it('still uploads and inserts a dropped file', async () => {
+    const upload = vi.fn(async (file: File) => ({
+      file_url: `/files/${file.name}`,
+    }))
+    const ctx = mount({ extensions: [CommentKit], uploadFunction: upload })
+    const editor = ctx.getEditor()
+    expect(editor.isEditable).toBe(true)
+
+    drop(editor, pdf())
+    await flush()
+
+    expect(upload).toHaveBeenCalledOnce()
+    expect(nodeCount(editor, 'attachment')).toBe(1)
+
+    ctx.app.unmount()
+  })
+})

--- a/src/molecules/editor/extensions/media-drop/media-drop-extension.test.ts
+++ b/src/molecules/editor/extensions/media-drop/media-drop-extension.test.ts
@@ -8,24 +8,10 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { CommentKit } from '../../kits'
-import { flush, mount } from '../../test-helpers'
+import { cleanupMounted, flush, mount } from '../../test-helpers'
 import type { Editor as TiptapEditor } from '../../useEditor'
 
-type Teardown = () => void
-const teardowns: Teardown[] = []
-
-/** Mounts through the shared helper and records how to take it back down. */
-function mountEditor(props: Parameters<typeof mount>[0]) {
-  const ctx = mount(props)
-  teardowns.push(() => ctx.app.unmount())
-  return ctx
-}
-
-afterEach(() => {
-  // Cleanup lives here, not at the end of a test body: a failed assertion
-  // skips the rest of the test and would leak a mounted editor into the next.
-  while (teardowns.length) teardowns.pop()!()
-})
+afterEach(cleanupMounted)
 
 const image = () =>
   new File([new Uint8Array([1, 2, 3])], 'shot.png', { type: 'image/png' })
@@ -63,7 +49,7 @@ function nodeCount(editor: TiptapEditor, typeName: string): number {
 describe('MediaDrop on a read-only editor', () => {
   it('does not upload or insert a dropped file', async () => {
     const upload = uploadSpy()
-    const ctx = mountEditor({
+    const ctx = mount({
       extensions: [CommentKit],
       uploadFunction: upload,
       editable: false,
@@ -80,7 +66,7 @@ describe('MediaDrop on a read-only editor', () => {
 
   it('claims the drop so the browser does not navigate to the file', async () => {
     const upload = uploadSpy()
-    const ctx = mountEditor({
+    const ctx = mount({
       extensions: [CommentKit],
       uploadFunction: upload,
       editable: false,
@@ -94,7 +80,7 @@ describe('MediaDrop on a read-only editor', () => {
 
   it('rejects dropFiles called directly, whatever the entry point', async () => {
     const upload = uploadSpy()
-    const ctx = mountEditor({
+    const ctx = mount({
       extensions: [CommentKit],
       uploadFunction: upload,
       editable: false,
@@ -112,7 +98,7 @@ describe('MediaDrop on a read-only editor', () => {
 describe('MediaDrop on an editable editor', () => {
   it('still uploads and inserts a dropped file', async () => {
     const upload = uploadSpy()
-    const ctx = mountEditor({
+    const ctx = mount({
       extensions: [CommentKit],
       uploadFunction: upload,
     })

--- a/src/molecules/editor/extensions/media-drop/media-drop-extension.test.ts
+++ b/src/molecules/editor/extensions/media-drop/media-drop-extension.test.ts
@@ -6,22 +6,18 @@
  * on a read-only editor too. Unguarded, dropping an image on a post you can only
  * read uploads the file and inserts it into the document you are reading.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { createApp, h, nextTick, reactive } from 'vue'
+import Editor from '../../Editor.vue'
+import EditorContent from '../../EditorContent.vue'
+import { CommentKit } from '../../kits'
+import type { Editor as TiptapEditor } from '../../useEditor'
 
-let Editor: any
-let EditorContent: any
-let CommentKit: any
+type EditorProps = InstanceType<typeof Editor>['$props']
 
-beforeEach(async () => {
-  ;({ default: Editor } = await import('../../Editor.vue'))
-  ;({ default: EditorContent } = await import('../../EditorContent.vue'))
-  ;({ CommentKit } = await import('../../kits'))
-})
-
-function mount(staticProps: Record<string, any>) {
-  const state = reactive<Record<string, any>>({ modelValue: '' })
-  let editor: any = null
+function mount(staticProps: EditorProps) {
+  const state = reactive({ modelValue: '' })
+  let editor: TiptapEditor | null = null
   const root = document.createElement('div')
   document.body.appendChild(root)
   const app = createApp({
@@ -30,7 +26,7 @@ function mount(staticProps: Record<string, any>) {
         Editor,
         { ...staticProps, ...state },
         {
-          default: ({ editor: e }: any) => {
+          default: ({ editor: e }: { editor: TiptapEditor | null }) => {
             editor = e
             return h(EditorContent, { editor: e })
           },
@@ -39,7 +35,7 @@ function mount(staticProps: Record<string, any>) {
     },
   })
   app.mount(root)
-  return { getEditor: () => editor, app }
+  return { getEditor: () => editor!, app }
 }
 
 const flush = async () => {
@@ -60,8 +56,12 @@ const pdf = () =>
     type: 'application/pdf',
   })
 
+// One spy per test, so call counts stay isolated.
+const uploadSpy = () =>
+  vi.fn(async (file: File) => ({ file_url: `/files/${file.name}` }))
+
 /** jsdom has no DataTransfer, and `collectFiles` only reads `items`. */
-function drop(editor: any, file: File) {
+function drop(editor: TiptapEditor, file: File) {
   const event: any = new Event('drop', { bubbles: true, cancelable: true })
   event.dataTransfer = { items: [{ kind: 'file', getAsFile: () => file }] }
   event.clientX = 0
@@ -70,9 +70,9 @@ function drop(editor: any, file: File) {
   return event
 }
 
-function nodeCount(editor: any, typeName: string): number {
+function nodeCount(editor: TiptapEditor, typeName: string): number {
   let count = 0
-  editor.state.doc.descendants((node: any) => {
+  editor.state.doc.descendants((node) => {
     if (node.type.name === typeName) count++
   })
   return count
@@ -80,9 +80,7 @@ function nodeCount(editor: any, typeName: string): number {
 
 describe('MediaDrop on a read-only editor', () => {
   it('does not upload or insert a dropped file', async () => {
-    const upload = vi.fn(async (file: File) => ({
-      file_url: `/files/${file.name}`,
-    }))
+    const upload = uploadSpy()
     const ctx = mount({
       extensions: [CommentKit],
       uploadFunction: upload,
@@ -101,9 +99,7 @@ describe('MediaDrop on a read-only editor', () => {
   })
 
   it('claims the drop so the browser does not navigate to the file', async () => {
-    const upload = vi.fn(async (file: File) => ({
-      file_url: `/files/${file.name}`,
-    }))
+    const upload = uploadSpy()
     const ctx = mount({
       extensions: [CommentKit],
       uploadFunction: upload,
@@ -119,9 +115,7 @@ describe('MediaDrop on a read-only editor', () => {
   })
 
   it('rejects dropFiles called directly, whatever the entry point', async () => {
-    const upload = vi.fn(async (file: File) => ({
-      file_url: `/files/${file.name}`,
-    }))
+    const upload = uploadSpy()
     const ctx = mount({
       extensions: [CommentKit],
       uploadFunction: upload,
@@ -141,9 +135,7 @@ describe('MediaDrop on a read-only editor', () => {
 
 describe('MediaDrop on an editable editor', () => {
   it('still uploads and inserts a dropped file', async () => {
-    const upload = vi.fn(async (file: File) => ({
-      file_url: `/files/${file.name}`,
-    }))
+    const upload = uploadSpy()
     const ctx = mount({ extensions: [CommentKit], uploadFunction: upload })
     const editor = ctx.getEditor()
     expect(editor.isEditable).toBe(true)

--- a/src/molecules/editor/extensions/media-drop/media-drop-extension.ts
+++ b/src/molecules/editor/extensions/media-drop/media-drop-extension.ts
@@ -130,7 +130,9 @@ export const MediaDrop = Extension.create({
               // Claimed rather than ignored: letting the event through means
               // the browser navigates the tab to the dropped file, which is a
               // worse outcome than a drop that does nothing. Propagation is
-              // left alone so an outer drop target still sees it.
+              // left alone, so the event still bubbles. Inside
+              // `EditorDropZone` it goes no further: that handler stops
+              // propagation itself, and it also bails on a read-only editor.
               if (!view.editable) {
                 event.preventDefault()
                 return true

--- a/src/molecules/editor/extensions/media-drop/media-drop-extension.ts
+++ b/src/molecules/editor/extensions/media-drop/media-drop-extension.ts
@@ -65,6 +65,11 @@ export const MediaDrop = Extension.create({
         (files: File[]) =>
         ({ editor }) => {
           if (files.length === 0) return false
+          // A read-only editor takes no files, whichever entry point asked.
+          // Guarding the command as well as its callers keeps the rule in one
+          // place: the drop plugin, `EditorDropZone`, and anything else that
+          // reaches for `dropFiles` all get it.
+          if (!editor.isEditable) return false
 
           const images = files.filter((f) => IMAGE_RE.test(f.type))
           const videos = files.filter((f) => VIDEO_RE.test(f.type))
@@ -116,6 +121,20 @@ export const MediaDrop = Extension.create({
             drop: (view: EditorView, event: DragEvent): boolean => {
               const files = collectFiles(event.dataTransfer)
               if (files.length === 0) return false
+
+              // ProseMirror runs `handleDOMEvents` before its own editable
+              // check (`runCustomHandler` in input.ts), so this fires on a
+              // read-only editor too. Without this guard, dropping an image on
+              // a post you are only reading uploads it and inserts it locally.
+              //
+              // Claimed rather than ignored: letting the event through means
+              // the browser navigates the tab to the dropped file, which is a
+              // worse outcome than a drop that does nothing. Propagation is
+              // left alone so an outer drop target still sees it.
+              if (!view.editable) {
+                event.preventDefault()
+                return true
+              }
               // Only claim drops we can actually route; let ProseMirror handle
               // the rest. Non-media files route to attachments when available.
               const hasMedia = files.some(

--- a/src/molecules/editor/test-helpers.ts
+++ b/src/molecules/editor/test-helpers.ts
@@ -61,7 +61,14 @@ export function mount(staticProps: EditorProps) {
     },
   })
   app.mount(root)
+  // Idempotent, and it takes itself out of the registry: a test may destroy
+  // early, and the afterEach hook must not then unmount a second time.
+  let destroyed = false
   const destroy = () => {
+    if (destroyed) return
+    destroyed = true
+    const i = teardowns.indexOf(destroy)
+    if (i !== -1) teardowns.splice(i, 1)
     app.unmount()
     root.remove()
   }

--- a/src/molecules/editor/test-helpers.ts
+++ b/src/molecules/editor/test-helpers.ts
@@ -28,9 +28,27 @@ export function registerCleanup(teardown: () => void) {
   teardowns.push(teardown)
 }
 
-/** Drains the registry, last registered first. Hand it to `afterEach`. */
+/**
+ * Drains the registry, last registered first. Hand it to `afterEach`.
+ *
+ * A throwing teardown must not strand the rest — that is the one thing this
+ * registry exists to guarantee — so the drain finishes and the first failure
+ * is rethrown afterwards. Swallowing it would hide a broken unmount.
+ */
 export function cleanupMounted() {
-  while (teardowns.length) teardowns.pop()!()
+  let failure: unknown
+  let failed = false
+  while (teardowns.length) {
+    try {
+      teardowns.pop()!()
+    } catch (error) {
+      if (!failed) {
+        failed = true
+        failure = error
+      }
+    }
+  }
+  if (failed) throw failure
 }
 
 /**

--- a/src/molecules/editor/test-helpers.ts
+++ b/src/molecules/editor/test-helpers.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared mount helpers for the editor's jsdom tests.
+ *
+ * Not part of the public API: nothing re-exports it from `index.ts`, so it is
+ * neither bundled nor documented. It stays extension-agnostic: each test
+ * passes its own kit through `extensions`.
+ */
+import { createApp, h, nextTick, reactive } from 'vue'
+import Editor from './Editor.vue'
+import EditorContent from './EditorContent.vue'
+import type { Editor as TiptapEditor } from './useEditor'
+
+type EditorProps = InstanceType<typeof Editor>['$props']
+
+/**
+ * Mounts `Editor` with `EditorContent` in its default slot and hands back the
+ * tiptap instance the slot receives. `modelValue` is reactive so the editor
+ * behaves like a controlled one; everything else is passed through as static.
+ */
+export function mount(staticProps: EditorProps) {
+  const state = reactive({ modelValue: '' })
+  let editor: TiptapEditor | null = null
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  const app = createApp({
+    render() {
+      return h(
+        Editor,
+        { ...staticProps, ...state },
+        {
+          default: ({ editor: e }: { editor: TiptapEditor | null }) => {
+            editor = e
+            return h(EditorContent, { editor: e })
+          },
+        },
+      )
+    },
+  })
+  app.mount(root)
+  return { getEditor: () => editor!, app, root }
+}
+
+/** Drains the microtask queue and Vue's render queue a few times over. */
+export const flush = async () => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}

--- a/src/molecules/editor/test-helpers.ts
+++ b/src/molecules/editor/test-helpers.ts
@@ -13,9 +13,33 @@ import type { Editor as TiptapEditor } from './useEditor'
 type EditorProps = InstanceType<typeof Editor>['$props']
 
 /**
+ * Every mount records how to take itself back down here. A failed assertion
+ * skips the rest of the test body, so cleanup cannot live at the end of a
+ * test. Without this registry a broken test leaks a mounted editor, and the
+ * root element it was mounted into, straight into the next test.
+ */
+const teardowns: Array<() => void> = []
+
+/**
+ * Adds a teardown for something a test mounted itself, so it drains in the
+ * same pass, and in the same order, as the ones `mount` registers.
+ */
+export function registerCleanup(teardown: () => void) {
+  teardowns.push(teardown)
+}
+
+/** Drains the registry, last registered first. Hand it to `afterEach`. */
+export function cleanupMounted() {
+  while (teardowns.length) teardowns.pop()!()
+}
+
+/**
  * Mounts `Editor` with `EditorContent` in its default slot and hands back the
  * tiptap instance the slot receives. `modelValue` is reactive so the editor
  * behaves like a controlled one; everything else is passed through as static.
+ *
+ * The returned `destroy` is already registered with `cleanupMounted`; call it
+ * directly only when a test needs the editor gone before the hook runs.
  */
 export function mount(staticProps: EditorProps) {
   const state = reactive({ modelValue: '' })
@@ -37,7 +61,12 @@ export function mount(staticProps: EditorProps) {
     },
   })
   app.mount(root)
-  return { getEditor: () => editor!, app, root }
+  const destroy = () => {
+    app.unmount()
+    root.remove()
+  }
+  registerCleanup(destroy)
+  return { getEditor: () => editor!, app, root, destroy }
 }
 
 /** Drains the microtask queue and Vue's render queue a few times over. */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,7 @@ export default mergeConfig(
           'src/**/*.cy.ts',
           'src/**/*.spec.ts',
           'src/**/*.test.ts',
+          'src/**/test-helpers.ts',
           'src/**/*.story.vue',
           'src/**/stories/**',
           'src/**/types.ts',


### PR DESCRIPTION
## The bug

Dropping a file on a **read-only** editor uploads it and inserts it into the
document. Found while debugging an image-upload report in Gameplan: an image
dropped on a discussion post you are only reading fires one `upload_file`
request and paints an `<img>` into the post.

ProseMirror runs `props.handleDOMEvents` before its own editable check —
`runCustomHandler` in `prosemirror-view`'s `input.ts`:

```js
if (eventBelongsToView(view, event) && !runCustomHandler(view, event) &&
    (view.editable || !(event.type in editHandlers)))
  handler(view, event)
```

`view.editable` gates only the built-in handler. `MediaDrop`'s
`handleDOMEvents.drop` had already run by then. `EditorDropZone` guards on
`editor.isEditable`; the plugin path did not.

## The fix

Two guards:

- `dropFiles` rejects when the editor is not editable, so every entry point into
  the single drop pipeline gets the rule — the plugin, `EditorDropZone`, and
  anything else that reaches for the command.
- `handleDOMEvents.drop` returns before it moves the selection, since
  dispatching a `setSelection` transaction into a read-only view is wrong on its
  own.

The plugin still claims the event (`preventDefault`, return `true`). Letting it
through means the browser navigates the tab to the dropped file, which is worse
than a drop that does nothing. Propagation is left alone so an outer drop target
still sees it.

`handlePaste` needs no guard: ProseMirror calls it from `editHandlers.paste`,
which only runs when the view is editable.

## Tests

New `media-drop-extension.test.ts` — 4 tests, driving a real `drop` event at the
editor DOM. Attachments carry the "did it upload?" assertions because
`uploadImage` probes the file's dimensions first, which jsdom cannot decode.

Passing with the fix:

```
✓ MediaDrop on a read-only editor > does not upload or insert a dropped file
✓ MediaDrop on a read-only editor > claims the drop so the browser does not navigate to the file
✓ MediaDrop on a read-only editor > rejects dropFiles called directly, whatever the entry point
✓ MediaDrop on an editable editor > still uploads and inserts a dropped file
Tests  4 passed (4)
```

Reverting only `media-drop-extension.ts` shows the bug:

```
× MediaDrop on a read-only editor > does not upload or insert a dropped file
  → expected "spy" to not be called at all, but actually been called 1 times
× MediaDrop on a read-only editor > rejects dropFiles called directly, whatever the entry point
  → expected true to be false
Tests  2 failed | 2 passed (4)
```

Full editor suite: `28 files, 204 tests passed`. `yarn type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1124/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 72.87% (+0.44% vs `main`)
<!-- coverage-report:end -->







