### PR TITLE
fix(ui): Improve settings dialog typography and spacing

### DIFF
--- a/src/components/SettingsDialog/SettingsBody.vue
+++ b/src/components/SettingsDialog/SettingsBody.vue
@@ -3,7 +3,7 @@
   <ScrollArea
     ref="scrollArea"
     class="min-h-0 flex-1"
-    viewport-class="px-[4.4rem] pb-16"
+    viewport-class="px-10 pb-16"
   >
     <slot />
   </ScrollArea>

--- a/src/components/SettingsDialog/SettingsHeader.vue
+++ b/src/components/SettingsDialog/SettingsHeader.vue
@@ -1,13 +1,13 @@
 <template>
   <!-- Fixed (non-scrolling) header region of a panel. -->
-  <div class="shrink-0 px-[4.4rem] pt-10">
+  <div class="shrink-0 px-10 pt-9">
     <slot>
       <div class="flex items-start justify-between gap-4">
         <div class="flex min-w-0 flex-col gap-1">
-          <h2 v-if="title" class="text-lg font-semibold text-ink-gray-8">
+          <h2 v-if="title" class="text-lg-semibold text-ink-gray-8">
             {{ title }}
           </h2>
-          <p v-if="description" class="text-base text-ink-gray-6">
+          <p v-if="description" class="text-p-base text-ink-gray-6">
             {{ description }}
           </p>
         </div>

--- a/src/components/SettingsDialog/SettingsNavGroup.vue
+++ b/src/components/SettingsDialog/SettingsNavGroup.vue
@@ -2,7 +2,7 @@
   <div>
     <div
       v-if="label || $slots.label"
-      class="flex h-7 items-center px-2 text-base text-ink-gray-5"
+      class="flex h-7 items-center px-2 text-sm-medium text-ink-gray-5"
     >
       <slot name="label">{{ label }}</slot>
     </div>

--- a/src/components/SettingsDialog/SettingsNavItem.vue
+++ b/src/components/SettingsDialog/SettingsNavItem.vue
@@ -6,7 +6,7 @@
   -->
   <TabsTrigger
     :value="value"
-    class="flex h-7 w-full items-center gap-2 rounded-4 px-2 text-left text-base text-ink-gray-7 data-[state=active]:bg-surface-elevation-3 data-[state=active]:shadow-sm data-[state=inactive]:hover:bg-surface-gray-2"
+    class="flex h-7 w-full items-center gap-2 rounded-4 px-2 text-left text-base text-ink-gray-7 data-[state=active]:text-ink-gray-8 data-[state=active]:bg-surface-elevation-3 data-[state=active]:shadow-sm data-[state=inactive]:hover:bg-surface-gray-2"
   >
     <slot name="prefix" />
     <span class="min-w-0 flex-1 truncate"><slot /></span>

--- a/src/components/SettingsDialog/SettingsRow.vue
+++ b/src/components/SettingsDialog/SettingsRow.vue
@@ -9,7 +9,7 @@
       >
         {{ title }}
       </component>
-      <div v-if="description" class="mt-1 text-base leading-5 text-ink-gray-6">
+      <div v-if="description" class="mt-1 text-p-base text-ink-gray-6">
         {{ description }}
       </div>
     </div>

--- a/src/components/SettingsDialog/SettingsSidebar.vue
+++ b/src/components/SettingsDialog/SettingsSidebar.vue
@@ -2,7 +2,7 @@
   <!-- role="tablist" + vertical roving focus, applied to the styled sidebar. -->
   <TabsList as-child>
     <div
-      class="flex max-h-[38vh] w-full shrink-0 flex-col overflow-y-auto border-b border-outline-gray-1 bg-surface-sidebar p-2 sm:max-h-none sm:w-[220px] sm:border-b-0 sm:border-r"
+      class="flex max-h-[38vh] w-full shrink-0 flex-col overflow-y-auto border-b border-outline-gray-1 bg-surface-alpha-sidebar p-2 sm:max-h-none sm:w-[220px] sm:border-b-0 sm:border-r"
     >
       <div class="space-y-4">
         <slot />

--- a/src/components/SettingsDialog/stories/panels/PreferencesPanel.vue
+++ b/src/components/SettingsDialog/stories/panels/PreferencesPanel.vue
@@ -36,7 +36,7 @@ const hideInactiveSpaces = ref(false)
       </SettingsRow>
 
       <section>
-        <h3 class="text-base font-semibold text-ink-gray-8">Sidebar</h3>
+        <h3 class="text-base-semibold text-ink-gray-8">Sidebar</h3>
         <div class="mt-2 divide-y divide-outline-gray-1">
           <SettingsRow
             title="Unread badge"

--- a/src/components/SettingsDialog/stories/panels/ProfilePanel.vue
+++ b/src/components/SettingsDialog/stories/panels/ProfilePanel.vue
@@ -22,7 +22,7 @@ const email = ref('alex@example.com')
     description="How you appear across the community."
   />
   <SettingsBody>
-    <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-6 pt-3.5">
       <div class="flex items-center gap-4">
         <Avatar size="3xl" label="Alex Rivera" />
         <div class="flex gap-2">

--- a/src/components/SettingsDialog/stories/panels/UsersPanel.vue
+++ b/src/components/SettingsDialog/stories/panels/UsersPanel.vue
@@ -39,7 +39,7 @@ const filtered = computed(() =>
   <SettingsHeader>
     <div class="flex flex-col gap-4">
       <div class="flex items-center justify-between gap-3">
-        <h2 class="text-lg font-semibold text-ink-gray-8">Users</h2>
+        <h2 class="text-lg-semibold text-ink-gray-8">Users</h2>
         <Button variant="solid" icon-left="lucide-plus">Invite</Button>
       </div>
       <TextInput v-model="search" placeholder="Search by name or email">
@@ -48,7 +48,7 @@ const filtered = computed(() =>
         </template>
       </TextInput>
       <div
-        class="grid h-8 grid-cols-[1fr_8rem] items-center border-b text-sm text-ink-gray-5"
+        class="grid h-8 grid-cols-[1fr_8rem] items-center border-b border-outline-gray-1 text-sm text-ink-gray-5"
       >
         <div>User</div>
         <div>Role</div>


### PR DESCRIPTION
## Before
<img width="856" height="432" alt="image" src="https://github.com/user-attachments/assets/2fa9644a-628c-4222-a107-ab3fcc24bff5" />

<img width="1296" height="748" alt="image" src="https://github.com/user-attachments/assets/ef439359-884f-4628-b72b-ad853ebbea9d" />


## After
- Settings Header has `pt-9` ( choosing this over pt-10, check below for explanation )

<img width="736" height="380" alt="image" src="https://github.com/user-attachments/assets/20de6657-822d-4017-b3dc-3ad3d1c97906" />
<img width="1123" height="619" alt="image" src="https://github.com/user-attachments/assets/9323ff55-848e-45c2-83a8-0df1fc45b8f8" />

<hr/>

Using `pt-10` for settingheader div  looks slightly off, the padding is mathemtically correct but visually it looks off cuz the text's lineheight takes a lil 0.25em spacing i think :thinking: 
 
<img width="699" height="358" alt="image" src="https://github.com/user-attachments/assets/40ffbaad-a453-4c99-bef4-940aa53a4666" />

<img width="1164" height="473" alt="image" src="https://github.com/user-attachments/assets/15c31486-fe67-4795-aba4-3db111cf863f" />

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1126/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 72.94% (-0.01% vs `main`)
<!-- coverage-report:end -->
