### PR TITLE
fix(editor): open mentions after opening brackets and quotes

### DIFF
--- a/docs/content/docs/changelog.md
+++ b/docs/content/docs/changelog.md
@@ -9,6 +9,12 @@ one-time dev-mode warning (unless noted). Removal is post-v1.
 
 ## Unreleased
 
+### Editor — mentions open after brackets and quotes
+
+Typing `@` after an opening bracket or quote (`(@jane`, `[@jane`, `"@jane`) now opens the mention list. TipTap only allowed a space before the trigger, so those sequences never matched. Emails (`jane@example.com`) still do not.
+
+`SuggestionExtension.configure` accepts `allowedPrefixes` for custom suggesters that need the same behaviour.
+
 ### Calendar — the Month view is a continuous strip that shows every event
 
 The Month view no longer draws a fixed 5- or 6-row grid that hid whatever

--- a/docs/content/docs/molecules/editor.md
+++ b/docs/content/docs/molecules/editor.md
@@ -83,6 +83,8 @@ To pick a different *named* size altogether, pass a Tailwind Typography size mod
 
 Build custom `@`, `#`, `/`, or `:` suggestion menus with `SuggestionExtension.configure(...)`, then pass the configured extension to a kit or to `useEditor`. The kits use this internally for `mention` (`@`) and `tag` (`#`).
 
