### PR TITLE
fix(docs): keep RichTextKit demo headings out of the page TOC

### DIFF
--- a/vitepress/components/Docs/Demo.vue
+++ b/vitepress/components/Docs/Demo.vue
@@ -25,6 +25,7 @@ const isEditorDemo = computed(() => props.name?.startsWith('Editor'))
       class="rounded-7 overflow-hidden border border-outline-gray-1 divide-y divide-outline-gray-1"
     >
       <div
+        data-demo-preview
         :class="[
           isEditorDemo ? '' : 'not-prose',
           'bg-surface-base overflow-x-auto scrollbar min-h-[200px]',

--- a/vitepress/components/Docs/OnThisPage.test.ts
+++ b/vitepress/components/Docs/OnThisPage.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, reactive } from 'vue'
+import OnThisPage from './OnThisPage.vue'
+
+// The real vitepress `route` is a reactive object; `watch(route, ...)` in
+// OnThisPage needs that to avoid an "invalid watch source" warning.
+vi.mock('vitepress', () => ({
+  useRoute: () => reactive({ path: '/docs/molecules/editor' }),
+}))
+
+// jsdom has no IntersectionObserver; OnThisPage only needs observe/disconnect.
+class FakeIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function mount(component: any) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  createApp({ render: () => h(component) }).mount(container)
+  return container
+}
+
+function addHeading(
+  tag: 'h2' | 'h3',
+  id: string,
+  text: string,
+  parent: HTMLElement = document.body,
+) {
+  const el = document.createElement(tag)
+  el.id = id
+  el.textContent = text
+  parent.appendChild(el)
+  return el
+}
+
+describe('OnThisPage', () => {
+  const originalIO = globalThis.IntersectionObserver
+
+  beforeEach(() => {
+    globalThis.IntersectionObserver = FakeIntersectionObserver as any
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    globalThis.IntersectionObserver = originalIO
+  })
+
+  it('excludes headings nested under [data-demo-preview] but keeps real doc headings', async () => {
+    addHeading('h2', 'rich-text-editor', 'Rich text editor')
+
+    // RichTextKit assigns real ids to headings typed inside its own demo, so
+    // presence of an id alone can't be used to tell these apart.
+    const demo = document.createElement('div')
+    demo.setAttribute('data-demo-preview', '')
+    document.body.appendChild(demo)
+    addHeading('h2', 'toc-abc-1', 'Onboarding playbook', demo)
+    addHeading('h3', 'toc-abc-2', 'First-week checklist', demo)
+
+    addHeading('h2', 'inline-editor', 'Inline editor')
+
+    const container = mount(OnThisPage)
+    await nextTick()
+    const names = Array.from(container.querySelectorAll('aside a')).map(
+      (a) => a.textContent,
+    )
+
+    expect(names).toEqual(['Rich text editor', 'Inline editor'])
+  })
+
+  it('renders nothing when every heading on the page lives inside a demo preview', async () => {
+    const demo = document.createElement('div')
+    demo.setAttribute('data-demo-preview', '')
+    document.body.appendChild(demo)
+    addHeading('h2', 'toc-xyz-1', 'Escalation matrix', demo)
+
+    const container = mount(OnThisPage)
+    await nextTick()
+    const names = Array.from(container.querySelectorAll('aside a')).map(
+      (a) => a.textContent,
+    )
+
+    expect(names).toEqual([])
+    expect(container.querySelector('aside')?.className).toContain('invisible')
+  })
+})

--- a/vitepress/components/Docs/OnThisPage.vue
+++ b/vitepress/components/Docs/OnThisPage.vue
@@ -18,10 +18,12 @@ let observer: IntersectionObserver | undefined
 const visible = new Set<string>()
 
 const setHeadings = () => {
-  // Only real doc headings carry an `id` (VitePress adds it for the anchor).
-  // Headings rendered by components in a preview — e.g. Accordion triggers —
-  // have none, so this keeps them out of the page outline.
-  const elements = Array.from(document.querySelectorAll('h2[id], h3[id]'))
+  // Real doc headings carry an id (VitePress adds it for the anchor); headings
+  // from components without one, e.g. Accordion triggers, are filtered out already.
+  // RichTextKit assigns its own ids too, so also drop anything under `[data-demo-preview]`.
+  const elements = Array.from(
+    document.querySelectorAll('h2[id], h3[id]'),
+  ).filter((el) => !el.closest('[data-demo-preview]'))
 
   h2Exists.value = elements.some((el) => el.tagName == 'H2')
 


### PR DESCRIPTION
- Issue: headings inside Editor demos were leaking into the "On this page" TOC on the frappe-ui docs site.
- Fixed by tagging the demo preview wrapper with a `data-demo-preview` attribute and excluding anything nested under it from the TOC heading scan.

| Before | After |
| ---- | ---- |
| <img width="2794" height="1681" alt="image" src="https://github.com/user-attachments/assets/5eb25dc6-fffb-4774-864f-ca6e92671ab0" /> | <img width="2788" height="1678" alt="image" src="https://github.com/user-attachments/assets/be3987d9-906f-449c-8a95-4999b271e354" /> |

<!-- coverage-report:start -->
Coverage: 72.94% (-0.01% vs `main`)
<!-- coverage-report:end -->

