### PR TITLE
fix(charts): mute the categorical red

### DIFF
--- a/src/charts/style.css
+++ b/src/charts/style.css
@@ -25,7 +25,10 @@
      The red family sits at hue 17. It was authored at 5, a crimson, whose light
      partner lightens into a pink rather than into a warning — so anything
      reading the ramp for a status had to leave it. 17 keeps the family clear of
-     the amber at 75 while its light partner still reads as red. */
+     the amber at 75 while its light partner still reads as red. Its chroma
+     sits at 0.155, under the cap, because the eye weights red above every
+     other hue and at the cap a slice of it reads as an alert. Lower still and
+     it turns brown. */
   --chart-categorical-1: #2283c3;
   --chart-categorical-2: #84c5f9;
   --chart-categorical-3: #289e60;
@@ -34,8 +37,8 @@
   --chart-categorical-6: #bb9df1;
   --chart-categorical-7: #c98c28;
   --chart-categorical-8: #f5ca8e;
-  --chart-categorical-9: #bd2040;
-  --chart-categorical-10: #fc8e94;
+  --chart-categorical-9: #c54b58;
+  --chart-categorical-10: #fca0a4;
 
   --chart-sequential-1: #095895;
   --chart-sequential-2: #2283c3;
@@ -95,8 +98,8 @@
   --chart-categorical-6: #b294e7;
   --chart-categorical-7: #bf8319;
   --chart-categorical-8: #ebc085;
-  --chart-categorical-9: #b20e37;
-  --chart-categorical-10: #f2858b;
+  --chart-categorical-9: #ba4250;
+  --chart-categorical-10: #f2979b;
 
   --chart-sequential-1: #074677;
   --chart-sequential-2: #1b699c;

--- a/src/charts/tokens.ts
+++ b/src/charts/tokens.ts
@@ -56,8 +56,8 @@ const LIGHT_CATEGORICAL = [
   '#bb9df1',
   '#c98c28',
   '#f5ca8e',
-  '#bd2040',
-  '#fc8e94',
+  '#c54b58',
+  '#fca0a4',
 ]
 
 const LIGHT_SEQUENTIAL = [
@@ -95,8 +95,8 @@ const DARK_CATEGORICAL = [
   '#b294e7',
   '#bf8319',
   '#ebc085',
-  '#b20e37',
-  '#f2858b',
+  '#ba4250',
+  '#f2979b',
 ]
 
 const DARK_SEQUENTIAL = [


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1482" height="766" alt="CleanShot 2026-09-09 at 20 16 18@2x" src="https://github.com/user-attachments/assets/0ab09f21-a781-4d5a-8b18-39266ac61c82" /> | <img width="1482" height="766" alt="CleanShot 2026-09-09 at 20 15 34@2x" src="https://github.com/user-attachments/assets/b8a6884b-3410-4466-8bf7-0fcc13a90117" /> |

<!-- coverage-report:start -->
Coverage: 73.38% (±0.00% vs `main`)
<!-- coverage-report:end -->
