### PR TITLE
fix: support mobile video fullscreen and empty tab slots

### DIFF
--- a/src/components/shared/slotReactivity.cy.ts
+++ b/src/components/shared/slotReactivity.cy.ts
@@ -359,4 +359,40 @@ describe('slot-derived computeds follow the slots', () => {
     cy.get('[data-cy="toggle"]').click()
     cy.get('[data-cy="mark"]').should('not.exist')
   })
+
+  it('Pill does not reserve space for a conditional empty suffix', () => {
+    const Harness = defineComponent({
+      setup() {
+        const show = ref(false)
+        return () =>
+          h('div', [
+            h(
+              'button',
+              {
+                'data-cy': 'toggle',
+                onClick: () => (show.value = !show.value),
+              },
+              'Toggle',
+            ),
+            h(
+              Pill,
+              { label: 'Discussions' },
+              {
+                suffix: () =>
+                  show.value ? h('span', { 'data-cy': 'count' }, '2') : null,
+              },
+            ),
+          ])
+      },
+    })
+
+    cy.mount(Harness)
+    cy.get('[data-slot="tab-suffix"]')
+      .should('have.class', 'empty:hidden')
+      .and('not.be.visible')
+
+    cy.get('[data-cy="toggle"]').click()
+    cy.get('[data-slot="tab-suffix"]').should('be.visible')
+    cy.get('[data-cy="count"]').should('have.text', '2')
+  })
 })

