### PR TITLE
feat(charts): tooltip columns, reference line labels, and chart fixes

### DIFF
--- a/src/charts/AreaChart.vue
+++ b/src/charts/AreaChart.vue
@@ -130,6 +130,7 @@ const {
   format: () => normalized.value.format,
   buildOption: buildAxisChartOption,
   stackShares: () => buildStackShares(config.value, hiddenSeries.value),
+  tooltipSeries: () => normalized.value.tooltipSeries,
   hiddenSeries,
   onSelect: (event) => emit('select', event),
 })

--- a/src/charts/AreaChart.vue
+++ b/src/charts/AreaChart.vue
@@ -49,10 +49,7 @@
     </template>
 
     <template v-if="legendItems.length > 1" #legend>
-      <ChartLegend
-        :items="legendItems"
-        @change="toggleSeries"
-      />
+      <ChartLegend :items="legendItems" @change="toggleSeries" />
     </template>
   </ChartContainer>
 </template>
@@ -130,7 +127,7 @@ const {
   format: () => normalized.value.format,
   buildOption: buildAxisChartOption,
   stackShares: () => buildStackShares(config.value, hiddenSeries.value),
-  tooltipSeries: () => normalized.value.tooltipSeries,
+  tooltipColumns: () => normalized.value.tooltipColumns,
   hiddenSeries,
   onSelect: (event) => emit('select', event),
 })

--- a/src/charts/AreaChart.vue
+++ b/src/charts/AreaChart.vue
@@ -40,6 +40,7 @@
         :y="tooltip.y"
         :label="tooltip.label"
         :items="tooltip.items"
+        :row="tooltip.row"
         :dir="dir"
       >
         <template v-if="$slots.tooltip" #default="slotProps">

--- a/src/charts/BarChart.cy.ts
+++ b/src/charts/BarChart.cy.ts
@@ -98,6 +98,57 @@ describe('BarChart', () => {
         .and('contain.text', 'Sales')
         .and('contain.text', '10')
     })
+
+    // `tooltipSeries` is the context in another unit — the count behind a rate.
+    // It reaches the tooltip and nothing else.
+    describe('a tooltip-only column', () => {
+      const withOrders = data.map((row, index) => ({
+        ...row,
+        orders: (index + 1) * 1000,
+      }))
+
+      const mountWithExtra = (props: Record<string, any> = {}) =>
+        mountChart({
+          data: withOrders,
+          tooltipSeries: ['orders'],
+          tooltipSeriesConfig: { orders: { label: 'Orders' } },
+          ...props,
+        })
+
+      it('prints in the tooltip', () => {
+        mountWithExtra()
+        cy.get('[data-slot="chart-plot"]').trigger('mousemove', 100, 150)
+        cy.get('[data-slot="chart-tooltip"]')
+          .should('contain.text', 'Orders')
+          .and('contain.text', '1,000')
+      })
+
+      it('carries no swatch, which would claim a mark on the plot', () => {
+        mountWithExtra()
+        cy.get('[data-slot="chart-plot"]').trigger('mousemove', 100, 150)
+        // Two series, and the extra adds no third.
+        cy.get('[data-slot="chart-tooltip"] .size-2').should('have.length', 2)
+      })
+
+      it('draws no mark and takes no legend entry', () => {
+        mountWithExtra()
+        bars().should('have.length', data.length * 2)
+        cy.get('[data-slot="chart-legend"] button').should('have.length', 2)
+        cy.get('[data-slot="chart-legend"]').should(
+          'not.contain.text',
+          'Orders',
+        )
+      })
+
+      it('stays in the tooltip when the legend hides a series', () => {
+        mountWithExtra()
+        cy.get('[aria-label="Hide Sales"]').click()
+        cy.get('[data-slot="chart-plot"]').trigger('mousemove', 100, 150)
+        cy.get('[data-slot="chart-tooltip"]')
+          .should('not.contain.text', 'Sales')
+          .and('contain.text', 'Orders')
+      })
+    })
   })
 
   describe('legend', () => {

--- a/src/charts/BarChart.cy.ts
+++ b/src/charts/BarChart.cy.ts
@@ -543,18 +543,92 @@ describe('BarChart', () => {
         .and('not.contain.text', 'Sales')
     })
 
+    describe('dismissal', () => {
+      function openTooltip() {
+        mountChart()
+        bars().should('have.length', data.length * 2)
+        plot().trigger('mousemove', 100, 150)
+        cy.get('[data-slot="chart-tooltip"]').should('exist')
+      }
+
+      it('closes when the page scrolls', () => {
+        openTooltip()
+        // Dispatched on the plot, not the window: a scroll event does not
+        // bubble, so this reaches the listener only through the capture phase.
+        // That is how a scroll inside a nested container arrives.
+        plot().then(($el) => $el[0].dispatchEvent(new Event('scroll')))
+        cy.get('[data-slot="chart-tooltip"]').should('not.exist')
+      })
+
+      it('closes when the window resizes', () => {
+        openTooltip()
+        cy.window().then((win) => win.dispatchEvent(new Event('resize')))
+        cy.get('[data-slot="chart-tooltip"]').should('not.exist')
+      })
+
+      it('closes when the pointer leaves the plot', () => {
+        openTooltip()
+        plot().trigger('pointerleave')
+        cy.get('[data-slot="chart-tooltip"]').should('not.exist')
+      })
+
+      it('closes when the window goes away', () => {
+        openTooltip()
+        cy.window().then((win) => win.dispatchEvent(new Event('blur')))
+        cy.get('[data-slot="chart-tooltip"]').should('not.exist')
+      })
+
+      it('closes when the tab is hidden', () => {
+        openTooltip()
+        cy.document().then((doc) => {
+          Object.defineProperty(doc, 'hidden', {
+            value: true,
+            configurable: true,
+          })
+          doc.dispatchEvent(new Event('visibilitychange'))
+        })
+        cy.get('[data-slot="chart-tooltip"]').should('not.exist')
+      })
+
+      it('closes when the rows behind it change', () => {
+        const rows = ref(data)
+        cy.mount(
+          defineComponent({
+            setup() {
+              return () =>
+                h('div', { style: 'width: 480px; height: 300px' }, [
+                  h(BarChart, {
+                    data: rows.value,
+                    x: 'month',
+                    y: ['sales', 'refunds'],
+                    echartOptions: { animation: false },
+                  }),
+                ])
+            },
+          }),
+        )
+        bars().should('have.length', data.length * 2)
+        plot().trigger('mousemove', 100, 150)
+        cy.get('[data-slot="chart-tooltip"]').should('exist')
+        cy.then(() => {
+          rows.value = data.map((row) => ({ ...row, sales: row.sales * 2 }))
+        })
+        cy.get('[data-slot="chart-tooltip"]').should('not.exist')
+      })
+    })
+
     it('hands the plotted row to the tooltip slot', () => {
       // The row carries every column, `tooltipColumns` or not: a tooltip the
       // app draws itself needs no prop to reach one.
-      mountChart(
-        { data: data.map((row) => ({ ...row, orders: 1000 })) },
-        {
-          tooltip: ({ row }: any) => h('span', `${row.orders} orders`),
-        } as any,
-      )
+      mountChart({ data: data.map((row) => ({ ...row, orders: 1000 })) }, {
+        tooltip: ({ row }: any) => h('span', `${row.orders} orders`),
+      } as any)
       bars().should('have.length', data.length * 2)
       plot().focus()
-      cy.get('[data-slot="chart-tooltip"]').should('contain.text', '1000 orders')
+      cy.get('[data-slot="chart-tooltip"]').should(
+        'contain.text',
+        '1000 orders',
+      )
     })
   })
 

--- a/src/charts/BarChart.cy.ts
+++ b/src/charts/BarChart.cy.ts
@@ -542,6 +542,20 @@ describe('BarChart', () => {
         .should('contain.text', 'at Jan: 2')
         .and('not.contain.text', 'Sales')
     })
+
+    it('hands the plotted row to the tooltip slot', () => {
+      // The row carries every column, `tooltipColumns` or not: a tooltip the
+      // app draws itself needs no prop to reach one.
+      mountChart(
+        { data: data.map((row) => ({ ...row, orders: 1000 })) },
+        {
+          tooltip: ({ row }: any) => h('span', `${row.orders} orders`),
+        } as any,
+      )
+      bars().should('have.length', data.length * 2)
+      plot().focus()
+      cy.get('[data-slot="chart-tooltip"]').should('contain.text', '1000 orders')
+    })
   })
 
   // echarts draws into one element, so the plot takes a single tab stop and the

--- a/src/charts/BarChart.cy.ts
+++ b/src/charts/BarChart.cy.ts
@@ -99,8 +99,8 @@ describe('BarChart', () => {
         .and('contain.text', '10')
     })
 
