### PR TITLE
fix(charts): spend the sequential ramp from the deep end

### DIFF
--- a/src/charts/areaChartOptions.test.ts
+++ b/src/charts/areaChartOptions.test.ts
@@ -9,7 +9,7 @@ import type { AxisChartConfig } from './types'
 
 const tokens: ChartTokens = {
   categorical: ['#111111', '#222222', '#333333'],
-  sequential: ['#000011', '#000022', '#000033', '#000044', '#000055'],
+  sequential: ['#000011', '#000022', '#000033'],
   diverging: ['#001100', '#002200', '#003300'],
   axisLabel: 'ink-5',
   axisTitle: 'ink-7',
@@ -169,9 +169,8 @@ describe('area chart option', () => {
       build({
         fillOpacity: 0.5,
         series: [{ name: 'sales', fillOpacity: 0.25 }],
-        // A lone series takes the ramp's mid stop, hence the shifted blue.
       }).series[0].areaStyle.color.colorStops[0].color,
-    ).toBe('rgba(0, 0, 34, 0.25)')
+    ).toBe('rgba(0, 0, 17, 0.25)')
   })
 
   it('falls back to a flat fill for a color it cannot add alpha to', () => {

--- a/src/charts/barChartOptions.test.ts
+++ b/src/charts/barChartOptions.test.ts
@@ -7,8 +7,8 @@ import type { AxisChartConfig, AxisChartSeriesConfig } from './types'
 
 const tokens: ChartTokens = {
   categorical: ['#111111', '#222222', '#333333'],
-  // Five stops so the sequential pale-tail trim and even spacing are visible.
-  sequential: ['#000011', '#000022', '#000033', '#000044', '#000055'],
+  // Three stops so even spacing across the ramp is visible.
+  sequential: ['#000011', '#000022', '#000033'],
   diverging: ['#001100', '#002200', '#003300'],
   axisLabel: 'ink-5',
   axisTitle: 'ink-7',
@@ -70,13 +70,13 @@ describe('resolveSeriesColors', () => {
     ).toEqual({ sales: '#000011', refunds: 'red' })
   })
 
-  it('gives a lone sequential series a mid stop, not the darkest', () => {
+  it('gives a lone sequential series the darkest stop', () => {
     expect(colorsFor({ series: [{ name: 'sales' }] })).toEqual({
-      sales: '#000022',
+      sales: '#000011',
     })
   })
 
-  it('spaces sequential series out dark to light, skipping the palest stops', () => {
+  it('spaces sequential series out dark to light', () => {
     expect(Object.values(colorsFor({ series: named(3) }))).toEqual([
       '#000011',
       '#000022',
@@ -84,10 +84,10 @@ describe('resolveSeriesColors', () => {
     ])
   })
 
-  it('cycles the sequential ramp once there are more series than usable stops', () => {
-    const colors = colorsFor({ series: named(6) })
+  it('cycles the sequential ramp once there are more series than stops', () => {
+    const colors = colorsFor({ series: named(4) })
     expect(colors.a).toBe('#000011')
-    expect(colors.f).toBe(colors.a)
+    expect(colors.d).toBe(colors.a)
   })
 
   it('cycles the categorical ramp in series order', () => {

--- a/src/charts/chartColors.test.ts
+++ b/src/charts/chartColors.test.ts
@@ -25,9 +25,6 @@ const tokens: ChartTokens = {
   backdrop: '#ffffff',
 }
 
-/** The sequential ramp minus the two palest stops, as every chart reads it. */
-const USABLE_SEQUENTIAL = tokens.sequential.slice(0, 7)
-
 describe('chartColors: precedence', () => {
   it("draws in the caller's own colors when they passed a list", () => {
     expect(
@@ -56,7 +53,7 @@ describe('chartColors: precedence', () => {
     ).toEqual(tokens.categorical.slice(0, 2))
     expect(
       chartColors([], tokens, { fallback: 'sequential', count: 'ramp' }),
-    ).toEqual(USABLE_SEQUENTIAL)
+    ).toEqual(tokens.sequential)
   })
 })
 
@@ -90,6 +87,38 @@ describe('chartColors: one color per thing drawn', () => {
   })
 })
 
+describe('chartColors: how a sequential ramp is spent', () => {
+  const stops = (count: number) =>
+    chartColors('sequential', tokens, { fallback: 'sequential', count }).map(
+      (color) => tokens.sequential.indexOf(color) + 1,
+    )
+
+  it('gives a lone series the deep end', () => {
+    expect(stops(1)).toEqual([1])
+  })
+
+  it('keeps a small chart a prefix of the next size up', () => {
+    expect(stops(2)).toEqual([1, 4])
+    expect(stops(3)).toEqual([1, 4, 7])
+  })
+
+  it('stays inside the first seven stops up to seven series', () => {
+    expect(stops(4)).toEqual([1, 3, 5, 7])
+    expect(stops(5)).toEqual([1, 3, 4, 6, 7])
+    expect(stops(6)).toEqual([1, 2, 3, 5, 6, 7])
+    expect(stops(7)).toEqual([1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it('reaches the pale stops only once the series outnumber the span', () => {
+    expect(stops(8)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+    expect(stops(9)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9])
+  })
+
+  it('cycles once there are more series than stops', () => {
+    expect(stops(10)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 1])
+  })
+})
+
 describe('chartColors: the ramp itself', () => {
   it('gives the stops rather than a slot each', () => {
     expect(
@@ -97,16 +126,7 @@ describe('chartColors: the ramp itself', () => {
         fallback: 'sequential',
         count: 'ramp',
       }),
-    ).toEqual(USABLE_SEQUENTIAL)
-  })
-
-  it('trims the sequential stops that vanish against a card', () => {
-    const ramp = chartColors(undefined, tokens, {
-      fallback: 'sequential',
-      count: 'ramp',
-    })
-    expect(ramp).not.toContain('#f5f5f5')
-    expect(ramp).not.toContain('#e0e0e0')
+    ).toEqual(tokens.sequential)
   })
 
   it('takes a diverging ramp end to end', () => {
@@ -151,7 +171,7 @@ describe('chartColors: which end of the ramp leads', () => {
         count: 'ramp',
         deepEnd: 'last',
       }),
-    ).toEqual([...USABLE_SEQUENTIAL].reverse())
+    ).toEqual([...tokens.sequential].reverse())
   })
 
   it('leaves a categorical set alone, having no order to reverse', () => {

--- a/src/charts/comboChartOptions.test.ts
+++ b/src/charts/comboChartOptions.test.ts
@@ -9,7 +9,7 @@ import type { AxisChartConfig, ChartMark } from './types'
 
 const tokens: ChartTokens = {
   categorical: ['#111111', '#222222', '#333333'],
-  sequential: ['#000011', '#000022', '#000033', '#000044', '#000055'],
+  sequential: ['#000011', '#000022', '#000033'],
   diverging: ['#001100', '#002200', '#003300'],
   axisLabel: 'ink-5',
   axisTitle: 'ink-7',

--- a/src/charts/donutChartOptions.test.ts
+++ b/src/charts/donutChartOptions.test.ts
@@ -6,7 +6,7 @@ import type { DonutChartConfig } from './types'
 
 const tokens: ChartTokens = {
   categorical: ['#111111', '#222222', '#333333'],
-  sequential: ['#000011', '#000022', '#000033', '#000044', '#000055'],
+  sequential: ['#000011', '#000022', '#000033'],
   diverging: ['#001100', '#002200', '#003300'],
   axisLabel: 'ink-5',
   axisTitle: 'ink-7',

--- a/src/charts/heatmapOptions.test.ts
+++ b/src/charts/heatmapOptions.test.ts
@@ -203,18 +203,10 @@ describe('buildHeatmapMatrix', () => {
 })
 
 describe('heatmapRampStops', () => {
-  it('reverses the sequential ramp and trims its palest stops', () => {
-    const stops = heatmapRampStops(config(), tokens)
-
-    expect(stops).toEqual([
-      '#cccccc',
-      '#aaaaaa',
-      '#8a8a8a',
-      '#5a5a5a',
-      '#3a3a3a',
-      '#1a1a1a',
-      '#0a0a0a',
-    ])
+  it('reverses the sequential ramp, palest first', () => {
+    expect(heatmapRampStops(config(), tokens)).toEqual(
+      [...tokens.sequential].reverse(),
+    )
   })
 
   it('takes the diverging ramp as authored, cool end first', () => {
@@ -347,7 +339,9 @@ describe('buildHeatmapOption', () => {
       const resting = cells[index].color
       const hovered = item.emphasis.itemStyle.color
       expect(hovered).toBe(hoverCellColor(resting))
-      expect(hexToOklch(hovered).l).toBeGreaterThan(hexToOklch(resting).l)
+      expect(hexToOklch(hovered).l).toBeGreaterThanOrEqual(
+        hexToOklch(resting).l,
+      )
     })
   })
 })

--- a/src/charts/lineChartOptions.test.ts
+++ b/src/charts/lineChartOptions.test.ts
@@ -5,7 +5,7 @@ import type { AxisChartConfig } from './types'
 
 const tokens: ChartTokens = {
   categorical: ['#111111', '#222222', '#333333'],
-  sequential: ['#000011', '#000022', '#000033', '#000044', '#000055'],
+  sequential: ['#000011', '#000022', '#000033'],
   diverging: ['#001100', '#002200', '#003300'],
   axisLabel: 'ink-5',
   axisTitle: 'ink-7',

--- a/src/charts/tokens.ts
+++ b/src/charts/tokens.ts
@@ -277,10 +277,6 @@ export function pickSeriesColor(ramp: string[], index: number) {
   return ramp[index % ramp.length]
 }
 
-/** The two palest sequential stops vanish against a white card. */
-const SEQUENTIAL_TAIL_TRIM = 2
-/** A lone series reads best as one confident mid-blue, not the ramp's dark end. */
-const SEQUENTIAL_SOLO_INDEX = 1
 /**
  * Below this relative luminance a fill needs white text on top of it. It is the
  * crossover, not a taste call: white and the near-black inside-label ink
@@ -290,23 +286,57 @@ const SEQUENTIAL_SOLO_INDEX = 1
 const DARK_FILL_LUMINANCE = 0.22
 
 /**
- * `count` evenly spaced stops from a continuous ramp, so a stack reads as one
- * progression rather than n unrelated hues. Cycles instead once there are more
- * series than usable stops, where even spacing would hand out duplicates.
+ * How much of the sequential ramp a chart spends before it must widen. The
+ * last two stops of a nine-stop ramp are pale enough that a series in them is
+ * hard to read against a card, so a chart stays inside the first seven until
+ * it has more series than that.
  */
-function rampStops(ramp: string[], count: number, lastIndex: number): string[] {
-  if (count > lastIndex + 1) {
+const SEQUENTIAL_SPAN = 7
+/**
+ * The most stops apart two neighbouring series sit. Without it two series
+ * take the two ends of the span, and a third then recolors the second. With
+ * it a chart of one, two or three series is a prefix of the next.
+ */
+const SEQUENTIAL_MAX_STEP = 3
+
+/**
+ * `count` stops from the deep end of a sequential ramp: spread evenly over the
+ * first `SEQUENTIAL_SPAN` stops, never more than `SEQUENTIAL_MAX_STEP` apart,
+ * widening past the span only for a chart with more series than it holds.
+ * Cycles once there are more series than stops.
+ */
+function sequentialStops(ramp: string[], count: number): string[] {
+  if (count === 1) return [ramp[0]]
+  if (count > ramp.length) {
     return Array.from({ length: count }, (_, i) => pickSeriesColor(ramp, i))
   }
+  const lastIndex = Math.min(Math.max(SEQUENTIAL_SPAN, count), ramp.length) - 1
+  return Array.from(
+    { length: count },
+    (_, i) =>
+      ramp[
+        Math.min(
+          Math.round((i * lastIndex) / (count - 1)),
+          i * SEQUENTIAL_MAX_STEP,
+        )
+      ],
+  )
+}
+
+/**
+ * `count` evenly spaced stops across the whole of a diverging ramp, which is
+ * read by its extremes. Cycles once there are more series than stops.
+ */
+function divergingStops(ramp: string[], count: number): string[] {
+  if (count === 1) return [ramp[0]]
+  if (count > ramp.length) {
+    return Array.from({ length: count }, (_, i) => pickSeriesColor(ramp, i))
+  }
+  const lastIndex = ramp.length - 1
   return Array.from(
     { length: count },
     (_, i) => ramp[Math.round((i * lastIndex) / (count - 1))],
   )
-}
-
-/** The sequential ramp without the stops that vanish against a card. */
-function usableSequential(ramp: string[]) {
-  return ramp.slice(0, Math.max(1, ramp.length - SEQUENTIAL_TAIL_TRIM))
 }
 
 /**
@@ -328,16 +358,9 @@ export function paletteColors(
 
   const ramp = name === 'diverging' ? tokens.diverging : tokens.sequential
   if (!ramp.length) return cycle(tokens.categorical)
-
-  if (count === 1) {
-    if (name === 'diverging') return [ramp[0]]
-    return [ramp[Math.min(SEQUENTIAL_SOLO_INDEX, ramp.length - 1)]]
-  }
-
-  // A diverging ramp is read by its extremes, so it always spans end to end.
-  const lastIndex =
-    name === 'diverging' ? ramp.length - 1 : usableSequential(ramp).length - 1
-  return rampStops(ramp, count, lastIndex)
+  return name === 'diverging'
+    ? divergingStops(ramp, count)
+    : sequentialStops(ramp, count)
 }
 
 /**
@@ -347,10 +370,7 @@ export function paletteColors(
  */
 function namedRamp(name: ChartPaletteName, tokens: ChartTokens): string[] {
   if (name === 'categorical') return tokens.categorical
-  const ramp =
-    name === 'diverging'
-      ? tokens.diverging
-      : usableSequential(tokens.sequential)
+  const ramp = name === 'diverging' ? tokens.diverging : tokens.sequential
   return ramp.length ? ramp : tokens.categorical
 }
 


### PR DESCRIPTION
A single-series bar chart drew `--chart-sequential-2`, one stop paler than the first series of the stacked chart next to it. Two series took the two ends of the ramp, so adding a third recolored the second.

The ramp is now spent from the deep end, stops never more than three apart, staying inside the first seven stops until a chart has more series than that:

| series | before | after |
|---|---|---|
| 1 | 2 | 1 |
| 2 | 1 7 | 1 4 |
| 3 | 1 4 7 | 1 4 7 |
| 4 | 1 3 5 7 | 1 3 5 7 |
| 8 | wraps | 1 … 8 |

The trim that hid the two palest stops is gone. Heatmap and funnel interpolate all nine, so improving the palette in `style.css` no longer needs a code change to show.

<!-- coverage-report:start -->
Coverage: 73.39% (+0.01% vs `main`)
<!-- coverage-report:end -->