--- a/src/components/shared/tabs/Pill.vue
+++ b/src/components/shared/tabs/Pill.vue
@@ -104,7 +104,6 @@ const iconClass = computed(() => {
 function hasLabel(label: PillProps['label']) {
   return label !== undefined && label !== null && label !== ''
 }
-
 </script>
 
 <template>
@@ -115,7 +114,7 @@ function hasLabel(label: PillProps['label']) {
     <span
       v-if="$slots.prefix"
       data-slot="tab-prefix"
-      class="inline-flex items-center"
+      class="inline-flex items-center empty:hidden"
     >
       <slot name="prefix" />
     </span>
@@ -131,7 +130,7 @@ function hasLabel(label: PillProps['label']) {
     <span
       v-if="$slots.suffix"
       data-slot="tab-suffix"
-      class="inline-flex items-center"
+      class="inline-flex items-center empty:hidden"
     >
       <slot name="suffix" />
     </span>

--- a/src/molecules/editor/components/MediaNodeView.test.ts
+++ b/src/molecules/editor/components/MediaNodeView.test.ts
@@ -158,6 +158,36 @@ describe('media node view in read mode', () => {
   })
 })
 
+describe('media node view native video fullscreen', () => {
+  it('hides editing chrome without restyling the inline container', async () => {
+    const ctx = mount(
+      '<p><video src="/files/clip.mp4" data-caption="Release demo"></video></p>',
+    )
+    await settle()
+
+    const video = ctx.root.querySelector('video') as HTMLVideoElement
+    const container = video.closest(
+      '[data-video-fullscreen-root]',
+    ) as HTMLElement
+    expect(captionInputs(ctx.root)).toHaveLength(1)
+
+    video.dispatchEvent(new Event('webkitbeginfullscreen'))
+    await settle()
+
+    expect(captionInputs(ctx.root)).toHaveLength(0)
+    expect(container.classList).not.toContain('bg-black')
+    expect(video.classList).toContain('rounded-4')
+    expect(video.classList).not.toContain('rounded-none')
+    expect(video.classList).not.toContain('size-full')
+
+    video.dispatchEvent(new Event('webkitendfullscreen'))
+    await settle()
+    expect(captionInputs(ctx.root)).toHaveLength(1)
+
+    ctx.app.unmount()
+  })
+})
+
 describe('media node view reuse', () => {
   it('does not carry a caption over to the next image', async () => {
     const ctx = mount(

--- a/src/molecules/editor/components/MediaNodeView.vue
+++ b/src/molecules/editor/components/MediaNodeView.vue
@@ -378,6 +378,7 @@ function setVideoOptions(options: {
           v-model:fullscreen="isFullscreen"
           :video-el="mediaRef as HTMLVideoElement | null"
           :hidden="isResizing"
+          :standard-fullscreen="isStandardFullscreen"
         />
 
         <MediaToolbar

--- a/src/molecules/editor/components/MediaNodeView.vue
+++ b/src/molecules/editor/components/MediaNodeView.vue
@@ -72,6 +72,10 @@ function syncFullscreen(): void {
     document.fullscreenElement === containerRef.value
 }
 
+function syncWebKitFullscreen(fullscreen: boolean): void {
+  isFullscreen.value = fullscreen
+}
+
 onMounted(() => document.addEventListener('fullscreenchange', syncFullscreen))
 onBeforeUnmount(() =>
   document.removeEventListener('fullscreenchange', syncFullscreen),
@@ -374,6 +378,7 @@ function setVideoOptions(options: {
           :video-el="mediaRef as HTMLVideoElement | null"
           :hidden="isResizing"
           :fullscreen="isFullscreen"
+          @fullscreen-change="syncWebKitFullscreen"
         />
 
         <MediaToolbar

--- a/src/molecules/editor/components/MediaNodeView.vue
+++ b/src/molecules/editor/components/MediaNodeView.vue
@@ -54,26 +54,25 @@ const isEditable = useNodeViewEditable(editor)
 const isVideo = computed(() => props.node.type.name === 'video')
 
 /**
- * Whether THIS media is the fullscreen element.
+ * Whether THIS media is fullscreen through either browser API.
  *
  * The browser stretches the fullscreen element to the viewport with UA
  * `!important` rules, but everything inside it kept the committed pixel size:
  * the video stayed small at the top, its playback bar pinned under it, with a
  * black slab filling the rest of the screen. In fullscreen the media is
  * centered in the black field and the controls run along the bottom of the
- * screen — and the editing chrome (toolbar, resize handles, caption) is not
- * rendered at all, since none of it is actionable there.
+ * screen. iPhone instead moves the video into its native player and leaves the
+ * in-page container alone. Editing chrome (toolbar, resize handles, caption)
+ * is not rendered in either mode, since none of it is actionable there.
  */
 const isFullscreen = ref(false)
+const isStandardFullscreen = ref(false)
 
 function syncFullscreen(): void {
-  isFullscreen.value =
+  isStandardFullscreen.value =
     containerRef.value !== null &&
     document.fullscreenElement === containerRef.value
-}
-
-function syncWebKitFullscreen(fullscreen: boolean): void {
-  isFullscreen.value = fullscreen
+  isFullscreen.value = isStandardFullscreen.value
 }
 
 onMounted(() => document.addEventListener('fullscreenchange', syncFullscreen))
@@ -315,7 +314,7 @@ function setVideoOptions(options: {
       ref="containerRef"
       class="group relative isolate overflow-hidden not-prose rounded-4"
       :class="
-        isFullscreen
+        isStandardFullscreen
           ? 'flex items-center justify-center bg-black'
           : containerClasses(node.attrs, selected)
       "
@@ -326,7 +325,8 @@ function setVideoOptions(options: {
         v-if="isUploaded || fileContent || node.attrs.loading"
         class="relative"
         :class="
-          isFullscreen && 'flex h-full w-full items-center justify-center'
+          isStandardFullscreen &&
+          'flex h-full w-full items-center justify-center'
         "
       >
         <img
@@ -360,7 +360,7 @@ function setVideoOptions(options: {
             // committed size the width/height attributes carry. `!outline-none`
             // drops the selected-node outline from `style.css`, which would
             // otherwise frame the video mid-screen.
-            isFullscreen &&
+            isStandardFullscreen &&
               'size-full rounded-none object-contain !outline-none',
           ]"
           :src="node.attrs.src || fileContent"
@@ -375,10 +375,9 @@ function setVideoOptions(options: {
 
         <VideoControls
           v-if="isVideo && isUploaded"
+          v-model:fullscreen="isFullscreen"
           :video-el="mediaRef as HTMLVideoElement | null"
           :hidden="isResizing"
-          :fullscreen="isFullscreen"
-          @fullscreen-change="syncWebKitFullscreen"
         />
 
         <MediaToolbar

--- a/src/molecules/editor/components/VideoControls.test.ts
+++ b/src/molecules/editor/components/VideoControls.test.ts
@@ -42,7 +42,11 @@ async function paint() {
 
 function mount(
   videoEl: HTMLVideoElement,
-  onUpdateFullscreen?: (fullscreen: boolean) => void,
+  options: {
+    fullscreen?: boolean
+    standardFullscreen?: boolean
+    onUpdateFullscreen?: (fullscreen: boolean) => void
+  } = {},
 ) {
   const root = document.createElement('div')
   document.body.appendChild(root)
@@ -50,7 +54,9 @@ function mount(
     render: () =>
       h(VideoControls, {
         videoEl,
-        'onUpdate:fullscreen': onUpdateFullscreen,
+        fullscreen: options.fullscreen,
+        standardFullscreen: options.standardFullscreen,
+        'onUpdate:fullscreen': options.onUpdateFullscreen,
       }),
   })
   app.mount(root)
@@ -58,6 +64,7 @@ function mount(
     root,
     fill: () => root.querySelector<HTMLElement>('[aria-label="Seek"] div div'),
     slider: () => root.querySelector<HTMLElement>('[aria-label="Seek"]'),
+    controls: () => root.firstElementChild as HTMLElement,
     fullscreenButton: () =>
       root.querySelector<HTMLButtonElement>('[aria-label="Fullscreen"]'),
     unmount: () => {
@@ -197,7 +204,7 @@ describe('VideoControls fullscreen', () => {
   it('reports native WebKit fullscreen transitions', () => {
     const video = fakeVideo()
     const onUpdateFullscreen = vi.fn()
-    const ctx = mount(video, onUpdateFullscreen)
+    const ctx = mount(video, { onUpdateFullscreen })
 
     video.dispatchEvent(new Event('webkitbeginfullscreen'))
     video.dispatchEvent(new Event('webkitendfullscreen'))
@@ -205,5 +212,24 @@ describe('VideoControls fullscreen', () => {
     expect(onUpdateFullscreen).toHaveBeenNthCalledWith(1, true)
     expect(onUpdateFullscreen).toHaveBeenNthCalledWith(2, false)
     ctx.unmount()
+  })
+
+  it('keeps inline spacing for native fullscreen', () => {
+    const native = mount(fakeVideo(), { fullscreen: true })
+
+    expect(native.controls().classList).toContain('rounded-b-4')
+    expect(native.controls().classList).not.toContain('px-6')
+    expect(
+      native.root.querySelector('[aria-label="Exit fullscreen"]'),
+    ).not.toBeNull()
+    native.unmount()
+
+    const standard = mount(fakeVideo(), {
+      fullscreen: true,
+      standardFullscreen: true,
+    })
+    expect(standard.controls().classList).toContain('px-6')
+    expect(standard.controls().classList).not.toContain('rounded-b-4')
+    standard.unmount()
   })
 })

--- a/src/molecules/editor/components/VideoControls.test.ts
+++ b/src/molecules/editor/components/VideoControls.test.ts
@@ -39,15 +39,22 @@ async function paint() {
   await nextTick()
 }
 
-function mount(videoEl: HTMLVideoElement) {
+function mount(
+  videoEl: HTMLVideoElement,
+  onFullscreenChange?: (fullscreen: boolean) => void,
+) {
   const root = document.createElement('div')
   document.body.appendChild(root)
-  const app = createApp({ render: () => h(VideoControls, { videoEl }) })
+  const app = createApp({
+    render: () => h(VideoControls, { videoEl, onFullscreenChange }),
+  })
   app.mount(root)
   return {
     root,
     fill: () => root.querySelector<HTMLElement>('[aria-label="Seek"] div div'),
     slider: () => root.querySelector<HTMLElement>('[aria-label="Seek"]'),
+    fullscreenButton: () =>
+      root.querySelector<HTMLButtonElement>('[aria-label="Fullscreen"]'),
     unmount: () => {
       app.unmount()
       root.remove()
@@ -114,6 +121,85 @@ describe('VideoControls playhead', () => {
     expect(ctx.slider()?.getAttribute('aria-valuemax')).toBe('200')
     expect(ctx.slider()?.getAttribute('aria-valuenow')).toBe('50')
 
+    ctx.unmount()
+  })
+})
+
+describe('VideoControls fullscreen', () => {
+  it('fullscreens the media wrapper with the standard API', () => {
+    const video = fakeVideo()
+    const wrapper = document.createElement('div')
+    wrapper.dataset.videoFullscreenRoot = ''
+    wrapper.appendChild(video)
+    const requestFullscreen = vi.fn(() => Promise.resolve())
+    Object.defineProperty(wrapper, 'requestFullscreen', {
+      value: requestFullscreen,
+    })
+    const ctx = mount(video)
+
+    ctx.fullscreenButton()?.click()
+
+    expect(requestFullscreen).toHaveBeenCalledOnce()
+    ctx.unmount()
+    wrapper.remove()
+  })
+
+  it('uses native video fullscreen when the standard API is disabled', () => {
+    const video = fakeVideo() as HTMLVideoElement & {
+      webkitSupportsFullscreen: boolean
+      webkitEnterFullscreen: () => void
+    }
+    const wrapper = document.createElement('div')
+    wrapper.dataset.videoFullscreenRoot = ''
+    wrapper.appendChild(video)
+    const requestFullscreen = vi.fn(() => Promise.resolve())
+    Object.defineProperty(wrapper, 'requestFullscreen', {
+      value: requestFullscreen,
+    })
+    Object.defineProperty(document, 'fullscreenEnabled', {
+      configurable: true,
+      value: false,
+    })
+    video.webkitSupportsFullscreen = true
+    video.webkitEnterFullscreen = vi.fn()
+    const ctx = mount(video)
+
+    ctx.fullscreenButton()?.click()
+
+    expect(requestFullscreen).not.toHaveBeenCalled()
+    expect(video.webkitEnterFullscreen).toHaveBeenCalledOnce()
+    ctx.unmount()
+    wrapper.remove()
+    Reflect.deleteProperty(document, 'fullscreenEnabled')
+  })
+
+  it('handles a rejected standard fullscreen request', async () => {
+    const video = fakeVideo()
+    const requestFullscreen = vi.fn(() =>
+      Promise.reject(new DOMException('Fullscreen denied', 'NotAllowedError')),
+    )
+    Object.defineProperty(video, 'requestFullscreen', {
+      value: requestFullscreen,
+    })
+    const ctx = mount(video)
+
+    ctx.fullscreenButton()?.click()
+    await Promise.resolve()
+
+    expect(requestFullscreen).toHaveBeenCalledOnce()
+    ctx.unmount()
+  })
+
+  it('reports native WebKit fullscreen transitions', () => {
+    const video = fakeVideo()
+    const onFullscreenChange = vi.fn()
+    const ctx = mount(video, onFullscreenChange)
+
+    video.dispatchEvent(new Event('webkitbeginfullscreen'))
+    video.dispatchEvent(new Event('webkitendfullscreen'))
+
+    expect(onFullscreenChange).toHaveBeenNthCalledWith(1, true)
+    expect(onFullscreenChange).toHaveBeenNthCalledWith(2, false)
     ctx.unmount()
   })
 })

--- a/src/molecules/editor/components/VideoControls.test.ts
+++ b/src/molecules/editor/components/VideoControls.test.ts
@@ -30,6 +30,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  Reflect.deleteProperty(document, 'fullscreenEnabled')
 })
 
 /** Run one animation frame, the way the browser would. */
@@ -41,12 +42,16 @@ async function paint() {
 
 function mount(
   videoEl: HTMLVideoElement,
-  onFullscreenChange?: (fullscreen: boolean) => void,
+  onUpdateFullscreen?: (fullscreen: boolean) => void,
 ) {
   const root = document.createElement('div')
   document.body.appendChild(root)
   const app = createApp({
-    render: () => h(VideoControls, { videoEl, onFullscreenChange }),
+    render: () =>
+      h(VideoControls, {
+        videoEl,
+        'onUpdate:fullscreen': onUpdateFullscreen,
+      }),
   })
   app.mount(root)
   return {
@@ -170,7 +175,6 @@ describe('VideoControls fullscreen', () => {
     expect(video.webkitEnterFullscreen).toHaveBeenCalledOnce()
     ctx.unmount()
     wrapper.remove()
-    Reflect.deleteProperty(document, 'fullscreenEnabled')
   })
 
   it('handles a rejected standard fullscreen request', async () => {
@@ -192,14 +196,14 @@ describe('VideoControls fullscreen', () => {
 
   it('reports native WebKit fullscreen transitions', () => {
     const video = fakeVideo()
-    const onFullscreenChange = vi.fn()
-    const ctx = mount(video, onFullscreenChange)
+    const onUpdateFullscreen = vi.fn()
+    const ctx = mount(video, onUpdateFullscreen)
 
     video.dispatchEvent(new Event('webkitbeginfullscreen'))
     video.dispatchEvent(new Event('webkitendfullscreen'))
 
-    expect(onFullscreenChange).toHaveBeenNthCalledWith(1, true)
-    expect(onFullscreenChange).toHaveBeenNthCalledWith(2, false)
+    expect(onUpdateFullscreen).toHaveBeenNthCalledWith(1, true)
+    expect(onUpdateFullscreen).toHaveBeenNthCalledWith(2, false)
     ctx.unmount()
   })
 })

--- a/src/molecules/editor/components/VideoControls.vue
+++ b/src/molecules/editor/components/VideoControls.vue
@@ -35,6 +35,8 @@ const props = defineProps<{
   videoEl: HTMLVideoElement | null
   /** Hidden entirely while true (e.g. during a resize drag). */
   hidden?: boolean
+  /** The wrapper uses the standard API and stretches this row to the screen. */
+  standardFullscreen?: boolean
 }>()
 
 /**
@@ -337,7 +339,7 @@ const SCRIM =
     class="absolute inset-x-0 bottom-0 z-20 flex items-center gap-3 text-white transition-opacity [filter:drop-shadow(0_1px_2px_rgb(0_0_0/0.45))]"
     :style="{ backgroundImage: SCRIM }"
     :class="[
-      fullscreen ? 'px-6 pt-16 pb-6' : 'rounded-b-4 px-3.5 pt-12 pb-3',
+      standardFullscreen ? 'px-6 pt-16 pb-6' : 'rounded-b-4 px-3.5 pt-12 pb-3',
       playing && !scrubbing
         ? 'opacity-0 group-hover:opacity-100 focus-within:opacity-100'
         : 'opacity-100',

--- a/src/molecules/editor/components/VideoControls.vue
+++ b/src/molecules/editor/components/VideoControls.vue
@@ -35,16 +35,14 @@ const props = defineProps<{
   videoEl: HTMLVideoElement | null
   /** Hidden entirely while true (e.g. during a resize drag). */
   hidden?: boolean
-  /**
-   * The media is the fullscreen element: the row spans the screen instead of a
-   * media box, so it drops the rounded corner and takes more breathing room.
-   */
-  fullscreen?: boolean
 }>()
 
-const emit = defineEmits<{
-  'fullscreen-change': [fullscreen: boolean]
-}>()
+/**
+ * Whether this video is fullscreen through either browser API. The node view
+ * writes standard Fullscreen API changes; WebKit native-player events write
+ * their changes here.
+ */
+const fullscreen = defineModel<boolean>('fullscreen', { default: false })
 
 type WebKitVideoElement = HTMLVideoElement & {
   readonly webkitSupportsFullscreen?: boolean
@@ -110,13 +108,13 @@ function bind(el: HTMLVideoElement) {
   on('volumechange', () => (muted.value = el.muted))
   // iPhone presents video through its native fullscreen player rather than
   // the standard Fullscreen API, so `document.fullscreenElement` never moves.
-  // Pass those transitions back to the node view to keep its editing chrome
-  // and control state in sync with either fullscreen implementation.
-  on('webkitbeginfullscreen', () => emit('fullscreen-change', true))
-  on('webkitendfullscreen', () => emit('fullscreen-change', false))
+  // Write those transitions through the shared fullscreen model to keep the
+  // node view's editing chrome in sync with either implementation.
+  on('webkitbeginfullscreen', () => (fullscreen.value = true))
+  on('webkitendfullscreen', () => (fullscreen.value = false))
 
   if ((el as WebKitVideoElement).webkitDisplayingFullscreen) {
-    emit('fullscreen-change', true)
+    fullscreen.value = true
   }
 }
 

--- a/src/molecules/editor/components/VideoControls.vue
+++ b/src/molecules/editor/components/VideoControls.vue
@@ -42,6 +42,17 @@ const props = defineProps<{
   fullscreen?: boolean
 }>()
 
+const emit = defineEmits<{
+  'fullscreen-change': [fullscreen: boolean]
+}>()
+
+type WebKitVideoElement = HTMLVideoElement & {
+  readonly webkitSupportsFullscreen?: boolean
+  readonly webkitDisplayingFullscreen?: boolean
+  webkitEnterFullscreen?: () => void
+  webkitExitFullscreen?: () => void
+}
+
 const playing = ref(false)
 const muted = ref(false)
 const currentTime = ref(0)
@@ -97,6 +108,16 @@ function bind(el: HTMLVideoElement) {
   on('loadedmetadata', () => (duration.value = el.duration || 0))
   on('durationchange', () => (duration.value = el.duration || 0))
   on('volumechange', () => (muted.value = el.muted))
+  // iPhone presents video through its native fullscreen player rather than
+  // the standard Fullscreen API, so `document.fullscreenElement` never moves.
+  // Pass those transitions back to the node view to keep its editing chrome
+  // and control state in sync with either fullscreen implementation.
+  on('webkitbeginfullscreen', () => emit('fullscreen-change', true))
+  on('webkitendfullscreen', () => emit('fullscreen-change', false))
+
+  if ((el as WebKitVideoElement).webkitDisplayingFullscreen) {
+    emit('fullscreen-change', true)
+  }
 }
 
 function unbind(el: HTMLVideoElement) {
@@ -158,16 +179,67 @@ function toggleMute() {
   if (el) el.muted = !el.muted
 }
 
+function ignoreFullscreenRejection(promise: Promise<void> | undefined) {
+  // A fullscreen request can be refused by browser policy. It is an optional
+  // presentation affordance, so a rejection must not become an unhandled app
+  // error.
+  void promise?.catch(() => {})
+}
+
 function toggleFullscreen() {
   const el = props.videoEl
   if (!el) return
-  if (document.fullscreenElement) {
-    void document.exitFullscreen()
+  const webkitVideo = el as WebKitVideoElement
+
+  if (webkitVideo.webkitDisplayingFullscreen) {
+    try {
+      webkitVideo.webkitExitFullscreen?.()
+    } catch {
+      // The native player may already be leaving fullscreen.
+    }
     return
   }
+
+  if (document.fullscreenElement) {
+    try {
+      ignoreFullscreenRejection(document.exitFullscreen?.())
+    } catch {
+      // Fullscreen state may have changed between the check and the request.
+    }
+    return
+  }
+
   // Fullscreen the wrapper so these controls stay visible over the video.
   const root = el.closest('[data-video-fullscreen-root]') ?? el
-  void (root as HTMLElement).requestFullscreen?.()
+  const requestFullscreen = (root as HTMLElement).requestFullscreen
+
+  // `fullscreenEnabled` is false on iPhone even though the video-specific
+  // WebKit API is available. Choose that path before making an asynchronous
+  // standard request: `webkitEnterFullscreen()` must run directly inside the
+  // click's user-activation window.
+  if (
+    typeof requestFullscreen === 'function' &&
+    document.fullscreenEnabled !== false
+  ) {
+    try {
+      ignoreFullscreenRejection(requestFullscreen.call(root))
+      return
+    } catch {
+      // A synchronous standard-API failure can still fall through to WebKit
+      // while this click retains user activation.
+    }
+  }
+
+  if (
+    webkitVideo.webkitSupportsFullscreen &&
+    typeof webkitVideo.webkitEnterFullscreen === 'function'
+  ) {
+    try {
+      webkitVideo.webkitEnterFullscreen()
+    } catch {
+      // Native fullscreen can be unavailable until media metadata is ready.
+    }
+  }
 }
 
 function timeFromPointer(event: PointerEvent): number {
@@ -367,14 +439,20 @@ const SCRIM =
       </button>
     </Tooltip>
 
-    <Tooltip text="Fullscreen" class="flex h-5">
+    <Tooltip
+      :text="fullscreen ? 'Exit fullscreen' : 'Fullscreen'"
+      class="flex h-5"
+    >
       <button
         type="button"
         class="opacity-90 transition-opacity hover:opacity-100"
-        aria-label="Fullscreen"
+        :aria-label="fullscreen ? 'Exit fullscreen' : 'Fullscreen'"
         @click="toggleFullscreen"
       >
-        <span class="lucide-maximize-2 size-5" />
+        <span
+          :class="fullscreen ? 'lucide-minimize-2' : 'lucide-maximize-2'"
+          class="size-5"
+        />
       </button>
     </Tooltip>
   </div>


### PR DESCRIPTION
## Summary

- enter native video fullscreen on iPhone/WebKit when the standard Fullscreen API is disabled, while preserving the wrapper fullscreen path elsewhere
- synchronize native WebKit fullscreen transitions through `v-model:fullscreen`, without applying wrapper-only layout styles to the inline video or its controls
- safely absorb fullscreen request rejections
- collapse empty Pill prefix/suffix wrappers so conditional tab badges do not leave stray spacing

## Verification

- `yarn test` — 104 files, 1704 tests passed
- `yarn type-check`
- `yarn build`
- `yarn cypress run --component --spec src/components/shared/slotReactivity.cy.ts --browser electron` — 14 tests passed
- focused VideoControls and MediaNodeView suites — 15 tests passed
- Prettier check on changed files

<!-- docs-preview:start -->
Docs preview: https://ui.frappe.io/pr-preview/pr-1136/
<!-- docs-preview:end -->

<!-- coverage-report:start -->
Coverage: 73.48% (+0.10% vs `main`)
<!-- coverage-report:end -->