-    // `tooltipSeries` is the context in another unit — the count behind a rate.
-    // It reaches the tooltip and nothing else.
+    // `tooltipColumns` is the context in another unit — the count behind a
+    // rate. It reaches the tooltip and nothing else.
     describe('a tooltip-only column', () => {
       const withOrders = data.map((row, index) => ({
         ...row,
@@ -110,8 +110,7 @@ describe('BarChart', () => {
       const mountWithExtra = (props: Record<string, any> = {}) =>
         mountChart({
           data: withOrders,
-          tooltipSeries: ['orders'],
-          tooltipSeriesConfig: { orders: { label: 'Orders' } },
+          tooltipColumns: [{ name: 'orders', label: 'Orders' }],
           ...props,
         })
 
@@ -126,7 +125,7 @@ describe('BarChart', () => {
       it('carries no swatch, which would claim a mark on the plot', () => {
         mountWithExtra()
         cy.get('[data-slot="chart-plot"]').trigger('mousemove', 100, 150)
-        // Two series, and the extra adds no third.
+        // Two series, and the column adds no third.
         cy.get('[data-slot="chart-tooltip"] .size-2').should('have.length', 2)
       })
 

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -133,6 +133,7 @@ const {
   format: () => normalized.value.format,
   buildOption: buildAxisChartOption,
   stackShares: () => buildStackShares(config.value, hiddenSeries.value),
+  tooltipSeries: () => normalized.value.tooltipSeries,
   horizontal: () => Boolean(props.horizontal),
   hiddenSeries,
   onSelect: (event) => emit('select', event),

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -41,6 +41,7 @@
         :y="tooltip.y"
         :label="tooltip.label"
         :items="tooltip.items"
+        :row="tooltip.row"
         :dir="dir"
       >
         <template v-if="$slots.tooltip" #default="slotProps">

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -50,10 +50,7 @@
     </template>
 
     <template v-if="legendItems.length > 1" #legend>
-      <ChartLegend
-        :items="legendItems"
-        @change="toggleSeries"
-      />
+      <ChartLegend :items="legendItems" @change="toggleSeries" />
     </template>
   </ChartContainer>
 </template>
@@ -133,7 +130,7 @@ const {
   format: () => normalized.value.format,
   buildOption: buildAxisChartOption,
   stackShares: () => buildStackShares(config.value, hiddenSeries.value),
-  tooltipSeries: () => normalized.value.tooltipSeries,
+  tooltipColumns: () => normalized.value.tooltipColumns,
   horizontal: () => Boolean(props.horizontal),
   hiddenSeries,
   onSelect: (event) => emit('select', event),

--- a/src/charts/DonutChart.vue
+++ b/src/charts/DonutChart.vue
@@ -105,6 +105,7 @@
 import { computed, reactive, ref, watch } from 'vue'
 import { PieChart as PieSeries } from 'echarts/charts'
 import { registerChartModules, useChart } from './core/useChart'
+import { useTooltipDismiss } from './core/useTooltipDismiss'
 import { usePlotKeyboard } from './core/usePlotKeyboard'
 import {
   buildDonutChartOption,
@@ -225,6 +226,14 @@ const tooltip = reactive({
   x: 0,
   y: 0,
   items: [] as ChartTooltipItem[],
+})
+
+useTooltipDismiss({
+  plot: plotEl,
+  data: () => visibleSlices.value,
+  close: () => {
+    tooltip.open = false
+  },
 })
 
 /** Slice under the pointer, or under the hovered legend entry. */

--- a/src/charts/FunnelChart.vue
+++ b/src/charts/FunnelChart.vue
@@ -42,10 +42,10 @@
           <div
             v-for="stage in stages"
             :key="stage.index"
-            class="min-w-0"
+            class="flex min-w-0 flex-col gap-1"
             :class="stage.index === 0 ? 'pe-3' : 'px-3'"
           >
-            <div class="truncate text-p-sm text-ink-gray-5">
+            <div class="truncate text-sm text-ink-gray-5">
               {{ stage.label }}
             </div>
             <div

--- a/src/charts/FunnelChart.vue
+++ b/src/charts/FunnelChart.vue
@@ -164,6 +164,7 @@
 import { computed, reactive, ref } from 'vue'
 import { formatLabel, formatPercent, formatValue } from './format'
 import { buildFunnelStages, funnelShapes } from './funnelGeometry'
+import { useTooltipDismiss } from './core/useTooltipDismiss'
 import { chartColors, useChartTokens } from './tokens'
 import { documentDir } from './utils'
 import ChartContainer from './components/ChartContainer.vue'
@@ -246,6 +247,14 @@ const tooltip = reactive({
   label: '' as string | undefined,
   items: [] as ChartTooltipItem[],
   rates: [] as { label: string; value: string }[],
+})
+
+useTooltipDismiss({
+  plot: root,
+  data: () => stages.value,
+  close: () => {
+    tooltip.open = false
+  },
 })
 
 function hover(stage: FunnelStage, event: MouseEvent) {

--- a/src/charts/FunnelChart.vue
+++ b/src/charts/FunnelChart.vue
@@ -38,7 +38,7 @@
           />
         </div>
 
-        <div class="relative mb-4 grid" :style="gridStyle">
+        <div class="relative mb-6 grid" :style="gridStyle">
           <div
             v-for="stage in stages"
             :key="stage.index"

--- a/src/charts/HeatmapChart.vue
+++ b/src/charts/HeatmapChart.vue
@@ -93,6 +93,7 @@ import { GridComponent, VisualMapContinuousComponent } from 'echarts/components'
 import { LabelLayout } from 'echarts/features'
 import { registerChartModules, useChart } from './core/useChart'
 import { usePlotKeyboard } from './core/usePlotKeyboard'
+import { useTooltipDismiss } from './core/useTooltipDismiss'
 import { AXIS_LABEL_MARGIN } from './axisChartCommon'
 import {
   buildHeatmapMatrix,
@@ -186,6 +187,14 @@ const tooltip = reactive({
   y: 0,
   label: undefined as string | undefined,
   items: [] as ChartTooltipItem[],
+})
+
+useTooltipDismiss({
+  plot: plotEl,
+  data: () => matrix.value.cells,
+  close: () => {
+    tooltip.open = false
+  },
 })
 
 /**

--- a/src/charts/HeatmapChart.vue
+++ b/src/charts/HeatmapChart.vue
@@ -344,8 +344,10 @@ function downplayCell(index: number | null) {
 const keyboard = usePlotKeyboard({
   marks: () => matrix.value.cells,
   // The pair of categories names the cell, whatever order the grid ends up in
-  // and whichever refetch built the rows.
-  key: (cell) => `${cell.y} ${cell.x}`,
+  // and whichever refetch built the rows. NUL joins them because no category
+  // can hold one, so no pair of values can collide on the seam. Written as an
+  // escape: a literal NUL makes every text tool read this file as binary.
+  key: (cell) => `${cell.y}\u0000${cell.x}`,
   move: (index, previous) => {
     downplayCell(previous)
     readCell(index)

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -130,6 +130,7 @@ const {
   format: () => normalized.value.format,
   buildOption: buildAxisChartOption,
   stackShares: () => buildStackShares(config.value, hiddenSeries.value),
+  tooltipSeries: () => normalized.value.tooltipSeries,
   hiddenSeries,
   onSelect: (event) => emit('select', event),
 })

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -49,10 +49,7 @@
     </template>
 
     <template v-if="legendItems.length > 1" #legend>
-      <ChartLegend
-        :items="legendItems"
-        @change="toggleSeries"
-      />
+      <ChartLegend :items="legendItems" @change="toggleSeries" />
     </template>
   </ChartContainer>
 </template>
@@ -130,7 +127,7 @@ const {
   format: () => normalized.value.format,
   buildOption: buildAxisChartOption,
   stackShares: () => buildStackShares(config.value, hiddenSeries.value),
-  tooltipSeries: () => normalized.value.tooltipSeries,
+  tooltipColumns: () => normalized.value.tooltipColumns,
   hiddenSeries,
   onSelect: (event) => emit('select', event),
 })

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -40,6 +40,7 @@
         :y="tooltip.y"
         :label="tooltip.label"
         :items="tooltip.items"
+        :row="tooltip.row"
         :dir="dir"
       >
         <template v-if="$slots.tooltip" #default="slotProps">

--- a/src/charts/SankeyChart.vue
+++ b/src/charts/SankeyChart.vue
@@ -53,6 +53,7 @@ import { computed, reactive, ref } from 'vue'
 import { SankeyChart as SankeySeries } from 'echarts/charts'
 import { registerChartModules, useChart } from './core/useChart'
 import { usePlotKeyboard } from './core/usePlotKeyboard'
+import { useTooltipDismiss } from './core/useTooltipDismiss'
 import { buildSankeyGraph, buildSankeyOption } from './sankeyOptions'
 import { formatLabel, formatValue } from './format'
 import { useChartTokens } from './tokens'
@@ -141,6 +142,14 @@ const tooltip = reactive({
   y: 0,
   label: undefined as string | undefined,
   items: [] as ChartTooltipItem[],
+})
+
+useTooltipDismiss({
+  plot: plotEl,
+  data: () => graph.value.links,
+  close: () => {
+    tooltip.open = false
+  },
 })
 
 const { chart, dispatch } = useChart({

--- a/src/charts/ScatterChart.vue
+++ b/src/charts/ScatterChart.vue
@@ -64,6 +64,7 @@ import { GridComponent, MarkLineComponent } from 'echarts/components'
 import { LabelLayout } from 'echarts/features'
 import { registerChartModules, useChart } from './core/useChart'
 import { usePlotKeyboard } from './core/usePlotKeyboard'
+import { useTooltipDismiss } from './core/useTooltipDismiss'
 import { buildScatterOption, buildScatterSeries } from './scatterOptions'
 import { formatLabel, formatValue } from './format'
 import { pruneHiddenSeries, toggleHiddenSeries } from './hiddenSeries'
@@ -381,6 +382,14 @@ function downplayPoint(index: number | null) {
     dataIndex: hit.dataIndex,
   })
 }
+
+useTooltipDismiss({
+  plot: plotEl,
+  data: () => walk.value,
+  close: () => {
+    tooltip.open = false
+  },
+})
 
 const keyboard = usePlotKeyboard({
   marks: () => walk.value,

--- a/src/charts/areaChartOptions.test.ts
+++ b/src/charts/areaChartOptions.test.ts
@@ -17,7 +17,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 /** What `AreaChart` hands the builder: the shared config, marked `'area'`. */

--- a/src/charts/axisChartCommon.ts
+++ b/src/charts/axisChartCommon.ts
@@ -172,7 +172,15 @@ export function axisChartBase(
         // points at stay whole.
         z: 1,
         ...(axisPointer === 'shadow'
-          ? { type: 'shadow' }
+          ? {
+              // Bars sit in a slot, so the pointer covers the slot. The fill is
+              // the gridline token, because the band is furniture at the same
+              // weight as a gridline — and translucent, so the gridlines it
+              // covers still read through it. Left unstyled, echarts fills it
+              // with a hard-coded mid-grey that no theme reaches.
+              type: 'shadow',
+              shadowStyle: { color: tokens.splitLine, opacity: 0.7 },
+            }
           : {
               type: 'line',
               lineStyle: { color: tokens.axisLine, width: 1 },
@@ -485,8 +493,11 @@ function valueAxisReserve(config: AxisChartBaseConfig): number {
 
   const onY2 = (series: AxisChartSeriesConfig) => series.axis === 'y2'
   return (
-    tickColumnWidth(config, config.series.filter((s) => !onY2(s)), config.yAxis) +
-    tickColumnWidth(config, config.series.filter(onY2), config.y2Axis)
+    tickColumnWidth(
+      config,
+      config.series.filter((s) => !onY2(s)),
+      config.yAxis,
+    ) + tickColumnWidth(config, config.series.filter(onY2), config.y2Axis)
   )
 }
 
@@ -515,7 +526,9 @@ function tickColumnWidth(
   ]
   const tick = drawnTick(axisConfig)
   const widest = Math.max(
-    ...ends.map((value) => estimateTextWidth(tick(value), AXIS_LABEL_FONT_SIZE)),
+    ...ends.map((value) =>
+      estimateTextWidth(tick(value), AXIS_LABEL_FONT_SIZE),
+    ),
   )
   return Math.ceil(widest) + AXIS_LABEL_MARGIN
 }

--- a/src/charts/axisChartCommon.ts
+++ b/src/charts/axisChartCommon.ts
@@ -31,8 +31,17 @@ export type AxisChartOptionContext = {
 
 export const AXIS_LABEL_FONT_SIZE = 11
 export const DATA_LABEL_FONT_SIZE = 11
+/** echarts' own default, named here because `niceExtent` has to split the same way. */
+const AXIS_SPLIT_NUMBER = 5
 /** How far the other series drop back while one is hovered in the legend. */
 export const BLUR_OPACITY = 0.75
+/**
+ * How far an axis drops back once the legend switches off every series on it.
+ * It lands about where `--ink-gray-4` does in either theme, which is the ink the
+ * legend fades a switched-off item to. Taken as opacity rather than as a second
+ * token, so the axis fades from whatever ink the page gave it.
+ */
+const EMPTY_AXIS_OPACITY = 0.7
 
 /**
  * Gridlines and the category baseline are drawn as fine dots rather than rules:
@@ -50,13 +59,10 @@ export const DOTTED_LINE = dottedLine(1)
 
 /**
  * The texture a broken reference line takes: long strokes with square ends,
- * where the grid draws round dots.
- *
- * The plot holds two kinds of broken line and they have to be told apart. The
- * grid locates a value and a reference line states one. Ink cannot carry that
- * difference — the rule is drawn quietly on purpose, so it lands a step or two
- * from the gridlines and reads as one of them. A dash against a dot is a
- * difference in kind, and it survives at any weight and any color.
+ * where the grid draws round dots. The grid locates a value and a reference
+ * line states one. Ink cannot carry that difference, because the rule is drawn
+ * quietly on purpose and lands a step or two from the gridlines. A dash against
+ * a dot is a difference in kind, and it survives at any weight and any color.
  */
 export function dashedLine(width: number) {
   return { type: [width * DASH_LENGTH, width * DASH_GAP], width }
@@ -611,23 +617,10 @@ function tickColumnWidth(
   series: AxisChartSeriesConfig[],
   axisConfig: ChartYAxisConfig | undefined,
 ): number {
-  let low = Infinity
-  let high = -Infinity
-  for (const row of config.data ?? []) {
-    for (const one of series) {
-      const value = toNumber(row[one.name])
-      if (value === null) continue
-      if (value < low) low = value
-      if (value > high) high = value
-    }
-  }
-
+  const extent = valueExtent(config.data ?? [], series)
   // An axis told where to start or stop prints ticks between those, whatever the
-  // rows hold. An axis with nothing numeric to plot still draws, and prints 0.
-  const ends = [
-    axisConfig?.min ?? (low === Infinity ? 0 : low),
-    axisConfig?.max ?? (high === -Infinity ? 0 : high),
-  ]
+  // rows hold.
+  const ends = [axisConfig?.min ?? extent.min, axisConfig?.max ?? extent.max]
   const tick = drawnTick(axisConfig)
   const widest = Math.max(
     ...ends.map((value) =>
@@ -691,14 +684,111 @@ export function valueAxisIndex(
 export function buildValueAxes(
   config: AxisChartBaseConfig,
   tokens: ChartTokens,
-  opts: { horizontal: boolean; isRTL: boolean },
+  opts: {
+    horizontal: boolean
+    isRTL: boolean
+    /** Series names the legend has switched off. See `emptyAxisExtent`. */
+    hiddenSeries?: string[]
+  },
 ) {
-  const primary = buildValueAxis(config.yAxis, tokens, opts)
-  if (!hasSecondaryValueAxis(config, opts.horizontal)) return primary
+  const hidden = opts.hiddenSeries ?? []
+  const secondary = hasSecondaryValueAxis(config, opts.horizontal)
+  const onY2 = (series: AxisChartSeriesConfig) =>
+    secondary && series.axis === 'y2'
+
+  const primary = buildValueAxis(config.yAxis, tokens, {
+    ...opts,
+    empty: emptyAxisExtent(
+      config,
+      config.series.filter((s) => !onY2(s)),
+      hidden,
+    ),
+  })
+  if (!secondary) return primary
   return [
     primary,
-    buildValueAxis(config.y2Axis, tokens, { ...opts, secondary: true }),
+    buildValueAxis(config.y2Axis, tokens, {
+      ...opts,
+      secondary: true,
+      empty: emptyAxisExtent(config, config.series.filter(onY2), hidden),
+    }),
   ]
+}
+
+/**
+ * The ends an axis holds while the legend has every one of its series switched
+ * off, and `null` while it still draws one.
+ *
+ * echarts blanks an axis that no series feeds: no ticks, no labels, and with
+ * them the gridlines the primary carries (see `buildValueAxis`). A dual-axis
+ * chart reaches that state on one click, so the ends its own series reach are
+ * handed over as fixed ones and the axis keeps the reading it had a moment
+ * earlier.
+ *
+ * A live axis is echarts' to scale. It rounds the ends better than fixing them
+ * does, and it is free to rescale to what is left on it.
+ */
+function emptyAxisExtent(
+  config: AxisChartBaseConfig,
+  series: AxisChartSeriesConfig[],
+  hidden: string[],
+): ValueExtent | null {
+  if (!series.length) return null
+  if (series.some((one) => !hidden.includes(one.name))) return null
+  const { min, max } = valueExtent(config.data ?? [], series)
+  // A value axis holds 0 unless told to `scale`, and none of these are, so the
+  // ends have to reach it the way the live axis did.
+  return niceExtent(Math.min(0, min), Math.max(0, max))
+}
+
+export type ValueExtent = { min: number; max: number }
+
+/**
+ * The low and the high a set of series reaches across the rows. Rows with
+ * nothing numeric in them read as 0 to 0, which is the scale echarts draws for
+ * them.
+ */
+export function valueExtent(
+  rows: Record<string, any>[],
+  series: AxisChartSeriesConfig[],
+): ValueExtent {
+  let low = Infinity
+  let high = -Infinity
+  for (const row of rows) {
+    for (const one of series) {
+      const value = toNumber(row[one.name])
+      if (value === null) continue
+      if (value < low) low = value
+      if (value > high) high = value
+    }
+  }
+  return { min: low === Infinity ? 0 : low, max: high === -Infinity ? 0 : high }
+}
+
+/** The steps a round axis interval is allowed to take, per power of ten. */
+const NICE_STEPS = [1, 2, 2.5, 5, 10]
+
+/**
+ * The extent widened until both ends sit on a round interval. echarts does this
+ * for an axis it scales itself; an axis handed a fixed `min` and `max` prints
+ * exactly what it was given, and a scale running to 1743 in five steps reads as
+ * noise.
+ */
+function niceExtent(min: number, max: number, splits = AXIS_SPLIT_NUMBER) {
+  if (!(max > min)) return { min, max: min + 1 }
+  const rough = (max - min) / splits
+  const magnitude = 10 ** Math.floor(Math.log10(rough))
+  const step =
+    (NICE_STEPS.find((s) => rough <= s * magnitude) ?? 10) * magnitude
+  return {
+    min: roundToStep(Math.floor(min / step) * step),
+    max: roundToStep(Math.ceil(max / step) * step),
+  }
+}
+
+/** Clears the float dust a multiple of 2.5 leaves behind: 0.30000000000000004. */
+function roundToStep(value: number) {
+  return Number(value.toPrecision(12))
 }
 
 /**
@@ -714,9 +804,11 @@ export function buildValueAxis(
     isRTL: boolean
     /** Drawn opposite the primary, and aligned to its ticks. */
     secondary?: boolean
+    /** The ends to pin it to while nothing is drawn on it. See `emptyAxisExtent`. */
+    empty?: ValueExtent | null
   },
 ) {
-  const { horizontal, isRTL } = opts
+  const { horizontal, isRTL, empty } = opts
   const secondary = Boolean(opts.secondary)
 
   const axis = {
@@ -729,8 +821,8 @@ export function buildValueAxis(
     // The value-axis title is chrome, not a mark: it is drawn as HTML above the
     // plot (see ChartContainer's `plotLabel`) so it lines up with the chart
     // title whichever way the bars run.
-    min: axisConfig?.min,
-    max: axisConfig?.max,
+    min: axisConfig?.min ?? empty?.min,
+    max: axisConfig?.max ?? empty?.max,
     // Gridlines carry the reading of the plot; the axis line itself is noise.
     // Only the primary draws them: with aligned ticks the second set lands on
     // the same rows, so it adds nothing but a doubled line.
@@ -748,6 +840,9 @@ export function buildValueAxis(
       showMaxLabel: true,
       margin: AXIS_LABEL_MARGIN,
       color: tokens.axisLabel,
+      // Dropped back rather than hidden: the numbers stay readable, and the
+      // axis reads as belonging to the series the legend has switched off.
+      ...(empty ? { opacity: EMPTY_AXIS_OPACITY } : {}),
       fontSize: AXIS_LABEL_FONT_SIZE,
       formatter: (value: number) => formatValue(value, 1, true),
     },

--- a/src/charts/axisChartCommon.ts
+++ b/src/charts/axisChartCommon.ts
@@ -14,7 +14,9 @@ import { chartColors, type ChartTokens } from './tokens'
 import { mergeDeep } from './utils'
 import type {
   AxisChartBaseConfig,
+  AxisChartConfig,
   AxisChartSeriesConfig,
+  ChartMark,
   ChartPaletteName,
   ChartYAxisConfig,
 } from './types'
@@ -65,20 +67,90 @@ export const AXIS_LABEL_MARGIN = 8
 
 const DEFAULT_PALETTE: ChartPaletteName = 'sequential'
 
+const MARKS: ChartMark[] = ['bar', 'line', 'area']
+
+/**
+ * How much ink a mark lays down, least first. A fill still reads in a pale
+ * ramp stop because it covers area; a 2px stroke in the same stop disappears
+ * against the card. So the ramp is handed out thinnest mark first.
+ */
+const INK_WEIGHT: Record<ChartMark, number> = { line: 0, area: 1, bar: 2 }
+
 /** Series colors, keyed by name so a hidden series never shifts its neighbours. */
 export function resolveSeriesColors(
-  config: AxisChartBaseConfig,
+  config: AxisChartConfig,
   tokens: ChartTokens,
 ): Record<string, string> {
   const assigned = chartColors(config.palette, tokens, {
     fallback: DEFAULT_PALETTE,
     count: config.series.length,
   })
+  const slots = colorSlots(config)
   const colors: Record<string, string> = {}
   config.series.forEach((series, index) => {
-    colors[series.name] = series.color || assigned[index]
+    colors[series.name] = series.color || assigned[slots[index]]
   })
   return colors
+}
+
+/**
+ * Which color each series takes, as an index into the resolved list. Series
+ * order everywhere else, and ink weight where the colors are a sequential ramp:
+ * one hue getting paler carries nothing in the order its stops are spent, so a
+ * combo chart may spend the deep end on the mark that needs it.
+ *
+ * The other three palettes are all order that means something. A caller's own
+ * list is drawn as it was written, a diverging ramp's direction is its meaning,
+ * and a categorical set is unrelated hues with no ramp to reorder.
+ */
+function colorSlots(config: AxisChartConfig): number[] {
+  const identity = config.series.map((_, index) => index)
+  if (Array.isArray(config.palette)) return identity
+  if ((config.palette ?? DEFAULT_PALETTE) !== 'sequential') return identity
+
+  const weights = config.series.map(
+    (series) => INK_WEIGHT[resolveMark(series, config, true)],
+  )
+  const slots: number[] = []
+  identity
+    .slice()
+    .sort((a, b) => weights[a] - weights[b] || a - b)
+    .forEach((seriesIndex, slot) => (slots[seriesIndex] = slot))
+  return slots
+}
+
+/**
+ * `quiet` for a second read of the same config: a series asking for a mark the
+ * library cannot draw is reported by the option build, once, rather than again
+ * by everything else that resolves the same marks.
+ */
+export function resolveMark(
+  series: AxisChartSeriesConfig,
+  config: AxisChartConfig,
+  quiet = false,
+): ChartMark {
+  // A saved config outlives the code that wrote it, so an unreadable mark is a
+  // value to recover from rather than a reason to draw nothing.
+  const asked = series.type ?? config.type
+  if (!MARKS.includes(asked)) {
+    if (!quiet)
+      warn(
+        `Series "${series.name}" asks for type "${asked}", which is not one of ${MARKS.join(', ')}. Drawing it as ${article(config.type)}.`,
+      )
+    return config.type
+  }
+  if (config.horizontal && asked !== 'bar') {
+    if (!quiet)
+      warn(
+        `\`horizontal\` runs the value axis across the plot, which only bars are drawn against. Series "${series.name}" asked for ${article(asked)} and is drawn as a bar.`,
+      )
+    return 'bar'
+  }
+  return asked
+}
+
+function article(mark: ChartMark) {
+  return mark === 'area' ? 'an area' : `a ${mark}`
 }
 
 export type ResolvedXAxis = {

--- a/src/charts/axisChartCommon.ts
+++ b/src/charts/axisChartCommon.ts
@@ -38,8 +38,40 @@ export const BLUR_OPACITY = 0.75
  * Gridlines and the category baseline are drawn as fine dots rather than rules:
  * they should locate a value without competing with the marks in front of them.
  * A short dash with a round cap gives round dots at any device pixel ratio.
+ *
+ * The dash scales with the width, so a heavier rule takes the same texture drawn
+ * heavier. Held at the gridline's own dash, a 1.5-wide dot comes out a bead.
  */
-export const DOTTED_LINE = { type: [1, 3], cap: 'round', width: 1 }
+export function dottedLine(width: number) {
+  return { type: [width, width * 3], cap: 'round' as const, width }
+}
+
+export const DOTTED_LINE = dottedLine(1)
+
+/**
+ * The texture a broken reference line takes: long strokes with square ends,
+ * where the grid draws round dots.
+ *
+ * The plot holds two kinds of broken line and they have to be told apart. The
+ * grid locates a value and a reference line states one. Ink cannot carry that
+ * difference — the rule is drawn quietly on purpose, so it lands a step or two
+ * from the gridlines and reads as one of them. A dash against a dot is a
+ * difference in kind, and it survives at any weight and any color.
+ */
+export function dashedLine(width: number) {
+  return { type: [width * DASH_LENGTH, width * DASH_GAP], width }
+}
+
+/** Both in multiples of the line's width, so the texture scales with the rule. */
+const DASH_LENGTH = 3.5
+const DASH_GAP = 3
+
+/**
+ * Marks paint in this order whatever order the series arrive in: a bar hides a
+ * band, a band hides a line. Above the axis pointer at z 1, which is a reading
+ * aid rather than a mark.
+ */
+export const MARK_Z: Record<ChartMark, number> = { bar: 2, area: 3, line: 4 }
 
 /**
  * Most of a horizontal chart that its category labels may claim. `containLabel`

--- a/src/charts/axisChartOptions.ts
+++ b/src/charts/axisChartOptions.ts
@@ -137,7 +137,7 @@ export function buildAxisChartOption(
   const valueAxis = buildValueAxes(
     pinNormalizedAxes(config, visible, shares, hasSecondary),
     tokens,
-    { horizontal, isRTL },
+    { horizontal, isRTL, hiddenSeries },
   )
   const carriesTip = tipResolver(visible, config, rows)
 

--- a/src/charts/axisChartOptions.ts
+++ b/src/charts/axisChartOptions.ts
@@ -14,6 +14,7 @@ import {
   toNumber,
   valueAxisIndex,
   DATA_LABEL_FONT_SIZE,
+  MARK_Z,
   type AxisChartOptionContext,
 } from './axisChartCommon'
 import { buildReferenceLineSeries } from './referenceLines'
@@ -48,13 +49,6 @@ const GRADIENT_FADE = 0.1
 /** The scale a 100% stack is read against, whatever the numbers behind it. */
 const NORMALIZED_MIN = 0
 const NORMALIZED_MAX = 100
-
-/**
- * Marks paint in this order whatever order the series arrive in: a bar hides a
- * band, a band hides a line. Above the axis pointer at z 1, which is a reading
- * aid rather than a mark.
- */
-const MARK_Z: Record<ChartMark, number> = { bar: 2, area: 3, line: 4 }
 
 /** A series with the two things the config only implies: its mark and its stack. */
 type PlottedSeries = {

--- a/src/charts/axisChartOptions.ts
+++ b/src/charts/axisChartOptions.ts
@@ -8,6 +8,7 @@ import {
   buildXAxis,
   hasSecondaryValueAxis,
   plotRows,
+  resolveMark,
   resolveSeriesColors,
   resolveXAxis,
   toNumber,
@@ -43,8 +44,6 @@ export const DEFAULT_FILL_OPACITY = 0.16
 export const DEFAULT_STACKED_FILL_OPACITY = 0.75
 /** Where the gradient lands by the time it reaches the axis. */
 const GRADIENT_FADE = 0.1
-
-const MARKS: ChartMark[] = ['bar', 'line', 'area']
 
 /** The scale a 100% stack is read against, whatever the numbers behind it. */
 const NORMALIZED_MIN = 0
@@ -193,41 +192,11 @@ export function buildAxisChartOption(
   return mergeDeep(option, config.echartOptions)
 }
 
-/**
- * `quiet` for a second read of the same config: a series asking for a mark the
- * library cannot draw is reported by the option build, once, rather than again
- * by everything else that resolves the same marks.
- */
 function plotSeries(config: AxisChartConfig, quiet = false): PlottedSeries[] {
   return config.series.map((series) => {
     const mark = resolveMark(series, config, quiet)
     return { series, mark, stack: stackKey(series, config, mark) }
   })
-}
-
-function resolveMark(
-  series: AxisChartSeriesConfig,
-  config: AxisChartConfig,
-  quiet = false,
-): ChartMark {
-  // A saved config outlives the code that wrote it, so an unreadable mark is a
-  // value to recover from rather than a reason to draw nothing.
-  const asked = series.type ?? config.type
-  if (!MARKS.includes(asked)) {
-    if (!quiet)
-      warn(
-        `Series "${series.name}" asks for type "${asked}", which is not one of ${MARKS.join(', ')}. Drawing it as ${article(config.type)}.`,
-      )
-    return config.type
-  }
-  if (config.horizontal && asked !== 'bar') {
-    if (!quiet)
-      warn(
-        `\`horizontal\` runs the value axis across the plot, which only bars are drawn against. Series "${series.name}" asked for ${article(asked)} and is drawn as a bar.`,
-      )
-    return 'bar'
-  }
-  return asked
 }
 
 /**
@@ -650,10 +619,6 @@ function withAlpha(color: string, alpha: number): string | null {
 
   const [r, g, b] = [0, 2, 4].map((i) => parseInt(hex.slice(i, i + 2), 16))
   return `rgba(${r}, ${g}, ${b}, ${Number(alpha.toFixed(3))})`
-}
-
-function article(mark: ChartMark) {
-  return mark === 'area' ? 'an area' : `a ${mark}`
 }
 
 function warn(message: string) {

--- a/src/charts/axisFormat.test.ts
+++ b/src/charts/axisFormat.test.ts
@@ -14,7 +14,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 function config(overrides: Partial<AxisChartConfig> = {}): AxisChartConfig {

--- a/src/charts/barChartOptions.test.ts
+++ b/src/charts/barChartOptions.test.ts
@@ -16,7 +16,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 /** What `BarChart` hands the builder: the shared config, marked `'bar'`. */
@@ -170,17 +170,14 @@ describe('resolveSeriesColors by ink weight', () => {
       { name: 'sales' },
       { name: 'refunds', type: 'line' },
     ]
-    // A categorical set has no ramp to reorder.
     expect(colorsFor({ palette: 'categorical', series: mixed })).toEqual({
       sales: '#111111',
       refunds: '#222222',
     })
-    // A diverging ramp's direction is its meaning.
     expect(colorsFor({ palette: 'diverging', series: mixed })).toEqual({
       sales: '#001100',
       refunds: '#003300',
     })
-    // A caller's own list is drawn in the order it was written.
     expect(colorsFor({ palette: ['a', 'b'], series: mixed })).toEqual({
       sales: 'a',
       refunds: 'b',

--- a/src/charts/barChartOptions.test.ts
+++ b/src/charts/barChartOptions.test.ts
@@ -3,7 +3,7 @@ import { buildAxisChartOption } from './axisChartOptions'
 import { AXIS_LABEL_FONT_SIZE, resolveSeriesColors } from './axisChartCommon'
 import { estimateTextWidth } from './format'
 import type { ChartTokens } from './tokens'
-import type { AxisChartConfig } from './types'
+import type { AxisChartConfig, AxisChartSeriesConfig } from './types'
 
 const tokens: ChartTokens = {
   categorical: ['#111111', '#222222', '#333333'],
@@ -110,6 +110,90 @@ describe('resolveSeriesColors', () => {
   it('cycles an explicit color list from palette', () => {
     expect(colorsFor({ palette: ['a', 'b'] }).sales).toBe('a')
     expect(colorsFor({ palette: ['a', 'b'] }).refunds).toBe('b')
+  })
+})
+
+describe('resolveSeriesColors by ink weight', () => {
+  it('hands the deep stop to the line and the pale one to the bar', () => {
+    expect(
+      colorsFor({
+        series: [{ name: 'sales' }, { name: 'refunds', type: 'line' }],
+      }),
+    ).toEqual({ sales: '#000033', refunds: '#000011' })
+  })
+
+  it('reads the same whichever order the series arrive in', () => {
+    expect(
+      colorsFor({
+        series: [{ name: 'refunds', type: 'line' }, { name: 'sales' }],
+      }),
+    ).toEqual({ sales: '#000033', refunds: '#000011' })
+  })
+
+  it('ranks an area between the line and the bar', () => {
+    expect(
+      colorsFor({
+        series: [
+          { name: 'a' },
+          { name: 'b', type: 'area' },
+          { name: 'c', type: 'line' },
+        ],
+      }),
+    ).toEqual({ a: '#000033', b: '#000022', c: '#000011' })
+  })
+
+  it('keeps series order among marks of the same weight', () => {
+    expect(
+      colorsFor({
+        series: [
+          { name: 'a', type: 'line' },
+          { name: 'b', type: 'line' },
+          { name: 'c' },
+        ],
+      }),
+    ).toEqual({ a: '#000011', b: '#000022', c: '#000033' })
+  })
+
+  it('still honours an explicit series color', () => {
+    expect(
+      colorsFor({
+        series: [
+          { name: 'sales' },
+          { name: 'refunds', type: 'line', color: 'red' },
+        ],
+      }),
+    ).toEqual({ sales: '#000033', refunds: 'red' })
+  })
+
+  it('leaves the other palettes on series order', () => {
+    const mixed: AxisChartSeriesConfig[] = [
+      { name: 'sales' },
+      { name: 'refunds', type: 'line' },
+    ]
+    // A categorical set has no ramp to reorder.
+    expect(colorsFor({ palette: 'categorical', series: mixed })).toEqual({
+      sales: '#111111',
+      refunds: '#222222',
+    })
+    // A diverging ramp's direction is its meaning.
+    expect(colorsFor({ palette: 'diverging', series: mixed })).toEqual({
+      sales: '#001100',
+      refunds: '#003300',
+    })
+    // A caller's own list is drawn in the order it was written.
+    expect(colorsFor({ palette: ['a', 'b'], series: mixed })).toEqual({
+      sales: 'a',
+      refunds: 'b',
+    })
+  })
+
+  it('draws every series as a bar on a horizontal chart, so order stands', () => {
+    expect(
+      colorsFor({
+        horizontal: true,
+        series: [{ name: 'sales' }, { name: 'refunds', type: 'line' }],
+      }),
+    ).toEqual({ sales: '#000011', refunds: '#000033' })
   })
 })
 

--- a/src/charts/categoryAxisFit.test.ts
+++ b/src/charts/categoryAxisFit.test.ts
@@ -21,7 +21,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 /** The plot width every case measures against, unless it says otherwise. */

--- a/src/charts/chartColors.test.ts
+++ b/src/charts/chartColors.test.ts
@@ -22,7 +22,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 /** The sequential ramp minus the two palest stops, as every chart reads it. */

--- a/src/charts/comboChartOptions.test.ts
+++ b/src/charts/comboChartOptions.test.ts
@@ -17,7 +17,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 /**

--- a/src/charts/comboChartOptions.test.ts
+++ b/src/charts/comboChartOptions.test.ts
@@ -41,7 +41,10 @@ function build(
   overrides: Partial<AxisChartConfig> = {},
   hiddenSeries?: string[],
 ) {
-  return buildAxisChartOption(config(overrides), { tokens, hiddenSeries }) as any
+  return buildAxisChartOption(config(overrides), {
+    tokens,
+    hiddenSeries,
+  }) as any
 }
 
 const typesOf = (option: any) => option.series.map((s: any) => s.type)
@@ -150,6 +153,14 @@ describe('combo axes', () => {
     // Re-spacing the axis on a legend toggle would move every remaining point.
     expect(option.xAxis.boundaryGap).toBe(true)
     expect(option.tooltip.axisPointer.type).toBe('shadow')
+  })
+
+  it('draws the band from a token, translucently', () => {
+    // Unstyled, echarts fills it with a hard-coded grey that no theme reaches.
+    // The alpha is what keeps the gridlines under it readable.
+    const { shadowStyle } = build().tooltip.axisPointer
+    expect(shadowStyle.color).toBe(tokens.splitLine)
+    expect(shadowStyle.opacity).toBeLessThan(1)
   })
 
   it('measures a line series against the second value axis', () => {

--- a/src/charts/comboChartOptions.test.ts
+++ b/src/charts/comboChartOptions.test.ts
@@ -195,19 +195,24 @@ describe('combo axes', () => {
 })
 
 describe('combo colors', () => {
-  it('assigns the same color to a series whatever mark it draws as', () => {
-    const bars = build({ series: [{ name: 'sales' }, { name: 'refunds' }] })
+  it('spends the deep end of the ramp on the line, not on the bar', () => {
     const mixed = build()
-    expect(bars.series[0].itemStyle.color).toBe(mixed.series[0].itemStyle.color)
-    expect(bars.series[1].itemStyle.color).toBe(mixed.series[1].itemStyle.color)
+    expect(mixed.series[0].itemStyle.color).toBe('#000033')
+    expect(mixed.series[1].itemStyle.color).toBe('#000011')
     // The line takes the same stop for its stroke as for its symbols.
     expect(mixed.series[1].lineStyle.color).toBe(
       mixed.series[1].itemStyle.color,
     )
   })
 
+  it('leaves a chart of one mark on series order', () => {
+    const bars = build({ series: [{ name: 'sales' }, { name: 'refunds' }] })
+    expect(bars.series[0].itemStyle.color).toBe('#000011')
+    expect(bars.series[1].itemStyle.color).toBe('#000033')
+  })
+
   it('keeps every series on its own color when one is hidden', () => {
-    expect(build({}, ['sales']).series[0].itemStyle.color).toBe('#000033')
+    expect(build({}, ['sales']).series[0].itemStyle.color).toBe('#000011')
   })
 })
 

--- a/src/charts/comboChartOptions.test.ts
+++ b/src/charts/comboChartOptions.test.ts
@@ -173,6 +173,58 @@ describe('combo axes', () => {
     expect(typesOf(option)).toEqual(['bar', 'line'])
   })
 
+  it('holds the second axis at its own ends once its last series is hidden', () => {
+    const dual = {
+      y2Axis: { title: 'rate' },
+      series: [
+        { name: 'sales' },
+        { name: 'rate', type: 'line' as ChartMark, axis: 'y2' as const },
+      ],
+    }
+    const [, live] = build(dual).yAxis
+    const [primary, emptied] = build(dual, ['rate']).yAxis
+
+    // echarts blanks an axis no series feeds: no ticks and no labels at all.
+    expect(live.min).toBeUndefined()
+    expect(emptied.min).toBe(0)
+    expect(emptied.max).toBe(40)
+    // The axis reads as switched off, the way the legend item does.
+    expect(emptied.axisLabel.opacity).toBeLessThan(1)
+    expect(live.axisLabel.opacity).toBeUndefined()
+    // The one still drawing its series is echarts' to scale.
+    expect(primary.min).toBeUndefined()
+  })
+
+  it('keeps the gridlines when the axis that carries them is the empty one', () => {
+    const option = build(
+      {
+        y2Axis: { title: 'rate' },
+        series: [{ name: 'sales' }, { name: 'rate', type: 'line', axis: 'y2' }],
+      },
+      ['sales'],
+    )
+    const [primary] = option.yAxis
+    expect(primary.min).toBe(0)
+    expect(primary.splitLine.show).toBe(true)
+  })
+
+  it('rounds the ends it pins, and yields them to the caller’s own', () => {
+    const dual = (y2Axis: any) => ({
+      y2Axis,
+      data: [
+        { month: 'Jan', sales: 10, rate: 17 },
+        { month: 'Feb', sales: 20, rate: 1743 },
+      ],
+      series: [
+        { name: 'sales' },
+        { name: 'rate', type: 'line' as ChartMark, axis: 'y2' as const },
+      ],
+    })
+    // A fixed end prints what it is given, so 1743 in five steps is unreadable.
+    expect(build(dual({}), ['rate']).yAxis[1].max).toBe(2000)
+    expect(build(dual({ max: 1800 }), ['rate']).yAxis[1].max).toBe(1800)
+  })
+
   it('reserves label room for the hungriest mark that shows labels', () => {
     const bare = build().grid.top
     const withLine = build({

--- a/src/charts/components/ChartTooltip.vue
+++ b/src/charts/components/ChartTooltip.vue
@@ -15,7 +15,7 @@
         </div>
         <div class="flex flex-col gap-1.5">
           <div
-            v-for="item in items"
+            v-for="item in seriesItems"
             :key="item.name"
             class="flex items-center justify-between gap-5 text-p-sm"
           >
@@ -39,6 +39,27 @@
             </span>
           </div>
         </div>
+
+        <!-- Context rows carry no swatch: a swatch says the reader can find
+             this on the plot, and an extra is drawn nowhere. The rule is what
+             tells them apart from the series above. -->
+        <div
+          v-if="contextItems.length"
+          class="mt-2 flex flex-col gap-1.5 border-t border-outline-gray-1 pt-2"
+        >
+          <div
+            v-for="item in contextItems"
+            :key="item.name"
+            class="flex items-center justify-between gap-5 text-p-sm"
+          >
+            <span class="min-w-0 truncate text-ink-gray-5">{{
+              item.label
+            }}</span>
+            <span class="shrink-0 tabular-nums text-ink-gray-7">
+              {{ item.formattedValue }}
+            </span>
+          </div>
+        </div>
       </slot>
     </div>
   </Teleport>
@@ -51,6 +72,15 @@ import { formatPercent } from '../format'
 import type { ChartTooltipProps, ChartTooltipSlots } from '../types'
 
 const props = defineProps<ChartTooltipProps>()
+
+// `kind` is optional, so an item that names none is a series: that is what
+// every caller before `tooltipSeries` existed was handing over.
+const seriesItems = computed(() =>
+  props.items.filter((item) => item.kind !== 'context'),
+)
+const contextItems = computed(() =>
+  props.items.filter((item) => item.kind === 'context'),
+)
 
 const portalTarget = usePortalTarget()
 

--- a/src/charts/components/ChartTooltip.vue
+++ b/src/charts/components/ChartTooltip.vue
@@ -40,15 +40,15 @@
           </div>
         </div>
 
-        <!-- Context rows carry no swatch: a swatch says the reader can find
-             this on the plot, and an extra is drawn nowhere. The rule is what
+        <!-- Column rows carry no swatch: a swatch says the reader can find
+             this on the plot, and a column is drawn nowhere. The rule is what
              tells them apart from the series above. -->
         <div
-          v-if="contextItems.length"
+          v-if="columnItems.length"
           class="mt-2 flex flex-col gap-1.5 border-t border-outline-gray-1 pt-2"
         >
           <div
-            v-for="item in contextItems"
+            v-for="item in columnItems"
             :key="item.name"
             class="flex items-center justify-between gap-5 text-p-sm"
           >
@@ -74,12 +74,12 @@ import type { ChartTooltipProps, ChartTooltipSlots } from '../types'
 const props = defineProps<ChartTooltipProps>()
 
 // `kind` is optional, so an item that names none is a series: that is what
-// every caller before `tooltipSeries` existed was handing over.
+// every caller before `tooltipColumns` existed was handing over.
 const seriesItems = computed(() =>
-  props.items.filter((item) => item.kind !== 'context'),
+  props.items.filter((item) => item.kind !== 'column'),
 )
-const contextItems = computed(() =>
-  props.items.filter((item) => item.kind === 'context'),
+const columnItems = computed(() =>
+  props.items.filter((item) => item.kind === 'column'),
 )
 
 const portalTarget = usePortalTarget()

--- a/src/charts/components/ChartTooltip.vue
+++ b/src/charts/components/ChartTooltip.vue
@@ -9,7 +9,7 @@
       :dir="dir"
       role="tooltip"
     >
-      <slot :label="label" :items="items">
+      <slot :label="label" :items="items" :row="row">
         <div v-if="label" class="mb-2 text-p-sm text-ink-gray-5">
           {{ label }}
         </div>

--- a/src/charts/components/ChartTooltip.vue
+++ b/src/charts/components/ChartTooltip.vue
@@ -4,7 +4,7 @@
       v-if="open && items.length"
       ref="tooltipEl"
       data-slot="chart-tooltip"
-      class="pointer-events-none fixed z-[100] max-w-xs rounded-6 border border-outline-gray-1 bg-surface-elevation-2 px-3 py-2 shadow-lg"
+      class="pointer-events-none fixed z-[100] max-w-xs rounded-6 bg-surface-elevation-2 px-3 py-2 shadow-lg"
       :style="style"
       :dir="dir"
       role="tooltip"

--- a/src/charts/core/useAxisChart.ts
+++ b/src/charts/core/useAxisChart.ts
@@ -11,7 +11,8 @@ import {
 } from '../axisChartCommon'
 import { applyAxisFormatters } from '../axisFormat'
 import { pruneHiddenSeries, toggleHiddenSeries } from '../hiddenSeries'
-import type { AxisChartFormatters } from '../seriesData'
+import { buildTooltipItems } from '../tooltipItems'
+import { seriesLabel, type AxisChartFormatters } from '../seriesData'
 import { formatAxisValue, formatLabel, formatValue } from '../format'
 import { useChartTokens } from '../tokens'
 import { documentDir, markName, plotReading } from '../utils'
@@ -151,9 +152,6 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
     })),
   )
 
-  function seriesLabel(series: AxisChartSeriesConfig) {
-    return series.label ?? formatLabel(series.name)
-  }
 
   // A series reads in the units of the axis it is actually drawn against, so
   // `y2` series never fall back to the primary formatter — except on a
@@ -250,22 +248,15 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
 
   function showIndex(index: number, clientX?: number, clientY?: number) {
     const row = rows.value[index]
-    const items = config.value.series
-      .filter((series) => !hiddenSeries.value.includes(series.name))
-      .map((series) => ({
-        name: series.name,
-        label: seriesLabel(series),
-        color: seriesColors.value[series.name],
-        value: Number(row[series.name]),
-        formattedValue: formatSeriesValue(series, Number(row[series.name])),
-        // A normalized plot draws the share, so the tooltip is the only place
-        // the measured number survives — it carries both.
-        percent: stackShares.value?.get(series.name)?.[index] ?? undefined,
-      }))
-      // A series that silently drops out of the tooltip reads as a bug, so a
-      // zero stays. Only a blank cell is dropped. Biggest contributor first.
-      .filter((item) => !isNaN(item.value))
-      .sort((a, b) => b.value - a.value)
+    const items = buildTooltipItems({
+      row,
+      index,
+      series: config.value.series,
+      hiddenSeries: hiddenSeries.value,
+      colors: seriesColors.value,
+      formatSeries: formatSeriesValue,
+      shares: stackShares.value,
+    })
 
     if (!items.length) {
       tooltip.open = false

--- a/src/charts/core/useAxisChart.ts
+++ b/src/charts/core/useAxisChart.ts
@@ -22,6 +22,7 @@ import type {
   ChartDatapointEvent,
   ChartLegendItem,
   ChartTooltipItem,
+  ChartTooltipSeries,
   PlotLabelPlacement,
 } from '../types'
 
@@ -43,6 +44,12 @@ export type UseAxisChartArgs<C extends AxisChartBaseConfig> = {
    * beside it, so the reader gets both.
    */
   stackShares?: () => Map<string, (number | null)[]>
+  /**
+   * Columns that reach the tooltip and nothing else. They are handed in beside
+   * the config, not inside it, so the option builder never sees them: an extra
+   * has no mark, no legend entry, no palette slot and no axis.
+   */
+  tooltipSeries?: () => ChartTooltipSeries[]
   onSelect?: (event: ChartDatapointEvent) => void
 }
 
@@ -61,6 +68,7 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
   const format = computed<AxisChartFormatters>(() => args.format?.() ?? {})
   const horizontal = computed(() => Boolean(args.horizontal?.()))
   const stackShares = computed(() => args.stackShares?.())
+  const tooltipSeries = computed(() => args.tooltipSeries?.() ?? [])
   const dir = computed(() => config.value.dir ?? documentDir())
   // Same resolution the option builder runs, so the hit-testing and the tooltip
   // read the axis the way it is actually drawn — and the same row list, so a
@@ -151,7 +159,6 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
       hidden: hiddenSeries.value.includes(series.name),
     })),
   )
-
 
   // A series reads in the units of the axis it is actually drawn against, so
   // `y2` series never fall back to the primary formatter — except on a
@@ -256,9 +263,12 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
       colors: seriesColors.value,
       formatSeries: formatSeriesValue,
       shares: stackShares.value,
+      tooltipSeries: tooltipSeries.value,
     })
 
-    if (!items.length) {
+    // The tooltip still stands on the series: extras alone would open one over
+    // a chart whose whole legend is switched off.
+    if (!items.some((item) => item.kind === 'series')) {
       tooltip.open = false
       return
     }

--- a/src/charts/core/useAxisChart.ts
+++ b/src/charts/core/useAxisChart.ts
@@ -22,7 +22,7 @@ import { formatAxisValue, formatLabel, formatValue } from '../format'
 import { useChartTokens } from '../tokens'
 import { documentDir, markName, plotReading } from '../utils'
 import type {
-  AxisChartBaseConfig,
+  AxisChartConfig,
   AxisChartSeriesConfig,
   ChartDatapointEvent,
   ChartLegendItem,
@@ -30,7 +30,7 @@ import type {
   PlotLabelPlacement,
 } from '../types'
 
-export type UseAxisChartArgs<C extends AxisChartBaseConfig> = {
+export type UseAxisChartArgs<C extends AxisChartConfig> = {
   config: () => C
   buildOption: (config: C, context: AxisChartOptionContext) => EChartsCoreOption
   /** Axis label and tooltip formatters, kept beside the config by `normalizeAxisChartProps`. */
@@ -62,7 +62,7 @@ export type UseAxisChartArgs<C extends AxisChartBaseConfig> = {
  * legend state and the hit-testing behind the HTML tooltip. Bar, line and area
  * differ only in the builder they hand in, so their interactions stay identical.
  */
-export function useAxisChart<C extends AxisChartBaseConfig>(
+export function useAxisChart<C extends AxisChartConfig>(
   args: UseAxisChartArgs<C>,
 ) {
   const plotEl = ref<HTMLElement>()

--- a/src/charts/core/useAxisChart.ts
+++ b/src/charts/core/useAxisChart.ts
@@ -12,7 +12,11 @@ import {
 import { applyAxisFormatters } from '../axisFormat'
 import { pruneHiddenSeries, toggleHiddenSeries } from '../hiddenSeries'
 import { buildTooltipItems } from '../tooltipItems'
-import { seriesLabel, type AxisChartFormatters } from '../seriesData'
+import {
+  seriesLabel,
+  type AxisChartFormatters,
+  type ResolvedTooltipColumn,
+} from '../seriesData'
 import { formatAxisValue, formatLabel, formatValue } from '../format'
 import { useChartTokens } from '../tokens'
 import { documentDir, markName, plotReading } from '../utils'
@@ -22,7 +26,6 @@ import type {
   ChartDatapointEvent,
   ChartLegendItem,
   ChartTooltipItem,
-  ChartTooltipSeries,
   PlotLabelPlacement,
 } from '../types'
 
@@ -49,7 +52,7 @@ export type UseAxisChartArgs<C extends AxisChartBaseConfig> = {
    * the config, not inside it, so the option builder never sees them: an extra
    * has no mark, no legend entry, no palette slot and no axis.
    */
-  tooltipSeries?: () => ChartTooltipSeries[]
+  tooltipColumns?: () => ResolvedTooltipColumn[]
   onSelect?: (event: ChartDatapointEvent) => void
 }
 
@@ -68,7 +71,7 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
   const format = computed<AxisChartFormatters>(() => args.format?.() ?? {})
   const horizontal = computed(() => Boolean(args.horizontal?.()))
   const stackShares = computed(() => args.stackShares?.())
-  const tooltipSeries = computed(() => args.tooltipSeries?.() ?? [])
+  const tooltipColumns = computed(() => args.tooltipColumns?.() ?? [])
   const dir = computed(() => config.value.dir ?? documentDir())
   // Same resolution the option builder runs, so the hit-testing and the tooltip
   // read the axis the way it is actually drawn — and the same row list, so a
@@ -263,7 +266,7 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
       colors: seriesColors.value,
       formatSeries: formatSeriesValue,
       shares: stackShares.value,
-      tooltipSeries: tooltipSeries.value,
+      tooltipColumns: tooltipColumns.value,
     })
 
     // The tooltip still stands on the series: extras alone would open one over

--- a/src/charts/core/useAxisChart.ts
+++ b/src/charts/core/useAxisChart.ts
@@ -186,6 +186,9 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
     y: 0,
     label: undefined as string | undefined,
     items: [] as ChartTooltipItem[],
+    // Handed to the `#tooltip` slot so a replacement body can read a column the
+    // chart never plotted.
+    row: undefined as Record<string, any> | undefined,
   })
 
   /**
@@ -281,6 +284,7 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
       ? format.value.x(category)
       : formatAxisValue(category, xAxis.value.type, xAxis.value.timeGrain)
     tooltip.items = items
+    tooltip.row = row
     tooltip.x = clientX ?? tooltip.x
     tooltip.y = clientY ?? tooltip.y
     tooltip.open = true

--- a/src/charts/core/useAxisChart.ts
+++ b/src/charts/core/useAxisChart.ts
@@ -2,6 +2,7 @@ import { computed, reactive, ref, watch, type Ref } from 'vue'
 import type { EChartsCoreOption } from 'echarts/core'
 import { useChart } from './useChart'
 import { usePlotKeyboard } from './usePlotKeyboard'
+import { useTooltipDismiss } from './useTooltipDismiss'
 import type { AxisChartOptionContext } from '../axisChartCommon'
 import {
   hasSecondaryValueAxis,
@@ -189,6 +190,14 @@ export function useAxisChart<C extends AxisChartBaseConfig>(
     // Handed to the `#tooltip` slot so a replacement body can read a column the
     // chart never plotted.
     row: undefined as Record<string, any> | undefined,
+  })
+
+  useTooltipDismiss({
+    plot: plotEl,
+    data: () => rows.value,
+    close: () => {
+      tooltip.open = false
+    },
   })
 
   /**

--- a/src/charts/core/useChart.test.ts
+++ b/src/charts/core/useChart.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { drawsSomething } from './useChart'
+
+// The entry animation is spent on the first option that draws. A chart that
+// fetches its rows sets an empty option first — and the plot stays mounted
+// through the loading and empty states, so that option reaches echarts like
+// any other. Counting it would leave the real data to arrive without the
+// animation, which is the state most charts are actually in.
+describe('whether an option draws anything', () => {
+  it('is false for a chart waiting on its rows', () => {
+    expect(drawsSomething({ series: [{ type: 'bar', data: [] }] })).toBe(false)
+  })
+
+  it('is false when the option carries no series at all', () => {
+    expect(drawsSomething({})).toBe(false)
+    expect(drawsSomething({ series: [] })).toBe(false)
+  })
+
+  it('is true once one series carries a point', () => {
+    expect(drawsSomething({ series: [{ type: 'bar', data: [1] }] })).toBe(true)
+  })
+
+  it('reads a single series object, which echarts also accepts', () => {
+    expect(drawsSomething({ series: { type: 'pie', data: [1] } })).toBe(true)
+  })
+
+  it('is true when only the second series carries anything', () => {
+    // A legend toggle can empty one series while the plot still draws.
+    const option = { series: [{ data: [] }, { data: [1, 2] }] }
+    expect(drawsSomething(option)).toBe(true)
+  })
+})

--- a/src/charts/core/useChart.ts
+++ b/src/charts/core/useChart.ts
@@ -91,6 +91,13 @@ export function useChart({
   const chart = shallowRef<ECharts>()
   let unmounted = false
 
+  // The entry animation belongs to the chart arriving, not to every later
+  // option. `notMerge` rebuilds the series each time, so echarts replays that
+  // entry animation on any change — a colour tweak in a chart builder makes the
+  // whole plot grow from nothing again. Zeroing the initial duration after the
+  // first render leaves the chart still while it is edited.
+  let rendered = false
+
   // `chart` is a shallowRef, so this re-runs once the instance exists and then
   // on every reactive change inside the option getter. Nothing is built before
   // then: an option may be built from what this composable measures (`width`),
@@ -100,7 +107,11 @@ export function useChart({
     if (!instance) return
     const nextOption = option()
     if (!nextOption) return
-    instance.setOption(nextOption, { notMerge: true, lazyUpdate: true })
+    instance.setOption(
+      rendered ? { ...nextOption, animationDuration: 0 } : nextOption,
+      { notMerge: true, lazyUpdate: true },
+    )
+    rendered = true
   })
 
   const width = ref(0)

--- a/src/charts/core/useChart.ts
+++ b/src/charts/core/useChart.ts
@@ -82,6 +82,17 @@ function whenFontsSettled(): Promise<void> {
   return settling
 }
 
+/**
+ * Whether an option puts anything on the plot. Every chart here builds its own
+ * `series[].data` rather than handing echarts a `dataset`, so one read covers
+ * every family.
+ */
+export function drawsSomething(option: EChartsCoreOption) {
+  const series = (option as any).series
+  const list = Array.isArray(series) ? series : series ? [series] : []
+  return list.some((entry: any) => entry?.data?.length > 0)
+}
+
 export function useChart({
   container,
   option,
@@ -96,7 +107,12 @@ export function useChart({
   // entry animation on any change — a colour tweak in a chart builder makes the
   // whole plot grow from nothing again. Zeroing the initial duration after the
   // first render leaves the chart still while it is edited.
-  let rendered = false
+  //
+  // The flag turns on the first option that *draws*, not the first one set. A
+  // chart that fetches its rows sets an empty option first, and the plot stays
+  // mounted through the loading and empty states — so counting that one would
+  // spend the entry animation before the reader has seen anything.
+  let drawn = false
 
   // `chart` is a shallowRef, so this re-runs once the instance exists and then
   // on every reactive change inside the option getter. Nothing is built before
@@ -108,10 +124,10 @@ export function useChart({
     const nextOption = option()
     if (!nextOption) return
     instance.setOption(
-      rendered ? { ...nextOption, animationDuration: 0 } : nextOption,
+      drawn ? { ...nextOption, animationDuration: 0 } : nextOption,
       { notMerge: true, lazyUpdate: true },
     )
-    rendered = true
+    drawn ||= drawsSomething(nextOption)
   })
 
   const width = ref(0)

--- a/src/charts/core/useTooltipDismiss.ts
+++ b/src/charts/core/useTooltipDismiss.ts
@@ -1,0 +1,48 @@
+import { onBeforeUnmount, onMounted, watch, type Ref } from 'vue'
+
+export type TooltipDismissArgs = {
+  plot: Ref<HTMLElement | undefined>
+  /** The marks the reading was taken from. A new list voids the reading. */
+  data: () => unknown
+  close: () => void
+}
+
+/**
+ * The reading sits at viewport coordinates taken from the pointer. Everything
+ * here moves the page, the plot or the data under a pointer that did not move,
+ * so echarts reports nothing and the reading hangs over what took its place.
+ * One rule covers them all: an invalid reading goes.
+ */
+export function useTooltipDismiss({ plot, data, close }: TooltipDismissArgs) {
+  const dismiss = () => close()
+  const onVisibility = () => document.hidden && close()
+
+  // Capture phase, because a scroll event does not bubble: a listener on
+  // `window` sees a nested container's scroll only on the way down.
+  onMounted(() => {
+    window.addEventListener('scroll', dismiss, { capture: true, passive: true })
+    window.addEventListener('resize', dismiss)
+    window.addEventListener('blur', dismiss)
+    document.addEventListener('visibilitychange', onVisibility)
+  })
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('scroll', dismiss, { capture: true })
+    window.removeEventListener('resize', dismiss)
+    window.removeEventListener('blur', dismiss)
+    document.removeEventListener('visibilitychange', onVisibility)
+  })
+
+  // The plot arrives after the chart has mounted, and again whenever the
+  // container swaps its loading, error or empty state back out for the plot.
+  watch(
+    plot,
+    (el, previous) => {
+      previous?.removeEventListener('pointerleave', dismiss)
+      el?.addEventListener('pointerleave', dismiss)
+    },
+    { immediate: true },
+  )
+
+  watch(data, dismiss)
+}

--- a/src/charts/docs/AreaChart.api.md
+++ b/src/charts/docs/AreaChart.api.md
@@ -79,6 +79,18 @@
     default: '[]'
   },
   {
+    name: 'tooltipSeries',
+    description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit — the count behind a rate, the target beside the actual.\n\nThey print after the series rows, in the order given, because a value in\nanother unit says nothing when it is ranked among the series.',
+    required: false,
+    type: 'string[]'
+  },
+  {
+    name: 'tooltipSeriesConfig',
+    description: 'Keyed by column name, the way `seriesConfig` is keyed by series.',
+    required: false,
+    type: 'Record<string, TooltipSeriesStyle>'
+  },
+  {
     name: 'xAxis',
     description: 'The category axis: its title, how the `x` column reads, and label format.',
     required: false,

--- a/src/charts/docs/AreaChart.api.md
+++ b/src/charts/docs/AreaChart.api.md
@@ -79,16 +79,10 @@
     default: '[]'
   },
   {
-    name: 'tooltipSeries',
+    name: 'tooltipColumns',
     description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit — the count behind a rate, the target beside the actual.\n\nThey print after the series rows, in the order given, because a value in\nanother unit says nothing when it is ranked among the series.',
     required: false,
-    type: 'string[]'
-  },
-  {
-    name: 'tooltipSeriesConfig',
-    description: 'Keyed by column name, the way `seriesConfig` is keyed by series.',
-    required: false,
-    type: 'Record<string, TooltipSeriesStyle>'
+    type: 'ChartTooltipColumn[]'
   },
   {
     name: 'xAxis',

--- a/src/charts/docs/AreaChart.api.md
+++ b/src/charts/docs/AreaChart.api.md
@@ -80,7 +80,7 @@
   },
   {
     name: 'tooltipColumns',
-    description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit — the count behind a rate, the target beside the actual.\n\nThey print after the series rows, in the order given, because a value in\nanother unit says nothing when it is ranked among the series.',
+    description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit, such as the count behind a rate. They print after the series rows,\nin the order given: a value in another unit cannot be ranked among them.',
     required: false,
     type: 'ChartTooltipColumn[]'
   },
@@ -163,21 +163,21 @@
   },
   {
     name: 'tooltip',
-    description: 'Replaces the tooltip body. `items` holds one entry per visible series at\nthe hovered category, biggest first.',
-    type: '{ label?: string | undefined; items: ChartTooltipItem[]; }'
+    description: 'Replaces the tooltip body. `items` holds one entry per visible series at\nthe hovered category, biggest first. `row` is the data row behind them,\nso a replacement body can read a column the chart never plotted.',
+    type: '{ label?: string | undefined; items: ChartTooltipItem[]; row?: Record<string, any> | undefined; }'
   }
 ]
 
   const emitsData = [
   {
-    name: 'select',
-    description: 'A mark was selected, by click or by Enter on the keyboard cursor. Carries\nthe series it belongs to, its position along the category axis, and the\nrow behind it.',
-    type: '[event: ChartDatapointEvent]'
-  },
-  {
     name: 'update:hiddenSeries',
     description: 'Fired when the hidden series changes.',
     type: '[value: string[]]'
+  },
+  {
+    name: 'select',
+    description: 'A mark was selected, by click or by Enter on the keyboard cursor. Carries\nthe series it belongs to, its position along the category axis, and the\nrow behind it.',
+    type: '[event: ChartDatapointEvent]'
   }
 ]
 </script>

--- a/src/charts/docs/AreaChart.md
+++ b/src/charts/docs/AreaChart.md
@@ -29,6 +29,32 @@ chart-level alpha; a `seriesConfig` entry overrides it per series.
 
 <ComponentPreview name="Charts-AreaLatency" csr="true" self-layout />
 
+## Context in the tooltip
+
+`tooltipSeries` names columns that reach the tooltip and nothing else: no mark,
+no legend entry, no palette slot, and no effect on the value axis. Use it for a
+number the reader needs beside the picture but that does not belong on the same
+scale — the order count behind a conversion rate, the target beside the actual.
+
+```vue
+<AreaChart
+  :data="data"
+  x="month"
+  :y="['conversion_rate']"
+  :tooltip-series="['orders']"
+  :tooltip-series-config="{ orders: { label: 'Orders' } }"
+/>
+```
+
+They print after the series rows, under a rule and without a swatch, in the
+order given. The series rows are ranked by magnitude; an extra is not, because
+a value in another unit says nothing when it is ranked among them.
+
+`tooltipSeriesConfig` is keyed by column name, the way `seriesConfig` is keyed
+by series. `format` prints the value: an extra sits on no axis, so it takes no
+formatter from one. A column holding text rather than a number is a legitimate
+extra, and prints as it stands.
+
 ## Hiding a series
 
 A chart with more than one series draws a legend under the plot. Press an entry

--- a/src/charts/docs/AreaChart.md
+++ b/src/charts/docs/AreaChart.md
@@ -31,7 +31,7 @@ chart-level alpha; a `seriesConfig` entry overrides it per series.
 
 ## Context in the tooltip
 
-`tooltipSeries` names columns that reach the tooltip and nothing else: no mark,
+`tooltipColumns` names columns that reach the tooltip and nothing else: no mark,
 no legend entry, no palette slot, and no effect on the value axis. Use it for a
 number the reader needs beside the picture but that does not belong on the same
 scale — the order count behind a conversion rate, the target beside the actual.
@@ -41,26 +41,26 @@ scale — the order count behind a conversion rate, the target beside the actual
   :data="data"
   x="month"
   :y="['conversion_rate']"
-  :tooltip-series="['orders']"
-  :tooltip-series-config="{ orders: { label: 'Orders' } }"
+  :tooltip-columns="[{ name: 'orders', label: 'Orders' }]"
 />
 ```
 
 They print after the series rows, under a rule and without a swatch, in the
-order given. The series rows are ranked by magnitude; an extra is not, because
-a value in another unit says nothing when it is ranked among them.
+order given. The series rows are ranked by magnitude; a column is not, because a
+value in another unit says nothing when it is ranked among them.
 
-`tooltipSeriesConfig` is keyed by column name, the way `seriesConfig` is keyed
-by series. `format` prints the value: an extra sits on no axis, so it takes no
-formatter from one. A column holding text rather than a number is a legitimate
-extra, and prints as it stands.
+`name` is the row key. `label` heads the row, and falls back to the column name.
+`format` prints the value: a column sits on no axis, so it takes no formatter
+from one. A column holding text rather than a number is legitimate, and prints
+as it stands.
+
 
 ## Hiding a series
 
 A chart with more than one series draws a legend under the plot. Press an entry
 to take that band out of the chart. The stack closes over it, and a normalized
 stack re-takes its shares over the bands that are left. Bind
-`v-model:hiddenSeries` to own that list yourself;
-it is described under [BarChart](/docs/charts/barchart#hiding-a-series).
+`v-model:hiddenSeries` to own that list yourself; it is described under
+[BarChart](/docs/charts/barchart#hiding-a-series).
 
 <!-- @include: ./AreaChart.api.md -->

--- a/src/charts/docs/AreaChart.md
+++ b/src/charts/docs/AreaChart.md
@@ -54,6 +54,9 @@ value in another unit says nothing when it is ranked among them.
 from one. A column holding text rather than a number is legitimate, and prints
 as it stands.
 
+To read a column in a tooltip you write yourself, take `row` from the `tooltip`
+slot instead. It carries the whole data row, plotted columns and all.
+
 
 ## Hiding a series
 

--- a/src/charts/docs/AreaChart.md
+++ b/src/charts/docs/AreaChart.md
@@ -32,31 +32,8 @@ chart-level alpha; a `seriesConfig` entry overrides it per series.
 ## Context in the tooltip
 
 `tooltipColumns` names columns that reach the tooltip and nothing else: no mark,
-no legend entry, no palette slot, and no effect on the value axis. Use it for a
-number the reader needs beside the picture but that does not belong on the same
-scale — the order count behind a conversion rate, the target beside the actual.
-
-```vue
-<AreaChart
-  :data="data"
-  x="month"
-  :y="['conversion_rate']"
-  :tooltip-columns="[{ name: 'orders', label: 'Orders' }]"
-/>
-```
-
-They print after the series rows, under a rule and without a swatch, in the
-order given. The series rows are ranked by magnitude; a column is not, because a
-value in another unit says nothing when it is ranked among them.
-
-`name` is the row key. `label` heads the row, and falls back to the column name.
-`format` prints the value: a column sits on no axis, so it takes no formatter
-from one. A column holding text rather than a number is legitimate, and prints
-as it stands.
-
-To read a column in a tooltip you write yourself, take `row` from the `tooltip`
-slot instead. It carries the whole data row, plotted columns and all.
-
+no legend entry, no palette slot, no place on the value axis. It is described
+under [LineChart](/docs/charts/linechart#context-in-the-tooltip).
 
 ## Hiding a series
 

--- a/src/charts/docs/BarChart.api.md
+++ b/src/charts/docs/BarChart.api.md
@@ -79,6 +79,18 @@
     default: '[]'
   },
   {
+    name: 'tooltipSeries',
+    description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit — the count behind a rate, the target beside the actual.\n\nThey print after the series rows, in the order given, because a value in\nanother unit says nothing when it is ranked among the series.',
+    required: false,
+    type: 'string[]'
+  },
+  {
+    name: 'tooltipSeriesConfig',
+    description: 'Keyed by column name, the way `seriesConfig` is keyed by series.',
+    required: false,
+    type: 'Record<string, TooltipSeriesStyle>'
+  },
+  {
     name: 'xAxis',
     description: 'The category axis: its title, how the `x` column reads, and label format.',
     required: false,

--- a/src/charts/docs/BarChart.api.md
+++ b/src/charts/docs/BarChart.api.md
@@ -79,16 +79,10 @@
     default: '[]'
   },
   {
-    name: 'tooltipSeries',
+    name: 'tooltipColumns',
     description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit — the count behind a rate, the target beside the actual.\n\nThey print after the series rows, in the order given, because a value in\nanother unit says nothing when it is ranked among the series.',
     required: false,
-    type: 'string[]'
-  },
-  {
-    name: 'tooltipSeriesConfig',
-    description: 'Keyed by column name, the way `seriesConfig` is keyed by series.',
-    required: false,
-    type: 'Record<string, TooltipSeriesStyle>'
+    type: 'ChartTooltipColumn[]'
   },
   {
     name: 'xAxis',

--- a/src/charts/docs/BarChart.api.md
+++ b/src/charts/docs/BarChart.api.md
@@ -80,7 +80,7 @@
   },
   {
     name: 'tooltipColumns',
-    description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit — the count behind a rate, the target beside the actual.\n\nThey print after the series rows, in the order given, because a value in\nanother unit says nothing when it is ranked among the series.',
+    description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit, such as the count behind a rate. They print after the series rows,\nin the order given: a value in another unit cannot be ranked among them.',
     required: false,
     type: 'ChartTooltipColumn[]'
   },
@@ -169,21 +169,21 @@
   },
   {
     name: 'tooltip',
-    description: 'Replaces the tooltip body. `items` holds one entry per visible series at\nthe hovered category, biggest first.',
-    type: '{ label?: string | undefined; items: ChartTooltipItem[]; }'
+    description: 'Replaces the tooltip body. `items` holds one entry per visible series at\nthe hovered category, biggest first. `row` is the data row behind them,\nso a replacement body can read a column the chart never plotted.',
+    type: '{ label?: string | undefined; items: ChartTooltipItem[]; row?: Record<string, any> | undefined; }'
   }
 ]
 
   const emitsData = [
   {
-    name: 'select',
-    description: 'A mark was selected, by click or by Enter on the keyboard cursor. Carries\nthe series it belongs to, its position along the category axis, and the\nrow behind it.',
-    type: '[event: ChartDatapointEvent]'
-  },
-  {
     name: 'update:hiddenSeries',
     description: 'Fired when the hidden series changes.',
     type: '[value: string[]]'
+  },
+  {
+    name: 'select',
+    description: 'A mark was selected, by click or by Enter on the keyboard cursor. Carries\nthe series it belongs to, its position along the category axis, and the\nrow behind it.',
+    type: '[event: ChartDatapointEvent]'
   }
 ]
 </script>

--- a/src/charts/docs/BarChart.md
+++ b/src/charts/docs/BarChart.md
@@ -102,6 +102,32 @@ a date. `horizontal` swaps the two axes and the lines follow. A line outside the
 range the plot covers is not drawn — the scale follows the data, not the
 annotation — so pin `yAxis.min` / `max` to bring a distant target into frame.
 
+## Context in the tooltip
+
+`tooltipSeries` names columns that reach the tooltip and nothing else: no mark,
+no legend entry, no palette slot, and no effect on the value axis. Use it for a
+number the reader needs beside the picture but that does not belong on the same
+scale — the order count behind a conversion rate, the target beside the actual.
+
+```vue
+<BarChart
+  :data="data"
+  x="month"
+  :y="['conversion_rate']"
+  :tooltip-series="['orders']"
+  :tooltip-series-config="{ orders: { label: 'Orders' } }"
+/>
+```
+
+They print after the series rows, under a rule and without a swatch, in the
+order given. The series rows are ranked by magnitude; an extra is not, because
+a value in another unit says nothing when it is ranked among them.
+
+`tooltipSeriesConfig` is keyed by column name, the way `seriesConfig` is keyed
+by series. `format` prints the value: an extra sits on no axis, so it takes no
+formatter from one. A column holding text rather than a number is a legitimate
+extra, and prints as it stands.
+
 ## Hiding a series
 
 A chart with more than one series draws a legend under the plot. Press an entry

--- a/src/charts/docs/BarChart.md
+++ b/src/charts/docs/BarChart.md
@@ -83,6 +83,12 @@ scale, which `axis: 'y2'` in the same entry gives it.
 
 <ComponentPreview name="Charts-BarCombo" csr="true" self-layout />
 
+The sequential ramp is handed out by mark, not by series order: the line takes
+the deep end and the bars take the pale stops. A bar covers enough area to read
+in a pale color; a 2px stroke in the same color disappears. The other palettes
+keep series order, because a caller's own list, a diverging ramp and a
+categorical set all mean something in the order they are written.
+
 Marks stack among their own: bars stack with bars and areas with areas, and a
 line never stacks. `horizontal` draws bars only — a series that asks for another
 mark there is drawn as a bar, with a dev-mode warning.

--- a/src/charts/docs/BarChart.md
+++ b/src/charts/docs/BarChart.md
@@ -85,7 +85,7 @@ scale, which `axis: 'y2'` in the same entry gives it.
 
 The sequential ramp is handed out by mark, not by series order: the line takes
 the deep end and the bars take the pale stops. A bar covers enough area to read
-in a pale color; a 2px stroke in the same color disappears. The other palettes
+in a pale color. A 2px stroke in the same color disappears. The other palettes
 keep series order, because a caller's own list, a diverging ramp and a
 categorical set all mean something in the order they are written.
 
@@ -99,6 +99,12 @@ mark there is drawn as a bar, with a dev-mode warning.
 break-even point, the date something shipped. Each line takes a `value`, an
 optional `label`, `color` and `dashed`. They are annotations, not series: no
 legend entry, and no way to switch one off.
+
+`labelPlacement` moves the label off whatever it lands on. It names an end of the
+rule and a side of it: `'end-top'` (the default), `'end-bottom'`, `'start-top'`
+or `'start-bottom'`. The ends are read in the direction of the axis the rule
+runs along, so an RTL chart swaps them. A rule drawn down the plot carries its
+label rotated, and its two sides are the left and the right of it.
 
 <ComponentPreview name="Charts-BarTarget" csr="true" self-layout />
 

--- a/src/charts/docs/BarChart.md
+++ b/src/charts/docs/BarChart.md
@@ -105,31 +105,8 @@ annotation — so pin `yAxis.min` / `max` to bring a distant target into frame.
 ## Context in the tooltip
 
 `tooltipColumns` names columns that reach the tooltip and nothing else: no mark,
-no legend entry, no palette slot, and no effect on the value axis. Use it for a
-number the reader needs beside the picture but that does not belong on the same
-scale — the order count behind a conversion rate, the target beside the actual.
-
-```vue
-<BarChart
-  :data="data"
-  x="month"
-  :y="['conversion_rate']"
-  :tooltip-columns="[{ name: 'orders', label: 'Orders' }]"
-/>
-```
-
-They print after the series rows, under a rule and without a swatch, in the
-order given. The series rows are ranked by magnitude; a column is not, because a
-value in another unit says nothing when it is ranked among them.
-
-`name` is the row key. `label` heads the row, and falls back to the column name.
-`format` prints the value: a column sits on no axis, so it takes no formatter
-from one. A column holding text rather than a number is legitimate, and prints
-as it stands.
-
-To read a column in a tooltip you write yourself, take `row` from the `tooltip`
-slot instead. It carries the whole data row, plotted columns and all.
-
+no legend entry, no palette slot, no place on the value axis. It is described
+under [LineChart](/docs/charts/linechart#context-in-the-tooltip).
 
 ## Hiding a series
 

--- a/src/charts/docs/BarChart.md
+++ b/src/charts/docs/BarChart.md
@@ -104,7 +104,7 @@ annotation — so pin `yAxis.min` / `max` to bring a distant target into frame.
 
 ## Context in the tooltip
 
-`tooltipSeries` names columns that reach the tooltip and nothing else: no mark,
+`tooltipColumns` names columns that reach the tooltip and nothing else: no mark,
 no legend entry, no palette slot, and no effect on the value axis. Use it for a
 number the reader needs beside the picture but that does not belong on the same
 scale — the order count behind a conversion rate, the target beside the actual.
@@ -114,19 +114,19 @@ scale — the order count behind a conversion rate, the target beside the actual
   :data="data"
   x="month"
   :y="['conversion_rate']"
-  :tooltip-series="['orders']"
-  :tooltip-series-config="{ orders: { label: 'Orders' } }"
+  :tooltip-columns="[{ name: 'orders', label: 'Orders' }]"
 />
 ```
 
 They print after the series rows, under a rule and without a swatch, in the
-order given. The series rows are ranked by magnitude; an extra is not, because
-a value in another unit says nothing when it is ranked among them.
+order given. The series rows are ranked by magnitude; a column is not, because a
+value in another unit says nothing when it is ranked among them.
 
-`tooltipSeriesConfig` is keyed by column name, the way `seriesConfig` is keyed
-by series. `format` prints the value: an extra sits on no axis, so it takes no
-formatter from one. A column holding text rather than a number is a legitimate
-extra, and prints as it stands.
+`name` is the row key. `label` heads the row, and falls back to the column name.
+`format` prints the value: a column sits on no axis, so it takes no formatter
+from one. A column holding text rather than a number is legitimate, and prints
+as it stands.
+
 
 ## Hiding a series
 

--- a/src/charts/docs/BarChart.md
+++ b/src/charts/docs/BarChart.md
@@ -127,6 +127,9 @@ value in another unit says nothing when it is ranked among them.
 from one. A column holding text rather than a number is legitimate, and prints
 as it stands.
 
+To read a column in a tooltip you write yourself, take `row` from the `tooltip`
+slot instead. It carries the whole data row, plotted columns and all.
+
 
 ## Hiding a series
 

--- a/src/charts/docs/ChartTooltip.api.md
+++ b/src/charts/docs/ChartTooltip.api.md
@@ -36,6 +36,12 @@
     type: 'ChartTooltipItem[]'
   },
   {
+    name: 'row',
+    description: 'The data row under the pointer, so the slot can read a column the chart\nnever plotted. Left out by charts that hover an aggregate.',
+    required: false,
+    type: 'Record<string, any>'
+  },
+  {
     name: 'dir',
     description: 'Forces layout direction; defaults to document.documentElement.dir',
     required: false,
@@ -47,7 +53,7 @@
   {
     name: 'default',
     description: 'Replaces the whole tooltip body, headline row included.',
-    type: '{ label?: string | undefined; items: ChartTooltipItem[]; }'
+    type: '{ label?: string | undefined; items: ChartTooltipItem[]; row?: Record<string, any> | undefined; }'
   }
 ]
 </script>

--- a/src/charts/docs/LineChart.api.md
+++ b/src/charts/docs/LineChart.api.md
@@ -79,6 +79,18 @@
     default: '[]'
   },
   {
+    name: 'tooltipSeries',
+    description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit — the count behind a rate, the target beside the actual.\n\nThey print after the series rows, in the order given, because a value in\nanother unit says nothing when it is ranked among the series.',
+    required: false,
+    type: 'string[]'
+  },
+  {
+    name: 'tooltipSeriesConfig',
+    description: 'Keyed by column name, the way `seriesConfig` is keyed by series.',
+    required: false,
+    type: 'Record<string, TooltipSeriesStyle>'
+  },
+  {
     name: 'xAxis',
     description: 'The category axis: its title, how the `x` column reads, and label format.',
     required: false,

--- a/src/charts/docs/LineChart.api.md
+++ b/src/charts/docs/LineChart.api.md
@@ -79,16 +79,10 @@
     default: '[]'
   },
   {
-    name: 'tooltipSeries',
+    name: 'tooltipColumns',
     description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit — the count behind a rate, the target beside the actual.\n\nThey print after the series rows, in the order given, because a value in\nanother unit says nothing when it is ranked among the series.',
     required: false,
-    type: 'string[]'
-  },
-  {
-    name: 'tooltipSeriesConfig',
-    description: 'Keyed by column name, the way `seriesConfig` is keyed by series.',
-    required: false,
-    type: 'Record<string, TooltipSeriesStyle>'
+    type: 'ChartTooltipColumn[]'
   },
   {
     name: 'xAxis',

--- a/src/charts/docs/LineChart.api.md
+++ b/src/charts/docs/LineChart.api.md
@@ -80,7 +80,7 @@
   },
   {
     name: 'tooltipColumns',
-    description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit — the count behind a rate, the target beside the actual.\n\nThey print after the series rows, in the order given, because a value in\nanother unit says nothing when it is ranked among the series.',
+    description: 'Columns that reach the tooltip and nothing else: no mark, no legend entry,\nno palette slot, and no effect on the value axis. For context in another\nunit, such as the count behind a rate. They print after the series rows,\nin the order given: a value in another unit cannot be ranked among them.',
     required: false,
     type: 'ChartTooltipColumn[]'
   },
@@ -163,21 +163,21 @@
   },
   {
     name: 'tooltip',
-    description: 'Replaces the tooltip body. `items` holds one entry per visible series at\nthe hovered category, biggest first.',
-    type: '{ label?: string | undefined; items: ChartTooltipItem[]; }'
+    description: 'Replaces the tooltip body. `items` holds one entry per visible series at\nthe hovered category, biggest first. `row` is the data row behind them,\nso a replacement body can read a column the chart never plotted.',
+    type: '{ label?: string | undefined; items: ChartTooltipItem[]; row?: Record<string, any> | undefined; }'
   }
 ]
 
   const emitsData = [
   {
-    name: 'select',
-    description: 'A mark was selected, by click or by Enter on the keyboard cursor. Carries\nthe series it belongs to, its position along the category axis, and the\nrow behind it.',
-    type: '[event: ChartDatapointEvent]'
-  },
-  {
     name: 'update:hiddenSeries',
     description: 'Fired when the hidden series changes.',
     type: '[value: string[]]'
+  },
+  {
+    name: 'select',
+    description: 'A mark was selected, by click or by Enter on the keyboard cursor. Carries\nthe series it belongs to, its position along the category axis, and the\nrow behind it.',
+    type: '[event: ChartDatapointEvent]'
   }
 ]
 </script>

--- a/src/charts/docs/LineChart.md
+++ b/src/charts/docs/LineChart.md
@@ -66,6 +66,32 @@ has to be to stay comparable. A line outside the range the plot covers is not
 drawn, because stretching the scale to fit a distant target would flatten the
 data it is meant to be read against; pin `yAxis.min` / `max` instead.
 
+## Context in the tooltip
+
+`tooltipSeries` names columns that reach the tooltip and nothing else: no mark,
+no legend entry, no palette slot, and no effect on the value axis. Use it for a
+number the reader needs beside the picture but that does not belong on the same
+scale — the order count behind a conversion rate, the target beside the actual.
+
+```vue
+<LineChart
+  :data="data"
+  x="month"
+  :y="['conversion_rate']"
+  :tooltip-series="['orders']"
+  :tooltip-series-config="{ orders: { label: 'Orders' } }"
+/>
+```
+
+They print after the series rows, under a rule and without a swatch, in the
+order given. The series rows are ranked by magnitude; an extra is not, because
+a value in another unit says nothing when it is ranked among them.
+
+`tooltipSeriesConfig` is keyed by column name, the way `seriesConfig` is keyed
+by series. `format` prints the value: an extra sits on no axis, so it takes no
+formatter from one. A column holding text rather than a number is a legitimate
+extra, and prints as it stands.
+
 ## Hiding a series
 
 A chart with more than one series draws a legend under the plot. Press an entry

--- a/src/charts/docs/LineChart.md
+++ b/src/charts/docs/LineChart.md
@@ -91,6 +91,9 @@ value in another unit says nothing when it is ranked among them.
 from one. A column holding text rather than a number is legitimate, and prints
 as it stands.
 
+To read a column in a tooltip you write yourself, take `row` from the `tooltip`
+slot instead. It carries the whole data row, plotted columns and all.
+
 
 ## Hiding a series
 

--- a/src/charts/docs/LineChart.md
+++ b/src/charts/docs/LineChart.md
@@ -58,6 +58,9 @@ the plot at a measured value, `'x'` for one down it at a category, a date, or a
 number on a numeric x axis. Each line also takes an optional `label`, `color`
 and `dashed`.
 
+`labelPlacement` moves the label off whatever it lands on. It is described under
+[BarChart](/docs/charts/barchart#targets-and-thresholds).
+
 <ComponentPreview name="Charts-LineThresholds" csr="true" self-layout />
 
 A reference line is an annotation, not a series: it has no legend entry, it is

--- a/src/charts/docs/LineChart.md
+++ b/src/charts/docs/LineChart.md
@@ -29,8 +29,8 @@ chart has none.
 `seriesConfig[key].axis` measures a series against a second value axis, drawn
 opposite the primary — for a series in another unit, like a rate against
 dollars. `y2Axis.min` / `max` pin that scale so the line reads as over or under
-plan rather than as its own trend. The axis is only drawn when a series asks
-for it.
+plan rather than as its own trend. The axis is only drawn when a series asks for
+it.
 
 <ComponentPreview name="Charts-LineDualAxis" csr="true" self-layout />
 
@@ -43,20 +43,20 @@ same way, keyed by a value of the `series` column.
 ## Filling one series
 
 `seriesConfig[key].type` sets the mark a single series draws as, so one line of
-a `LineChart` carries a fill on `type: 'area'` while the rest stay bare. There is
-no separate fill flag: an area *is* a filled line. `fillOpacity` sets the alpha,
-chart-wide or per series. The same key takes `'bar'`, which is what makes a
-combo chart.
+a `LineChart` carries a fill on `type: 'area'` while the rest stay bare. There
+is no separate fill flag: an area _is_ a filled line. `fillOpacity` sets the
+alpha, chart-wide or per series. The same key takes `'bar'`, which is what makes
+a combo chart.
 
 <ComponentPreview name="Charts-LineFilledSeries" csr="true" self-layout />
 
 ## Targets and thresholds
 
-`referenceLines` draws a rule over the plot at a fixed position. `axis` says what
-`value` is read against: `'y'` (the default) or `'y2'` for a rule across the plot
-at a measured value, `'x'` for one down it at a category, a date, or a number on
-a numeric x axis. Each line
-also takes an optional `label`, `color` and `dashed`.
+`referenceLines` draws a rule over the plot at a fixed position. `axis` says
+what `value` is read against: `'y'` (the default) or `'y2'` for a rule across
+the plot at a measured value, `'x'` for one down it at a category, a date, or a
+number on a numeric x axis. Each line also takes an optional `label`, `color`
+and `dashed`.
 
 <ComponentPreview name="Charts-LineThresholds" csr="true" self-layout />
 
@@ -68,7 +68,7 @@ data it is meant to be read against; pin `yAxis.min` / `max` instead.
 
 ## Context in the tooltip
 
-`tooltipSeries` names columns that reach the tooltip and nothing else: no mark,
+`tooltipColumns` names columns that reach the tooltip and nothing else: no mark,
 no legend entry, no palette slot, and no effect on the value axis. Use it for a
 number the reader needs beside the picture but that does not belong on the same
 scale — the order count behind a conversion rate, the target beside the actual.
@@ -78,19 +78,19 @@ scale — the order count behind a conversion rate, the target beside the actual
   :data="data"
   x="month"
   :y="['conversion_rate']"
-  :tooltip-series="['orders']"
-  :tooltip-series-config="{ orders: { label: 'Orders' } }"
+  :tooltip-columns="[{ name: 'orders', label: 'Orders' }]"
 />
 ```
 
 They print after the series rows, under a rule and without a swatch, in the
-order given. The series rows are ranked by magnitude; an extra is not, because
-a value in another unit says nothing when it is ranked among them.
+order given. The series rows are ranked by magnitude; a column is not, because a
+value in another unit says nothing when it is ranked among them.
 
-`tooltipSeriesConfig` is keyed by column name, the way `seriesConfig` is keyed
-by series. `format` prints the value: an extra sits on no axis, so it takes no
-formatter from one. A column holding text rather than a number is a legitimate
-extra, and prints as it stands.
+`name` is the row key. `label` heads the row, and falls back to the column name.
+`format` prints the value: a column sits on no axis, so it takes no formatter
+from one. A column holding text rather than a number is legitimate, and prints
+as it stands.
+
 
 ## Hiding a series
 

--- a/src/charts/docs/LineChart.md
+++ b/src/charts/docs/LineChart.md
@@ -69,9 +69,9 @@ data it is meant to be read against; pin `yAxis.min` / `max` instead.
 ## Context in the tooltip
 
 `tooltipColumns` names columns that reach the tooltip and nothing else: no mark,
-no legend entry, no palette slot, and no effect on the value axis. Use it for a
-number the reader needs beside the picture but that does not belong on the same
-scale — the order count behind a conversion rate, the target beside the actual.
+no legend entry, no palette slot, no place on the value axis. Use it for a
+number that does not belong on the same scale, such as the order count behind
+a conversion rate.
 
 ```vue
 <LineChart
@@ -82,18 +82,21 @@ scale — the order count behind a conversion rate, the target beside the actual
 />
 ```
 
-They print after the series rows, under a rule and without a swatch, in the
-order given. The series rows are ranked by magnitude; a column is not, because a
-value in another unit says nothing when it is ranked among them.
+<ComponentPreview name="Charts-LineTooltipColumns" csr="true" self-layout />
 
-`name` is the row key. `label` heads the row, and falls back to the column name.
-`format` prints the value: a column sits on no axis, so it takes no formatter
-from one. A column holding text rather than a number is legitimate, and prints
-as it stands.
+Columns print after the series rows, in the order given. They are not ranked
+by magnitude: a value in another unit cannot be ranked among the series.
 
-To read a column in a tooltip you write yourself, take `row` from the `tooltip`
-slot instead. It carries the whole data row, plotted columns and all.
+`name` is the row key. `label` falls back to it, and `format` prints the value.
+A column holding text prints as it stands.
 
+For a tooltip you write yourself, take `row` from the `tooltip` slot instead.
+
+```vue
+<LineChart :data="data" x="month" y="conversion_rate">
+  <template #tooltip="{ row }">{{ row.orders }} orders</template>
+</LineChart>
+```
 
 ## Hiding a series
 

--- a/src/charts/docs/Overview.md
+++ b/src/charts/docs/Overview.md
@@ -177,7 +177,7 @@ on a light page takes the panel's colors. Pass the element the plot draws into.
 it rebuilds and `setOption` runs again with the new values. It carries the three
 ramps — `categorical`, `sequential` and `diverging` — and the inks the chrome
 draws in: `axisLabel`, `axisTitle`, `axisLine`, `splitLine`, `dataLabel`,
-`insideLabel` and `cellGap`.
+`insideLabel` and `backdrop`.
 
 Color a chart's own series through the `palette` prop instead. `useChartTokens`
 is for a plot the library does not draw.

--- a/src/charts/docs/ScatterChart.md
+++ b/src/charts/docs/ScatterChart.md
@@ -38,6 +38,9 @@ and `dashed`. They are annotations, not series: no legend entry, no tooltip
 entry, and no way to switch one off, so a rule stays put while a legend toggle
 takes a group out of the plot.
 
+`labelPlacement` moves the label off whatever it lands on. It is described under
+[BarChart](/docs/charts/barchart#targets-and-thresholds).
+
 `axis` says which scale `value` is read against. Both scales are measured here,
 so `'x'` and `'y'` are the same kind of thing: a number. An axis chart reads
 `'x'` as a category or a date instead, unless `xAxis.type` is `'value'`. `'y'`

--- a/src/charts/donutChartOptions.test.ts
+++ b/src/charts/donutChartOptions.test.ts
@@ -14,7 +14,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 function config(overrides: Partial<DonutChartConfig> = {}): DonutChartConfig {

--- a/src/charts/heatmapOptions.test.ts
+++ b/src/charts/heatmapOptions.test.ts
@@ -33,7 +33,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 function config(
@@ -312,7 +312,7 @@ describe('buildHeatmapOption', () => {
     expect(itemStyle).toMatchObject({
       borderRadius: 2,
       borderWidth: 2,
-      borderColor: tokens.cellGap,
+      borderColor: tokens.backdrop,
     })
   })
 
@@ -325,7 +325,7 @@ describe('buildHeatmapOption', () => {
 
     // The resting border, restated: a hovered cell keeps the gap around it.
     expect(series.emphasis.itemStyle).toEqual({
-      borderColor: tokens.cellGap,
+      borderColor: tokens.backdrop,
       borderWidth: 2,
       shadowBlur: 0,
       shadowColor: 'transparent',

--- a/src/charts/heatmapOptions.ts
+++ b/src/charts/heatmapOptions.ts
@@ -363,7 +363,7 @@ export function buildHeatmapOption(
         itemStyle: {
           borderRadius: CELL_RADIUS,
           borderWidth: CELL_BORDER_WIDTH,
-          borderColor: tokens.cellGap,
+          borderColor: tokens.backdrop,
         },
         // Hover only lightens the fill (per cell, below). The border stays the
         // resting one and the shadow is turned off: a heatmap is read by
@@ -372,7 +372,7 @@ export function buildHeatmapOption(
         emphasis: {
           focus: 'none',
           itemStyle: {
-            borderColor: tokens.cellGap,
+            borderColor: tokens.backdrop,
             borderWidth: CELL_BORDER_WIDTH,
             shadowBlur: 0,
             shadowColor: 'transparent',

--- a/src/charts/index.ts
+++ b/src/charts/index.ts
@@ -61,6 +61,7 @@ export type {
   ChartLegendEmits,
   ChartLegendProps,
   ChartStateSlots,
+  ChartTooltipFormatter,
   ChartTooltipProps,
   ChartTooltipSlots,
   ChartValueAxisOptions,
@@ -87,6 +88,7 @@ export type {
   ScatterChartProps,
   ScatterChartSlots,
   SeriesStyle,
+  TooltipSeriesStyle,
 } from './types'
 
 // Only what the props, emits, slots and template refs above reach for; the

--- a/src/charts/index.ts
+++ b/src/charts/index.ts
@@ -88,7 +88,6 @@ export type {
   ScatterChartProps,
   ScatterChartSlots,
   SeriesStyle,
-  TooltipSeriesStyle,
 } from './types'
 
 // Only what the props, emits, slots and template refs above reach for; the
@@ -101,6 +100,7 @@ export type {
   ChartMark,
   ChartPalette,
   ChartPaletteName,
+  ChartTooltipColumn,
   ChartTooltipItem,
   DonutSliceEvent,
   DonutVariant,

--- a/src/charts/lineChartOptions.test.ts
+++ b/src/charts/lineChartOptions.test.ts
@@ -13,7 +13,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 /** What `LineChart` hands the builder: the shared config, marked `'line'`. */

--- a/src/charts/normalizedStackOptions.test.ts
+++ b/src/charts/normalizedStackOptions.test.ts
@@ -21,7 +21,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 /** Two series whose totals are round numbers, so the shares read at a glance. */

--- a/src/charts/referenceLines.test.ts
+++ b/src/charts/referenceLines.test.ts
@@ -198,6 +198,30 @@ describe('reference line looks', () => {
     expect(label.formatter()).toBe('Target')
   })
 
+  it('places the label at the end and the side the caller names', () => {
+    const option = build({
+      referenceLines: [
+        { value: 10, label: 'A', labelPlacement: 'start-top' },
+        { value: 20, label: 'B', labelPlacement: 'start-bottom' },
+        { value: 30, label: 'C', labelPlacement: 'end-top' },
+        { value: 40, label: 'D', labelPlacement: 'end-bottom' },
+      ],
+    })
+    expect(entriesOf(option).map((entry: any) => entry.label.position)).toEqual([
+      'insideStartTop',
+      'insideStartBottom',
+      'insideEndTop',
+      'insideEndBottom',
+    ])
+  })
+
+  it('reads the two ends off the axis, so an RTL chart swaps them itself', () => {
+    // Nothing to assert on the option: echarts places `Start` where the axis
+    // begins.
+    const rtl = build({ dir: 'rtl', referenceLines: [{ value: 15, label: 'T' }] })
+    expect(entriesOf(rtl)[0].label.position).toBe('insideEndTop')
+  })
+
   it('carries no label at all when none is set', () => {
     expect(
       entriesOf(build({ referenceLines: [{ value: 15 }] }))[0].label,

--- a/src/charts/referenceLines.test.ts
+++ b/src/charts/referenceLines.test.ts
@@ -56,7 +56,7 @@ describe('reference line placement', () => {
   it('draws a horizontal rule at a value on the value axis', () => {
     const option = build({ referenceLines: [{ value: 15 }] })
     expect(entriesOf(option)).toEqual([
-      { yAxis: 15, lineStyle: { width: 1.5, color: 'ink-5' } },
+      { yAxis: 15, lineStyle: { width: 1.5, color: 'ink-5' }, label: { show: false } },
     ])
   })
 
@@ -222,10 +222,12 @@ describe('reference line looks', () => {
     expect(entriesOf(rtl)[0].label.position).toBe('insideEndTop')
   })
 
-  it('carries no label at all when none is set', () => {
-    expect(
-      entriesOf(build({ referenceLines: [{ value: 15 }] }))[0].label,
-    ).toBeUndefined()
+  it('turns the label off when none is set, rather than leaving it out', () => {
+    // Leaving it out hands the rule to echarts' own label, which prints the raw
+    // value past the end of the rule, outside the plot.
+    expect(entriesOf(build({ referenceLines: [{ value: 15 }] }))[0].label).toEqual(
+      { show: false },
+    )
   })
 
   it('takes the axis labels’ ink, not the palette and not the data labels’', () => {

--- a/src/charts/referenceLines.test.ts
+++ b/src/charts/referenceLines.test.ts
@@ -15,7 +15,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 function config(overrides: Partial<AxisChartConfig> = {}): AxisChartConfig {
@@ -56,7 +56,7 @@ describe('reference line placement', () => {
   it('draws a horizontal rule at a value on the value axis', () => {
     const option = build({ referenceLines: [{ value: 15 }] })
     expect(entriesOf(option)).toEqual([
-      { yAxis: 15, lineStyle: { width: 1.5, color: 'ink-6' } },
+      { yAxis: 15, lineStyle: { width: 1.5, color: 'ink-5' } },
     ])
   })
 
@@ -204,21 +204,33 @@ describe('reference line looks', () => {
     ).toBeUndefined()
   })
 
-  it('takes its default ink from the tokens, not from the palette', () => {
+  it('takes the axis labels’ ink, not the palette and not the data labels’', () => {
     const option = build({ referenceLines: [{ value: 15, label: 'Target' }] })
     const [entry] = entriesOf(option)
-    expect(entry.lineStyle.color).toBe(tokens.dataLabel)
-    expect(entry.label.color).toBe(tokens.dataLabel)
+    expect(entry.lineStyle.color).toBe(tokens.axisLabel)
+    expect(entry.label.color).toBe(tokens.axisLabel)
   })
 
-  it('breaks a dashed line up with the same texture the gridlines use', () => {
+  it('prints its label on a plate of the surface behind the plot', () => {
+    const option = build({ referenceLines: [{ value: 15, label: 'Target' }] })
+    const [entry] = entriesOf(option)
+    // Short of opaque, so a mark under the label still reads through it.
+    expect(entry.label.backgroundColor).toBe(
+      `color-mix(in srgb, ${tokens.backdrop} 80%, transparent)`,
+    )
+    expect(entry.label.padding).toEqual([2, 4])
+  })
+
+  it('breaks a dashed line up with a dash of its own, not the gridline dots', () => {
     const option = build({
       referenceLines: [{ value: 15, dashed: true }, { value: 25 }],
     })
     const [dashed, solid] = entriesOf(option)
-    expect(dashed.lineStyle.type).toEqual(DOTTED_LINE.type)
-    expect(dashed.lineStyle.cap).toBe(DOTTED_LINE.cap)
-    // Heavier than the gridline the texture is borrowed from.
+    // A dash against the grid's dots: the two kinds of broken line have to be
+    // told apart by pattern, because the rule is drawn at furniture weight.
+    expect(dashed.lineStyle.type).toEqual([5.25, 4.5])
+    expect(dashed.lineStyle.cap).toBeUndefined()
+    expect(dashed.lineStyle.type).not.toEqual(DOTTED_LINE.type)
     expect(dashed.lineStyle.width).toBe(1.5)
     expect(solid.lineStyle.type).toBeUndefined()
   })
@@ -303,5 +315,17 @@ describe('reference lines against the rest of the plot', () => {
       structure(bare.series),
     )
     expect(annotated.series[3]).toBe(hostsOf(annotated)[0])
+  })
+
+  it('draws over every mark, so its label is never covered', () => {
+    const overrides: Partial<AxisChartConfig> = {
+      series: [{ name: 'sales' }, { name: 'refunds', type: 'line' }],
+    }
+    const option = build({ ...overrides, referenceLines: [{ value: 15 }] })
+    const marks = option.series
+      .filter((series: any) => !series.markLine)
+      .map((series: any) => series.z)
+
+    expect(hostsOf(option)[0].z).toBeGreaterThan(Math.max(...marks))
   })
 })

--- a/src/charts/referenceLines.test.ts
+++ b/src/charts/referenceLines.test.ts
@@ -56,7 +56,7 @@ describe('reference line placement', () => {
   it('draws a horizontal rule at a value on the value axis', () => {
     const option = build({ referenceLines: [{ value: 15 }] })
     expect(entriesOf(option)).toEqual([
-      { yAxis: 15, lineStyle: { width: 1.5, color: 'ink-5' }, label: { show: false } },
+      { yAxis: 15, lineStyle: { width: 1, color: 'ink-5' }, label: { show: false } },
     ])
   })
 
@@ -223,8 +223,6 @@ describe('reference line looks', () => {
   })
 
   it('turns the label off when none is set, rather than leaving it out', () => {
-    // Leaving it out hands the rule to echarts' own label, which prints the raw
-    // value past the end of the rule, outside the plot.
     expect(entriesOf(build({ referenceLines: [{ value: 15 }] }))[0].label).toEqual(
       { show: false },
     )
@@ -254,10 +252,10 @@ describe('reference line looks', () => {
     const [dashed, solid] = entriesOf(option)
     // A dash against the grid's dots: the two kinds of broken line have to be
     // told apart by pattern, because the rule is drawn at furniture weight.
-    expect(dashed.lineStyle.type).toEqual([5.25, 4.5])
+    expect(dashed.lineStyle.type).toEqual([3.5, 3])
     expect(dashed.lineStyle.cap).toBeUndefined()
     expect(dashed.lineStyle.type).not.toEqual(DOTTED_LINE.type)
-    expect(dashed.lineStyle.width).toBe(1.5)
+    expect(dashed.lineStyle.width).toBe(1)
     expect(solid.lineStyle.type).toBeUndefined()
   })
 

--- a/src/charts/referenceLines.ts
+++ b/src/charts/referenceLines.ts
@@ -7,8 +7,14 @@ import {
 import { translucent, type ChartTokens } from './tokens'
 import type { ReferenceLine, ReferenceLineLabelPlacement } from './types'
 
-/** Heavier than a gridline: the rule is a statement, not part of the grid. */
-const REFERENCE_LINE_WIDTH = 1.5
+/**
+ * A hairline, the gridline's own weight. What separates the rule from the grid
+ * is its dash against the grid's dots and its ink against the grid's, which is
+ * the difference `dashedLine` is built to carry at any weight. Weight is a third
+ * signal saying the same thing, and it costs: 1.5 lands between device pixels,
+ * so the rule renders as a two-pixel smear rather than as a line.
+ */
+const REFERENCE_LINE_WIDTH = 1
 
 /**
  * The annotation layer, above every mark. The rule is furniture and could sit

--- a/src/charts/referenceLines.ts
+++ b/src/charts/referenceLines.ts
@@ -156,24 +156,25 @@ function markLineEntry(
       width: REFERENCE_LINE_WIDTH,
       color,
     },
-    ...(line.label
+    // Written out even when the rule carries no text. Left off, echarts falls
+    // back to its own label, which prints the raw value past the end of the
+    // rule, outside the plot.
+    label: line.label
       ? {
-          label: {
-            show: true,
-            position:
-              LABEL_PLACEMENTS[line.labelPlacement ?? DEFAULT_LABEL_PLACEMENT],
-            // A function rather than the string itself: echarts reads a string
-            // formatter as a template, so a label with braces in it would come
-            // out substituted.
-            formatter: () => line.label,
-            color,
-            fontSize: DATA_LABEL_FONT_SIZE,
-            // The surface behind the plot, as a plate: wherever the label is
-            // placed, on a busy chart it is placed on top of a mark.
-            backgroundColor: translucent(tokens.backdrop, LABEL_PLATE_OPACITY),
-            padding: LABEL_PADDING,
-          },
+          show: true,
+          position:
+            LABEL_PLACEMENTS[line.labelPlacement ?? DEFAULT_LABEL_PLACEMENT],
+          // A function rather than the string itself: echarts reads a string
+          // formatter as a template, so a label with braces in it would come
+          // out substituted.
+          formatter: () => line.label,
+          color,
+          fontSize: DATA_LABEL_FONT_SIZE,
+          // The surface behind the plot, as a plate: wherever the label is
+          // placed, on a busy chart it is placed on top of a mark.
+          backgroundColor: translucent(tokens.backdrop, LABEL_PLATE_OPACITY),
+          padding: LABEL_PADDING,
         }
-      : {}),
+      : { show: false },
   }
 }

--- a/src/charts/referenceLines.ts
+++ b/src/charts/referenceLines.ts
@@ -1,9 +1,32 @@
-import { DATA_LABEL_FONT_SIZE, DOTTED_LINE, toNumber } from './axisChartCommon'
-import type { ChartTokens } from './tokens'
+import {
+  DATA_LABEL_FONT_SIZE,
+  MARK_Z,
+  dashedLine,
+  toNumber,
+} from './axisChartCommon'
+import { translucent, type ChartTokens } from './tokens'
 import type { ReferenceLine } from './types'
 
 /** Heavier than a gridline: the rule is a statement, not part of the grid. */
 const REFERENCE_LINE_WIDTH = 1.5
+
+/**
+ * The annotation layer, above every mark. The rule is furniture and could sit
+ * under the marks, but its label cannot: a label a series draws over is a label
+ * nobody reads. Both hang off one `markLine`, so the layer is one tier, and the
+ * rule is kept quiet by its ink rather than by its depth.
+ */
+const REFERENCE_LINE_Z = MARK_Z.line + 1
+
+/** Keeps a label off whatever it lands on. Padding is [vertical, horizontal]. */
+const LABEL_PADDING = [2, 4]
+
+/**
+ * How much of the plate is the surface behind the plot. Short of opaque, so a
+ * mark the label covers reads on as a ghost rather than being cut in half — the
+ * label wins the contrast, the plot keeps its shape.
+ */
+const LABEL_PLATE_OPACITY = 80
 
 /**
  * Name of the series that carries the lines targeting one value axis. Prefixed
@@ -71,6 +94,7 @@ export function buildReferenceLineSeries(
       name: `${HOST_SERIES_NAME}-${axisIndex}`,
       data: [],
       silent: true,
+      z: REFERENCE_LINE_Z,
       [axisIndexKey]: axisIndex,
       markLine: { silent: true, symbol: 'none', data },
     })
@@ -106,17 +130,18 @@ function markLineEntry(
   // value as a horizontal rule. `horizontal` swaps which axis carries the
   // categories, so it swaps the key each kind of line needs.
   const axisKey = onXAxis !== horizontal ? 'xAxis' : 'yAxis'
-  // The ink data labels are printed in: a reference line annotates the plot, so
-  // it should not read as another measure drawn in a palette color.
-  const color = line.color || tokens.dataLabel
+  // The ink the axis labels are printed in: a reference line annotates the plot,
+  // so it should read as furniture rather than as another measure. The data
+  // labels' darker ink puts it at the weight of the marks it is drawn over.
+  const color = line.color || tokens.axisLabel
 
   return {
     [axisKey]: at,
     lineStyle: {
-      // Every rule v2 draws that is not a mark — the gridlines, the category
-      // baseline — carries this one dot texture, so a broken reference line
-      // takes it too rather than introducing a second dash pattern.
-      ...(line.dashed ? DOTTED_LINE : {}),
+      // A dash, not the dot texture the gridlines and the category baseline
+      // carry: a reference line is a statement about a value, not part of the
+      // furniture that locates one. See `dashedLine`.
+      ...(line.dashed ? dashedLine(REFERENCE_LINE_WIDTH) : {}),
       width: REFERENCE_LINE_WIDTH,
       color,
     },
@@ -131,6 +156,10 @@ function markLineEntry(
             formatter: () => line.label,
             color,
             fontSize: DATA_LABEL_FONT_SIZE,
+            // The surface behind the plot, as a plate: the label lands wherever
+            // its line ends, which on a busy chart is on top of a mark.
+            backgroundColor: translucent(tokens.backdrop, LABEL_PLATE_OPACITY),
+            padding: LABEL_PADDING,
           },
         }
       : {}),

--- a/src/charts/referenceLines.ts
+++ b/src/charts/referenceLines.ts
@@ -5,7 +5,7 @@ import {
   toNumber,
 } from './axisChartCommon'
 import { translucent, type ChartTokens } from './tokens'
-import type { ReferenceLine } from './types'
+import type { ReferenceLine, ReferenceLineLabelPlacement } from './types'
 
 /** Heavier than a gridline: the rule is a statement, not part of the grid. */
 const REFERENCE_LINE_WIDTH = 1.5
@@ -22,8 +22,23 @@ const REFERENCE_LINE_Z = MARK_Z.line + 1
 const LABEL_PADDING = [2, 4]
 
 /**
+ * Each placement as echarts spells it. The names are a pass-through and not a
+ * calculation: echarts reads `Start` and `End` off the axis the rule runs along,
+ * so an inverted axis, such as an RTL chart, swaps the two ends on its own.
+ */
+const LABEL_PLACEMENTS: Record<ReferenceLineLabelPlacement, string> = {
+  'start-top': 'insideStartTop',
+  'start-bottom': 'insideStartBottom',
+  'end-top': 'insideEndTop',
+  'end-bottom': 'insideEndBottom',
+}
+
+/** The far end of the rule, above it: clear of the axis and of most marks. */
+const DEFAULT_LABEL_PLACEMENT: ReferenceLineLabelPlacement = 'end-top'
+
+/**
  * How much of the plate is the surface behind the plot. Short of opaque, so a
- * mark the label covers reads on as a ghost rather than being cut in half — the
+ * mark the label covers reads on as a ghost rather than being cut in half. The
  * label wins the contrast, the plot keeps its shape.
  */
 const LABEL_PLATE_OPACITY = 80
@@ -130,17 +145,13 @@ function markLineEntry(
   // value as a horizontal rule. `horizontal` swaps which axis carries the
   // categories, so it swaps the key each kind of line needs.
   const axisKey = onXAxis !== horizontal ? 'xAxis' : 'yAxis'
-  // The ink the axis labels are printed in: a reference line annotates the plot,
-  // so it should read as furniture rather than as another measure. The data
-  // labels' darker ink puts it at the weight of the marks it is drawn over.
+  // Axis-label ink: the rule reads as furniture, not as another measure.
   const color = line.color || tokens.axisLabel
 
   return {
     [axisKey]: at,
     lineStyle: {
-      // A dash, not the dot texture the gridlines and the category baseline
-      // carry: a reference line is a statement about a value, not part of the
-      // furniture that locates one. See `dashedLine`.
+      // A dash against the grid's dots: see `dashedLine`.
       ...(line.dashed ? dashedLine(REFERENCE_LINE_WIDTH) : {}),
       width: REFERENCE_LINE_WIDTH,
       color,
@@ -149,15 +160,16 @@ function markLineEntry(
       ? {
           label: {
             show: true,
-            position: 'insideEndTop',
+            position:
+              LABEL_PLACEMENTS[line.labelPlacement ?? DEFAULT_LABEL_PLACEMENT],
             // A function rather than the string itself: echarts reads a string
             // formatter as a template, so a label with braces in it would come
             // out substituted.
             formatter: () => line.label,
             color,
             fontSize: DATA_LABEL_FONT_SIZE,
-            // The surface behind the plot, as a plate: the label lands wherever
-            // its line ends, which on a busy chart is on top of a mark.
+            // The surface behind the plot, as a plate: wherever the label is
+            // placed, on a busy chart it is placed on top of a mark.
             backgroundColor: translucent(tokens.backdrop, LABEL_PLATE_OPACITY),
             padding: LABEL_PADDING,
           },

--- a/src/charts/sankeyOptions.test.ts
+++ b/src/charts/sankeyOptions.test.ts
@@ -13,7 +13,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 function config(overrides: Partial<SankeyChartConfig> = {}): SankeyChartConfig {

--- a/src/charts/scatterOptions.test.ts
+++ b/src/charts/scatterOptions.test.ts
@@ -477,7 +477,7 @@ describe('reference lines on a scatter', () => {
     const option = build({ referenceLines: [{ value: 1500 }] })
 
     expect(entriesOf(option)).toEqual([
-      { yAxis: 1500, lineStyle: { width: 1.5, color: 'ink-5' }, label: { show: false } },
+      { yAxis: 1500, lineStyle: { width: 1, color: 'ink-5' }, label: { show: false } },
     ])
   })
 
@@ -487,7 +487,7 @@ describe('reference lines on a scatter', () => {
     const option = build({ referenceLines: [{ value: 500, axis: 'x' }] })
 
     expect(entriesOf(option)).toEqual([
-      { xAxis: 500, lineStyle: { width: 1.5, color: 'ink-5' }, label: { show: false } },
+      { xAxis: 500, lineStyle: { width: 1, color: 'ink-5' }, label: { show: false } },
     ])
   })
 
@@ -504,8 +504,8 @@ describe('reference lines on a scatter', () => {
     })
 
     expect(entriesOf(option)).toEqual([
-      { xAxis: 500, lineStyle: { width: 1.5, color: 'ink-5' }, label: { show: false } },
-      { yAxis: 1500, lineStyle: { width: 1.5, color: 'ink-5' }, label: { show: false } },
+      { xAxis: 500, lineStyle: { width: 1, color: 'ink-5' }, label: { show: false } },
+      { yAxis: 1500, lineStyle: { width: 1, color: 'ink-5' }, label: { show: false } },
     ])
   })
 

--- a/src/charts/scatterOptions.test.ts
+++ b/src/charts/scatterOptions.test.ts
@@ -477,7 +477,7 @@ describe('reference lines on a scatter', () => {
     const option = build({ referenceLines: [{ value: 1500 }] })
 
     expect(entriesOf(option)).toEqual([
-      { yAxis: 1500, lineStyle: { width: 1.5, color: 'ink-5' } },
+      { yAxis: 1500, lineStyle: { width: 1.5, color: 'ink-5' }, label: { show: false } },
     ])
   })
 
@@ -487,7 +487,7 @@ describe('reference lines on a scatter', () => {
     const option = build({ referenceLines: [{ value: 500, axis: 'x' }] })
 
     expect(entriesOf(option)).toEqual([
-      { xAxis: 500, lineStyle: { width: 1.5, color: 'ink-5' } },
+      { xAxis: 500, lineStyle: { width: 1.5, color: 'ink-5' }, label: { show: false } },
     ])
   })
 
@@ -504,8 +504,8 @@ describe('reference lines on a scatter', () => {
     })
 
     expect(entriesOf(option)).toEqual([
-      { xAxis: 500, lineStyle: { width: 1.5, color: 'ink-5' } },
-      { yAxis: 1500, lineStyle: { width: 1.5, color: 'ink-5' } },
+      { xAxis: 500, lineStyle: { width: 1.5, color: 'ink-5' }, label: { show: false } },
+      { yAxis: 1500, lineStyle: { width: 1.5, color: 'ink-5' }, label: { show: false } },
     ])
   })
 

--- a/src/charts/scatterOptions.test.ts
+++ b/src/charts/scatterOptions.test.ts
@@ -15,7 +15,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 /** Diameters the size measure is mapped onto. */
@@ -477,7 +477,7 @@ describe('reference lines on a scatter', () => {
     const option = build({ referenceLines: [{ value: 1500 }] })
 
     expect(entriesOf(option)).toEqual([
-      { yAxis: 1500, lineStyle: { width: 1.5, color: 'ink-6' } },
+      { yAxis: 1500, lineStyle: { width: 1.5, color: 'ink-5' } },
     ])
   })
 
@@ -487,7 +487,7 @@ describe('reference lines on a scatter', () => {
     const option = build({ referenceLines: [{ value: 500, axis: 'x' }] })
 
     expect(entriesOf(option)).toEqual([
-      { xAxis: 500, lineStyle: { width: 1.5, color: 'ink-6' } },
+      { xAxis: 500, lineStyle: { width: 1.5, color: 'ink-5' } },
     ])
   })
 
@@ -504,8 +504,8 @@ describe('reference lines on a scatter', () => {
     })
 
     expect(entriesOf(option)).toEqual([
-      { xAxis: 500, lineStyle: { width: 1.5, color: 'ink-6' } },
-      { yAxis: 1500, lineStyle: { width: 1.5, color: 'ink-6' } },
+      { xAxis: 500, lineStyle: { width: 1.5, color: 'ink-5' } },
+      { yAxis: 1500, lineStyle: { width: 1.5, color: 'ink-5' } },
     ])
   })
 
@@ -562,8 +562,8 @@ describe('reference lines on a scatter', () => {
     })
     const [dashed, solid] = entriesOf(option)
 
-    expect(dashed.lineStyle.color).toBe(tokens.dataLabel)
-    expect(dashed.lineStyle.type).toEqual(DOTTED_LINE.type)
+    expect(dashed.lineStyle.color).toBe(tokens.axisLabel)
+    expect(dashed.lineStyle.type).not.toEqual(DOTTED_LINE.type)
     expect(solid.lineStyle.type).toBeUndefined()
   })
 

--- a/src/charts/seriesData.test.ts
+++ b/src/charts/seriesData.test.ts
@@ -196,7 +196,7 @@ describe('normalizeAxisChartProps: the second value axis', () => {
       cellGap: '#ffffff',
     }
     const colorsOf = (props: Partial<AxisChartProps>) =>
-      resolveSeriesColors(normalize(props).config, tokens)
+      resolveSeriesColors({ ...normalize(props).config, type: 'bar' }, tokens)
 
     expect(colorsOf({ seriesConfig: { refunds: { axis: 'y2' } } })).toEqual(
       colorsOf({}),

--- a/src/charts/seriesData.test.ts
+++ b/src/charts/seriesData.test.ts
@@ -193,7 +193,7 @@ describe('normalizeAxisChartProps: the second value axis', () => {
       splitLine: 'outline-1',
       dataLabel: 'ink-6',
       insideLabel: 'ink-8',
-      cellGap: '#ffffff',
+      backdrop: '#ffffff',
     }
     const colorsOf = (props: Partial<AxisChartProps>) =>
       resolveSeriesColors({ ...normalize(props).config, type: 'bar' }, tokens)

--- a/src/charts/seriesData.ts
+++ b/src/charts/seriesData.ts
@@ -8,6 +8,7 @@ import type {
   ChartYAxisConfig,
 } from './types'
 import { toNumber } from './axisChartCommon'
+import { formatLabel } from './format'
 import { OTHERS_KEY, OTHERS_LABEL } from './utils'
 
 /** Below two there is nothing left to collapse into. */
@@ -84,6 +85,11 @@ export function normalizeAxisChartProps(
       y2: props.y2Axis?.format,
     },
   }
+}
+
+/** What a series is called wherever it is printed: legend, tooltip, reading. */
+export function seriesLabel(series: AxisChartSeriesConfig) {
+  return series.label ?? formatLabel(series.name)
 }
 
 /**

--- a/src/charts/seriesData.ts
+++ b/src/charts/seriesData.ts
@@ -3,6 +3,7 @@ import type {
   AxisChartProps,
   AxisChartSeriesConfig,
   ChartCategoryFormatter,
+  ChartTooltipSeries,
   ChartValueAxisOptions,
   ChartValueFormatter,
   ChartYAxisConfig,
@@ -27,6 +28,12 @@ export type AxisChartFormatters = {
 export type NormalizedAxisChart = {
   config: AxisChartBaseConfig
   format: AxisChartFormatters
+  /**
+   * The tooltip-only columns, resolved. They travel beside the config rather
+   * than inside it: the option builders read the config, and nothing an option
+   * builder draws should learn that these exist.
+   */
+  tooltipSeries: ChartTooltipSeries[]
 }
 
 /**
@@ -84,6 +91,14 @@ export function normalizeAxisChartProps(
       y: props.yAxis?.format,
       y2: props.y2Axis?.format,
     },
+    tooltipSeries: (props.tooltipSeries ?? []).map((name) => {
+      const style = props.tooltipSeriesConfig?.[name]
+      return {
+        name,
+        label: style?.label ?? formatLabel(name),
+        format: style?.format,
+      }
+    }),
   }
 }
 

--- a/src/charts/seriesData.ts
+++ b/src/charts/seriesData.ts
@@ -25,7 +25,6 @@ export type AxisChartFormatters = {
   y2?: ChartValueFormatter
 }
 
-/** A `ChartTooltipColumn` after normalization, i.e. with its label filled in. */
 export type ResolvedTooltipColumn = ChartTooltipColumn & { label: string }
 
 export type NormalizedAxisChart = {
@@ -80,6 +79,20 @@ export function normalizeAxisChartProps(
       )
     : { data: rows, names: yColumns }
 
+  // A pivoted row holds one value per key, so a group value equal to a tooltip
+  // column's name lands on the same key and the plotted measure wins. Keeping
+  // the column would print the measure under the column's label.
+  const clobbered = props.series
+    ? tooltipColumns.filter((column) => names.includes(column.name))
+    : []
+
+  if (import.meta.env.DEV && clobbered.length) {
+    const named = clobbered.map((column) => `"${column.name}"`).join(', ')
+    console.warn(
+      `[frappe-ui] \`series="${props.series}"\` produces a series named ${named}, which \`tooltipColumns\` also names. The series keeps the key and the column is dropped. Rename the column, or change the values in "${props.series}".`,
+    )
+  }
+
   return {
     config: {
       data,
@@ -105,7 +118,9 @@ export function normalizeAxisChartProps(
       y: props.yAxis?.format,
       y2: props.y2Axis?.format,
     },
-    tooltipColumns,
+    tooltipColumns: tooltipColumns.filter(
+      (column) => !clobbered.includes(column),
+    ),
   }
 }
 
@@ -149,8 +164,8 @@ function toColumns(value?: string | string[]): string[] {
  * survives. Duplicate (x, series) pairs are last-write-wins.
  *
  * `carry` names columns to copy across untouched. A tooltip column reads per
- * category rather than per group — the tooltip prints one row for it, not one
- * per series — so the first row to reach a category decides its value.
+ * category, not per group, so the first row to reach a category decides its
+ * value.
  */
 function pivot(
   rows: Record<string, any>[],

--- a/src/charts/seriesData.ts
+++ b/src/charts/seriesData.ts
@@ -3,7 +3,7 @@ import type {
   AxisChartProps,
   AxisChartSeriesConfig,
   ChartCategoryFormatter,
-  ChartTooltipSeries,
+  ChartTooltipColumn,
   ChartValueAxisOptions,
   ChartValueFormatter,
   ChartYAxisConfig,
@@ -25,6 +25,9 @@ export type AxisChartFormatters = {
   y2?: ChartValueFormatter
 }
 
+/** A `ChartTooltipColumn` after normalization, i.e. with its label filled in. */
+export type ResolvedTooltipColumn = ChartTooltipColumn & { label: string }
+
 export type NormalizedAxisChart = {
   config: AxisChartBaseConfig
   format: AxisChartFormatters
@@ -33,7 +36,7 @@ export type NormalizedAxisChart = {
    * than inside it: the option builders read the config, and nothing an option
    * builder draws should learn that these exist.
    */
-  tooltipSeries: ChartTooltipSeries[]
+  tooltipColumns: ResolvedTooltipColumn[]
 }
 
 /**
@@ -91,14 +94,10 @@ export function normalizeAxisChartProps(
       y: props.yAxis?.format,
       y2: props.y2Axis?.format,
     },
-    tooltipSeries: (props.tooltipSeries ?? []).map((name) => {
-      const style = props.tooltipSeriesConfig?.[name]
-      return {
-        name,
-        label: style?.label ?? formatLabel(name),
-        format: style?.format,
-      }
-    }),
+    tooltipColumns: (props.tooltipColumns ?? []).map((column) => ({
+      ...column,
+      label: column.label ?? formatLabel(column.name),
+    })),
   }
 }
 

--- a/src/charts/seriesData.ts
+++ b/src/charts/seriesData.ts
@@ -62,9 +62,20 @@ export function normalizeAxisChartProps(
     )
   }
 
+  const tooltipColumns = (props.tooltipColumns ?? []).map((column) => ({
+    ...column,
+    label: column.label ?? formatLabel(column.name),
+  }))
+
   const { data, names } = props.series
     ? capSeries(
-        pivot(rows, props.x, yColumns[0], props.series),
+        pivot(
+          rows,
+          props.x,
+          yColumns[0],
+          props.series,
+          tooltipColumns.map((column) => column.name),
+        ),
         props.maxSeries,
       )
     : { data: rows, names: yColumns }
@@ -94,10 +105,7 @@ export function normalizeAxisChartProps(
       y: props.yAxis?.format,
       y2: props.y2Axis?.format,
     },
-    tooltipColumns: (props.tooltipColumns ?? []).map((column) => ({
-      ...column,
-      label: column.label ?? formatLabel(column.name),
-    })),
+    tooltipColumns,
   }
 }
 
@@ -139,12 +147,17 @@ function toColumns(value?: string | string[]): string[] {
  * Long rows to wide: one row per x value, one column per value of the grouping
  * column. Both orders follow first appearance in the data, so the caller's sort
  * survives. Duplicate (x, series) pairs are last-write-wins.
+ *
+ * `carry` names columns to copy across untouched. A tooltip column reads per
+ * category rather than per group — the tooltip prints one row for it, not one
+ * per series — so the first row to reach a category decides its value.
  */
 function pivot(
   rows: Record<string, any>[],
   x: string,
   y: string,
   series: string,
+  carry: string[] = [],
 ) {
   const names: string[] = []
   // Keyed by the stringified x value: `Date` objects and numbers still have to
@@ -156,10 +169,13 @@ function pivot(
     let wide = byCategory.get(key)
     if (!wide) {
       wide = { [x]: row[x] }
+      for (const column of carry) wide[column] = row[column]
       byCategory.set(key, wide)
     }
     const name = String(row[series])
     if (!names.includes(name)) names.push(name)
+    // Written after the carried columns, so a series named like one of them
+    // keeps the plot's number rather than losing it to the tooltip's.
     wide[name] = row[y]
   }
 

--- a/src/charts/stories/BarCombo.vue
+++ b/src/charts/stories/BarCombo.vue
@@ -22,7 +22,6 @@ const quarterly = [
         format: (value) => `$${(value / 1000).toFixed(0)}k`,
       }"
       :y2-axis="{ title: 'Margin (%)', min: 0, max: 25 }"
-      palette="categorical"
       :series-config="{
         margin: {
           type: 'line',

--- a/src/charts/stories/LineTooltipColumns.vue
+++ b/src/charts/stories/LineTooltipColumns.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { LineChart } from 'frappe-ui/charts'
+
+// A rate is the only thing on the axis. The count it was taken from and the
+// money behind it are two other units, so drawing them would need two more
+// scales to say what the tooltip says in two lines.
+const checkout = [
+  { month: '2025-08-01', conversion_rate: 2.9, orders: 1540, aov: 68.4 },
+  { month: '2025-09-01', conversion_rate: 3.1, orders: 1682, aov: 71.2 },
+  { month: '2025-10-01', conversion_rate: 3.4, orders: 1910, aov: 69.8 },
+  { month: '2025-11-01', conversion_rate: 4.1, orders: 2604, aov: 74.5 },
+  { month: '2025-12-01', conversion_rate: 3.8, orders: 2471, aov: 81.3 },
+  { month: '2026-01-01', conversion_rate: 2.8, orders: 1489, aov: 63.9 },
+  { month: '2026-02-01', conversion_rate: 3.0, orders: 1603, aov: 66.1 },
+  { month: '2026-03-01', conversion_rate: 3.3, orders: 1855, aov: 70.7 },
+  { month: '2026-04-01', conversion_rate: 3.5, orders: 1994, aov: 73.2 },
+  { month: '2026-05-01', conversion_rate: 3.6, orders: 2088, aov: 75.6 },
+  { month: '2026-06-01', conversion_rate: 3.4, orders: 1962, aov: 72.8 },
+  { month: '2026-07-01', conversion_rate: 3.7, orders: 2205, aov: 78.1 },
+]
+</script>
+
+<template>
+  <div class="h-80 w-full">
+    <LineChart
+      :data="checkout"
+      x="month"
+      y="conversion_rate"
+      :x-axis="{ type: 'time', timeGrain: 'month' }"
+      :y-axis="{ title: 'Conversion rate', format: (value) => `${value}%` }"
+      :series-config="{ conversion_rate: { label: 'Conversion rate' } }"
+      :tooltip-columns="[
+        { name: 'orders', label: 'Orders' },
+        {
+          name: 'aov',
+          label: 'Average order value',
+          format: (value) => `$${value}`,
+        },
+      ]"
+      title="Checkout conversion"
+      subtitle="Hover a month: the count and the basket behind the rate"
+    />
+  </div>
+</template>

--- a/src/charts/style.css
+++ b/src/charts/style.css
@@ -76,12 +76,11 @@
      page. Charts flip to white on a fill dark enough to need it. */
   --chart-inside-label: oklch(0.271 0 0);
 
-  /* What a heatmap paints the gap between two cells in. A gap has to be drawn,
-     not left out — a cell is a filled rect, so the only way to separate two of
-     them is a border in whatever is behind the plot. Defaults to the elevated
-     card surface, which is where a chart normally sits; an app that puts one on
-     another background redefines this on that subtree. */
-  --chart-cell-gap: var(--surface-elevation-2);
+  /* The surface behind the plot: what a heatmap paints the gap between two cells
+     in, and what a reference line's label sits on. `--chart-backdrop` is
+     deliberately not set here. A chart reads it off its own ancestors, see
+     `backdropColor` in tokens.ts. Set it for a chart on a background the walk
+     cannot read, such as an image. */
 }
 
 [data-theme='dark'] {

--- a/src/charts/style.css
+++ b/src/charts/style.css
@@ -14,13 +14,18 @@
  */
 :root {
   /* The "Jewel" ramp: ten slots are five hue families — blue, emerald, violet,
-     amber, crimson — each a dark member followed by its light partner, so a
+     amber, red — each a dark member followed by its light partner, so a
      two-series chart opens on one family at two strengths and a five-series one
      never repeats a hue. Slot 1 is the sequential ramp's mid-blue.
 
      The hues sit at jewel-tone depth rather than at their safe positions, so the
      dark members run a step below the anchor's lightness; chroma is capped at
-     0.19 so the violet and the crimson cannot out-shout the blue. */
+     0.19 so the violet and the red cannot out-shout the blue.
+
+     The red family sits at hue 17. It was authored at 5, a crimson, whose light
+     partner lightens into a pink rather than into a warning — so anything
+     reading the ramp for a status had to leave it. 17 keeps the family clear of
+     the amber at 75 while its light partner still reads as red. */
   --chart-categorical-1: #2283c3;
   --chart-categorical-2: #84c5f9;
   --chart-categorical-3: #289e60;
@@ -29,8 +34,8 @@
   --chart-categorical-6: #bb9df1;
   --chart-categorical-7: #c98c28;
   --chart-categorical-8: #f5ca8e;
-  --chart-categorical-9: #ba205a;
-  --chart-categorical-10: #f98da7;
+  --chart-categorical-9: #bd2040;
+  --chart-categorical-10: #fc8e94;
 
   --chart-sequential-1: #095895;
   --chart-sequential-2: #2283c3;
@@ -91,8 +96,8 @@
   --chart-categorical-6: #b294e7;
   --chart-categorical-7: #bf8319;
   --chart-categorical-8: #ebc085;
-  --chart-categorical-9: #af0f52;
-  --chart-categorical-10: #ef849e;
+  --chart-categorical-9: #b20e37;
+  --chart-categorical-10: #f2858b;
 
   --chart-sequential-1: #074677;
   --chart-sequential-2: #1b699c;

--- a/src/charts/tokens.test.ts
+++ b/src/charts/tokens.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveChartTokens } from './tokens'
+
+/** A chart element inside `depth` wrappers, appended to the document. */
+function mount(...backgrounds: (string | undefined)[]) {
+  let parent: HTMLElement = document.body
+  for (const background of backgrounds) {
+    const el = document.createElement('div')
+    if (background) el.style.backgroundColor = background
+    parent.appendChild(el)
+    parent = el
+  }
+  return parent
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  document.documentElement.style.backgroundColor = ''
+  document.documentElement.style.removeProperty('--chart-backdrop')
+})
+
+describe('the surface behind the plot', () => {
+  it('takes the painted background of the chart itself', () => {
+    const el = mount('rgb(20, 20, 20)')
+    expect(resolveChartTokens(el).backdrop).toBe('rgb(20, 20, 20)')
+  })
+
+  it('walks past see-through ancestors to the one that paints', () => {
+    // The card is what a viewer sees behind the plot; the wrappers between the
+    // chart and it are painted by nobody.
+    const el = mount('rgb(40, 40, 40)', undefined, undefined)
+    expect(resolveChartTokens(el).backdrop).toBe('rgb(40, 40, 40)')
+  })
+
+  it('reaches the page when nothing between paints', () => {
+    document.documentElement.style.backgroundColor = 'rgb(10, 10, 10)'
+    expect(resolveChartTokens(mount(undefined)).backdrop).toBe(
+      'rgb(10, 10, 10)',
+    )
+  })
+
+  it('lets the token override the walk, for a background it cannot read', () => {
+    const el = mount('rgb(20, 20, 20)')
+    // Set on the element rather than the root: a custom property inherits in a
+    // browser, but jsdom's getComputedStyle does not walk up for one.
+    el.style.setProperty('--chart-backdrop', '#abcdef')
+    expect(resolveChartTokens(el).backdrop).toBe('#abcdef')
+  })
+
+  it('falls back to the scheme when no ancestor paints at all', () => {
+    expect(resolveChartTokens(mount(undefined)).backdrop).toBe('#ffffff')
+  })
+})

--- a/src/charts/tokens.ts
+++ b/src/charts/tokens.ts
@@ -46,6 +46,7 @@ export const CHART_DIVERGING_LENGTH = 9
  * series keeps its hue across a theme flip. See style.css for the derivation.
  */
 // "Jewel": five hue families, each a dark member then its light partner.
+// blue, emerald, violet, amber, red.
 const LIGHT_CATEGORICAL = [
   '#2283c3',
   '#84c5f9',
@@ -55,8 +56,8 @@ const LIGHT_CATEGORICAL = [
   '#bb9df1',
   '#c98c28',
   '#f5ca8e',
-  '#ba205a',
-  '#f98da7',
+  '#bd2040',
+  '#fc8e94',
 ]
 
 const LIGHT_SEQUENTIAL = [
@@ -94,8 +95,8 @@ const DARK_CATEGORICAL = [
   '#b294e7',
   '#bf8319',
   '#ebc085',
-  '#af0f52',
-  '#ef849e',
+  '#b20e37',
+  '#f2858b',
 ]
 
 const DARK_SEQUENTIAL = [
@@ -214,7 +215,9 @@ export function resolveChartTokens(el?: HTMLElement | null): ChartTokens {
   const diverging = readRamp('--chart-diverging-', CHART_DIVERGING_LENGTH)
 
   return {
-    categorical: categorical.length ? categorical : FALLBACK_CATEGORICAL[scheme],
+    categorical: categorical.length
+      ? categorical
+      : FALLBACK_CATEGORICAL[scheme],
     sequential: sequential.length ? sequential : FALLBACK_SEQUENTIAL[scheme],
     diverging: diverging.length ? diverging : FALLBACK_DIVERGING[scheme],
     axisLabel: read(TOKENS.axisLabel) || fallbacks.axisLabel,
@@ -317,7 +320,9 @@ export function paletteColors(
 function namedRamp(name: ChartPaletteName, tokens: ChartTokens): string[] {
   if (name === 'categorical') return tokens.categorical
   const ramp =
-    name === 'diverging' ? tokens.diverging : usableSequential(tokens.sequential)
+    name === 'diverging'
+      ? tokens.diverging
+      : usableSequential(tokens.sequential)
   return ramp.length ? ramp : tokens.categorical
 }
 

--- a/src/charts/tokens.ts
+++ b/src/charts/tokens.ts
@@ -21,8 +21,8 @@ export type ChartTokens = {
   dataLabel: string
   /** Ink for a label printed on a pale fill rather than beside it. */
   insideLabel: string
-  /** What a heatmap draws between two cells, i.e. the surface behind the plot. */
-  cellGap: string
+  /** The surface behind the plot. Read off the page, not named: see `backdropColor`. */
+  backdrop: string
 }
 
 /**
@@ -153,7 +153,10 @@ const TOKENS = {
   // fill, not to the page, and `--ink-gray-8` inverts to a light gray in dark
   // mode — invisible on the categorical ramp's light-tier stops. See style.css.
   insideLabel: '--chart-inside-label',
-  cellGap: '--chart-cell-gap',
+  // Unset by default, unlike every other token here: the surface behind the plot
+  // is read off the page. This is the override for a chart drawn on something
+  // the walk cannot see, an image say. See `backdropColor`.
+  backdrop: '--chart-backdrop',
 } as const
 
 const FALLBACK_TOKENS: Record<
@@ -167,7 +170,7 @@ const FALLBACK_TOKENS: Record<
     splitLine: 'oklch(0.946 0 0)',
     dataLabel: 'oklch(0.439 0 0)',
     insideLabel: 'oklch(0.271 0 0)',
-    cellGap: '#ffffff',
+    backdrop: '#ffffff',
   },
   dark: {
     axisLabel: 'oklch(0.58 0 0)',
@@ -177,8 +180,33 @@ const FALLBACK_TOKENS: Record<
     dataLabel: 'oklch(0.683 0 0)',
     // Same near-black as light: see the note on `TOKENS.insideLabel`.
     insideLabel: 'oklch(0.271 0 0)',
-    cellGap: '#242424',
+    backdrop: '#242424',
   },
+}
+
+/**
+ * The painted background behind `el`: its first ancestor whose own background is
+ * not see-through, which is what a viewer actually sees behind the plot.
+ *
+ * Not a named surface token, because there is no one surface a chart sits on. A
+ * card puts it on `--surface-elevation-2` and a bare page on `--surface-base`,
+ * and in dark mode those are two different grays, so a plate filled with the
+ * card's color on a page draws a visible box. Light mode hides the mistake
+ * entirely: every light surface token is white.
+ */
+function backdropColor(el: HTMLElement | null | undefined): string {
+  let node: HTMLElement | null = el ?? document.documentElement
+  while (node) {
+    const background = getComputedStyle(node).backgroundColor
+    if (!isTransparent(background)) return background
+    node = node.parentElement
+  }
+  return ''
+}
+
+/** An alpha of zero, in any notation a computed `background-color` comes back in. */
+function isTransparent(color: string) {
+  return !color || color === 'transparent' || /[,/]\s*0\s*\)$/.test(color)
 }
 
 /**
@@ -226,7 +254,7 @@ export function resolveChartTokens(el?: HTMLElement | null): ChartTokens {
     splitLine: read(TOKENS.splitLine) || fallbacks.splitLine,
     dataLabel: read(TOKENS.dataLabel) || fallbacks.dataLabel,
     insideLabel: read(TOKENS.insideLabel) || fallbacks.insideLabel,
-    cellGap: read(TOKENS.cellGap) || fallbacks.cellGap,
+    backdrop: read(TOKENS.backdrop) || backdropColor(el) || fallbacks.backdrop,
   }
 }
 
@@ -380,6 +408,17 @@ export function chartColors(
   return name === 'sequential' && deepEnd === 'last'
     ? colors.slice().reverse()
     : colors
+}
+
+/**
+ * `color` at a fraction of its opacity. `color-mix` rather than an alpha channel
+ * written into the value, because a `--chart-*` token is read back in whatever
+ * notation it was authored in, oklch for the surface tokens and hex for the
+ * ramps, and only a mix takes all of them without a branch per notation. Both the SVG
+ * renderer and the canvas one resolve it.
+ */
+export function translucent(color: string, percent: number) {
+  return `color-mix(in srgb, ${color} ${percent}%, transparent)`
 }
 
 /**

--- a/src/charts/tooltipItems.test.ts
+++ b/src/charts/tooltipItems.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import { buildAxisChartOption } from './axisChartOptions'
+import { normalizeAxisChartProps } from './seriesData'
+import { buildTooltipItems, type TooltipItemsArgs } from './tooltipItems'
+import type { ChartTokens } from './tokens'
+import type { AxisChartProps, ChartTooltipItem } from './types'
+
+// A rate beside the count behind it: two units, which is the case `tooltipSeries`
+// exists for. `orders` is never drawn — it only prints in the tooltip.
+const ROW = { month: 'Jan', conversion: 12, refund_rate: 3, orders: 1840 }
+
+function items(overrides: Partial<TooltipItemsArgs> = {}): ChartTooltipItem[] {
+  return buildTooltipItems({
+    row: ROW,
+    index: 0,
+    series: [{ name: 'conversion' }, { name: 'refund_rate' }],
+    hiddenSeries: [],
+    colors: { conversion: '#111111', refund_rate: '#222222' },
+    formatSeries: (_series, value) => `${value}%`,
+    tooltipSeries: [{ name: 'orders', label: 'Orders' }],
+    ...overrides,
+  })
+}
+
+const labels = (rows: ChartTooltipItem[]) => rows.map((row) => row.label)
+
+describe('a tooltip-only column', () => {
+  it('prints in the tooltip', () => {
+    expect(items().find((row) => row.name === 'orders')).toMatchObject({
+      label: 'Orders',
+      value: 1840,
+      formattedValue: '1,840',
+      kind: 'context',
+    })
+  })
+
+  it('carries no color, so nothing invites the reader to find it on the plot', () => {
+    expect(items().find((row) => row.name === 'orders')?.color).toBeUndefined()
+  })
+
+  it('prints after every series, whatever its magnitude', () => {
+    // 1840 is the largest number in the row. Sorted among the series it would
+    // lead the tooltip, which would read as the biggest contributor.
+    expect(labels(items())).toEqual(['Conversion', 'Refund Rate', 'Orders'])
+  })
+
+  it('holds the order the author gave, rather than being ranked', () => {
+    const rows = items({
+      tooltipSeries: [
+        { name: 'orders', label: 'Orders' },
+        { name: 'refunds', label: 'Refunds' },
+      ],
+      row: { ...ROW, refunds: 9000 },
+    })
+    expect(labels(rows).slice(-2)).toEqual(['Orders', 'Refunds'])
+  })
+
+  it('survives a legend toggle that hides a series', () => {
+    const rows = items({ hiddenSeries: ['conversion'] })
+    expect(labels(rows)).toEqual(['Refund Rate', 'Orders'])
+  })
+
+  it('takes its format from its own config, not from an axis', () => {
+    const rows = items({
+      tooltipSeries: [
+        {
+          name: 'orders',
+          label: 'Orders',
+          format: (value) => `${value} orders`,
+        },
+      ],
+    })
+    // `formatSeries` prints a percent, because the series sit on a rate axis.
+    // An extra sits on no axis, so it never reaches that formatter.
+    expect(rows.at(-1)?.formattedValue).toBe('1840 orders')
+  })
+
+  it('carries a text attribute as well as a number', () => {
+    const rows = items({
+      row: { ...ROW, category: 'Outerwear' },
+      tooltipSeries: [{ name: 'category', label: 'Category' }],
+    })
+    expect(rows.at(-1)).toMatchObject({
+      value: 'Outerwear',
+      formattedValue: 'Outerwear',
+    })
+  })
+
+  it('drops a blank cell rather than printing an empty row', () => {
+    const rows = items({
+      row: { ...ROW, orders: null, target: '' },
+      tooltipSeries: [
+        { name: 'orders', label: 'Orders' },
+        { name: 'target', label: 'Target' },
+      ],
+    })
+    expect(labels(rows)).toEqual(['Conversion', 'Refund Rate'])
+  })
+
+  it('keeps a zero, which is a reading like any other', () => {
+    const rows = items({ row: { ...ROW, orders: 0 } })
+    expect(rows.at(-1)?.formattedValue).toBe('0')
+  })
+})
+
+describe('the series rows are untouched by it', () => {
+  it('still ranks the series by magnitude', () => {
+    const rows = items({ row: { ...ROW, conversion: 1, refund_rate: 50 } })
+    expect(labels(rows)).toEqual(['Refund Rate', 'Conversion', 'Orders'])
+  })
+
+  it('marks a series row as one, so a caller can tell the two apart', () => {
+    expect(items().map((row) => row.kind)).toEqual([
+      'series',
+      'series',
+      'context',
+    ])
+  })
+})
+
+// The claim these guard is that an extra reaches the tooltip and nowhere else.
+// `normalizeAxisChartProps` keeps it out of the config, so no option builder
+// can read it even by mistake.
+
+const tokens: ChartTokens = {
+  categorical: ['#111111', '#222222', '#333333'],
+  sequential: ['#000011', '#000022', '#000033', '#000044', '#000055'],
+  diverging: ['#001100', '#002200', '#003300'],
+  axisLabel: 'ink-5',
+  axisTitle: 'ink-7',
+  axisLine: 'outline-2',
+  splitLine: 'outline-1',
+  dataLabel: 'ink-6',
+  insideLabel: 'ink-8',
+  cellGap: '#ffffff',
+}
+
+function props(overrides: Partial<AxisChartProps> = {}): AxisChartProps {
+  return {
+    data: [
+      { month: 'Jan', conversion: 12, orders: 1840 },
+      { month: 'Feb', conversion: 14, orders: 2100 },
+    ],
+    x: 'month',
+    y: ['conversion'],
+    ...overrides,
+  }
+}
+
+function optionFor(overrides: Partial<AxisChartProps> = {}) {
+  const { config } = normalizeAxisChartProps(props(overrides))
+  return buildAxisChartOption({ ...config, type: 'bar' }, { tokens }) as any
+}
+
+describe('what an extra is kept out of', () => {
+  it('is not a series the config carries', () => {
+    const { config, tooltipSeries } = normalizeAxisChartProps(
+      props({ tooltipSeries: ['orders'] }),
+    )
+    expect(config.series.map((series) => series.name)).toEqual(['conversion'])
+    expect(tooltipSeries).toEqual([
+      { name: 'orders', label: 'Orders', format: undefined },
+    ])
+  })
+
+  it('is not drawn: the option carries the series alone', () => {
+    const drawn = optionFor({ tooltipSeries: ['orders'] })
+    expect(drawn.series.map((series: any) => series.name)).toEqual([
+      'conversion',
+    ])
+  })
+
+  it('does not move the value axis', () => {
+    // 2100 is an order of magnitude over the largest drawn value. An axis that
+    // read it would put every bar in the bottom tenth of the plot.
+    const extent = (option: any) => [option.yAxis.min, option.yAxis.max]
+    expect(extent(optionFor({ tooltipSeries: ['orders'] }))).toEqual(
+      extent(optionFor()),
+    )
+  })
+
+  it('takes its label from `tooltipSeriesConfig`', () => {
+    const { tooltipSeries } = normalizeAxisChartProps(
+      props({
+        tooltipSeries: ['orders'],
+        tooltipSeriesConfig: { orders: { label: 'Orders placed' } },
+      }),
+    )
+    expect(tooltipSeries[0].label).toBe('Orders placed')
+  })
+})

--- a/src/charts/tooltipItems.test.ts
+++ b/src/charts/tooltipItems.test.ts
@@ -185,6 +185,40 @@ describe('what a tooltip-only column is kept out of', () => {
     expect(tooltipColumns[0].label).toBe('Orders')
   })
 
+  it('survives the pivot that long data goes through', () => {
+    // `pivot` rebuilds each row as one x plus one column per group, so a column
+    // it does not carry is gone before the tooltip ever reads it.
+    const { config } = normalizeAxisChartProps({
+      data: [
+        { month: 'Jan', region: 'North', conversion: 12, orders: 1840 },
+        { month: 'Jan', region: 'South', conversion: 9, orders: 1840 },
+        { month: 'Feb', region: 'North', conversion: 14, orders: 2100 },
+      ],
+      x: 'month',
+      y: 'conversion',
+      series: 'region',
+      tooltipColumns: [{ name: 'orders' }],
+    })
+    expect(config.data.map((row) => row.orders)).toEqual([1840, 2100])
+  })
+
+  it('reads a carried column per category, not per group', () => {
+    // One tooltip row is printed for the column, so one value per category is
+    // all there is room for. The first row to reach a category decides it.
+    const { config } = normalizeAxisChartProps({
+      data: [
+        { month: 'Jan', region: 'North', conversion: 12, orders: 900 },
+        { month: 'Jan', region: 'South', conversion: 9, orders: 940 },
+      ],
+      x: 'month',
+      y: 'conversion',
+      series: 'region',
+      tooltipColumns: [{ name: 'orders' }],
+    })
+    expect(config.data).toHaveLength(1)
+    expect(config.data[0].orders).toBe(900)
+  })
+
   it('takes the label the entry gives', () => {
     const { tooltipColumns } = normalizeAxisChartProps(
       props({ tooltipColumns: [{ name: 'orders', label: 'Orders placed' }] }),

--- a/src/charts/tooltipItems.test.ts
+++ b/src/charts/tooltipItems.test.ts
@@ -5,8 +5,9 @@ import { buildTooltipItems, type TooltipItemsArgs } from './tooltipItems'
 import type { ChartTokens } from './tokens'
 import type { AxisChartProps, ChartTooltipItem } from './types'
 
-// A rate beside the count behind it: two units, which is the case `tooltipSeries`
-// exists for. `orders` is never drawn — it only prints in the tooltip.
+// A rate beside the count behind it: two units, which is the case
+// `tooltipColumns` exists for. `orders` is never drawn — it only prints in the
+// tooltip.
 const ROW = { month: 'Jan', conversion: 12, refund_rate: 3, orders: 1840 }
 
 function items(overrides: Partial<TooltipItemsArgs> = {}): ChartTooltipItem[] {
@@ -17,7 +18,7 @@ function items(overrides: Partial<TooltipItemsArgs> = {}): ChartTooltipItem[] {
     hiddenSeries: [],
     colors: { conversion: '#111111', refund_rate: '#222222' },
     formatSeries: (_series, value) => `${value}%`,
-    tooltipSeries: [{ name: 'orders', label: 'Orders' }],
+    tooltipColumns: [{ name: 'orders', label: 'Orders' }],
     ...overrides,
   })
 }
@@ -30,7 +31,7 @@ describe('a tooltip-only column', () => {
       label: 'Orders',
       value: 1840,
       formattedValue: '1,840',
-      kind: 'context',
+      kind: 'column',
     })
   })
 
@@ -46,7 +47,7 @@ describe('a tooltip-only column', () => {
 
   it('holds the order the author gave, rather than being ranked', () => {
     const rows = items({
-      tooltipSeries: [
+      tooltipColumns: [
         { name: 'orders', label: 'Orders' },
         { name: 'refunds', label: 'Refunds' },
       ],
@@ -62,7 +63,7 @@ describe('a tooltip-only column', () => {
 
   it('takes its format from its own config, not from an axis', () => {
     const rows = items({
-      tooltipSeries: [
+      tooltipColumns: [
         {
           name: 'orders',
           label: 'Orders',
@@ -71,14 +72,14 @@ describe('a tooltip-only column', () => {
       ],
     })
     // `formatSeries` prints a percent, because the series sit on a rate axis.
-    // An extra sits on no axis, so it never reaches that formatter.
+    // A column sits on no axis, so it never reaches that formatter.
     expect(rows.at(-1)?.formattedValue).toBe('1840 orders')
   })
 
   it('carries a text attribute as well as a number', () => {
     const rows = items({
       row: { ...ROW, category: 'Outerwear' },
-      tooltipSeries: [{ name: 'category', label: 'Category' }],
+      tooltipColumns: [{ name: 'category', label: 'Category' }],
     })
     expect(rows.at(-1)).toMatchObject({
       value: 'Outerwear',
@@ -89,7 +90,7 @@ describe('a tooltip-only column', () => {
   it('drops a blank cell rather than printing an empty row', () => {
     const rows = items({
       row: { ...ROW, orders: null, target: '' },
-      tooltipSeries: [
+      tooltipColumns: [
         { name: 'orders', label: 'Orders' },
         { name: 'target', label: 'Target' },
       ],
@@ -113,12 +114,12 @@ describe('the series rows are untouched by it', () => {
     expect(items().map((row) => row.kind)).toEqual([
       'series',
       'series',
-      'context',
+      'column',
     ])
   })
 })
 
-// The claim these guard is that an extra reaches the tooltip and nowhere else.
+// The claim these guard is that a column reaches the tooltip and nowhere else.
 // `normalizeAxisChartProps` keeps it out of the config, so no option builder
 // can read it even by mistake.
 
@@ -152,19 +153,17 @@ function optionFor(overrides: Partial<AxisChartProps> = {}) {
   return buildAxisChartOption({ ...config, type: 'bar' }, { tokens }) as any
 }
 
-describe('what an extra is kept out of', () => {
+describe('what a tooltip-only column is kept out of', () => {
   it('is not a series the config carries', () => {
-    const { config, tooltipSeries } = normalizeAxisChartProps(
-      props({ tooltipSeries: ['orders'] }),
+    const { config, tooltipColumns } = normalizeAxisChartProps(
+      props({ tooltipColumns: [{ name: 'orders' }] }),
     )
     expect(config.series.map((series) => series.name)).toEqual(['conversion'])
-    expect(tooltipSeries).toEqual([
-      { name: 'orders', label: 'Orders', format: undefined },
-    ])
+    expect(tooltipColumns).toEqual([{ name: 'orders', label: 'Orders' }])
   })
 
   it('is not drawn: the option carries the series alone', () => {
-    const drawn = optionFor({ tooltipSeries: ['orders'] })
+    const drawn = optionFor({ tooltipColumns: [{ name: 'orders' }] })
     expect(drawn.series.map((series: any) => series.name)).toEqual([
       'conversion',
     ])
@@ -174,18 +173,22 @@ describe('what an extra is kept out of', () => {
     // 2100 is an order of magnitude over the largest drawn value. An axis that
     // read it would put every bar in the bottom tenth of the plot.
     const extent = (option: any) => [option.yAxis.min, option.yAxis.max]
-    expect(extent(optionFor({ tooltipSeries: ['orders'] }))).toEqual(
+    expect(extent(optionFor({ tooltipColumns: [{ name: 'orders' }] }))).toEqual(
       extent(optionFor()),
     )
   })
 
-  it('takes its label from `tooltipSeriesConfig`', () => {
-    const { tooltipSeries } = normalizeAxisChartProps(
-      props({
-        tooltipSeries: ['orders'],
-        tooltipSeriesConfig: { orders: { label: 'Orders placed' } },
-      }),
+  it('falls back to the column name when the entry names no label', () => {
+    const { tooltipColumns } = normalizeAxisChartProps(
+      props({ tooltipColumns: [{ name: 'orders' }] }),
     )
-    expect(tooltipSeries[0].label).toBe('Orders placed')
+    expect(tooltipColumns[0].label).toBe('Orders')
+  })
+
+  it('takes the label the entry gives', () => {
+    const { tooltipColumns } = normalizeAxisChartProps(
+      props({ tooltipColumns: [{ name: 'orders', label: 'Orders placed' }] }),
+    )
+    expect(tooltipColumns[0].label).toBe('Orders placed')
   })
 })

--- a/src/charts/tooltipItems.test.ts
+++ b/src/charts/tooltipItems.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { buildAxisChartOption } from './axisChartOptions'
 import { normalizeAxisChartProps } from './seriesData'
 import { buildTooltipItems, type TooltipItemsArgs } from './tooltipItems'
@@ -217,6 +217,39 @@ describe('what a tooltip-only column is kept out of', () => {
     })
     expect(config.data).toHaveLength(1)
     expect(config.data[0].orders).toBe(900)
+  })
+
+  it('drops a column a series name has taken, rather than printing the measure', () => {
+    // Long data flattens every group onto one row, so a group value equal to a
+    // column's name lands on the same key. Keeping the column would print the
+    // plotted measure under the column's label.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { config, tooltipColumns } = normalizeAxisChartProps({
+      data: [
+        { month: 'Jan', region: 'orders', sales: 12, orders: 1840 },
+        { month: 'Jan', region: 'South', sales: 9, orders: 1840 },
+      ],
+      x: 'month',
+      y: 'sales',
+      series: 'region',
+      tooltipColumns: [{ name: 'orders' }],
+    })
+    // The plot keeps the key: the series is what the reader can point at.
+    expect(config.data[0].orders).toBe(12)
+    expect(tooltipColumns).toEqual([])
+    expect(warn).toHaveBeenCalledOnce()
+    warn.mockRestore()
+  })
+
+  it('keeps a column whose name no series has taken', () => {
+    const { tooltipColumns } = normalizeAxisChartProps({
+      data: [{ month: 'Jan', region: 'North', sales: 12, orders: 1840 }],
+      x: 'month',
+      y: 'sales',
+      series: 'region',
+      tooltipColumns: [{ name: 'orders' }],
+    })
+    expect(tooltipColumns).toEqual([{ name: 'orders', label: 'Orders' }])
   })
 
   it('takes the label the entry gives', () => {

--- a/src/charts/tooltipItems.test.ts
+++ b/src/charts/tooltipItems.test.ts
@@ -133,7 +133,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 function props(overrides: Partial<AxisChartProps> = {}): AxisChartProps {

--- a/src/charts/tooltipItems.ts
+++ b/src/charts/tooltipItems.ts
@@ -1,11 +1,20 @@
-import type { AxisChartSeriesConfig, ChartTooltipItem } from './types'
+import { formatValue } from './format'
 import { seriesLabel } from './seriesData'
+import type {
+  AxisChartSeriesConfig,
+  ChartTooltipItem,
+  ChartTooltipSeries,
+} from './types'
 
 /**
  * The rows a shared tooltip prints for one plotted row.
  *
- * Ranked by magnitude, biggest contributor first: every row here is a mark the
- * reader can find on the plot, so the order says which one dominates.
+ * Two kinds, and the split is the whole point of this module. A `'series'` row
+ * is a mark the reader can find on the plot, so the rows are ranked by
+ * magnitude: biggest contributor first. A `'context'` row is a `tooltipSeries`
+ * column, which is drawn nowhere and is usually measured in another unit — so
+ * ranking it among the series would compare two things that do not compare.
+ * The extras keep the author's order, and print after every series row.
  */
 export type TooltipItemsArgs = {
   /** The plotted row under the pointer. */
@@ -17,30 +26,62 @@ export type TooltipItemsArgs = {
   colors: Record<string, string>
   /** Prints a series value in the unit of the axis it is drawn against. */
   formatSeries: (series: AxisChartSeriesConfig, value: number) => string
-  /** Each series' share of its stack, row by row. Only a normalized plot sets it. */
+  /** Each series' share of its stack, for this row. Only a normalized plot sets it. */
   shares?: Map<string, (number | null)[]>
   /** Index of `row`, which is how `shares` is addressed. */
   index: number
+  tooltipSeries?: ChartTooltipSeries[]
 }
 
 export function buildTooltipItems(args: TooltipItemsArgs): ChartTooltipItem[] {
-  return args.series
-    .filter((series) => !args.hiddenSeries.includes(series.name))
-    .map((series) => {
-      const value = Number(args.row[series.name])
-      return {
-        name: series.name,
-        label: seriesLabel(series),
-        color: args.colors[series.name],
-        value,
-        formattedValue: args.formatSeries(series, value),
-        // A normalized plot draws the share, so the tooltip is the only place
-        // the measured number survives — it carries both.
-        percent: args.shares?.get(series.name)?.[args.index] ?? undefined,
-      }
-    })
-    // A series that silently drops out of the tooltip reads as a bug, so a zero
-    // stays. Only a blank cell is dropped.
-    .filter((item) => !isNaN(item.value))
-    .sort((a, b) => b.value - a.value)
+  return [...seriesItems(args), ...contextItems(args)]
+}
+
+function seriesItems(args: TooltipItemsArgs): ChartTooltipItem[] {
+  return (
+    args.series
+      .filter((series) => !args.hiddenSeries.includes(series.name))
+      .map((series) => {
+        const value = Number(args.row[series.name])
+        return {
+          name: series.name,
+          label: seriesLabel(series),
+          color: args.colors[series.name],
+          value,
+          formattedValue: args.formatSeries(series, value),
+          // A normalized plot draws the share, so the tooltip is the only place
+          // the measured number survives — it carries both.
+          percent: args.shares?.get(series.name)?.[args.index] ?? undefined,
+          kind: 'series' as const,
+        }
+      })
+      // A series that silently drops out of the tooltip reads as a bug, so a zero
+      // stays. Only a blank cell is dropped.
+      .filter((item) => !isNaN(item.value as number))
+      .sort((a, b) => (b.value as number) - (a.value as number))
+  )
+}
+
+function contextItems(args: TooltipItemsArgs): ChartTooltipItem[] {
+  return (args.tooltipSeries ?? [])
+    .map((extra) => ({ extra, value: args.row[extra.name] }))
+    .filter(
+      ({ value }) => value !== null && value !== undefined && value !== '',
+    )
+    .map(({ extra, value }) => ({
+      name: extra.name,
+      label: extra.label,
+      value: typeof value === 'number' ? value : String(value),
+      formattedValue: formatContextValue(extra, value),
+      kind: 'context' as const,
+    }))
+}
+
+/**
+ * An extra sits on no axis, so it takes no formatter from one: its own, or the
+ * default. Only a number is formatted — anything else is already text.
+ */
+function formatContextValue(extra: ChartTooltipSeries, value: any) {
+  if (extra.format) return extra.format(value)
+  return typeof value === 'number' ? formatValue(value) : String(value)
 }

--- a/src/charts/tooltipItems.ts
+++ b/src/charts/tooltipItems.ts
@@ -1,0 +1,46 @@
+import type { AxisChartSeriesConfig, ChartTooltipItem } from './types'
+import { seriesLabel } from './seriesData'
+
+/**
+ * The rows a shared tooltip prints for one plotted row.
+ *
+ * Ranked by magnitude, biggest contributor first: every row here is a mark the
+ * reader can find on the plot, so the order says which one dominates.
+ */
+export type TooltipItemsArgs = {
+  /** The plotted row under the pointer. */
+  row: Record<string, any>
+  series: AxisChartSeriesConfig[]
+  /** Series the legend has switched off, by name. */
+  hiddenSeries: string[]
+  /** Keyed by series name. */
+  colors: Record<string, string>
+  /** Prints a series value in the unit of the axis it is drawn against. */
+  formatSeries: (series: AxisChartSeriesConfig, value: number) => string
+  /** Each series' share of its stack, row by row. Only a normalized plot sets it. */
+  shares?: Map<string, (number | null)[]>
+  /** Index of `row`, which is how `shares` is addressed. */
+  index: number
+}
+
+export function buildTooltipItems(args: TooltipItemsArgs): ChartTooltipItem[] {
+  return args.series
+    .filter((series) => !args.hiddenSeries.includes(series.name))
+    .map((series) => {
+      const value = Number(args.row[series.name])
+      return {
+        name: series.name,
+        label: seriesLabel(series),
+        color: args.colors[series.name],
+        value,
+        formattedValue: args.formatSeries(series, value),
+        // A normalized plot draws the share, so the tooltip is the only place
+        // the measured number survives — it carries both.
+        percent: args.shares?.get(series.name)?.[args.index] ?? undefined,
+      }
+    })
+    // A series that silently drops out of the tooltip reads as a bug, so a zero
+    // stays. Only a blank cell is dropped.
+    .filter((item) => !isNaN(item.value))
+    .sort((a, b) => b.value - a.value)
+}

--- a/src/charts/tooltipItems.ts
+++ b/src/charts/tooltipItems.ts
@@ -1,40 +1,27 @@
 import { formatValue } from './format'
-import { seriesLabel } from './seriesData'
-import type {
-  AxisChartSeriesConfig,
-  ChartTooltipItem,
-  ChartTooltipSeries,
-} from './types'
+import { seriesLabel, type ResolvedTooltipColumn } from './seriesData'
+import type { AxisChartSeriesConfig, ChartTooltipItem } from './types'
 
 /**
- * The rows a shared tooltip prints for one plotted row.
- *
- * Two kinds, and the split is the whole point of this module. A `'series'` row
- * is a mark the reader can find on the plot, so the rows are ranked by
- * magnitude: biggest contributor first. A `'context'` row is a `tooltipSeries`
- * column, which is drawn nowhere and is usually measured in another unit — so
- * ranking it among the series would compare two things that do not compare.
- * The extras keep the author's order, and print after every series row.
+ * The rows a shared tooltip prints for one plotted row. Series rows are ranked
+ * by magnitude, biggest first. Column rows are drawn nowhere and usually in
+ * another unit, so they keep the author's order and print after every series.
  */
 export type TooltipItemsArgs = {
-  /** The plotted row under the pointer. */
   row: Record<string, any>
   series: AxisChartSeriesConfig[]
-  /** Series the legend has switched off, by name. */
   hiddenSeries: string[]
-  /** Keyed by series name. */
   colors: Record<string, string>
   /** Prints a series value in the unit of the axis it is drawn against. */
   formatSeries: (series: AxisChartSeriesConfig, value: number) => string
   /** Each series' share of its stack, for this row. Only a normalized plot sets it. */
   shares?: Map<string, (number | null)[]>
-  /** Index of `row`, which is how `shares` is addressed. */
   index: number
-  tooltipSeries?: ChartTooltipSeries[]
+  tooltipColumns?: ResolvedTooltipColumn[]
 }
 
 export function buildTooltipItems(args: TooltipItemsArgs): ChartTooltipItem[] {
-  return [...seriesItems(args), ...contextItems(args)]
+  return [...seriesItems(args), ...columnItems(args)]
 }
 
 function seriesItems(args: TooltipItemsArgs): ChartTooltipItem[] {
@@ -62,26 +49,22 @@ function seriesItems(args: TooltipItemsArgs): ChartTooltipItem[] {
   )
 }
 
-function contextItems(args: TooltipItemsArgs): ChartTooltipItem[] {
-  return (args.tooltipSeries ?? [])
-    .map((extra) => ({ extra, value: args.row[extra.name] }))
+function columnItems(args: TooltipItemsArgs): ChartTooltipItem[] {
+  return (args.tooltipColumns ?? [])
+    .map((column) => ({ column, value: args.row[column.name] }))
     .filter(
       ({ value }) => value !== null && value !== undefined && value !== '',
     )
-    .map(({ extra, value }) => ({
-      name: extra.name,
-      label: extra.label,
+    .map(({ column, value }) => ({
+      name: column.name,
+      label: column.label,
       value: typeof value === 'number' ? value : String(value),
-      formattedValue: formatContextValue(extra, value),
-      kind: 'context' as const,
+      formattedValue: formatColumnValue(column, value),
+      kind: 'column' as const,
     }))
 }
 
-/**
- * An extra sits on no axis, so it takes no formatter from one: its own, or the
- * default. Only a number is formatted — anything else is already text.
- */
-function formatContextValue(extra: ChartTooltipSeries, value: any) {
-  if (extra.format) return extra.format(value)
+function formatColumnValue(column: ResolvedTooltipColumn, value: any) {
+  if (column.format) return column.format(value)
   return typeof value === 'number' ? formatValue(value) : String(value)
 }

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -565,11 +565,19 @@ export type ChartLegendItem = {
 export type ChartTooltipItem = {
   name: string
   label: string
-  color: string
-  value: number
+  /** Left out by a `'context'` item: a swatch would claim a mark on the plot. */
+  color?: string
+  /** A `'context'` item may carry a text attribute, so it is not always a number. */
+  value: number | string
   formattedValue: string
   /** Share of the total, printed after the value. Only part-to-whole charts set it. */
   percent?: number
+  /**
+   * `'series'` is a row the plot draws, and is the default. `'context'` is a
+   * `tooltipSeries` column: it reaches the tooltip and nothing else, and is
+   * printed after the series rows.
+   */
+  kind?: 'series' | 'context'
 }
 
 export type ChartDatapointEvent = {
@@ -593,6 +601,9 @@ export type ChartValueFormatter = (value: number) => string
 
 /** A category axis carries whatever the column holds, so its formatter takes any. */
 export type ChartCategoryFormatter = (value: any) => string
+
+/** Prints a tooltip-only value, which may be a text attribute rather than a number. */
+export type ChartTooltipFormatter = (value: number | string) => string
 
 export type ChartBaseProps = {
   /** Heads the card. Left out, the chart draws no header row at all. */
@@ -695,6 +706,28 @@ export type SeriesStyle = {
   echartOptions?: EchartOptionsOverride
 }
 
+/**
+ * Look of a tooltip-only column. A `tooltipSeries` column draws no mark, so it
+ * has no color, no axis and no stack — only what it is called, and how it prints.
+ */
+export type TooltipSeriesStyle = {
+  /** Display name. The `tooltipSeriesConfig` key stays the identity. */
+  label?: string
+  /**
+   * Prints this column's value in the tooltip. An extra sits on no axis, so it
+   * takes no formatter from one. Left out, a number prints with the default
+   * grouping and anything else prints as it stands.
+   */
+  format?: ChartTooltipFormatter
+}
+
+/** One tooltip-only column, with its style already resolved. */
+export type ChartTooltipSeries = {
+  name: string
+  label: string
+  format?: ChartTooltipFormatter
+}
+
 export type AxisChartProps = ChartBaseProps & {
   /** The rows to plot. One row is one position on the category axis. */
   data: Record<string, any>[]
@@ -723,6 +756,17 @@ export type AxisChartProps = ChartBaseProps & {
    * reader hid across a reload. Left unbound, the legend owns it.
    */
   hiddenSeries?: string[]
+  /**
+   * Columns that reach the tooltip and nothing else: no mark, no legend entry,
+   * no palette slot, and no effect on the value axis. For context in another
+   * unit — the count behind a rate, the target beside the actual.
+   *
+   * They print after the series rows, in the order given, because a value in
+   * another unit says nothing when it is ranked among the series.
+   */
+  tooltipSeries?: string[]
+  /** Keyed by column name, the way `seriesConfig` is keyed by series. */
+  tooltipSeriesConfig?: Record<string, TooltipSeriesStyle>
   /** The category axis: its title, how the `x` column reads, and label format. */
   xAxis?: ChartXAxisOptions
   /** The primary value axis: its title, its range, and how a value prints. */

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -117,7 +117,7 @@ export type ReferenceLine = {
   axis?: 'y' | 'y2' | 'x'
   /** Printed at the far end of the line. Left out, the rule carries no text. */
   label?: string
-  /** Defaults to the ink data labels are printed in, so it reads as an annotation. */
+  /** Defaults to the ink the axis labels are printed in, so it reads as furniture. */
   color?: string
   /** Breaks the rule up, for a line that should not read as a hard boundary. */
   dashed?: boolean

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -565,19 +565,19 @@ export type ChartLegendItem = {
 export type ChartTooltipItem = {
   name: string
   label: string
-  /** Left out by a `'context'` item: a swatch would claim a mark on the plot. */
+  /** Left out by a `'column'` item: a swatch would claim a mark on the plot. */
   color?: string
-  /** A `'context'` item may carry a text attribute, so it is not always a number. */
+  /** A `'column'` item may carry a text attribute, so it is not always a number. */
   value: number | string
   formattedValue: string
   /** Share of the total, printed after the value. Only part-to-whole charts set it. */
   percent?: number
   /**
-   * `'series'` is a row the plot draws, and is the default. `'context'` is a
-   * `tooltipSeries` column: it reaches the tooltip and nothing else, and is
+   * `'series'` is a row the plot draws, and is the default. `'column'` is a
+   * `tooltipColumns` entry: it reaches the tooltip and nothing else, and is
    * printed after the series rows.
    */
-  kind?: 'series' | 'context'
+  kind?: 'series' | 'column'
 }
 
 export type ChartDatapointEvent = {
@@ -707,24 +707,18 @@ export type SeriesStyle = {
 }
 
 /**
- * Look of a tooltip-only column. A `tooltipSeries` column draws no mark, so it
- * has no color, no axis and no stack — only what it is called, and how it prints.
+ * One tooltip-only column: it reaches the tooltip and nothing else — no mark,
+ * no legend entry, no palette slot, and no effect on the value axis.
  */
-export type TooltipSeriesStyle = {
-  /** Display name. The `tooltipSeriesConfig` key stays the identity. */
+export type ChartTooltipColumn = {
+  /** Row key. Also the label when none is given. */
+  name: string
   label?: string
   /**
-   * Prints this column's value in the tooltip. An extra sits on no axis, so it
-   * takes no formatter from one. Left out, a number prints with the default
-   * grouping and anything else prints as it stands.
+   * Prints this column's value. A column sits on no axis, so it takes no
+   * formatter from one. Left out, a number prints with the default grouping
+   * and anything else prints as it stands.
    */
-  format?: ChartTooltipFormatter
-}
-
-/** One tooltip-only column, with its style already resolved. */
-export type ChartTooltipSeries = {
-  name: string
-  label: string
   format?: ChartTooltipFormatter
 }
 
@@ -764,9 +758,7 @@ export type AxisChartProps = ChartBaseProps & {
    * They print after the series rows, in the order given, because a value in
    * another unit says nothing when it is ranked among the series.
    */
-  tooltipSeries?: string[]
-  /** Keyed by column name, the way `seriesConfig` is keyed by series. */
-  tooltipSeriesConfig?: Record<string, TooltipSeriesStyle>
+  tooltipColumns?: ChartTooltipColumn[]
   /** The category axis: its title, how the `x` column reads, and label format. */
   xAxis?: ChartXAxisOptions
   /** The primary value axis: its title, its range, and how a value prints. */

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -142,6 +142,8 @@ export type AxisChartBaseConfig = {
   /**
    * Ramp series colors are drawn from. Defaults to `'sequential'`: one series
    * gets a single mid-blue, more get evenly spaced stops running dark to light.
+   * A chart of mixed marks spends those stops by mark rather than by series
+   * order — see `resolveSeriesColors`.
    */
   palette?: ChartPalette
   /** Forces layout direction; defaults to document.documentElement.dir */

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -567,16 +567,11 @@ export type ChartTooltipItem = {
   label: string
   /** Left out by a `'column'` item: a swatch would claim a mark on the plot. */
   color?: string
-  /** A `'column'` item may carry a text attribute, so it is not always a number. */
   value: number | string
   formattedValue: string
   /** Share of the total, printed after the value. Only part-to-whole charts set it. */
   percent?: number
-  /**
-   * `'series'` is a row the plot draws, and is the default. `'column'` is a
-   * `tooltipColumns` entry: it reaches the tooltip and nothing else, and is
-   * printed after the series rows.
-   */
+  /** `'column'` is a `tooltipColumns` entry. Left out, `'series'`. */
   kind?: 'series' | 'column'
 }
 
@@ -602,7 +597,7 @@ export type ChartValueFormatter = (value: number) => string
 /** A category axis carries whatever the column holds, so its formatter takes any. */
 export type ChartCategoryFormatter = (value: any) => string
 
-/** Prints a tooltip-only value, which may be a text attribute rather than a number. */
+/** A tooltip column may hold text, so its formatter takes either. */
 export type ChartTooltipFormatter = (value: number | string) => string
 
 export type ChartBaseProps = {
@@ -706,18 +701,14 @@ export type SeriesStyle = {
   echartOptions?: EchartOptionsOverride
 }
 
-/**
- * One tooltip-only column: it reaches the tooltip and nothing else — no mark,
- * no legend entry, no palette slot, and no effect on the value axis.
- */
+/** One `tooltipColumns` entry. */
 export type ChartTooltipColumn = {
   /** Row key. Also the label when none is given. */
   name: string
   label?: string
   /**
-   * Prints this column's value. A column sits on no axis, so it takes no
-   * formatter from one. Left out, a number prints with the default grouping
-   * and anything else prints as it stands.
+   * A column sits on no axis, so it takes no formatter from one. Left out, a
+   * number prints with the default grouping and text prints as it stands.
    */
   format?: ChartTooltipFormatter
 }
@@ -753,10 +744,8 @@ export type AxisChartProps = ChartBaseProps & {
   /**
    * Columns that reach the tooltip and nothing else: no mark, no legend entry,
    * no palette slot, and no effect on the value axis. For context in another
-   * unit — the count behind a rate, the target beside the actual.
-   *
-   * They print after the series rows, in the order given, because a value in
-   * another unit says nothing when it is ranked among the series.
+   * unit, such as the count behind a rate. They print after the series rows,
+   * in the order given: a value in another unit cannot be ranked among them.
    */
   tooltipColumns?: ChartTooltipColumn[]
   /** The category axis: its title, how the `x` column reads, and label format. */
@@ -1039,6 +1028,11 @@ export type ChartTooltipProps = {
   label?: string
   /** One row per reading, in the order they should be read. */
   items: ChartTooltipItem[]
+  /**
+   * The data row under the pointer, so the slot can read a column the chart
+   * never plotted. Left out by charts that hover an aggregate.
+   */
+  row?: Record<string, any>
   /** Forces layout direction; defaults to document.documentElement.dir */
   dir?: ChartDir
 }
@@ -1081,9 +1075,14 @@ export type AxisChartSlots = ChartActionsSlot &
   ChartStateSlots & {
     /**
      * Replaces the tooltip body. `items` holds one entry per visible series at
-     * the hovered category, biggest first.
+     * the hovered category, biggest first. `row` is the data row behind them,
+     * so a replacement body can read a column the chart never plotted.
      */
-    tooltip?: (props: { label?: string; items: ChartTooltipItem[] }) => unknown
+    tooltip?: (props: {
+      label?: string
+      items: ChartTooltipItem[]
+      row?: Record<string, any>
+    }) => unknown
   }
 
 export type BarChartEmits = AxisChartEmits
@@ -1215,5 +1214,9 @@ export type ChartLegendEmits = {
 
 export type ChartTooltipSlots = {
   /** Replaces the whole tooltip body, headline row included. */
-  default: (props: { label?: string; items: ChartTooltipItem[] }) => unknown
+  default: (props: {
+    label?: string
+    items: ChartTooltipItem[]
+    row?: Record<string, any>
+  }) => unknown
 }

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -96,6 +96,13 @@ export type AxisChartSeriesConfig = {
  * budget, or the date something changed. An annotation rather than a series —
  * it has no legend entry, cannot be switched off, and is never in the tooltip.
  */
+/** An end of a reference line, and a side of it. See `ReferenceLine.labelPlacement`. */
+export type ReferenceLineLabelPlacement =
+  | 'start-top'
+  | 'start-bottom'
+  | 'end-top'
+  | 'end-bottom'
+
 export type ReferenceLine = {
   /**
    * Where the line sits: a number on a value axis, or whatever the category
@@ -115,8 +122,16 @@ export type ReferenceLine = {
    * with `xAxis.type: 'value'` reads `'x'` the same way: a number on the scale.
    */
   axis?: 'y' | 'y2' | 'x'
-  /** Printed at the far end of the line. Left out, the rule carries no text. */
+  /** Printed on the line. Left out, the rule carries no text. */
   label?: string
+  /**
+   * Where the label sits, as an end of the rule and a side of it. Defaults to
+   * `'end-top'`. Move it when the default lands on a mark or on another rule's
+   * label. The ends are read in the direction of the axis the rule runs along,
+   * so an RTL chart swaps them. A rule drawn down the plot carries its label
+   * rotated, so its sides are the left and the right of it.
+   */
+  labelPlacement?: ReferenceLineLabelPlacement
   /** Defaults to the ink the axis labels are printed in, so it reads as furniture. */
   color?: string
   /** Breaks the rule up, for a line that should not read as a hard boundary. */
@@ -143,7 +158,7 @@ export type AxisChartBaseConfig = {
    * Ramp series colors are drawn from. Defaults to `'sequential'`: one series
    * gets a single mid-blue, more get evenly spaced stops running dark to light.
    * A chart of mixed marks spends those stops by mark rather than by series
-   * order — see `resolveSeriesColors`.
+   * order: see `resolveSeriesColors`.
    */
   palette?: ChartPalette
   /** Forces layout direction; defaults to document.documentElement.dir */

--- a/src/charts/valueAxisOptions.test.ts
+++ b/src/charts/valueAxisOptions.test.ts
@@ -15,7 +15,7 @@ const tokens: ChartTokens = {
   splitLine: 'outline-1',
   dataLabel: 'ink-6',
   insideLabel: 'ink-8',
-  cellGap: '#ffffff',
+  backdrop: '#ffffff',
 }
 
 /**


### PR DESCRIPTION
`tooltipColumns` on `BarChart`, `LineChart` and `AreaChart`: columns that reach the tooltip and nothing else.

```vue
<BarChart
  :data="data"
  x="month"
  :y="['conversion_rate']"
  :tooltip-columns="[{ name: 'orders', label: 'Orders' }]"
/>
```

A column takes no mark, no legend entry, no palette slot and no place on the value axis. It travels beside the config, so no option builder can read one by mistake. That seam is the part worth reviewing.

The `#tooltip` slot also gets `row`, so a tooltip the app draws itself reaches any column without this prop.

`ChartTooltipItem`: `value` widens to `number | string`, `color` becomes optional, `kind` is new: `'series' | 'column'`, default `'series'`.

| Before | After |
|--------|--------|
| <img width="1844" height="971" alt="before" src="https://github.com/user-attachments/assets/b444a9da-9a6f-4762-9430-d2f6704d87e3" /> | <img width="1841" height="965" alt="after" src="https://github.com/user-attachments/assets/9857cc50-8a71-4e88-a9f2-8ef20663a1ae" /> |

## Reference lines

A rule read as a gridline: same dot texture, same weight as the marks. It now takes the axis-label ink, a dash of its own at a hairline, the top layer, and a label plate filled with the surface behind the plot. That surface is read off the page rather than named, because a card and a bare page sit on different grays in dark mode. `cellGap` becomes `backdrop`. The `backdropColor` walk in `tokens.ts` is the part worth a second look, since it reads computed styles at build time.

`labelPlacement` names an end of the rule and a side of it: `'end-top'` (the default), `'end-bottom'`, `'start-top'`, `'start-bottom'`. The names pass straight to echarts, so an RTL chart swaps the ends itself.

| Before | After |
|--------|--------|
| <img width="1480" height="708" alt="CleanShot 2026-09-08 at 18 25 50@2x" src="https://github.com/user-attachments/assets/bd1d87a9-b3de-493c-99a8-9ae2236bb9e0" /> | <img width="1482" height="708" alt="CleanShot 2026-09-08 at 18 48 08@2x" src="https://github.com/user-attachments/assets/4a38b545-68fc-42db-8de6-2dbbb8599276" /> | 

## Also in here

Tooltip
- `pivot` dropped tooltip columns on long data.
- A tooltip stayed pinned when the page scrolled, the window resized, or the data changed under it. One composable now closes it, in all six charts.
- The border never showed under the shadow. Dropped.
- The bar hover band ignored the theme. Now the gridline token at 70%.

Color
- Categorical slots 9 and 10 move off crimson to hue 17, so the light partner still reads as red.
- A combo chart spent the sequential ramp by list order, so a 2px line could land on the palest stop. The thinnest mark now takes the deep end.

Axis and layout
- A value axis went blank when the legend hid its last series. It now holds its ends and fades.
- The entry animation played on the empty option a chart sets while fetching, so async data never got it.
- The funnel's stage labels sat too close to the value.

Housekeeping
- `HeatmapChart.vue` held a literal NUL byte, so grep skipped the file. Same character, written as an escape.

<!-- coverage-report:start -->
Coverage: 73.14% (+0.19% vs `main`)
<!-- coverage-report:end -->