+`allowSpaces` lets the query contain spaces. `allowedPrefixes` is the list of characters that may sit immediately before the trigger (TipTap's default is a space); pass `null` to allow any. Mentions in the kits already open after brackets and quotes.
+
 ```ts
 import { SuggestionExtension } from 'frappe-ui/editor'
 

--- a/src/molecules/editor/SuggestionExtension.ts
+++ b/src/molecules/editor/SuggestionExtension.ts
@@ -17,10 +17,21 @@ export type SuggestionExtensionOptions<TItem = any> = {
   component?: Component
   floatingOptions?: SuggestionFloatingOptions
   allowSpaces?: boolean
-  command: (props: { editor: Editor; item: TItem; range: SuggestionRange }) => void
+  /**
+   * TipTap joins this into a regex character class with no extra escaping.
+   * Keep entries to a single character; do not use `]`, `-`, or a leading `^`.
+   */
+  allowedPrefixes?: string[] | null
+  command: (props: {
+    editor: Editor
+    item: TItem
+    range: SuggestionRange
+  }) => void
 }
 
-function buildSuggestionExtension<TItem = any>(options: SuggestionExtensionOptions<TItem>) {
+function buildSuggestionExtension<TItem = any>(
+  options: SuggestionExtensionOptions<TItem>,
+) {
   return Extension.create({
     name: options.name,
     addOptions() {
@@ -28,10 +39,21 @@ function buildSuggestionExtension<TItem = any>(options: SuggestionExtensionOptio
         suggestion: {
           char: options.trigger,
           allowSpaces: options.allowSpaces,
+          allowedPrefixes: options.allowedPrefixes,
           pluginKey: new PluginKey(options.name),
           items: ({ query }: { query: string }) =>
-            typeof options.items === 'function' ? options.items(query) : options.items,
-          command: ({ editor, range, props }: { editor: Editor; range: Range; props: TItem }) => {
+            typeof options.items === 'function'
+              ? options.items(query)
+              : options.items,
+          command: ({
+            editor,
+            range,
+            props,
+          }: {
+            editor: Editor
+            range: Range
+            props: TItem
+          }) => {
             options.command({ editor, item: props, range })
           },
           render: options.component

--- a/src/molecules/editor/SuggestionExtension.ts
+++ b/src/molecules/editor/SuggestionExtension.ts
@@ -20,6 +20,7 @@ export type SuggestionExtensionOptions<TItem = any> = {
   /**
    * TipTap joins this into a regex character class with no extra escaping.
    * Keep entries to a single character; do not use `]`, `-`, or a leading `^`.
+   * An empty array is not useful: every prefix fails the matcher.
    */
   allowedPrefixes?: string[] | null
   command: (props: {

--- a/src/molecules/editor/extensions/mention/mention-extension.test.ts
+++ b/src/molecules/editor/extensions/mention/mention-extension.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * TipTap only opens `@` after a space by default. Mentions also have to fire
+ * after opening brackets and quotes (`(@jane`) without matching emails
+ * (`jane@example.com`).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { Editor } from '@tiptap/core'
+import { Document } from '@tiptap/extension-document'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { PluginKey } from '@tiptap/pm/state'
+import { MentionExtension } from './mention-extension'
+
+const openEditors: Editor[] = []
+
+function makeEditor() {
+  const editor = new Editor({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      MentionExtension.configure({
+        items: [{ id: 'jane', label: 'Jane' }],
+      }),
+    ],
+    content: '<p></p>',
+  })
+  openEditors.push(editor)
+  return editor
+}
+
+function mentionActive(editor: Editor) {
+  const ext = editor.extensionManager.extensions.find(
+    (e) => e.name === 'mentionSuggestion',
+  )
+  const key = ext?.options.suggestion.pluginKey as PluginKey | undefined
+  return Boolean(
+    key && (key.getState(editor.state) as { active?: boolean })?.active,
+  )
+}
+
+describe('Mention allowedPrefixes', () => {
+  afterEach(() => {
+    while (openEditors.length) openEditors.pop()?.destroy()
+  })
+
+  it('opens at the start of a paragraph and after a space', () => {
+    const editor = makeEditor()
+    editor.commands.insertContent('@')
+    expect(mentionActive(editor)).toBe(true)
+
+    editor.commands.setContent('<p></p>')
+    editor.commands.insertContent('hello @')
+    expect(mentionActive(editor)).toBe(true)
+  })
+
+  it.each(['(', '[', '{', '<', '（', '【', '《', '"', "'"])(
+    'opens immediately after %s',
+    (prefix) => {
+      const editor = makeEditor()
+      editor.commands.insertContent(`${prefix}@`)
+      expect(mentionActive(editor)).toBe(true)
+    },
+  )
+
+  it('does not open in the middle of an email address', () => {
+    const editor = makeEditor()
+    editor.commands.insertContent('jane@')
+    expect(mentionActive(editor)).toBe(false)
+  })
+})

--- a/src/molecules/editor/extensions/mention/mention-extension.test.ts
+++ b/src/molecules/editor/extensions/mention/mention-extension.test.ts
@@ -49,12 +49,8 @@ function type(editor: Editor, text: string) {
   for (const char of text) {
     const { from, to } = editor.state.selection
     const handled = editor.view.someProp('handleTextInput', (handler) =>
-      handler(
-        editor.view,
-        from,
-        to,
-        char,
-        () => editor.state.tr.insertText(char),
+      handler(editor.view, from, to, char, () =>
+        editor.state.tr.insertText(char),
       ),
     )
     if (!handled) editor.view.dispatch(editor.state.tr.insertText(char))
@@ -76,14 +72,41 @@ describe('Mention allowedPrefixes', () => {
     expect(mentionActive(editor)).toBe(true)
   })
 
-  it.each(['(', '[', '{', '<', '（', '【', '《', '"', "'", '“', '”', '‘', '’'])(
-    'opens immediately after %s',
-    (prefix) => {
-      const editor = makeEditor()
-      editor.commands.insertContent(`${prefix}@`)
-      expect(mentionActive(editor)).toBe(true)
-    },
-  )
+  it.each([
+    '(',
+    '[',
+    '{',
+    '<',
+    '（',
+    '【',
+    '《',
+    '「',
+    '『',
+    '«',
+    '‹',
+    '"',
+    "'",
+    '“',
+    '”',
+    '‘',
+    '’',
+    '」',
+    '』',
+    '»',
+    '›',
+  ])('opens immediately after %s', (prefix) => {
+    const editor = makeEditor()
+    editor.commands.insertContent(`${prefix}@`)
+    expect(mentionActive(editor)).toBe(true)
+  })
+
+  it('opens the toolbar mention after a bracket without inserting a space', () => {
+    const editor = makeEditor()
+    editor.commands.insertContent('(')
+    expect(editor.commands.openSuggestionMenu('mentionSuggestion')).toBe(true)
+    expect(editor.state.doc.textContent).toBe('(@')
+    expect(mentionActive(editor)).toBe(true)
+  })
 
   it('opens after a quote that Typography has already curled', () => {
     const editor = makeEditor([Typography])

--- a/src/molecules/editor/extensions/mention/mention-extension.test.ts
+++ b/src/molecules/editor/extensions/mention/mention-extension.test.ts
@@ -120,6 +120,12 @@ describe('Mention allowedPrefixes', () => {
     expect(mentionActive(editor)).toBe(true)
   })
 
+  it('opens after a pasted non-breaking space', () => {
+    const editor = makeEditor()
+    editor.commands.insertContent('\u00a0@')
+    expect(mentionActive(editor)).toBe(true)
+  })
+
   it('does not open in the middle of an email address', () => {
     const editor = makeEditor()
     editor.commands.insertContent('jane@')

--- a/src/molecules/editor/extensions/mention/mention-extension.test.ts
+++ b/src/molecules/editor/extensions/mention/mention-extension.test.ts
@@ -3,7 +3,8 @@
  *
  * TipTap only opens `@` after a space by default. Mentions also have to fire
  * after opening brackets and quotes (`(@jane`) without matching emails
- * (`jane@example.com`).
+ * (`jane@example.com`). Typography rewrites straight quotes to curly ones, so
+ * those prefixes are covered too.
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import { Editor } from '@tiptap/core'
@@ -11,11 +12,12 @@ import { Document } from '@tiptap/extension-document'
 import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
 import { PluginKey } from '@tiptap/pm/state'
+import { Typography } from '../../extensions'
 import { MentionExtension } from './mention-extension'
 
 const openEditors: Editor[] = []
 
-function makeEditor() {
+function makeEditor(extra: Parameters<typeof Editor>[0]['extensions'] = []) {
   const editor = new Editor({
     extensions: [
       Document,
@@ -24,6 +26,7 @@ function makeEditor() {
       MentionExtension.configure({
         items: [{ id: 'jane', label: 'Jane' }],
       }),
+      ...extra,
     ],
     content: '<p></p>',
   })
@@ -41,6 +44,17 @@ function mentionActive(editor: Editor) {
   )
 }
 
+/** Type one character at a time so Typography input rules can fire. */
+function type(editor: Editor, text: string) {
+  for (const char of text) {
+    const { from, to } = editor.state.selection
+    const handled = editor.view.someProp('handleTextInput', (handler) =>
+      handler(editor.view, from, to, char),
+    )
+    if (!handled) editor.view.dispatch(editor.state.tr.insertText(char))
+  }
+}
+
 describe('Mention allowedPrefixes', () => {
   afterEach(() => {
     while (openEditors.length) openEditors.pop()?.destroy()
@@ -56,7 +70,7 @@ describe('Mention allowedPrefixes', () => {
     expect(mentionActive(editor)).toBe(true)
   })
 
-  it.each(['(', '[', '{', '<', '（', '【', '《', '"', "'"])(
+  it.each(['(', '[', '{', '<', '（', '【', '《', '"', "'", '“', '”', '‘', '’'])(
     'opens immediately after %s',
     (prefix) => {
       const editor = makeEditor()
@@ -64,6 +78,18 @@ describe('Mention allowedPrefixes', () => {
       expect(mentionActive(editor)).toBe(true)
     },
   )
+
+  it('opens after a quote that Typography has already curled', () => {
+    const editor = makeEditor([Typography])
+    type(editor, '"@')
+    expect(editor.state.doc.textContent.startsWith('“')).toBe(true)
+    expect(mentionActive(editor)).toBe(true)
+
+    editor.commands.setContent('<p></p>')
+    type(editor, "'@")
+    expect(editor.state.doc.textContent.startsWith('‘')).toBe(true)
+    expect(mentionActive(editor)).toBe(true)
+  })
 
   it('does not open in the middle of an email address', () => {
     const editor = makeEditor()

--- a/src/molecules/editor/extensions/mention/mention-extension.test.ts
+++ b/src/molecules/editor/extensions/mention/mention-extension.test.ts
@@ -7,7 +7,7 @@
  * those prefixes are covered too.
  */
 import { describe, it, expect, afterEach } from 'vitest'
-import { Editor } from '@tiptap/core'
+import { Editor, type AnyExtension } from '@tiptap/core'
 import { Document } from '@tiptap/extension-document'
 import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
@@ -17,7 +17,7 @@ import { MentionExtension } from './mention-extension'
 
 const openEditors: Editor[] = []
 
-function makeEditor(extra: Parameters<typeof Editor>[0]['extensions'] = []) {
+function makeEditor(extra: AnyExtension[] = []) {
   const editor = new Editor({
     extensions: [
       Document,
@@ -49,7 +49,13 @@ function type(editor: Editor, text: string) {
   for (const char of text) {
     const { from, to } = editor.state.selection
     const handled = editor.view.someProp('handleTextInput', (handler) =>
-      handler(editor.view, from, to, char),
+      handler(
+        editor.view,
+        from,
+        to,
+        char,
+        () => editor.state.tr.insertText(char),
+      ),
     )
     if (!handled) editor.view.dispatch(editor.state.tr.insertText(char))
   }

--- a/src/molecules/editor/extensions/mention/mention-extension.ts
+++ b/src/molecules/editor/extensions/mention/mention-extension.ts
@@ -108,12 +108,31 @@ function createMentionNode(component?: Component) {
   })
 }
 
+/**
+ * Characters that may sit immediately before `@`. TipTap defaults to `[' ']`,
+ * so `(@jane` never opened the list. `[` is written `\\[` because TipTap joins
+ * prefixes into a character class without escaping them.
+ */
+const ALLOWED_MENTION_PREFIXES = [
+  ' ',
+  '(',
+  '\\[',
+  '{',
+  '<',
+  '（',
+  '【',
+  '《',
+  '"',
+  "'",
+]
+
 const MentionSuggestionExtension =
   createSuggestionExtension<MentionSuggestionItem>({
     name: 'mentionSuggestion',
     char: '@',
     pluginKey: new PluginKey('mentionSuggestion'),
     component: SuggestionList,
+    allowedPrefixes: ALLOWED_MENTION_PREFIXES,
 
     addOptions() {
       return {

--- a/src/molecules/editor/extensions/mention/mention-extension.ts
+++ b/src/molecules/editor/extensions/mention/mention-extension.ts
@@ -110,13 +110,13 @@ function createMentionNode(component?: Component) {
 
 /**
  * Characters that may sit immediately before `@`. TipTap defaults to `[' ']`,
- * so `(@jane` never opened the list. `[` is written `\\[` because TipTap joins
- * prefixes into a character class without escaping them.
+ * so `(@jane` never opened the list. Curly quotes are included because
+ * Typography (on in RichTextKit) rewrites `"`/`'` the moment they are typed.
  */
 const ALLOWED_MENTION_PREFIXES = [
   ' ',
   '(',
-  '\\[',
+  '[',
   '{',
   '<',
   '（',
@@ -124,6 +124,10 @@ const ALLOWED_MENTION_PREFIXES = [
   '《',
   '"',
   "'",
+  '“',
+  '”',
+  '‘',
+  '’',
 ]
 
 const MentionSuggestionExtension =

--- a/src/molecules/editor/extensions/mention/mention-extension.ts
+++ b/src/molecules/editor/extensions/mention/mention-extension.ts
@@ -112,6 +112,9 @@ function createMentionNode(component?: Component) {
  * Characters that may sit immediately before `@`. TipTap defaults to `[' ']`,
  * so `(@jane` never opened the list. Curly quotes are included because
  * Typography (on in RichTextKit) rewrites `"`/`'` the moment they are typed.
+ *
+ * Slash (`/`), tag (`#`), and emoji (`:`) keep the default: those triggers
+ * after a word usually mean a path, a heading, or a colon, not a menu.
  */
 const ALLOWED_MENTION_PREFIXES = [
   ' ',
@@ -122,12 +125,20 @@ const ALLOWED_MENTION_PREFIXES = [
   '（',
   '【',
   '《',
+  '「',
+  '『',
+  '«',
+  '‹',
   '"',
   "'",
   '“',
   '”',
   '‘',
   '’',
+  '」',
+  '』',
+  '»',
+  '›',
 ]
 
 const MentionSuggestionExtension =

--- a/src/molecules/editor/extensions/mention/mention-extension.ts
+++ b/src/molecules/editor/extensions/mention/mention-extension.ts
@@ -112,12 +112,14 @@ function createMentionNode(component?: Component) {
  * Characters that may sit immediately before `@`. TipTap defaults to `[' ']`,
  * so `(@jane` never opened the list. Curly quotes are included because
  * Typography (on in RichTextKit) rewrites `"`/`'` the moment they are typed.
+ * NBSP is included because pasted-from-email content often uses it as a space.
  *
  * Slash (`/`), tag (`#`), and emoji (`:`) keep the default: those triggers
  * after a word usually mean a path, a heading, or a colon, not a menu.
  */
 const ALLOWED_MENTION_PREFIXES = [
   ' ',
+  '\u00a0',
   '(',
   '[',
   '{',

--- a/src/molecules/editor/extensions/mention/mention-extension.ts
+++ b/src/molecules/editor/extensions/mention/mention-extension.ts
@@ -113,6 +113,8 @@ function createMentionNode(component?: Component) {
  * so `(@jane` never opened the list. Curly quotes are included because
  * Typography (on in RichTextKit) rewrites `"`/`'` the moment they are typed.
  * NBSP is included because pasted-from-email content often uses it as a space.
+ * Closing quotes (`” ’`) are included because Typography curls a quote after a
+ * word into the closing form; CJK and guillemet closers (`」 』 » ›`) match.
  *
  * Slash (`/`), tag (`#`), and emoji (`:`) keep the default: those triggers
  * after a word usually mean a path, a heading, or a colon, not a menu.

--- a/src/molecules/editor/extensions/shared/suggestion-open.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.test.ts
@@ -170,6 +170,15 @@ describe('openSuggestionMenu', () => {
     expect(tr.getMeta('suggestionAutoOpen').padded).toBe(false)
   })
 
+  it('pads after a non-breaking space so the matcher sees an allowed prefix', () => {
+    const editor = makeEditor('\u00a0')
+    caretTo(editor, 2)
+    const tr = editor.state.tr
+    insertSuggestionTrigger(tr, CHAR)
+    expect(tr.doc.textContent).toBe('\u00a0 /')
+    expect(tr.getMeta('suggestionAutoOpen').padded).toBe(true)
+  })
+
   it('removes the whole query run, not just the trigger', () => {
     const editor = makeEditor('hello')
     caretTo(editor, 6)

--- a/src/molecules/editor/extensions/shared/suggestion-open.test.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.test.ts
@@ -159,6 +159,17 @@ describe('openSuggestionMenu', () => {
     expect(body(editor)).toBe('hello')
   })
 
+  it('does not pad after a character the suggester already allows', () => {
+    const editor = makeEditor('(')
+    caretTo(editor, 2)
+    const tr = editor.state.tr
+    insertSuggestionTrigger(tr, CHAR, [' ', '('])
+    // Inspect the transaction: dispatching would run TestSuggester, whose
+    // prefixes are still only space, so cleanup would take the char back out.
+    expect(tr.doc.textContent).toBe('(/')
+    expect(tr.getMeta('suggestionAutoOpen').padded).toBe(false)
+  })
+
   it('removes the whole query run, not just the trigger', () => {
     const editor = makeEditor('hello')
     caretTo(editor, 6)

--- a/src/molecules/editor/extensions/shared/suggestion-open.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.ts
@@ -90,8 +90,9 @@ function isStrandedPadding(doc: ProseMirrorNode, pos: number): boolean {
  * there throws `Applying a mismatched transaction`.
  *
  * `allowedPrefixes` is the same list TipTap's matcher uses (`[' ']` when
- * omitted, `null` to allow any). Pad only when the preceding character would
- * make the trigger fail to match — so a mention after `(` stays `(@`, not `( @`.
+ * omitted, `null` to allow any). Pad only when the preceding character is
+ * not in that list — including other whitespace such as NBSP — so a mention
+ * after `(` stays `(@`, and a toolbar open after pasted NBSP still matches.
  */
 export function insertSuggestionTrigger(
   tr: Transaction,
@@ -102,10 +103,7 @@ export function insertSuggestionTrigger(
   const $from = tr.doc.resolve(from)
   const before = from > $from.start() ? tr.doc.textBetween(from - 1, from) : ''
   const prefixOk =
-    allowedPrefixes === null ||
-    !before ||
-    /\s/.test(before) ||
-    allowedPrefixes.includes(before)
+    allowedPrefixes === null || !before || allowedPrefixes.includes(before)
   const text = prefixOk ? char : ` ${char}`
 
   tr.insertText(text, from, to)

--- a/src/molecules/editor/extensions/shared/suggestion-open.ts
+++ b/src/molecules/editor/extensions/shared/suggestion-open.ts
@@ -88,15 +88,25 @@ function isStrandedPadding(doc: ProseMirrorNode, pos: number): boolean {
  * Writes to the caller's transaction rather than dispatching its own: the
  * `openSuggestionMenu` command runs mid-dispatch, and a nested `editor.chain()`
  * there throws `Applying a mismatched transaction`.
+ *
+ * `allowedPrefixes` is the same list TipTap's matcher uses (`[' ']` when
+ * omitted, `null` to allow any). Pad only when the preceding character would
+ * make the trigger fail to match — so a mention after `(` stays `(@`, not `( @`.
  */
-export function insertSuggestionTrigger(tr: Transaction, char: string): void {
+export function insertSuggestionTrigger(
+  tr: Transaction,
+  char: string,
+  allowedPrefixes: string[] | null = [' '],
+): void {
   const { from, to } = tr.selection
-  // `allowedPrefixes` defaults to [' '], so a trigger glued to the end of a
-  // word never matches — but an unconditional space would leave a stray blank
-  // in an empty paragraph. Pad only when the caret follows text.
   const $from = tr.doc.resolve(from)
   const before = from > $from.start() ? tr.doc.textBetween(from - 1, from) : ''
-  const text = before && !/\s/.test(before) ? ` ${char}` : char
+  const prefixOk =
+    allowedPrefixes === null ||
+    !before ||
+    /\s/.test(before) ||
+    allowedPrefixes.includes(before)
+  const text = prefixOk ? char : ` ${char}`
 
   tr.insertText(text, from, to)
   tr.setMeta(AUTO_OPEN_META, {

--- a/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
+++ b/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
@@ -60,6 +60,10 @@ export interface CreateSuggestionExtensionOptions<
   component: VueComponent
   floatingOptions?: SuggestionFloatingOptions
   allowSpaces?: boolean
+  /**
+   * TipTap joins this into a regex character class with no extra escaping.
+   * Keep entries to a single character; do not use `]`, `-`, or a leading `^`.
+   */
   allowedPrefixes?: string[] | null
   startOfLine?: boolean
   decorationTag?: string

--- a/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
+++ b/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
@@ -63,6 +63,7 @@ export interface CreateSuggestionExtensionOptions<
   /**
    * TipTap joins this into a regex character class with no extra escaping.
    * Keep entries to a single character; do not use `]`, `-`, or a leading `^`.
+   * An empty array is not useful: every prefix fails the matcher.
    */
   allowedPrefixes?: string[] | null
   startOfLine?: boolean

--- a/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
+++ b/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
@@ -60,6 +60,7 @@ export interface CreateSuggestionExtensionOptions<
   component: VueComponent
   floatingOptions?: SuggestionFloatingOptions
   allowSpaces?: boolean
+  allowedPrefixes?: string[] | null
   startOfLine?: boolean
   decorationTag?: string
   decorationClass?: string
@@ -97,6 +98,9 @@ export function createSuggestionExtension<TItem extends BaseSuggestionItem>(
           // (`:`/`#`/`@`) is literal source the author is typing — not a cue.
           allow: ({ state, range }) => !isInCode(state.doc, range.from),
           allowSpaces: options.allowSpaces,
+          ...(options.allowedPrefixes !== undefined
+            ? { allowedPrefixes: options.allowedPrefixes }
+            : {}),
           startOfLine: options.startOfLine,
           decorationTag: options.decorationTag || 'span',
           decorationClass: options.decorationClass || 'suggestion',

--- a/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
+++ b/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
@@ -98,9 +98,7 @@ export function createSuggestionExtension<TItem extends BaseSuggestionItem>(
           // (`:`/`#`/`@`) is literal source the author is typing — not a cue.
           allow: ({ state, range }) => !isInCode(state.doc, range.from),
           allowSpaces: options.allowSpaces,
-          ...(options.allowedPrefixes !== undefined
-            ? { allowedPrefixes: options.allowedPrefixes }
-            : {}),
+          allowedPrefixes: options.allowedPrefixes,
           startOfLine: options.startOfLine,
           decorationTag: options.decorationTag || 'span',
           decorationClass: options.decorationClass || 'suggestion',

--- a/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
+++ b/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
@@ -63,7 +63,9 @@ export interface CreateSuggestionExtensionOptions<
   /**
    * TipTap joins this into a regex character class with no extra escaping.
    * Keep entries to a single character; do not use `]`, `-`, or a leading `^`.
-   * An empty array is not useful: every prefix fails the matcher.
+   * An empty array is not useful: every prefix fails the matcher. The opener
+   * pads with a space, so omit `' '` from the list only if you do not use
+   * `openSuggestionMenu`.
    */
   allowedPrefixes?: string[] | null
   startOfLine?: boolean

--- a/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
+++ b/src/molecules/editor/extensions/suggestion/createSuggestionExtension.ts
@@ -121,7 +121,10 @@ export function createSuggestionExtension<TItem extends BaseSuggestionItem>(
           (extensionName: string) =>
           ({ editor, tr, commands, dispatch }) => {
             const target = getSuggestionOptions<{
-              suggestion?: { char?: string }
+              suggestion?: {
+                char?: string
+                allowedPrefixes?: string[] | null
+              }
             }>(editor, extensionName)
             const char = target?.suggestion?.char
             if (!char) return false
@@ -139,7 +142,11 @@ export function createSuggestionExtension<TItem extends BaseSuggestionItem>(
             // shares this transaction — only `editor.chain()` would start a
             // rival one and throw.
             commands.focus()
-            insertSuggestionTrigger(tr, char)
+            insertSuggestionTrigger(
+              tr,
+              char,
+              target.suggestion?.allowedPrefixes,
+            )
             return true
           },
       }

--- a/src/molecules/editor/useEditor.test.ts
+++ b/src/molecules/editor/useEditor.test.ts
@@ -172,6 +172,21 @@ describe('frappe-ui/editor minimal primitives', () => {
     expect(options.suggestion.allowSpaces).toBe(true)
   })
 
+  it('forwards allowedPrefixes from SuggestionExtension options to the suggestion plugin', async () => {
+    const { SuggestionExtension } = await import('./index')
+
+    const extension = SuggestionExtension.configure({
+      name: 'people',
+      trigger: '@',
+      items: [],
+      allowedPrefixes: [' ', '('],
+      command: vi.fn(),
+    })
+
+    const options = (extension as any).addOptions()
+    expect(options.suggestion.allowedPrefixes).toEqual([' ', '('])
+  })
+
   it('creates and destroys a shallow editor ref', async () => {
     const { useEditor } = await import('./index')
     let editorRef: ReturnType<typeof useEditor> | undefined


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem
Typing `@` immediately after an opening bracket or quote (`(@user`, `[@user`, `"@user`) did not open the mention list. TipTap’s suggestion matcher defaults to `allowedPrefixes: [' ']`, so the trigger only fired after a space (or at the start of a paragraph).

This showed up in Gameplan as a local monkey-patch of `Mention.config.addExtensions` ([frappe/gameplan#567](https://github.com/frappe/gameplan/pull/567)). The fix belongs here.

### Fix
- Thread `allowedPrefixes` through `createSuggestionExtension`.
- Set mention prefixes to space, opening brackets (ASCII, full-width, CJK corner, guillemets), and both straight and curly quotes.
- `openSuggestionMenu` reads that list before padding, so a toolbar `@` after `(` inserts `(@`, not `( @`.
- Slash, tag, and emoji keep TipTap’s default (space only): `/`, `#`, and `:` after a word are usually a path, a heading, or a colon.

Emails (`jane@example.com`) and mid-word `@` still do not open the list.

### Tests
`mention-extension.test.ts` covers each prefix, the email case, Typography-curled quotes, and `openSuggestionMenu` after `(`. `suggestion-open.test.ts` covers the no-pad path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c76fd3a8-27e7-4aeb-8018-b00e687c6e21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c76fd3a8-27e7-4aeb-8018-b00e687c6e21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1129/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 72.95% (+0.01% vs `main`)
<!-- coverage-report:end -->












