### PR TITLE
feat: DateCalendar, DateRangeCalendar, PickerShell on Popover

### DIFF
--- a/docs/content/docs/experimental.md
+++ b/docs/content/docs/experimental.md
@@ -31,6 +31,7 @@ it is likely to move:
 | [Charts (v1)](#charts-v1) | Parked | Apps moving to [`frappe-ui/charts`](/docs/charts/overview) |
 | [`CodeEditor`](#codeeditor) | Incubating | Its API settling |
 | [`CommandPalette`](#commandpalette) | Incubating | gameplan, helpdesk and this site running on it |
+| [`DateCalendar`](#date-calendar) | Incubating | Its API settling |
 | [`FloatingWindow`](#floatingwindow) | Incubating | Its API settling |
 | [`ListView`](#listview) | Parked | [`frappe-ui/list`](/docs/molecules/list) reaching parity |
 | [`MultiEmailInput`](#multiemailinput) | Incubating | Its API settling |
@@ -119,6 +120,20 @@ import {
 
 See the [CommandPalette page](/docs/experimental/commandpalette) for filtering,
 server search, link items and the styling hooks.
+
+## Date calendar
+
+The calendar inside the single-date pickers, as a standalone component. `DateCalendar` holds one date as `v-model`, accepts `min`, `max` and `isDateUnavailable`, and exposes `focus()`.
+
+```ts
+import { DateCalendar } from 'frappe-ui/experimental'
+```
+
+It emits `select` on every click and `today` from the Today button, even when the value does not change. `update:modelValue` alone does not fire for an unchanged value, so listen to these when every click matters, for example to close a popover.
+
+<ComponentPreview name="DatePicker-DateCalendar" />
+
+Setting the value from outside moves the view to that month. Clicking inside the calendar does not move the view.
 
 ## FloatingWindow
 
@@ -320,11 +335,7 @@ form fields (this example shows a required error until a recipient is added).
 
 ## PickerShell
 
-The input-and-panel half of the date pickers: a `TextInput` trigger, a `Popover`
-the input drives rather than toggles, and the typing, open and focus wiring
-between them. Build a picker of your own on it instead of copying `DatePicker` —
-fill `#default` with the panel, and read or write the text through
-`v-model:input-value`.
+The input half of the date pickers: a `TextInput`, a `Popover` that the input opens rather than toggles, and the focus wiring between them. Use it to build a picker instead of copying `DatePicker`. Put the panel in `#default` and bind the text with `v-model:input-value`.
 
 ```vue
 <script setup lang="ts">
@@ -351,10 +362,7 @@ const text = ref('')
 </template>
 ```
 
-Style it through the `data-slot` hooks `TextInput` and
-[`Popover`](/docs/components/popover) already render — there are no
-class-injection props, and the panel takes its width from whatever `#default`
-renders.
+Style it through the `data-slot` hooks that `TextInput` and [`Popover`](/docs/components/popover) render. There are no class props. The panel is as wide as its content.
 
 ## useInputLabeling
 

--- a/docs/content/docs/experimental.md
+++ b/docs/content/docs/experimental.md
@@ -34,6 +34,7 @@ it is likely to move:
 | [`FloatingWindow`](#floatingwindow) | Incubating | Its API settling |
 | [`ListView`](#listview) | Parked | [`frappe-ui/list`](/docs/molecules/list) reaching parity |
 | [`MultiEmailInput`](#multiemailinput) | Incubating | Its API settling |
+| [`PickerShell`](#pickershell) | Incubating | Its API settling |
 | [Sprite icons](#sprite-icons) | Parked | Apps moving to `lucide-*` classes |
 | [`ThemeSwitcher`](#themeswitcher) | Parked | Apps moving to `Select` plus `useColorScheme` |
 | [TextEditor (v0)](#texteditor-v0) | Parked | Apps moving to [`frappe-ui/editor`](/docs/molecules/editor) |
@@ -316,6 +317,44 @@ entirely with `#tag`:
 form fields (this example shows a required error until a recipient is added).
 
 <ComponentPreview name="MultiEmailInput-Labeling" csr="true" />
+
+## PickerShell
+
+The input-and-panel half of the date pickers: a `TextInput` trigger, a `Popover`
+the input drives rather than toggles, and the typing, open and focus wiring
+between them. Build a picker of your own on it instead of copying `DatePicker` —
+fill `#default` with the panel, and read or write the text through
+`v-model:input-value`.
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { PickerShell } from 'frappe-ui/experimental'
+
+const open = ref(false)
+const text = ref('')
+</script>
+
+<template>
+  <PickerShell
+    v-model:open="open"
+    v-model:input-value="text"
+    side="bottom"
+    align="start"
+    :offset="4"
+    label="Colour"
+  >
+    <template #default="{ close }">
+      <ColourGrid @select="close" />
+    </template>
+  </PickerShell>
+</template>
+```
+
+Style it through the `data-slot` hooks `TextInput` and
+[`Popover`](/docs/components/popover) already render — there are no
+class-injection props, and the panel takes its width from whatever `#default`
+renders.
 
 ## useInputLabeling
 

--- a/docs/content/docs/experimental.md
+++ b/docs/content/docs/experimental.md
@@ -31,7 +31,8 @@ it is likely to move:
 | [Charts (v1)](#charts-v1) | Parked | Apps moving to [`frappe-ui/charts`](/docs/charts/overview) |
 | [`CodeEditor`](#codeeditor) | Incubating | Its API settling |
 | [`CommandPalette`](#commandpalette) | Incubating | gameplan, helpdesk and this site running on it |
-| [`DateCalendar`](#date-calendar) | Incubating | Its API settling |
+| [`DateCalendar`](#date-calendars) | Incubating | Its API settling |
+| [`DateRangeCalendar`](#date-calendars) | Incubating | Its API settling |
 | [`FloatingWindow`](#floatingwindow) | Incubating | Its API settling |
 | [`ListView`](#listview) | Parked | [`frappe-ui/list`](/docs/molecules/list) reaching parity |
 | [`MultiEmailInput`](#multiemailinput) | Incubating | Its API settling |
@@ -121,19 +122,21 @@ import {
 See the [CommandPalette page](/docs/experimental/commandpalette) for filtering,
 server search, link items and the styling hooks.
 
-## Date calendar
+## Date calendars
 
-The calendar inside the single-date pickers, as a standalone component. `DateCalendar` holds one date as `v-model`, accepts `min`, `max` and `isDateUnavailable`, and exposes `focus()`.
+The calendars inside the date pickers, as standalone components. `DateCalendar` holds one date as `v-model`. `DateRangeCalendar` holds a `[from, to]` pair, previews the pending range under the cursor, and shows two months with `dualPane`. Both accept `min`, `max` and `isDateUnavailable`, and expose `focus()`.
 
 ```ts
-import { DateCalendar } from 'frappe-ui/experimental'
+import { DateCalendar, DateRangeCalendar } from 'frappe-ui/experimental'
 ```
 
-It emits `select` on every click and `today` from the Today button, even when the value does not change. `update:modelValue` alone does not fire for an unchanged value, so listen to these when every click matters, for example to close a popover.
+Both emit `select` on every click and `today` from the Today button, even when the value does not change. `update:modelValue` alone does not fire for an unchanged value, so listen to these when every click matters, for example to close a popover.
 
 <ComponentPreview name="DatePicker-DateCalendar" />
 
 Setting the value from outside moves the view to that month. Clicking inside the calendar does not move the view.
+
+<ComponentPreview name="DatePicker-DateRangeCalendar" />
 
 ## FloatingWindow
 

--- a/experimental.ts
+++ b/experimental.ts
@@ -35,16 +35,23 @@ export * from './experimental/Charts'
 // rebuilt here as seven composable parts. Unstable: the parts stay here until
 // gameplan, helpdesk and this repo's docs site all run on them.
 export * from './experimental/CommandPalette'
+// DateCalendar. The calendar inside the single-date pickers, as a standalone
+// component. Incubating while its props and events settle.
+export { default as DateCalendar } from './src/components/DatePicker/DateCalendar.vue'
+export type {
+  DateCalendarProps,
+  DateCalendarEmits,
+  DateCalendarExposed,
+} from './src/components/DatePicker/calendarTypes'
 // ListView family. Moved out of root (#985) — `frappe-ui/list` is
 // composition-based by design (P3) and doesn't replicate ListView's
 // config-driven columns (resizable widths, per-column getLabel/prefix
 // functions, tooltips, disabled-row exclusion, the select banner), so this
 // stays here, unstable, until `frappe-ui/list` reaches parity.
 export * from './experimental/ListView'
-// PickerShell. The input-and-panel half of the date pickers: a `TextInput`
-// trigger, a manual `Popover`, and the typing, open and focus wiring between
-// them. Incubating — exported so an app can build a picker of its own instead
-// of copying it, while the props and slots settle.
+// PickerShell. The input half of the date pickers: a `TextInput`, a manual
+// `Popover` and the focus wiring between them. Incubating while its props and
+// slots settle.
 export { default as PickerShell } from './src/components/shared/picker/PickerShell.vue'
 export type {
   PickerShellProps,

--- a/experimental.ts
+++ b/experimental.ts
@@ -35,13 +35,18 @@ export * from './experimental/Charts'
 // rebuilt here as seven composable parts. Unstable: the parts stay here until
 // gameplan, helpdesk and this repo's docs site all run on them.
 export * from './experimental/CommandPalette'
-// DateCalendar. The calendar inside the single-date pickers, as a standalone
-// component. Incubating while its props and events settle.
+// Date calendars. `DateCalendar` and `DateRangeCalendar` are the calendars
+// inside the date pickers, as standalone components. Incubating while their
+// props and events settle.
 export { default as DateCalendar } from './src/components/DatePicker/DateCalendar.vue'
+export { default as DateRangeCalendar } from './src/components/DatePicker/DateRangeCalendar.vue'
 export type {
   DateCalendarProps,
   DateCalendarEmits,
   DateCalendarExposed,
+  DateRangeCalendarProps,
+  DateRangeCalendarEmits,
+  DateRangeCalendarExposed,
 } from './src/components/DatePicker/calendarTypes'
 // ListView family. Moved out of root (#985) — `frappe-ui/list` is
 // composition-based by design (P3) and doesn't replicate ListView's

--- a/experimental.ts
+++ b/experimental.ts
@@ -41,6 +41,17 @@ export * from './experimental/CommandPalette'
 // functions, tooltips, disabled-row exclusion, the select banner), so this
 // stays here, unstable, until `frappe-ui/list` reaches parity.
 export * from './experimental/ListView'
+// PickerShell. The input-and-panel half of the date pickers: a `TextInput`
+// trigger, a manual `Popover`, and the typing, open and focus wiring between
+// them. Incubating — exported so an app can build a picker of its own instead
+// of copying it, while the props and slots settle.
+export { default as PickerShell } from './src/components/shared/picker/PickerShell.vue'
+export type {
+  PickerShellProps,
+  PickerShellTriggerSlotProps,
+  PickerShellSlots,
+  PickerShellExposed,
+} from './src/components/shared/picker/types'
 // v0 TextEditor family. Moved out of root (#974) — `frappe-ui/editor` is the
 // composition-based replacement. Parked here (#1007), unstable, as an interim
 // import path while apps migrate. Deletion stays human-gated (spec/editor.md

--- a/src/charts/components/ChartContainer.cy.ts
+++ b/src/charts/components/ChartContainer.cy.ts
@@ -55,6 +55,46 @@ describe('ChartContainer', () => {
       cy.get('[data-slot="chart-header"] #period').should('exist')
     })
 
+    it('keeps the row the height of the title line, with a tall action', () => {
+      mountContainer({ title: 'Revenue' })
+      cy.get('.text-ink-gray-8').invoke('outerHeight').as('titleHeight')
+
+      mountContainer({ title: 'Revenue' }, {
+        default: () => h('div', 'Plot'),
+        actions: () =>
+          h('button', { id: 'period', style: 'height: 28px' }, 'Last 30 days'),
+      } as any)
+
+      cy.get('[data-slot="chart-header"]')
+        .invoke('outerHeight')
+        .then((rowHeight) => {
+          cy.get('@titleHeight').should('be.closeTo', rowHeight as number, 0.5)
+        })
+    })
+
+    it('centres a tall action on the title line', () => {
+      mountContainer({ title: 'Revenue' }, {
+        default: () => h('div', 'Plot'),
+        actions: () =>
+          h('button', { id: 'period', style: 'height: 28px' }, 'Last 30 days'),
+      } as any)
+
+      cy.get('.text-ink-gray-8')
+        .then(($title) => $title[0].getBoundingClientRect())
+        .as('title')
+
+      cy.get('#period')
+        .then(($action) => $action[0].getBoundingClientRect())
+        .then((action) => {
+          cy.get<DOMRect>('@title').should((title) => {
+            expect(action.top + action.height / 2).to.be.closeTo(
+              title.top + title.height / 2,
+              0.5,
+            )
+          })
+        })
+    })
+
     // A card with only controls still needs the row to hang them on.
     it('draws the header for actions alone', () => {
       mountContainer({}, {

--- a/src/charts/components/ChartContainer.vue
+++ b/src/charts/components/ChartContainer.vue
@@ -21,7 +21,13 @@
           {{ subtitle }}
         </div>
       </div>
-      <div v-if="$slots.actions" class="shrink-0">
+      <!-- `1lh` is one line of this element's text. The line-height is set
+           explicitly to the title's (14px × 1.5) instead of via `text-p-base`,
+           so the slot does not inherit a font-size. -->
+      <div
+        v-if="$slots.actions"
+        class="flex h-[1lh] shrink-0 items-center leading-[21px]"
+      >
         <slot name="actions" />
       </div>
     </div>

--- a/src/charts/docs/ChartContainer.md
+++ b/src/charts/docs/ChartContainer.md
@@ -23,6 +23,9 @@ picker, a menu, or a link to the records behind the chart. It keeps its width
 and the title truncates, because a control that shrinks stops being pressable
 while a name that shortens still reads.
 
+The header row is one title line tall. An action taller than that is centred on
+the title instead of making the row taller.
+
 ## Value-axis titles
 
 `plotLabel` titles the primary value axis and `plotLabelSecondary` the second

--- a/src/components/DatePicker/CalendarPanel.vue
+++ b/src/components/DatePicker/CalendarPanel.vue
@@ -204,56 +204,13 @@ import { computed, nextTick, ref, watch } from 'vue'
 import type { Dayjs } from 'dayjs/esm'
 import { Button } from '../Button'
 import { months } from './utils'
-import type { DatePickerViewMode as ViewMode } from './types'
+import type {
+  CalendarPanelCell,
+  CalendarPanelExposed,
+  CalendarPanelProps,
+} from './calendarTypes'
 
-export interface CalendarPanelCell {
-  date: Dayjs
-  key: string
-  inMonth: boolean
-  isToday: boolean
-  isSelected: boolean
-  isUnavailable: boolean
-  isRangeStart?: boolean
-  isRangeEnd?: boolean
-  inRange?: boolean
-}
-
-interface Props {
-  view: ViewMode
-  currentYear: number
-  currentMonth: number
-  weeks: CalendarPanelCell[][]
-  /** Label for the optional Today/Now action button between prev/next. Empty/undefined hides it. */
-  todayLabel?: string
-  /** Hide the prev nav button — used in dual-pane right side. */
-  hidePrev?: boolean
-  /** Hide the next nav button — used in dual-pane left side. */
-  hideNext?: boolean
-  /** Hide the Today/Now button — used in dual-pane to avoid duplicates. */
-  hideToday?: boolean
-  /** Render out-of-month cells as empty placeholders — used in dual-pane to avoid showing the same date in both panes. */
-  hideOutOfMonth?: boolean
-  /**
-   * Render a slim header with prev/next flanking a centered, non-clickable
-   * month label. Used in dual-pane so the two panels read as
-   * `< First Month | Second Month >`.
-   */
-  centerHeader?: boolean
-  /** Earliest selectable date in YYYY-MM-DD format. Used to bound keyboard nav. */
-  min?: string
-  /** Latest selectable date in YYYY-MM-DD format. Used to bound keyboard nav. */
-  max?: string
-  /**
-   * The date that currently holds the roving tabindex. Controlled — parent
-   * owns the state, panel emits `update:focusedDate` when arrow keys land on
-   * a new cell. Multiple panels (e.g. dual-pane DateRangePicker) can share
-   * the same value; each panel only renders `tabindex=0` if the date falls
-   * inside its own visible weeks.
-   */
-  focusedDate?: Dayjs | null
-}
-
-const props = withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<CalendarPanelProps>(), {
   todayLabel: '',
   hidePrev: false,
   hideNext: false,
@@ -348,11 +305,6 @@ function pickInitialFocusDate(weeks: CalendarPanelCell[][]): Dayjs | null {
   return firstAvailable?.date ?? null
 }
 
-// (Seeding `focusedDate` is the parent's responsibility — it knows the full
-// picture: selected/from value, whether dual-pane is active, etc. CalendarPanel
-// stays purely controlled so multiple panels sharing one focused-date can't
-// race each other on mount.)
-
 // When the focused date changes, move DOM focus to the matching cell — but
 // only if the cell is in *our* grid and focus is already inside a calendar
 // panel. The "already inside a panel" guard avoids stealing focus from the
@@ -433,7 +385,7 @@ function focusInitialCell() {
   })
 }
 
-defineExpose({ focusInitialCell })
+defineExpose<CalendarPanelExposed>({ focusInitialCell })
 
 const WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 

--- a/src/components/DatePicker/DateCalendar.cy.ts
+++ b/src/components/DatePicker/DateCalendar.cy.ts
@@ -1,0 +1,149 @@
+import DateCalendar from './DateCalendar.vue'
+
+const pad = (n: number) => String(n).padStart(2, '0')
+const getTodaysDate = () => {
+  const d = new Date()
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+describe('DateCalendar', () => {
+  it('renders the grid inline, with no popover', () => {
+    cy.mount(DateCalendar)
+
+    cy.get('[role=dialog]').should('not.exist')
+    cy.get('[role=grid]').should('exist')
+    cy.get(`[aria-label^="${getTodaysDate()}"]`).should('exist')
+  })
+
+  it('opens on the month of its value', () => {
+    cy.mount(DateCalendar, { props: { modelValue: '2025-06-15' } })
+    cy.get('[aria-label=cycle-calendar-view]').should('have.text', 'Jun 2025')
+  })
+
+  it('selecting a date emits update:modelValue and select', () => {
+    cy.mount(DateCalendar, {
+      props: {
+        modelValue: '2025-06-15',
+        'onUpdate:modelValue': cy.spy().as('onUpdate'),
+        onSelect: cy.spy().as('onSelect'),
+      },
+    })
+    cy.get('[aria-label="2025-06-16"]').click()
+    cy.get('@onUpdate').should('have.been.calledWith', '2025-06-16')
+    cy.get('@onSelect').should('have.been.calledWith', '2025-06-16')
+  })
+
+  it('re-selecting the current value still emits select', () => {
+    cy.mount(DateCalendar, {
+      props: {
+        modelValue: '2025-06-15',
+        onSelect: cy.spy().as('onSelect'),
+      },
+    })
+    cy.get('[aria-label="2025-06-15"]').click()
+    cy.get('@onSelect').should('have.been.calledOnceWith', '2025-06-15')
+  })
+
+  it('clicking an out-of-month cell keeps the view put', () => {
+    cy.mount(DateCalendar, {
+      props: {
+        modelValue: '2025-06-15',
+        onSelect: cy.spy().as('onSelect'),
+      },
+    })
+    cy.get('[aria-label="2025-07-01"]').click()
+    cy.get('@onSelect').should('have.been.calledWith', '2025-07-01')
+    cy.get('[aria-label=cycle-calendar-view]').should('have.text', 'Jun 2025')
+  })
+
+  it('a value set from outside pulls the view to its month', () => {
+    cy.mount(DateCalendar, { props: { modelValue: '2025-06-15' } }).then(
+      ({ wrapper }) => wrapper.setProps({ modelValue: '2025-09-03' }),
+    )
+    cy.get('[aria-label=cycle-calendar-view]').should('have.text', 'Sep 2025')
+  })
+
+  it('today button selects today and emits today', () => {
+    cy.mount(DateCalendar, {
+      props: {
+        'onUpdate:modelValue': cy.spy().as('onUpdate'),
+        onToday: cy.spy().as('onToday'),
+      },
+    })
+    cy.get('[aria-label="Today"]').click()
+    cy.get('@onUpdate').should('have.been.calledWith', getTodaysDate())
+    cy.get('@onToday').should('have.been.calledOnceWith', getTodaysDate())
+  })
+
+  it('today button emits today even when today is already selected', () => {
+    cy.mount(DateCalendar, {
+      props: {
+        modelValue: getTodaysDate(),
+        onToday: cy.spy().as('onToday'),
+      },
+    })
+    cy.get('[aria-label="Today"]').click()
+    cy.get('@onToday').should('have.been.calledOnceWith', getTodaysDate())
+  })
+
+  it('empty todayLabel hides the button', () => {
+    cy.mount(DateCalendar, { props: { todayLabel: '' } })
+    cy.get('[aria-label="Today"]').should('not.exist')
+  })
+
+  it('min disables earlier cells and blocks selecting them', () => {
+    cy.mount(DateCalendar, {
+      props: {
+        modelValue: '2025-06-15',
+        min: '2025-06-10',
+        'onUpdate:modelValue': cy.spy().as('onUpdate'),
+      },
+    })
+    cy.get('[aria-label="2025-06-09"]').should(
+      'have.attr',
+      'aria-disabled',
+      'true',
+    )
+    cy.get('[aria-label="2025-06-10"]').should('not.have.attr', 'aria-disabled')
+    cy.get('[aria-label="2025-06-09"]').click({ force: true })
+    cy.get('@onUpdate').should('not.have.been.called')
+  })
+
+  describe('keyboard navigation', () => {
+    it('arrow-right moves focus one day', () => {
+      cy.mount(DateCalendar, { props: { modelValue: '2025-06-15' } })
+      cy.get('[aria-label="2025-06-15"]').focus()
+      cy.focused().trigger('keydown', { key: 'ArrowRight' })
+      cy.focused().should('have.attr', 'data-value', '2025-06-16')
+    })
+
+    it('arrowing past the end of the month steps the view', () => {
+      cy.mount(DateCalendar, { props: { modelValue: '2025-06-30' } })
+      cy.get('[aria-label="2025-06-30"]').focus()
+      cy.focused().trigger('keydown', { key: 'ArrowRight' })
+      cy.focused().should('have.attr', 'data-value', '2025-07-01')
+      cy.get('[aria-label=cycle-calendar-view]').should('have.text', 'Jul 2025')
+    })
+
+    it('Enter selects the focused cell', () => {
+      cy.mount(DateCalendar, {
+        props: {
+          modelValue: '2025-06-15',
+          'onUpdate:modelValue': cy.spy().as('onUpdate'),
+        },
+      })
+      cy.get('[aria-label="2025-06-15"]').focus()
+      cy.focused().trigger('keydown', { key: 'ArrowRight' })
+      cy.focused().trigger('keydown', { key: 'Enter' })
+      cy.get('@onUpdate').should('have.been.calledWith', '2025-06-16')
+    })
+
+    it('a value set from outside takes the tabindex in its own month', () => {
+      cy.mount(DateCalendar, { props: { modelValue: '2025-06-15' } }).then(
+        ({ wrapper }) => wrapper.setProps({ modelValue: '2025-09-03' }),
+      )
+      cy.get('[aria-label=cycle-calendar-view]').should('have.text', 'Sep 2025')
+      cy.get('[aria-label="2025-09-03"]').should('have.attr', 'tabindex', '0')
+    })
+  })
+})

--- a/src/components/DatePicker/DateCalendar.vue
+++ b/src/components/DatePicker/DateCalendar.vue
@@ -1,0 +1,114 @@
+<template>
+  <CalendarPanel
+    ref="panelRef"
+    :view="view"
+    :current-year="currentYear"
+    :current-month="currentMonth"
+    :weeks="weeks"
+    :today-label="props.todayLabel"
+    :min="props.min"
+    :max="props.max"
+    v-model:focused-date="focusedDate"
+    @prev="prev"
+    @next="next"
+    @today="selectToday"
+    @cycle-view="cycleView"
+    @select-month="selectMonth"
+    @select-year="selectYear"
+    @select-date="select"
+    @navigate="focusOn"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { Dayjs } from 'dayjs/esm'
+import { dayjs, dayjsLocal } from '../../utils/dayjs'
+import CalendarPanel from './CalendarPanel.vue'
+import {
+  makeUnavailableCheck,
+  useCalendarView,
+  useFocusedDate,
+} from './composables'
+import { generateWeeks } from './utils'
+import type {
+  CalendarPanelCell,
+  CalendarPanelExposed,
+  DateCalendarEmits,
+  DateCalendarExposed,
+  DateCalendarProps,
+} from './calendarTypes'
+
+const props = withDefaults(defineProps<DateCalendarProps>(), {
+  todayLabel: 'Today',
+})
+
+const emit = defineEmits<DateCalendarEmits>()
+
+/** Selected date in `YYYY-MM-DD` format, or `''` when nothing is selected. */
+const model = defineModel<string>({ default: '' })
+
+const DATE_FORMAT = 'YYYY-MM-DD'
+
+const {
+  view,
+  currentYear,
+  currentMonth,
+  prev,
+  next,
+  cycleView,
+  selectMonth,
+  selectYear,
+  focusOn,
+  resetView,
+} = useCalendarView()
+
+const checkUnavailable = makeUnavailableCheck(
+  () => props.min,
+  () => props.max,
+  () => props.isDateUnavailable,
+)
+
+const weeks = computed<CalendarPanelCell[][]>(() =>
+  generateWeeks(currentYear.value, currentMonth.value, model.value).map(
+    (week) =>
+      week.map((d) => ({ ...d, isUnavailable: checkUnavailable(d.date) })),
+  ),
+)
+
+const panelRef = ref<CalendarPanelExposed | null>(null)
+
+const { focusedDate, markOwnCommit, focus } = useFocusedDate({
+  key: () => model.value,
+  anchor: () => (model.value ? dayjs(model.value) : null),
+  months: () => [{ year: currentYear.value, month: currentMonth.value }],
+  isUnavailable: checkUnavailable,
+  focusOn,
+  resetView,
+  panels: () => [panelRef.value],
+})
+
+// `v-model` does not emit when the value is unchanged. `select` and `today`
+// fire on every click, so a parent can react to re-selecting the current value.
+function commit(value: string): void {
+  markOwnCommit(value)
+  model.value = value
+}
+
+function select(date: Dayjs): void {
+  if (checkUnavailable(date)) return
+  const value = date.format(DATE_FORMAT)
+  commit(value)
+  emit('select', value)
+}
+
+function selectToday(): void {
+  const today = dayjsLocal()
+  if (checkUnavailable(today)) return
+  const value = today.format(DATE_FORMAT)
+  commit(value)
+  emit('today', value)
+}
+
+defineExpose<DateCalendarExposed>({ focus })
+</script>

--- a/src/components/DatePicker/DatePicker.cy.ts
+++ b/src/components/DatePicker/DatePicker.cy.ts
@@ -89,6 +89,22 @@ describe('DatePicker', () => {
     cy.get('input').should('have.value', getTodaysDate())
   })
 
+  it('clicking the already-selected date closes the popover', () => {
+    cy.mount(DatePicker, { props: { modelValue: '2025-06-15' } })
+    cy.get('input').dblclick()
+    cy.get('[role=dialog]').should('exist')
+    cy.get('[aria-label="2025-06-15"]').click()
+    cy.get('[role=dialog]').should('not.exist')
+  })
+
+  it('today button closes the popover when today is already selected', () => {
+    cy.mount(DatePicker, { props: { modelValue: getTodaysDate() } })
+    cy.get('input').dblclick()
+    cy.get('[role=dialog]').should('exist')
+    cy.get('[aria-label="Today"]').click()
+    cy.get('[role=dialog]').should('not.exist')
+  })
+
   it('clear slot prop removes the value', () => {
     // Consumer renders Clear in the #actions sidebar; verifies clear() + close() wiring.
     cy.mount(DatePicker, {
@@ -168,8 +184,16 @@ describe('DatePicker', () => {
     })
     cy.get('input').dblclick()
     cy.get('[role=dialog]').should('exist')
-    cy.get('[aria-label="2025-06-09"]').should('have.attr', 'aria-disabled', 'true')
-    cy.get('[aria-label="2025-06-21"]').should('have.attr', 'aria-disabled', 'true')
+    cy.get('[aria-label="2025-06-09"]').should(
+      'have.attr',
+      'aria-disabled',
+      'true',
+    )
+    cy.get('[aria-label="2025-06-21"]').should(
+      'have.attr',
+      'aria-disabled',
+      'true',
+    )
     cy.get('[aria-label="2025-06-15"]').should('not.have.attr', 'aria-disabled')
   })
 
@@ -183,8 +207,16 @@ describe('DatePicker', () => {
     })
     cy.get('input').dblclick()
     // 2025-06-14 is a Saturday, 2025-06-15 is a Sunday, 2025-06-16 is a Monday
-    cy.get('[aria-label="2025-06-14"]').should('have.attr', 'aria-disabled', 'true')
-    cy.get('[aria-label="2025-06-15"]').should('have.attr', 'aria-disabled', 'true')
+    cy.get('[aria-label="2025-06-14"]').should(
+      'have.attr',
+      'aria-disabled',
+      'true',
+    )
+    cy.get('[aria-label="2025-06-15"]').should(
+      'have.attr',
+      'aria-disabled',
+      'true',
+    )
     cy.get('[aria-label="2025-06-16"]').should('not.have.attr', 'aria-disabled')
   })
 
@@ -362,7 +394,8 @@ describe('DatePicker', () => {
         props: {
           modelValue: '2025-06-15',
           // Disable 2025-06-16 only — pressing → from 15 should skip to 17.
-          isDateUnavailable: (d: any) => d.format('YYYY-MM-DD') === '2025-06-16',
+          isDateUnavailable: (d: any) =>
+            d.format('YYYY-MM-DD') === '2025-06-16',
         },
       })
       cy.get('input').focus().type('{downArrow}')
@@ -376,7 +409,10 @@ describe('DatePicker', () => {
       cy.get('input').focus().type('{downArrow}')
       cy.focused().trigger('keydown', { key: 'ArrowRight' })
       cy.focused().should('have.attr', 'data-value', '2025-07-01')
-      cy.get('[aria-label=cycle-calendar-view]').should('contain.text', 'Jul 2025')
+      cy.get('[aria-label=cycle-calendar-view]').should(
+        'contain.text',
+        'Jul 2025',
+      )
     })
   })
 })

--- a/src/components/DatePicker/DatePicker.md
+++ b/src/components/DatePicker/DatePicker.md
@@ -3,12 +3,15 @@
 A set of pickers for selecting dates, date ranges, or date and time. Smooth, intuitive interfaces make choosing and adjusting values quick and precise.
 
 ## Date Picker
+
 <ComponentPreview name="DatePicker-Examples" />
 
 ## DateTime Picker
+
 <ComponentPreview name="DatePicker-DateTime" />
 
 ## Date Range Picker
+
 <ComponentPreview name="DatePicker-Range" />
 
 <!-- @include: ./DatePicker.api.md -->

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -51,24 +51,15 @@
             }"
           />
         </aside>
-        <CalendarPanel
-          ref="panelRef"
-          :view="view"
-          :current-year="currentYear"
-          :current-month="currentMonth"
-          :weeks="weeks"
+        <DateCalendar
+          ref="calendarRef"
+          :model-value="selected"
           today-label="Today"
           :min="props.min"
           :max="props.max"
-          v-model:focused-date="focusedDate"
-          @prev="prev"
-          @next="next"
-          @today="handleTodayClick"
-          @cycle-view="cycleView"
-          @select-month="selectMonth"
-          @select-year="selectYear"
-          @select-date="handleDateCellClick"
-          @navigate="onPanelNavigate"
+          :is-date-unavailable="props.isDateUnavailable"
+          @select="handleDateCellClick"
+          @today="handleDateCellClick"
         />
       </div>
     </template>
@@ -78,11 +69,9 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from 'vue'
 import { dayjs, dayjsLocal } from '../../utils/dayjs'
-import { generateWeeks } from './utils'
-import CalendarPanel, { type CalendarPanelCell } from './CalendarPanel.vue'
+import DateCalendar from './DateCalendar.vue'
 import PickerShell from '../shared/picker/PickerShell.vue'
 import {
-  useCalendarView,
   usePopoverPositioning,
   useKeepOpen,
   useTypeable,
@@ -90,11 +79,8 @@ import {
   makeUnavailableCheck,
 } from './composables'
 import type { Dayjs } from 'dayjs/esm'
-import type {
-  DatePickerProps,
-  DatePickerEmits,
-  DatePickerSlots,
-} from './types'
+import type { DatePickerProps, DatePickerEmits, DatePickerSlots } from './types'
+import type { DateCalendarExposed } from './calendarTypes'
 
 const props = withDefaults(defineProps<DatePickerProps>(), {
   modelValue: '',
@@ -130,54 +116,20 @@ watch(isOpen, (val) => {
 
 function onShellOpen() {
   initFromValue()
-  seedFocusedDate()
 }
 
 function onShellClose() {
-  resetView()
   if (isTyping.value) {
     commitInput()
     isTyping.value = false
   }
-  // Drop the focused-date so the next open re-seeds it from today/selected
-  // rather than resuming on a stale arrow-key target.
-  focusedDate.value = null
 }
 
-const panelRef = ref<{ focusInitialCell: () => void } | null>(null)
-const focusedDate = ref<Dayjs | null>(null)
-
-function seedFocusedDate() {
-  if (focusedDate.value) return
-  if (selected.value) {
-    const d = dayjs(selected.value)
-    if (!checkUnavailable(d)) {
-      focusedDate.value = d
-      return
-    }
-  }
-  const today = dayjsLocal()
-  if (!checkUnavailable(today)) {
-    focusedDate.value = today
-    return
-  }
-  const first = weeks.value.flat().find((c) => c.inMonth && !c.isUnavailable)
-  if (first) focusedDate.value = first.date
-}
+const calendarRef = ref<DateCalendarExposed | null>(null)
 
 function onShellRequestFocus() {
-  // Seed synchronously *before* the reactive flush so the CalendarPanel
-  // mounts with `props.focusedDate` already set — that way the focused cell
-  // has `tabindex=0` on first render and `focusInitialCell` (queued for
-  // next tick) finds it.
-  seedFocusedDate()
-  nextTick(() => panelRef.value?.focusInitialCell())
-}
-
-function onPanelNavigate(target: Dayjs) {
-  // Single-pane: target dictates the view. focusedDate stays in sync via
-  // CalendarPanel's `update:focusedDate` (already wired via v-model).
-  focusOn(target)
+  // The calendar only mounts with the popover, so wait a tick for it.
+  nextTick(() => calendarRef.value?.focus())
 }
 
 defineExpose({
@@ -192,19 +144,6 @@ const shouldKeepOpen = useKeepOpen(props)
 const inputReadonly = useTypeable(props)
 
 // ── Calendar state ───────────────────────────────────────────────────────────
-
-const {
-  view,
-  currentYear,
-  currentMonth,
-  prev,
-  next,
-  cycleView,
-  selectMonth,
-  selectYear,
-  focusOn,
-  resetView,
-} = useCalendarView()
 
 const DATE_FORMAT = 'YYYY-MM-DD'
 const selected = ref<string>('')
@@ -221,9 +160,7 @@ const coerceToDayjs = useDateCoercion(() => props.format)
 function syncFromValue(val?: string): void {
   if (!val) {
     if (!props.clearable) {
-      const today = dayjsLocal()
-      focusOn(today)
-      selected.value = today.format(DATE_FORMAT)
+      selected.value = dayjsLocal().format(DATE_FORMAT)
     } else {
       selected.value = ''
     }
@@ -234,7 +171,6 @@ function syncFromValue(val?: string): void {
     selected.value = ''
     return
   }
-  focusOn(d)
   selected.value = d.format(DATE_FORMAT)
 }
 
@@ -269,18 +205,6 @@ const isTyping = ref(false)
 watch(displayLabel, (val) => {
   if (!isTyping.value) inputValue.value = val
 })
-
-// ── Calendar grid ────────────────────────────────────────────────────────────
-
-const weeks = computed<CalendarPanelCell[][]>(() =>
-  generateWeeks(currentYear.value, currentMonth.value, selected.value).map(
-    (week) =>
-      week.map((d) => ({
-        ...d,
-        isUnavailable: checkUnavailable(d.date),
-      })),
-  ),
-)
 
 // ── Input commit / selection ─────────────────────────────────────────────────
 
@@ -320,7 +244,6 @@ function selectDate(date: string | Date | Dayjs): void {
   if (checkUnavailable(d)) return
   const prev = selected.value
   selected.value = d.format(DATE_FORMAT)
-  focusOn(d)
 
   if (selected.value !== initialValue.value) {
     emit('update:modelValue', selected.value)
@@ -333,7 +256,6 @@ function selectDate(date: string | Date | Dayjs): void {
       ? formatter(selected.value, props.format)
       : selected.value
   }
-  resetView()
 }
 
 function handleDateCellClick(date: string | Date | Dayjs) {
@@ -342,14 +264,9 @@ function handleDateCellClick(date: string | Date | Dayjs) {
   isTyping.value = false
 }
 
-function handleTodayClick() {
-  handleDateCellClick(dayjsLocal())
-}
-
 function handleClearClick() {
   clearSelection()
   if (!shouldKeepOpen.value) isOpen.value = false
   isTyping.value = false
-  resetView()
 }
 </script>

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -20,7 +20,6 @@
     :disabled="props.disabled"
     :readonly="inputReadonly"
     :display-label="displayLabel"
-    :content-class="contentClass"
     @blur="commitInput()"
     @enter="commitInput(true)"
     @open="onShellOpen"
@@ -34,7 +33,7 @@
     <template #default="{ close }">
       <div
         class="flex"
-        :class="$slots.actions ? 'divide-x divide-outline-gray-2' : ''"
+        :class="$slots.actions ? 'w-fit divide-x divide-outline-gray-2' : 'w-56'"
       >
         <aside
           v-if="$slots.actions"
@@ -78,7 +77,6 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from 'vue'
-import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import { dayjs, dayjsLocal } from '../../utils/dayjs'
 import { generateWeeks } from './utils'
 import CalendarPanel, { type CalendarPanelCell } from './CalendarPanel.vue'
@@ -111,11 +109,6 @@ const props = withDefaults(defineProps<DatePickerProps>(), {
 const emit = defineEmits<DatePickerEmits>()
 
 defineSlots<DatePickerSlots>()
-const slots = useReactiveSlots<DatePickerSlots>()
-
-// Layout only — the elevated shell (rounded/bg/shadow/ring) is owned by
-// PopoverPanel inside PickerShell.
-const contentClass = computed(() => (slots.actions ? 'w-fit' : 'w-56'))
 
 // ── Popover open state ───────────────────────────────────────────────────────
 

--- a/src/components/DatePicker/DateRangeCalendar.cy.ts
+++ b/src/components/DatePicker/DateRangeCalendar.cy.ts
@@ -1,0 +1,186 @@
+import { defineComponent, h, ref } from 'vue'
+import DateRangeCalendar from './DateRangeCalendar.vue'
+import type { DateRangeValue } from './types'
+
+const pad = (n: number) => String(n).padStart(2, '0')
+const getTodaysDate = () => {
+  const d = new Date()
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+// The range is only half-picked between the two clicks, so the value has to
+// travel back down for the second click to read it. A harness holding the
+// `v-model` is the smallest way to test the component the way it is used.
+function mountCalendar(
+  modelValue: DateRangeValue = [],
+  props: Record<string, unknown> = {},
+) {
+  const onUpdate = cy.spy().as('onUpdate')
+  const onSelect = cy.spy().as('onSelect')
+  const onToday = cy.spy().as('onToday')
+  return cy.mount(
+    defineComponent({
+      setup() {
+        const range = ref<DateRangeValue>(modelValue)
+        return () =>
+          h(DateRangeCalendar, {
+            ...props,
+            modelValue: range.value,
+            onSelect,
+            onToday,
+            'onUpdate:modelValue': (value: DateRangeValue) => {
+              range.value = value
+              onUpdate(value)
+            },
+          })
+      },
+    }),
+  )
+}
+
+describe('DateRangeCalendar', () => {
+  it('renders the grid inline, with no popover', () => {
+    mountCalendar()
+
+    cy.get('[role=dialog]').should('not.exist')
+    cy.get('[role=grid]').should('have.length', 1)
+    cy.get(`[aria-label^="${getTodaysDate()}"]`).should('exist')
+  })
+
+  it('opens on the month of its range start', () => {
+    mountCalendar(['2025-06-10', '2025-06-15'])
+    cy.get('[aria-label=cycle-calendar-view]').should('have.text', 'Jun 2025')
+  })
+
+  it('first click opens the range, second closes it', () => {
+    mountCalendar(['2025-06-10', '2025-06-15'])
+    cy.get('[aria-label="2025-06-12"]').click()
+    cy.get('@onUpdate').should('have.been.calledWith', ['2025-06-12', ''])
+    cy.get('[aria-label="2025-06-18"]').click()
+    cy.get('@onUpdate').should('have.been.calledWith', [
+      '2025-06-12',
+      '2025-06-18',
+    ])
+  })
+
+  it('clicking a current endpoint still emits select', () => {
+    mountCalendar(['2025-06-10', '2025-06-15'])
+    cy.get('[aria-label="2025-06-10"]').click()
+    cy.get('@onSelect').should('have.been.calledOnceWith', ['2025-06-10', ''])
+    cy.get('[aria-label="2025-06-10"]').click()
+    cy.get('@onSelect').should('have.been.calledTwice')
+  })
+
+  it('clicking an out-of-month cell keeps the view put', () => {
+    mountCalendar(['2025-06-10', '2025-06-15'])
+    cy.get('[aria-label="2025-07-01"]').click()
+    cy.get('@onSelect').should('have.been.calledWith', ['2025-07-01', ''])
+    cy.get('[aria-label=cycle-calendar-view]').should('have.text', 'Jun 2025')
+  })
+
+  it('a range set from outside pulls the view to its start', () => {
+    cy.mount(DateRangeCalendar, {
+      props: { modelValue: ['2025-06-15', '2025-06-20'] },
+    }).then(({ wrapper }) =>
+      wrapper.setProps({ modelValue: ['2025-09-03', '2025-09-10'] }),
+    )
+    cy.get('[aria-label=cycle-calendar-view]').should('have.text', 'Sep 2025')
+  })
+
+  it('picking the end before the start swaps them', () => {
+    mountCalendar(['2025-06-10', '2025-06-15'])
+    cy.get('[aria-label="2025-06-20"]').click()
+    cy.get('[aria-label="2025-06-05"]').click()
+    cy.get('@onUpdate').should('have.been.calledWith', [
+      '2025-06-05',
+      '2025-06-20',
+    ])
+  })
+
+  it('hovering after the first click previews the range', () => {
+    mountCalendar(['2025-06-10', '2025-06-15'])
+    cy.get('[aria-label="2025-06-20"]').click()
+    cy.get('[aria-label="2025-06-24"]').trigger('mouseenter')
+    cy.get('[aria-label="2025-06-22"]').should(
+      'have.class',
+      'bg-surface-gray-3',
+    )
+    cy.get('[aria-label="2025-06-26"]').should(
+      'not.have.class',
+      'bg-surface-gray-3',
+    )
+  })
+
+  it('today button selects today at both ends and emits today', () => {
+    mountCalendar()
+    cy.get('[aria-label="Today"]').click()
+    cy.get('@onUpdate').should('have.been.calledWith', [
+      getTodaysDate(),
+      getTodaysDate(),
+    ])
+    cy.get('@onToday').should('have.been.calledOnceWith', [
+      getTodaysDate(),
+      getTodaysDate(),
+    ])
+  })
+
+  it('today button emits today even when today is already the range', () => {
+    mountCalendar([getTodaysDate(), getTodaysDate()])
+    cy.get('[aria-label="Today"]').click()
+    cy.get('@onToday').should('have.been.calledOnceWith', [
+      getTodaysDate(),
+      getTodaysDate(),
+    ])
+  })
+
+  it('empty todayLabel hides the button', () => {
+    mountCalendar([], { todayLabel: '' })
+    cy.get('[aria-label="Today"]').should('not.exist')
+  })
+
+  it('min disables earlier cells and blocks selecting them', () => {
+    mountCalendar(['2025-06-15', '2025-06-15'], { min: '2025-06-10' })
+    cy.get('[aria-label="2025-06-09"]').should(
+      'have.attr',
+      'aria-disabled',
+      'true',
+    )
+    cy.get('[aria-label="2025-06-09"]').click({ force: true })
+    cy.get('@onUpdate').should('not.have.been.called')
+  })
+
+  it('dualPane renders two grids and drops the cycle-view button', () => {
+    mountCalendar(['2025-06-10', '2025-06-15'], { dualPane: true })
+    cy.get('[role=grid][aria-label="Calendar dates"]').should('have.length', 2)
+    cy.get('[aria-label=cycle-calendar-view]').should('not.exist')
+    cy.get('[aria-label="2025-07-05"]').should('exist')
+  })
+
+  describe('keyboard navigation', () => {
+    it('arrowing past the end of the month steps the view', () => {
+      mountCalendar(['2025-06-30', '2025-06-30'])
+      cy.get('[aria-label="2025-06-30"]').focus()
+      cy.focused().trigger('keydown', { key: 'ArrowRight' })
+      cy.focused().should('have.attr', 'data-value', '2025-07-01')
+      cy.get('[aria-label=cycle-calendar-view]').should('have.text', 'Jul 2025')
+    })
+
+    it('Enter selects the focused cell', () => {
+      mountCalendar(['2025-06-15', '2025-06-15'])
+      cy.get('[aria-label="2025-06-15"]').focus()
+      cy.focused().trigger('keydown', { key: 'ArrowRight' })
+      cy.focused().trigger('keydown', { key: 'Enter' })
+      cy.get('@onUpdate').should('have.been.calledWith', ['2025-06-16', ''])
+    })
+
+    it('a range set from outside hands the tabindex to its start', () => {
+      cy.mount(DateRangeCalendar, {
+        props: { modelValue: ['2025-06-15', '2025-06-20'] },
+      }).then(({ wrapper }) =>
+        wrapper.setProps({ modelValue: ['2025-09-03', '2025-09-10'] }),
+      )
+      cy.get('[aria-label=cycle-calendar-view]').should('have.text', 'Sep 2025')
+      cy.get('[aria-label="2025-09-03"]').should('have.attr', 'tabindex', '0')
+    })
+  })
+})

--- a/src/components/DatePicker/DateRangeCalendar.vue
+++ b/src/components/DatePicker/DateRangeCalendar.vue
@@ -1,0 +1,211 @@
+<template>
+  <div
+    class="flex"
+    :class="isDualPaneActive ? 'divide-x divide-outline-gray-2' : ''"
+  >
+    <CalendarPanel
+      ref="leftPanelRef"
+      :view="view"
+      :current-year="currentYear"
+      :current-month="currentMonth"
+      :weeks="weeks"
+      :today-label="isDualPaneActive ? '' : props.todayLabel"
+      :hide-next="isDualPaneActive"
+      :hide-out-of-month="isDualPaneActive"
+      :center-header="isDualPaneActive"
+      :min="props.min"
+      :max="props.max"
+      v-model:focused-date="focusedDate"
+      @prev="prev"
+      @next="next"
+      @today="selectToday"
+      @cycle-view="cycleView"
+      @select-month="selectMonth"
+      @select-year="selectYear"
+      @select-date="select"
+      @hover-cell="onCellHover"
+      @navigate="onPanelNavigate"
+    />
+    <CalendarPanel
+      v-if="isDualPaneActive"
+      ref="rightPanelRef"
+      :view="view"
+      :current-year="rightYear"
+      :current-month="rightMonth"
+      :weeks="rightWeeks"
+      hide-prev
+      hide-today
+      hide-out-of-month
+      center-header
+      :min="props.min"
+      :max="props.max"
+      v-model:focused-date="focusedDate"
+      @next="next"
+      @cycle-view="cycleView"
+      @select-date="select"
+      @hover-cell="onCellHover"
+      @navigate="onPanelNavigate"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { Dayjs } from 'dayjs/esm'
+import { dayjs, dayjsLocal } from '../../utils/dayjs'
+import CalendarPanel from './CalendarPanel.vue'
+import {
+  makeUnavailableCheck,
+  useCalendarView,
+  useFocusedDate,
+} from './composables'
+import { generateRangeWeeks, rangeKey, stepRange } from './utils'
+import type {
+  CalendarPanelCell,
+  CalendarPanelExposed,
+  DateRangeCalendarEmits,
+  DateRangeCalendarExposed,
+  DateRangeCalendarProps,
+} from './calendarTypes'
+import type { DateRangeValue } from './types'
+
+const props = withDefaults(defineProps<DateRangeCalendarProps>(), {
+  todayLabel: 'Today',
+  dualPane: false,
+})
+
+const emit = defineEmits<DateRangeCalendarEmits>()
+
+/** Selected range as `[from, to]` in `YYYY-MM-DD` format, or `[]` when empty. */
+const model = defineModel<DateRangeValue>({ default: () => [] })
+
+const DATE_FORMAT = 'YYYY-MM-DD'
+
+const fromDate = computed<string>(() => model.value[0] ?? '')
+const toDate = computed<string>(() => model.value[1] ?? '')
+
+const {
+  view,
+  currentYear,
+  currentMonth,
+  prev,
+  next,
+  cycleView,
+  selectMonth,
+  selectYear,
+  focusOn,
+  resetView,
+} = useCalendarView()
+
+const checkUnavailable = makeUnavailableCheck(
+  () => props.min,
+  () => props.max,
+  () => props.isDateUnavailable,
+)
+
+// The date under the cursor after the first click, for previewing the range.
+const hoverDate = ref<Dayjs | null>(null)
+
+function buildRangeWeeks(year: number, month: number): CalendarPanelCell[][] {
+  // Until the end is picked, the previewed date and the cells between it and
+  // `from` render as in-range. Only committed endpoints render as selected.
+  // Hover takes priority over keyboard focus as the preview.
+  return generateRangeWeeks({
+    year,
+    monthIndex: month,
+    from: fromDate.value,
+    to: toDate.value,
+    preview: hoverDate.value ?? focusedDate.value,
+    isUnavailable: checkUnavailable,
+  })
+}
+
+const weeks = computed<CalendarPanelCell[][]>(() =>
+  buildRangeWeeks(currentYear.value, currentMonth.value),
+)
+
+// ── Dual pane ────────────────────────────────────────────────────────────────
+// The second pane renders only for the day grid. The month-year view falls
+// back to one panel.
+
+const isDualPaneActive = computed(() => props.dualPane && view.value === 'date')
+
+const rightAnchor = computed(() =>
+  dayjs().year(currentYear.value).month(currentMonth.value).add(1, 'month'),
+)
+const rightYear = computed(() => rightAnchor.value.year())
+const rightMonth = computed(() => rightAnchor.value.month())
+const rightWeeks = computed<CalendarPanelCell[][]>(() =>
+  buildRangeWeeks(rightYear.value, rightMonth.value),
+)
+
+// ── Keyboard focus ───────────────────────────────────────────────────────────
+
+const leftPanelRef = ref<CalendarPanelExposed | null>(null)
+const rightPanelRef = ref<CalendarPanelExposed | null>(null)
+
+const { focusedDate, markOwnCommit, focus } = useFocusedDate({
+  key: () => rangeKey(model.value),
+  anchor: () => (fromDate.value ? dayjs(fromDate.value) : null),
+  months: () =>
+    isDualPaneActive.value
+      ? [
+          { year: currentYear.value, month: currentMonth.value },
+          { year: rightYear.value, month: rightMonth.value },
+        ]
+      : [{ year: currentYear.value, month: currentMonth.value }],
+  isUnavailable: checkUnavailable,
+  focusOn,
+  resetView,
+  panels: () => [leftPanelRef.value, rightPanelRef.value],
+})
+
+function onPanelNavigate(target: Dayjs): void {
+  // In dual pane the target may be visible in the other panel. Then only the
+  // focused date moves, and that panel focuses its matching cell.
+  if (isDualPaneActive.value) {
+    const inLeft =
+      target.month() === currentMonth.value &&
+      target.year() === currentYear.value
+    const inRight =
+      target.month() === rightMonth.value && target.year() === rightYear.value
+    if (inLeft || inRight) {
+      focusedDate.value = target
+      return
+    }
+  }
+  focusOn(target)
+}
+
+// ── Selection ────────────────────────────────────────────────────────────────
+
+// `v-model` does not emit when the range is unchanged. `select` and `today`
+// fire on every click, so a parent can react to re-selecting the current range.
+function commit(range: DateRangeValue): void {
+  if (range[0] && range[1]) hoverDate.value = null
+  markOwnCommit(rangeKey(range))
+  model.value = range
+}
+
+function select(date: Dayjs): void {
+  if (checkUnavailable(date)) return
+  const range = stepRange([fromDate.value, toDate.value], date)
+  commit(range)
+  emit('select', range)
+}
+
+function selectToday(): void {
+  const today = dayjsLocal().startOf('day')
+  if (checkUnavailable(today)) return
+  const value = today.format(DATE_FORMAT)
+  const range: DateRangeValue = [value, value]
+  commit(range)
+  emit('today', range)
+}
+
+function onCellHover(d: Dayjs | null): void {
+  hoverDate.value = fromDate.value && !toDate.value ? d : null
+}
+
+defineExpose<DateRangeCalendarExposed>({ focus })
+</script>

--- a/src/components/DatePicker/DateRangePicker.vue
+++ b/src/components/DatePicker/DateRangePicker.vue
@@ -26,9 +26,15 @@
     @close="onShellClose"
     @request-focus="onShellRequestFocus"
   >
-    <template v-if="$slots.trigger" #trigger="ts"><slot name="trigger" v-bind="ts" /></template>
-    <template v-if="$slots.prefix" #prefix="ts"><slot name="prefix" v-bind="ts" /></template>
-    <template v-if="$slots.suffix" #suffix="ts"><slot name="suffix" v-bind="ts" /></template>
+    <template v-if="$slots.trigger" #trigger="ts"
+      ><slot name="trigger" v-bind="ts"
+    /></template>
+    <template v-if="$slots.prefix" #prefix="ts"
+      ><slot name="prefix" v-bind="ts"
+    /></template>
+    <template v-if="$slots.suffix" #suffix="ts"
+      ><slot name="suffix" v-bind="ts"
+    /></template>
 
     <template #default="{ close }">
       <div
@@ -110,7 +116,7 @@
 import { ref, computed, nextTick, watch } from 'vue'
 import { dayjs, dayjsLocal } from '../../utils/dayjs'
 import { generateWeeks } from './utils'
-import CalendarPanel, { type CalendarPanelCell } from './CalendarPanel.vue'
+import CalendarPanel from './CalendarPanel.vue'
 import PickerShell from '../shared/picker/PickerShell.vue'
 import {
   useCalendarView,
@@ -127,6 +133,7 @@ import type {
   DateRangePickerSlots,
   DateRangeValue,
 } from './types'
+import type { CalendarPanelCell } from './calendarTypes'
 
 const props = withDefaults(defineProps<DateRangePickerProps>(), {
   modelValue: () => [],
@@ -239,8 +246,7 @@ function onPanelNavigate(target: Dayjs) {
       target.month() === currentMonth.value &&
       target.year() === currentYear.value
     const inRight =
-      target.month() === rightMonth.value &&
-      target.year() === rightYear.value
+      target.month() === rightMonth.value && target.year() === rightYear.value
     if (inLeft || inRight) {
       focusedDate.value = target
       return
@@ -381,8 +387,7 @@ function buildRangeWeeks(year: number, month: number): CalendarPanelCell[][] {
       if (f && t) {
         inRange = d.date.isAfter(f, 'day') && d.date.isBefore(t, 'day')
       } else if (hoverEnd && f) {
-        inRange =
-          d.date.isAfter(f, 'day') && !d.date.isAfter(hoverEnd, 'day')
+        inRange = d.date.isAfter(f, 'day') && !d.date.isAfter(hoverEnd, 'day')
       } else if (hoverStart && f) {
         inRange =
           !d.date.isBefore(hoverStart, 'day') && d.date.isBefore(f, 'day')
@@ -518,9 +523,7 @@ function handleTodayClick() {
   resetView()
 }
 
-function handleSetRange(
-  range: [string | Date | Dayjs, string | Date | Dayjs],
-) {
+function handleSetRange(range: [string | Date | Dayjs, string | Date | Dayjs]) {
   const a = dayjs(range[0])
   const b = dayjs(range[1])
   if (!a.isValid() || !b.isValid()) return

--- a/src/components/DatePicker/DateRangePicker.vue
+++ b/src/components/DatePicker/DateRangePicker.vue
@@ -20,7 +20,6 @@
     :disabled="props.disabled"
     :readonly="inputReadonly"
     :display-label="displayLabel"
-    content-class="w-fit"
     @blur="commitInput()"
     @enter="commitInput(true)"
     @open="onShellOpen"
@@ -33,7 +32,7 @@
 
     <template #default="{ close }">
       <div
-        class="flex"
+        class="flex w-fit"
         :class="$slots.actions ? 'divide-x divide-outline-gray-2' : ''"
       >
         <aside

--- a/src/components/DatePicker/DateRangePicker.vue
+++ b/src/components/DatePicker/DateRangePicker.vue
@@ -59,54 +59,17 @@
             }"
           />
         </aside>
-        <div
-          class="flex"
-          :class="isDualPaneActive ? 'divide-x divide-outline-gray-2' : ''"
-        >
-          <CalendarPanel
-            ref="leftPanelRef"
-            :view="view"
-            :current-year="currentYear"
-            :current-month="currentMonth"
-            :weeks="weeks"
-            :today-label="isDualPaneActive ? '' : 'Today'"
-            :hide-next="isDualPaneActive"
-            :hide-out-of-month="isDualPaneActive"
-            :center-header="isDualPaneActive"
-            :min="props.min"
-            :max="props.max"
-            v-model:focused-date="focusedDate"
-            @prev="prev"
-            @next="next"
-            @today="handleTodayClick"
-            @cycle-view="cycleView"
-            @select-month="selectMonth"
-            @select-year="selectYear"
-            @select-date="handleDateCellClick"
-            @hover-cell="onCellHover"
-            @navigate="onPanelNavigate"
-          />
-          <CalendarPanel
-            v-if="isDualPaneActive"
-            ref="rightPanelRef"
-            :view="view"
-            :current-year="rightYear"
-            :current-month="rightMonth"
-            :weeks="rightWeeks"
-            hide-prev
-            hide-today
-            hide-out-of-month
-            center-header
-            :min="props.min"
-            :max="props.max"
-            v-model:focused-date="focusedDate"
-            @next="next"
-            @cycle-view="cycleView"
-            @select-date="handleDateCellClick"
-            @hover-cell="onCellHover"
-            @navigate="onPanelNavigate"
-          />
-        </div>
+        <DateRangeCalendar
+          ref="calendarRef"
+          :model-value="[fromDate, toDate]"
+          :dual-pane="props.dualPane"
+          today-label="Today"
+          :min="props.min"
+          :max="props.max"
+          :is-date-unavailable="props.isDateUnavailable"
+          @select="handleRangeSelect"
+          @today="handleRangeSelect"
+        />
       </div>
     </template>
   </PickerShell>
@@ -114,12 +77,11 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from 'vue'
-import { dayjs, dayjsLocal } from '../../utils/dayjs'
-import { generateWeeks } from './utils'
-import CalendarPanel from './CalendarPanel.vue'
+import { dayjs } from '../../utils/dayjs'
+import { orderRange, rangeKey, stepRange } from './utils'
+import DateRangeCalendar from './DateRangeCalendar.vue'
 import PickerShell from '../shared/picker/PickerShell.vue'
 import {
-  useCalendarView,
   usePopoverPositioning,
   useKeepOpen,
   useTypeable,
@@ -133,7 +95,7 @@ import type {
   DateRangePickerSlots,
   DateRangeValue,
 } from './types'
-import type { CalendarPanelCell } from './calendarTypes'
+import type { DateRangeCalendarExposed } from './calendarTypes'
 
 const props = withDefaults(defineProps<DateRangePickerProps>(), {
   modelValue: () => [],
@@ -170,93 +132,25 @@ watch(isOpen, (val) => {
 
 function onShellOpen() {
   initFromValue()
-  seedFocusedDate()
 }
 
 function onShellClose() {
-  resetView()
-  hoverDate.value = null
   if (isTyping.value) {
     commitInput()
     isTyping.value = false
   }
-  focusedDate.value = null
+}
+
+const calendarRef = ref<DateRangeCalendarExposed | null>(null)
+
+function onShellRequestFocus() {
+  // The calendar only mounts with the popover, so wait a tick for it.
+  nextTick(() => calendarRef.value?.focus())
 }
 
 defineExpose({
   open: () => shellRef.value?.open(),
 })
-
-// ── Keyboard focus management ────────────────────────────────────────────────
-
-const leftPanelRef = ref<{ focusInitialCell: () => void } | null>(null)
-const rightPanelRef = ref<{ focusInitialCell: () => void } | null>(null)
-const focusedDate = ref<Dayjs | null>(null)
-
-function seedFocusedDate() {
-  if (focusedDate.value) return
-  // Prefer the existing range start, then today, then first available cell
-  // in the left pane, then in the right pane (dual-pane fallback).
-  if (fromDate.value) {
-    const d = dayjs(fromDate.value)
-    if (!checkUnavailable(d)) {
-      focusedDate.value = d
-      return
-    }
-  }
-  const today = dayjsLocal().startOf('day')
-  if (!checkUnavailable(today)) {
-    focusedDate.value = today
-    return
-  }
-  const leftFirst = weeks.value
-    .flat()
-    .find((c) => c.inMonth && !c.isUnavailable)
-  if (leftFirst) {
-    focusedDate.value = leftFirst.date
-    return
-  }
-  if (props.dualPane) {
-    const rightFirst = rightWeeks.value
-      .flat()
-      .find((c) => c.inMonth && !c.isUnavailable)
-    if (rightFirst) focusedDate.value = rightFirst.date
-  }
-}
-
-function onShellRequestFocus() {
-  // Seed synchronously so panels mount with `props.focusedDate` already
-  // set — important for dual-pane, where two panels otherwise race to seed
-  // and the wrong one wins. Then queue the actual `.focus()` call for
-  // after the popover has rendered.
-  seedFocusedDate()
-  nextTick(() => {
-    leftPanelRef.value?.focusInitialCell()
-    rightPanelRef.value?.focusInitialCell()
-  })
-}
-
-function onPanelNavigate(target: Dayjs) {
-  // In dual-pane mode, the target may already be visible in the sibling
-  // panel (right pane = currentMonth + 1). In that case we don't advance the
-  // view — instead, just push the focused date so the sibling panel's watch
-  // picks it up and focuses its own matching cell.
-  if (props.dualPane) {
-    const inLeft =
-      target.month() === currentMonth.value &&
-      target.year() === currentYear.value
-    const inRight =
-      target.month() === rightMonth.value && target.year() === rightYear.value
-    if (inLeft || inRight) {
-      focusedDate.value = target
-      return
-    }
-  }
-  // Single-pane (or dual-pane crossing beyond the right edge): advance the
-  // view. After the parent re-renders, the originating panel's shiftFocus
-  // retry will find the cell and emit `update:focusedDate`.
-  focusOn(target)
-}
 
 // ── Positioning / keepOpen ────────────────────────────────────────────────────
 
@@ -265,27 +159,11 @@ const { resolvedSide, resolvedAlign, resolvedOffset } =
 const shouldKeepOpen = useKeepOpen(props)
 const inputReadonly = useTypeable(props)
 
-// ── Calendar state ───────────────────────────────────────────────────────────
-
-const {
-  view,
-  currentYear,
-  currentMonth,
-  prev,
-  next,
-  cycleView,
-  selectMonth,
-  selectYear,
-  focusOn,
-  resetView,
-} = useCalendarView()
+// ── Range state ──────────────────────────────────────────────────────────────
 
 const DATE_FORMAT = 'YYYY-MM-DD'
 const fromDate = ref<string>('')
 const toDate = ref<string>('')
-// Tracks the date under the cursor while the user is mid-selection
-// (start picked, end not yet) so we can preview the in-progress range.
-const hoverDate = ref<Dayjs | null>(null)
 
 const checkUnavailable = makeUnavailableCheck(
   () => props.min,
@@ -323,12 +201,11 @@ function syncFromValue(val?: string[]): void {
   const [f, t] = normalizeIncoming(val)
   fromDate.value = f
   toDate.value = t
-  if (f) focusOn(dayjs(f))
 }
 
 const initialValue = ref<string>('')
 syncFromValue(pickIncoming())
-initialValue.value = serialize(fromDate.value, toDate.value)
+initialValue.value = rangeKey([fromDate.value, toDate.value])
 
 function initFromValue(): void {
   syncFromValue(pickIncoming())
@@ -365,64 +242,6 @@ watch(displayLabel, (val) => {
   if (!isTyping.value) inputValue.value = val
 })
 
-// ── Calendar grid (with range markers) ───────────────────────────────────────
-
-function buildRangeWeeks(year: number, month: number): CalendarPanelCell[][] {
-  const raw = generateWeeks(year, month, '')
-  const f = fromDate.value ? dayjs(fromDate.value) : null
-  const t = toDate.value ? dayjs(toDate.value) : null
-  // While picking the end date, the hovered cell and everything between
-  // `from` and it render as in-range (light gray) — only committed endpoints
-  // get the dark "selected" treatment. Mouse hover and keyboard focus both
-  // act as the preview anchor; mouse wins when both exist.
-  const previewAnchor = hoverDate.value ?? focusedDate.value
-  const hovering = !t && f && previewAnchor ? previewAnchor : null
-  const hoverEnd = hovering && hovering.isAfter(f!, 'day') ? hovering : null
-  const hoverStart = hovering && hovering.isBefore(f!, 'day') ? hovering : null
-  return raw.map((week) =>
-    week.map((d) => {
-      const isRangeStart = !!(f && d.date.isSame(f, 'day'))
-      const isRangeEnd = !!(t && d.date.isSame(t, 'day'))
-      let inRange = false
-      if (f && t) {
-        inRange = d.date.isAfter(f, 'day') && d.date.isBefore(t, 'day')
-      } else if (hoverEnd && f) {
-        inRange = d.date.isAfter(f, 'day') && !d.date.isAfter(hoverEnd, 'day')
-      } else if (hoverStart && f) {
-        inRange =
-          !d.date.isBefore(hoverStart, 'day') && d.date.isBefore(f, 'day')
-      }
-      return {
-        ...d,
-        isSelected: false,
-        isUnavailable: checkUnavailable(d.date),
-        isRangeStart,
-        isRangeEnd,
-        inRange,
-      }
-    }),
-  )
-}
-
-const weeks = computed<CalendarPanelCell[][]>(() =>
-  buildRangeWeeks(currentYear.value, currentMonth.value),
-)
-
-// ── Dual-pane (right side) ───────────────────────────────────────────────────
-// Dual pane only renders for the day-grid view; cycling to month/year falls
-// back to a single panel to avoid duplicate selectors.
-
-const isDualPaneActive = computed(() => props.dualPane && view.value === 'date')
-
-const rightAnchor = computed(() =>
-  dayjs().year(currentYear.value).month(currentMonth.value).add(1, 'month'),
-)
-const rightYear = computed(() => rightAnchor.value.year())
-const rightMonth = computed(() => rightAnchor.value.month())
-const rightWeeks = computed<CalendarPanelCell[][]>(() =>
-  buildRangeWeeks(rightYear.value, rightMonth.value),
-)
-
 // ── Input commit / selection ─────────────────────────────────────────────────
 
 function commitInput(close = false): void {
@@ -436,7 +255,7 @@ function commitInput(close = false): void {
   if (f && !checkUnavailable(f)) fromDate.value = f.format(DATE_FORMAT)
   if (t && !checkUnavailable(t)) toDate.value = t.format(DATE_FORMAT)
   else if (!t) toDate.value = ''
-  ensureOrder()
+  setOrdered([fromDate.value, toDate.value])
   emitIfChanged()
   inputValue.value = displayLabel.value
   if (close && !shouldKeepOpen.value && fromDate.value && toDate.value) {
@@ -444,50 +263,32 @@ function commitInput(close = false): void {
   }
 }
 
-function selectDate(date: string | Date | Dayjs): void {
-  const d = dayjs(date as any)
-  if (!d.isValid() || checkUnavailable(d)) return
+// The calendar reports every click, including the half-open range after the
+// first one. Emit and close only once both ends are set.
+function handleRangeSelect(range: DateRangeValue) {
+  fromDate.value = range[0] ?? ''
+  toDate.value = range[1] ?? ''
   if (fromDate.value && toDate.value) {
-    fromDate.value = d.format(DATE_FORMAT)
-    toDate.value = ''
-  } else if (fromDate.value && !toDate.value) {
-    toDate.value = d.format(DATE_FORMAT)
-  } else {
-    fromDate.value = d.format(DATE_FORMAT)
-  }
-  ensureOrder()
-}
-function ensureOrder() {
-  if (fromDate.value && toDate.value) {
-    if (dayjs(fromDate.value).isAfter(dayjs(toDate.value))) {
-      const tmp = fromDate.value
-      fromDate.value = toDate.value
-      toDate.value = tmp
-    }
-  }
-}
-
-function handleDateCellClick(date: string | Date | Dayjs) {
-  selectDate(date)
-  if (fromDate.value && toDate.value) {
-    hoverDate.value = null
     emitIfChanged()
     if (!shouldKeepOpen.value) isOpen.value = false
   }
   isTyping.value = false
 }
 
-function onCellHover(d: Dayjs | null) {
-  hoverDate.value = fromDate.value && !toDate.value ? d : null
+function handleDateCellClick(date: string | Date | Dayjs) {
+  const d = dayjs(date as any)
+  if (!d.isValid() || checkUnavailable(d)) return
+  handleRangeSelect(stepRange([fromDate.value, toDate.value], d))
 }
 
-function serialize(from: string, to: string): string {
-  if (!from && !to) return ''
-  return `${from},${to}`
+function setOrdered(range: [string, string]): void {
+  const [from, to] = orderRange(range)
+  fromDate.value = from
+  toDate.value = to
 }
 
 function emitIfChanged() {
-  const next = serialize(fromDate.value, toDate.value)
+  const next = rangeKey([fromDate.value, toDate.value])
   if (next === initialValue.value) return
   const payload: DateRangeValue =
     fromDate.value && toDate.value ? [fromDate.value, toDate.value] : []
@@ -500,7 +301,6 @@ function clearSelection() {
   if (!fromDate.value && !toDate.value) return
   fromDate.value = ''
   toDate.value = ''
-  hoverDate.value = null
   emitIfChanged()
   inputValue.value = ''
 }
@@ -509,18 +309,6 @@ function handleClearClick() {
   clearSelection()
   if (!shouldKeepOpen.value) isOpen.value = false
   isTyping.value = false
-  resetView()
-}
-
-function handleTodayClick() {
-  const now = dayjsLocal().startOf('day')
-  if (checkUnavailable(now)) return
-  fromDate.value = now.format(DATE_FORMAT)
-  toDate.value = now.format(DATE_FORMAT)
-  emitIfChanged()
-  if (!shouldKeepOpen.value) isOpen.value = false
-  isTyping.value = false
-  resetView()
 }
 
 function handleSetRange(range: [string | Date | Dayjs, string | Date | Dayjs]) {
@@ -528,13 +316,8 @@ function handleSetRange(range: [string | Date | Dayjs, string | Date | Dayjs]) {
   const b = dayjs(range[1])
   if (!a.isValid() || !b.isValid()) return
   if (checkUnavailable(a) || checkUnavailable(b)) return
-  fromDate.value = a.format(DATE_FORMAT)
-  toDate.value = b.format(DATE_FORMAT)
-  ensureOrder()
-  hoverDate.value = null
+  setOrdered([a.format(DATE_FORMAT), b.format(DATE_FORMAT)])
   emitIfChanged()
-  focusOn(dayjs(fromDate.value))
   isTyping.value = false
-  resetView()
 }
 </script>

--- a/src/components/DatePicker/DateTimePicker.cy.ts
+++ b/src/components/DatePicker/DateTimePicker.cy.ts
@@ -1,4 +1,5 @@
 import { h } from 'vue'
+import { dayjs } from '../../utils/dayjs'
 import DateTimePicker from './DateTimePicker.vue'
 import type {
   DateTimePickerActionsSlotProps,
@@ -38,12 +39,41 @@ describe('DateTimePicker', () => {
     cy.get('[aria-label=cycle-calendar-view]').should('exist')
   })
 
-  it('Now button selects current date and time', () => {
-    cy.mount(DateTimePicker)
+  it('Now button selects current date and time, and closes', () => {
+    cy.mount(DateTimePicker, {
+      props: { 'onUpdate:modelValue': cy.spy().as('onUpdate') },
+    })
     cy.get('input').first().dblclick()
     cy.get('[role=dialog]').should('exist')
     cy.get('[aria-label="Now"]').click()
+    cy.get('[role=dialog]').should('not.exist')
     cy.get('input').first().should('not.have.value', '')
+    cy.get('@onUpdate').then((spy) => {
+      // One press, one emit — no transient midnight value on the way.
+      expect((spy as any).callCount).to.equal(1)
+      const emitted = (spy as any).lastCall.args[0] as string
+      // The current time, not the midnight a plain date selection would give.
+      expect(dayjs(emitted).diff(dayjs(), 'minute')).to.be.closeTo(0, 1)
+    })
+  })
+
+  it('Now emits once with the current time when today is already selected', () => {
+    const today = dayjs().format('YYYY-MM-DD')
+    cy.mount(DateTimePicker, {
+      props: {
+        modelValue: `${today} 00:00:00`,
+        'onUpdate:modelValue': cy.spy().as('onUpdate'),
+      },
+    })
+    cy.get('input').first().dblclick()
+    cy.get('[aria-label="Now"]').click()
+    cy.get('[role=dialog]').should('not.exist')
+    cy.get('@onUpdate').then((spy) => {
+      expect((spy as any).callCount).to.equal(1)
+      const emitted = (spy as any).lastCall.args[0] as string
+      expect(emitted.startsWith(today)).to.equal(true)
+      expect(dayjs(emitted).diff(dayjs(), 'minute')).to.be.closeTo(0, 1)
+    })
   })
 
   it('Clear from #actions slot resets the value', () => {
@@ -66,8 +96,16 @@ describe('DateTimePicker', () => {
       },
     })
     cy.get('input').first().dblclick()
-    cy.get('[aria-label="2025-06-09"]').should('have.attr', 'aria-disabled', 'true')
-    cy.get('[aria-label="2025-06-21"]').should('have.attr', 'aria-disabled', 'true')
+    cy.get('[aria-label="2025-06-09"]').should(
+      'have.attr',
+      'aria-disabled',
+      'true',
+    )
+    cy.get('[aria-label="2025-06-21"]').should(
+      'have.attr',
+      'aria-disabled',
+      'true',
+    )
     cy.get('[aria-label="2025-06-15"]').should('not.have.attr', 'aria-disabled')
   })
 

--- a/src/components/DatePicker/DateTimePicker.vue
+++ b/src/components/DatePicker/DateTimePicker.vue
@@ -26,14 +26,22 @@
     @close="onShellClose"
     @request-focus="onShellRequestFocus"
   >
-    <template v-if="$slots.trigger" #trigger="ts"><slot name="trigger" v-bind="ts" /></template>
-    <template v-if="$slots.prefix" #prefix="ts"><slot name="prefix" v-bind="ts" /></template>
-    <template v-if="$slots.suffix" #suffix="ts"><slot name="suffix" v-bind="ts" /></template>
+    <template v-if="$slots.trigger" #trigger="ts"
+      ><slot name="trigger" v-bind="ts"
+    /></template>
+    <template v-if="$slots.prefix" #prefix="ts"
+      ><slot name="prefix" v-bind="ts"
+    /></template>
+    <template v-if="$slots.suffix" #suffix="ts"
+      ><slot name="suffix" v-bind="ts"
+    /></template>
 
     <template #default="{ close }">
       <div
         class="flex"
-        :class="$slots.actions ? 'w-fit divide-x divide-outline-gray-2' : 'w-56'"
+        :class="
+          $slots.actions ? 'w-fit divide-x divide-outline-gray-2' : 'w-56'
+        "
       >
         <aside
           v-if="$slots.actions"
@@ -53,24 +61,15 @@
           />
         </aside>
         <div class="flex flex-col">
-          <CalendarPanel
-            ref="panelRef"
-            :view="view"
-            :current-year="currentYear"
-            :current-month="currentMonth"
-            :weeks="weeks"
+          <DateCalendar
+            ref="calendarRef"
+            :model-value="selectedDate"
             today-label="Now"
             :min="resolvedMin"
             :max="resolvedMax"
-            v-model:focused-date="focusedDate"
-            @prev="prev"
-            @next="next"
+            :is-date-unavailable="props.isDateUnavailable"
+            @select="handleDateCellClick"
             @today="handleNowClick"
-            @cycle-view="cycleView"
-            @select-month="selectMonth"
-            @select-year="selectYear"
-            @select-date="handleDateCellClick"
-            @navigate="onPanelNavigate"
           />
           <div class="flex flex-col gap-2 p-2 pt-0">
             <TimePicker
@@ -95,11 +94,9 @@
 import { ref, computed, nextTick, watch } from 'vue'
 import TimePicker from '../TimePicker/TimePicker.vue'
 import { dayjs, dayjsLocal, dayjsSystem } from '../../utils/dayjs'
-import { generateWeeks } from './utils'
-import CalendarPanel, { type CalendarPanelCell } from './CalendarPanel.vue'
+import DateCalendar from './DateCalendar.vue'
 import PickerShell from '../shared/picker/PickerShell.vue'
 import {
-  useCalendarView,
   usePopoverPositioning,
   useKeepOpen,
   useTypeable,
@@ -111,6 +108,7 @@ import type {
   DateTimePickerEmits,
   DateTimePickerSlots,
 } from './types'
+import type { DateCalendarExposed } from './calendarTypes'
 
 const props = withDefaults(defineProps<DateTimePickerProps>(), {
   modelValue: '',
@@ -147,51 +145,25 @@ watch(isOpen, (val) => {
 
 function onShellOpen() {
   initFromValue()
-  seedFocusedDate()
 }
 
 function onShellClose() {
-  resetView()
   if (isTyping.value) {
     commitInput()
     isTyping.value = false
   }
-  focusedDate.value = null
 }
 
 defineExpose({
   open: () => shellRef.value?.open(),
 })
 
-const panelRef = ref<{ focusInitialCell: () => void } | null>(null)
+const calendarRef = ref<DateCalendarExposed | null>(null)
 const timePickerRef = ref<{ focus: () => void } | null>(null)
-const focusedDate = ref<Dayjs | null>(null)
-
-function seedFocusedDate() {
-  if (focusedDate.value) return
-  if (selectedDate.value) {
-    const d = dayjs(selectedDate.value)
-    if (!checkUnavailable(d)) {
-      focusedDate.value = d
-      return
-    }
-  }
-  const today = dayjsLocal()
-  if (!checkUnavailable(today)) {
-    focusedDate.value = today
-    return
-  }
-  const first = weeks.value.flat().find((c) => c.inMonth && !c.isUnavailable)
-  if (first) focusedDate.value = first.date
-}
 
 function onShellRequestFocus() {
-  seedFocusedDate()
-  nextTick(() => panelRef.value?.focusInitialCell())
-}
-
-function onPanelNavigate(target: Dayjs) {
-  focusOn(target)
+  // The calendar only mounts with the popover, so wait a tick for it.
+  nextTick(() => calendarRef.value?.focus())
 }
 
 // ── Positioning / keepOpen ────────────────────────────────────────────────────
@@ -202,19 +174,6 @@ const shouldKeepOpen = useKeepOpen(props)
 const inputReadonly = useTypeable(props)
 
 // ── Calendar state ───────────────────────────────────────────────────────────
-
-const {
-  view,
-  currentYear,
-  currentMonth,
-  prev,
-  next,
-  cycleView,
-  selectMonth,
-  selectYear,
-  focusOn,
-  resetView,
-} = useCalendarView()
 
 const DATE_FORMAT = 'YYYY-MM-DD'
 const DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss'
@@ -254,7 +213,6 @@ function syncFromValue(val?: string): void {
   if (!val) {
     if (!props.clearable) {
       const now = dayjsLocal()
-      focusOn(now)
       selectedDate.value = now.format(DATE_FORMAT)
       timeValue.value = now.format('HH:mm:ss')
     } else {
@@ -269,7 +227,6 @@ function syncFromValue(val?: string): void {
     timeValue.value = ''
     return
   }
-  focusOn(d)
   selectedDate.value = d.format(DATE_FORMAT)
   timeValue.value = d.format('HH:mm:ss')
 }
@@ -308,18 +265,6 @@ const isTyping = ref(false)
 watch(displayLabel, (val) => {
   if (!isTyping.value) inputValue.value = val
 })
-
-// ── Calendar grid ────────────────────────────────────────────────────────────
-
-const weeks = computed<CalendarPanelCell[][]>(() =>
-  generateWeeks(currentYear.value, currentMonth.value, selectedDate.value).map(
-    (week) =>
-      week.map((d) => ({
-        ...d,
-        isUnavailable: checkUnavailable(d.date),
-      })),
-  ),
-)
 
 const computedMinTime = computed<string>(() => {
   if (!minDT.value || !selectedDate.value) return ''
@@ -374,18 +319,14 @@ function selectDate(date: string | Date | Dayjs): void {
   const d = dayjs(date as any)
   if (!d.isValid() || checkUnavailable(d)) return
   selectedDate.value = d.format(DATE_FORMAT)
-  focusOn(d)
 }
 
 function handleDateCellClick(date: string | Date | Dayjs) {
   selectDate(date)
   emitChange()
-  // Keep the popover open — DateTimePicker is a two-step selection (date
-  // then time). Auto-close on date alone strands the embedded TimePicker.
   isTyping.value = false
-  resetView()
-  // Move keyboard focus to the time input so the user can immediately
-  // continue with the time. Harmless for mouse users.
+  // A date alone is half a selection. Keep the popover open and move focus to
+  // the TimePicker.
   nextTick(() => timePickerRef.value?.focus?.())
 }
 
@@ -423,19 +364,18 @@ function clearSelection() {
   inputValue.value = ''
 }
 
-function handleNowClick() {
-  const now = dayjsLocal()
-  selectDate(now)
-  timeValue.value = now.format('HH:mm:ss')
+// Now commits date and time together, in one emit.
+function handleNowClick(date: string) {
+  selectDate(date)
+  timeValue.value = dayjsLocal().format('HH:mm:ss')
   emitChange()
-  if (!shouldKeepOpen.value) isOpen.value = false
   isTyping.value = false
+  if (!shouldKeepOpen.value) isOpen.value = false
 }
 
 function handleClearClick() {
   clearSelection()
   if (!shouldKeepOpen.value) isOpen.value = false
   isTyping.value = false
-  resetView()
 }
 </script>

--- a/src/components/DatePicker/DateTimePicker.vue
+++ b/src/components/DatePicker/DateTimePicker.vue
@@ -20,7 +20,6 @@
     :disabled="props.disabled"
     :readonly="inputReadonly"
     :display-label="displayLabel"
-    :content-class="contentClass"
     @blur="commitInput()"
     @enter="commitInput(true)"
     @open="onShellOpen"
@@ -34,7 +33,7 @@
     <template #default="{ close }">
       <div
         class="flex"
-        :class="$slots.actions ? 'divide-x divide-outline-gray-2' : ''"
+        :class="$slots.actions ? 'w-fit divide-x divide-outline-gray-2' : 'w-56'"
       >
         <aside
           v-if="$slots.actions"
@@ -94,7 +93,6 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from 'vue'
-import { useReactiveSlots } from '../../composables/useReactiveSlots'
 import TimePicker from '../TimePicker/TimePicker.vue'
 import { dayjs, dayjsLocal, dayjsSystem } from '../../utils/dayjs'
 import { generateWeeks } from './utils'
@@ -128,11 +126,6 @@ const props = withDefaults(defineProps<DateTimePickerProps>(), {
 const emit = defineEmits<DateTimePickerEmits>()
 
 defineSlots<DateTimePickerSlots>()
-const slots = useReactiveSlots<DateTimePickerSlots>()
-
-// Layout only — the elevated shell (rounded/bg/shadow/ring) is owned by
-// PopoverPanel inside PickerShell.
-const contentClass = computed(() => (slots.actions ? 'w-fit' : 'w-56'))
 
 // ── Popover open state ───────────────────────────────────────────────────────
 

--- a/src/components/DatePicker/calendarTypes.ts
+++ b/src/components/DatePicker/calendarTypes.ts
@@ -1,0 +1,98 @@
+import type { Dayjs } from 'dayjs/esm'
+import type { DatePickerDateObj, DatePickerViewMode } from './types'
+
+// Types for the calendars. Not in `types.ts`, which `index.ts` re-exports: the
+// calendars ship from `frappe-ui/experimental`, and `CalendarPanel` is internal.
+
+// ── DateCalendar ─────────────────────────────────────────────────────────────
+
+export interface DateCalendarProps {
+  /**
+   * Earliest selectable date in `YYYY-MM-DD` format. Also bounds keyboard
+   * navigation and the year list.
+   */
+  min?: string
+
+  /**
+   * Latest selectable date in `YYYY-MM-DD` format. Also bounds keyboard
+   * navigation and the year list.
+   */
+  max?: string
+
+  /** Return true to prevent a date from being selected. Combined with `min`/`max`. */
+  isDateUnavailable?: (date: Dayjs) => boolean
+
+  /** Label for the action that selects today. Empty hides the button. Default: `Today`. */
+  todayLabel?: string
+}
+
+export type DateCalendarEmits = {
+  /** Fired on every date click, even when it re-selects the current value. */
+  select: [date: string]
+
+  /** Fired when the Today button is pressed, with today's date. */
+  today: [date: string]
+}
+
+export interface DateCalendarExposed {
+  /** Move keyboard focus into the day grid. */
+  focus(): void
+}
+
+// ── CalendarPanel (internal) ─────────────────────────────────────────────────
+
+/** A single day cell in the calendar grid. */
+export interface CalendarPanelCell extends DatePickerDateObj {
+  /** The date cannot be selected (outside `min`/`max`, or `isDateUnavailable`). */
+  isUnavailable: boolean
+  /** Start endpoint of a range selection. */
+  isRangeStart?: boolean
+  /** End endpoint of a range selection. */
+  isRangeEnd?: boolean
+  /** Between the two endpoints of a range selection. */
+  inRange?: boolean
+}
+
+export interface CalendarPanelProps {
+  /** Day grid or the month-year split view. */
+  view: DatePickerViewMode
+  /** Year the grid shows. */
+  currentYear: number
+  /** Month the grid shows, 0-indexed. */
+  currentMonth: number
+  /** The grid to render. The parent owns the selection and computes it. */
+  weeks: CalendarPanelCell[][]
+  /** Label for the optional Today/Now action button between prev/next. Empty/undefined hides it. */
+  todayLabel?: string
+  /** Hide the prev nav button — used in dual-pane right side. */
+  hidePrev?: boolean
+  /** Hide the next nav button — used in dual-pane left side. */
+  hideNext?: boolean
+  /** Hide the Today/Now button — used in dual-pane to avoid duplicates. */
+  hideToday?: boolean
+  /** Render out-of-month cells as empty placeholders — used in dual-pane to avoid showing the same date in both panes. */
+  hideOutOfMonth?: boolean
+  /**
+   * Render a slim header with prev/next flanking a centered, non-clickable
+   * month label. Used in dual-pane so the two panels read as
+   * `< First Month | Second Month >`.
+   */
+  centerHeader?: boolean
+  /** Earliest selectable date in YYYY-MM-DD format. Used to bound keyboard nav. */
+  min?: string
+  /** Latest selectable date in YYYY-MM-DD format. Used to bound keyboard nav. */
+  max?: string
+  /**
+   * The date that currently holds the roving tabindex. Controlled — parent
+   * owns the state, panel emits `update:focusedDate` when arrow keys land on
+   * a new cell. Multiple panels (e.g. dual-pane DateRangePicker) can share
+   * the same value; each panel only renders `tabindex=0` if the date falls
+   * inside its own visible weeks.
+   */
+  focusedDate?: Dayjs | null
+}
+
+/** What a `CalendarPanel` ref gives its parent. */
+export interface CalendarPanelExposed {
+  focusInitialCell: () => void
+}

--- a/src/components/DatePicker/calendarTypes.ts
+++ b/src/components/DatePicker/calendarTypes.ts
@@ -1,5 +1,9 @@
 import type { Dayjs } from 'dayjs/esm'
-import type { DatePickerDateObj, DatePickerViewMode } from './types'
+import type {
+  DatePickerDateObj,
+  DatePickerViewMode,
+  DateRangeValue,
+} from './types'
 
 // Types for the calendars. Not in `types.ts`, which `index.ts` re-exports: the
 // calendars ship from `frappe-ui/experimental`, and `CalendarPanel` is internal.
@@ -35,6 +39,47 @@ export type DateCalendarEmits = {
 }
 
 export interface DateCalendarExposed {
+  /** Move keyboard focus into the day grid. */
+  focus(): void
+}
+
+// ── DateRangeCalendar ────────────────────────────────────────────────────────
+
+export interface DateRangeCalendarProps {
+  /**
+   * Earliest selectable date in `YYYY-MM-DD` format. Also bounds keyboard
+   * navigation and the year list.
+   */
+  min?: string
+
+  /**
+   * Latest selectable date in `YYYY-MM-DD` format. Also bounds keyboard
+   * navigation and the year list.
+   */
+  max?: string
+
+  /** Return true to prevent a date from being selected. Combined with `min`/`max`. */
+  isDateUnavailable?: (date: Dayjs) => boolean
+
+  /** Label for the action that selects today. Empty hides the button. Default: `Today`. */
+  todayLabel?: string
+
+  /** Render two calendar panels side by side (current month + next month). */
+  dualPane?: boolean
+}
+
+export type DateRangeCalendarEmits = {
+  /**
+   * Fired on every endpoint click, even when the range is unchanged. After the
+   * first click it carries `[from, '']`.
+   */
+  select: [range: DateRangeValue]
+
+  /** Fired when the Today button is pressed, with `[today, today]`. */
+  today: [range: DateRangeValue]
+}
+
+export interface DateRangeCalendarExposed {
   /** Move keyboard focus into the day grid. */
   focus(): void
 }

--- a/src/components/DatePicker/composables.ts
+++ b/src/components/DatePicker/composables.ts
@@ -1,7 +1,8 @@
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import type { Dayjs } from 'dayjs/esm'
 import { dayjs } from '../../utils/dayjs'
-import { monthStart, getDateValue } from './utils'
+import { generateWeeks, monthStart, getDateValue } from './utils'
+import type { CalendarPanelExposed } from './calendarTypes'
 import type {
   CommonDatePickerProps,
   PopoverAlign,
@@ -131,3 +132,64 @@ export function makeUnavailableCheck(
   }
 }
 
+export interface UseFocusedDateOptions {
+  /** Identity of the current value. The watch fires when it changes. */
+  key: () => string
+  /** The date the view and the roving tabindex follow. */
+  anchor: () => Dayjs | null
+  /** The months on screen, so the seed can scan every pane. */
+  months: () => Array<{ year: number; month: number }>
+  isUnavailable: (date: Dayjs) => boolean
+  focusOn: (date: Dayjs) => void
+  resetView: () => void
+  panels: () => Array<CalendarPanelExposed | null | undefined>
+}
+
+// The panels' roving tabindex is controlled, so the focused date lives here. It
+// is seeded at setup so the first render already has `tabindex=0` on the cell
+// `focus()` will land on.
+export function useFocusedDate(options: UseFocusedDateOptions) {
+  const focusedDate = ref<Dayjs | null>(null)
+  let ownKey: string | null = null
+
+  function seed(): void {
+    const anchor = options.anchor()
+    if (anchor?.isValid() && !options.isUnavailable(anchor)) {
+      focusedDate.value = anchor
+      return
+    }
+    const cells = options
+      .months()
+      .flatMap(({ year, month }) => generateWeeks(year, month, '').flat())
+      .filter((cell) => cell.inMonth && !options.isUnavailable(cell.date))
+    const target = cells.find((cell) => cell.isToday) ?? cells[0]
+    if (target) focusedDate.value = target.date
+  }
+
+  // Only a value set from outside moves the view. The calendar's own click
+  // landed on a visible cell, and following it would move the view after an
+  // out-of-month click or a click in the second pane.
+  watch(
+    options.key,
+    (key) => {
+      if (key === ownKey) return
+      options.resetView()
+      const anchor = options.anchor()
+      if (anchor?.isValid()) options.focusOn(anchor)
+      seed()
+    },
+    { immediate: true },
+  )
+
+  /** Record the value the calendar is committing, so the watch ignores it. */
+  function markOwnCommit(key: string): void {
+    ownKey = key
+  }
+
+  /** Move keyboard focus into the day grid. */
+  function focus(): void {
+    for (const panel of options.panels()) panel?.focusInitialCell()
+  }
+
+  return { focusedDate, markOwnCommit, focus }
+}

--- a/src/components/DatePicker/stories/DateCalendar.vue
+++ b/src/components/DatePicker/stories/DateCalendar.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import DateCalendar from '../DateCalendar.vue'
+import { dayjs } from '../../../utils/dayjs'
+
+const shiftDate = ref(dayjs().format('YYYY-MM-DD'))
+const today = dayjs().format('YYYY-MM-DD')
+const inSixtyDays = dayjs().add(60, 'day').format('YYYY-MM-DD')
+</script>
+
+<template>
+  <div class="flex w-full flex-col items-center gap-3 py-10">
+    <DateCalendar v-model="shiftDate" :min="today" :max="inSixtyDays" />
+    <span class="text-p-sm text-ink-gray-6">
+      {{ shiftDate || 'No date selected' }}
+    </span>
+  </div>
+</template>

--- a/src/components/DatePicker/stories/DateRangeCalendar.vue
+++ b/src/components/DatePicker/stories/DateRangeCalendar.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import DateRangeCalendar from '../DateRangeCalendar.vue'
+import type { DateRangeValue } from 'frappe-ui'
+import { dayjs } from '../../../utils/dayjs'
+
+const stay = ref<DateRangeValue>([
+  dayjs().format('YYYY-MM-DD'),
+  dayjs().add(4, 'day').format('YYYY-MM-DD'),
+])
+const today = dayjs().format('YYYY-MM-DD')
+const inSixtyDays = dayjs().add(60, 'day').format('YYYY-MM-DD')
+</script>
+
+<template>
+  <div class="flex w-full flex-col items-center gap-3 py-10">
+    <DateRangeCalendar
+      v-model="stay"
+      :min="today"
+      :max="inSixtyDays"
+      dual-pane
+    />
+    <span class="text-p-sm text-ink-gray-6">
+      {{ stay[0] ? `${stay[0]} to ${stay[1] || '…'}` : 'No range selected' }}
+    </span>
+  </div>
+</template>

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -1,6 +1,7 @@
 import { dayjs, dayjsLocal } from '../../utils/dayjs'
 import type { Dayjs } from 'dayjs/esm'
-import type { DatePickerDateObj as DateObj } from './types'
+import type { DatePickerDateObj as DateObj, DateRangeValue } from './types'
+import type { CalendarPanelCell } from './calendarTypes'
 
 // Constant list of month labels
 export const months: string[] = [
@@ -61,4 +62,74 @@ export function getDateValue(date: Date | string) {
     .set('second', 0)
     .set('millisecond', 0)
     .format('YYYY-MM-DD')
+}
+
+/**
+ * Build the weeks grid for a range. Until the end is picked, `preview` (the
+ * hovered or focused date) stands in for it: cells between the start and the
+ * preview render as in-range, not as selected.
+ */
+export function generateRangeWeeks(options: {
+  year: number
+  monthIndex: number
+  from: string
+  to: string
+  preview?: Dayjs | null
+  isUnavailable: (date: Dayjs) => boolean
+}): CalendarPanelCell[][] {
+  const { year, monthIndex, from, to, preview, isUnavailable } = options
+  const raw = generateWeeks(year, monthIndex, '')
+  const f = from ? dayjs(from) : null
+  const t = to ? dayjs(to) : null
+  const hovering = !t && f && preview ? preview : null
+  const hoverEnd = hovering && hovering.isAfter(f!, 'day') ? hovering : null
+  const hoverStart = hovering && hovering.isBefore(f!, 'day') ? hovering : null
+  return raw.map((week) =>
+    week.map((d) => {
+      const isRangeStart = !!(f && d.date.isSame(f, 'day'))
+      const isRangeEnd = !!(t && d.date.isSame(t, 'day'))
+      let inRange = false
+      if (f && t) {
+        inRange = d.date.isAfter(f, 'day') && d.date.isBefore(t, 'day')
+      } else if (hoverEnd && f) {
+        inRange = d.date.isAfter(f, 'day') && !d.date.isAfter(hoverEnd, 'day')
+      } else if (hoverStart && f) {
+        inRange =
+          !d.date.isBefore(hoverStart, 'day') && d.date.isBefore(f, 'day')
+      }
+      return {
+        ...d,
+        isSelected: false,
+        isUnavailable: isUnavailable(d.date),
+        isRangeStart,
+        isRangeEnd,
+        inRange,
+      }
+    }),
+  )
+}
+
+/** Put a range's endpoints in order, so picking the end first gives the same result. */
+export function orderRange(range: [string, string]): [string, string] {
+  const [from, to] = range
+  return from && to && from > to ? [to, from] : [from, to]
+}
+
+/** A range as one string, for comparing two ranges. */
+export function rangeKey(range: DateRangeValue | [string, string]): string {
+  return `${range[0] ?? ''},${range[1] ?? ''}`
+}
+
+/**
+ * Apply one click to a range: the first click starts a range, the second
+ * completes it, and a click on a completed range starts a new one.
+ */
+export function stepRange(
+  range: [string, string],
+  date: Dayjs,
+): [string, string] {
+  const [from, to] = range
+  const value = date.format('YYYY-MM-DD')
+  if (!from || to) return [value, '']
+  return orderRange([from, value])
 }

--- a/src/components/Popover/Popover.api.md
+++ b/src/components/Popover/Popover.api.md
@@ -53,6 +53,26 @@
     default: 'true'
   },
   {
+    name: 'autoFocus',
+    description: 'Whether the content takes focus when it opens. Set to `false` when typing\nin the trigger drives the panel, so the caret stays in the input.\nDefault: `true`.',
+    required: false,
+    type: 'boolean',
+    default: 'true'
+  },
+  {
+    name: 'trigger',
+    description: 'What opens the popover. `click` toggles it from the trigger element.\n`manual` does nothing on click; only `v-model:open` opens and closes it.\nIn `manual` mode the trigger gets no `aria-expanded` or `aria-controls`.\nDefault: `click`.',
+    required: false,
+    type: '"click" | "manual"',
+    default: '"click"'
+  },
+  {
+    name: 'reference',
+    description: 'Element to position the content against, instead of the trigger. Use it\nwhen the trigger is a labelled field, so the panel sits under the input row\nrather than under the description.',
+    required: false,
+    type: 'Element'
+  },
+  {
     name: 'matchTriggerWidth',
     description: 'Whether the content\'s min-width matches the trigger width.',
     required: false,
@@ -95,14 +115,14 @@
     type: '[]'
   },
   {
-    name: 'update:open',
-    description: 'Fired when the open state changes.',
-    type: '[value: boolean]'
-  },
-  {
     name: 'close',
     description: 'Fired when the component closes.',
     type: '[]'
+  },
+  {
+    name: 'update:open',
+    description: 'Fired when the open state changes.',
+    type: '[value: boolean]'
   }
 ]
 </script>

--- a/src/components/Popover/Popover.cy.ts
+++ b/src/components/Popover/Popover.cy.ts
@@ -90,7 +90,9 @@ describe('Popover', () => {
       cy.mount(Popover, { props: { bare: true }, slots: NewSlots })
 
       cy.get('[data-cy="trigger"]').click()
-      cy.get('[data-slot="content"]').find('[data-cy="content"]').should('exist')
+      cy.get('[data-slot="content"]')
+        .find('[data-cy="content"]')
+        .should('exist')
       cy.get('[data-slot="content-body"]').should('not.exist')
     })
 
@@ -98,7 +100,9 @@ describe('Popover', () => {
       cy.mount(Popover, { props: { arrow: true }, slots: NewSlots })
 
       cy.get('[data-cy="trigger"]').click()
-      cy.get('[data-slot="content"]').find('[data-slot="arrow"]').should('exist')
+      cy.get('[data-slot="content"]')
+        .find('[data-slot="arrow"]')
+        .should('exist')
     })
 
     it('wires aria-haspopup and aria-expanded on the trigger', () => {
@@ -302,6 +306,49 @@ describe('Popover', () => {
       })
     })
 
+    describe('trigger="manual"', () => {
+      it('does not open on a trigger click', () => {
+        cy.mount(Popover, { slots: NewSlots, props: { trigger: 'manual' } })
+
+        cy.get('[data-cy="trigger"]').click()
+        cy.get('[data-slot="content"]').should('not.exist')
+      })
+
+      it('stays open when the trigger is clicked while open', () => {
+        const Harness = defineComponent({
+          setup() {
+            const open = ref(true)
+            return () =>
+              h(
+                Popover,
+                {
+                  trigger: 'manual',
+                  open: open.value,
+                  'onUpdate:open': (value: boolean) => (open.value = value),
+                },
+                {
+                  trigger: () => h(Button, { 'data-cy': 'trigger' }, () => 'T'),
+                  default: () => h('div', { 'data-cy': 'content' }, 'manual'),
+                },
+              )
+          },
+        })
+
+        cy.mount(Harness)
+        cy.get('[data-slot="content"]').should('exist')
+        cy.get('[data-cy="trigger"]').click()
+        cy.get('[data-slot="content"]').should('exist')
+      })
+    })
+
+    it('leaves focus on the trigger when autoFocus is false', () => {
+      cy.mount(Popover, { slots: NewSlots, props: { autoFocus: false } })
+
+      cy.get('[data-cy="trigger"]').click()
+      cy.get('[data-slot="content"]').should('exist')
+      cy.focused().should('have.attr', 'data-cy', 'trigger')
+    })
+
     it('exposes open() and close() methods', () => {
       const popoverRef = ref()
       const Harness = defineComponent({
@@ -324,6 +371,73 @@ describe('Popover', () => {
       cy.get('[data-slot="content"]').should('exist')
       cy.then(() => popoverRef.value.close())
       cy.get('[data-slot="content"]').should('not.exist')
+    })
+
+    it('exposes contentEl, null while closed', () => {
+      const popoverRef = ref()
+      const Harness = defineComponent({
+        setup() {
+          return () =>
+            h(
+              Popover,
+              { ref: (el: unknown) => (popoverRef.value = el) },
+              {
+                trigger: () => h(Button, { 'data-cy': 'trigger' }, () => 'T'),
+                default: () => h('div', { 'data-cy': 'content' }, 'exposed'),
+              },
+            )
+        },
+      })
+
+      cy.mount(Harness)
+      cy.then(() => expect(popoverRef.value.contentEl).to.equal(null))
+      cy.get('[data-cy="trigger"]').click()
+      cy.get('[data-slot="content"]').should('exist')
+      cy.get('[data-slot="content"]').then(($content) => {
+        expect(popoverRef.value.contentEl).to.equal($content[0])
+      })
+    })
+
+    it('positions the content against `reference` in click mode', () => {
+      const referenceEl = ref<HTMLElement | null>(null)
+      const Harness = defineComponent({
+        setup() {
+          return () =>
+            h('div', [
+              h('div', {
+                ref: (el: unknown) => (referenceEl.value = el as HTMLElement),
+                'data-cy': 'reference',
+                style:
+                  'position: absolute; top: 120px; left: 200px; width: 140px; height: 24px',
+              }),
+              h(
+                Popover,
+                { reference: referenceEl.value ?? undefined },
+                {
+                  trigger: () => h(Button, { 'data-cy': 'trigger' }, () => 'T'),
+                  default: () => h('div', { 'data-cy': 'content' }, 'anchored'),
+                },
+              ),
+            ])
+        },
+      })
+
+      cy.mount(Harness)
+      cy.get('[data-cy="trigger"]').click()
+      cy.get('[data-slot="content"]').should('exist')
+
+      cy.get('[data-cy="reference"]').then(($reference) => {
+        const reference = $reference[0].getBoundingClientRect()
+        cy.get('[data-cy="trigger"]').then(($trigger) => {
+          const trigger = $trigger[0].getBoundingClientRect()
+          cy.get('[data-slot="content"]').then(($content) => {
+            const content = $content[0].getBoundingClientRect()
+            expect(content.left).to.be.closeTo(reference.left, 2)
+            expect(content.top).to.be.closeTo(reference.bottom + 4, 2)
+            expect(Math.abs(content.left - trigger.left)).to.be.greaterThan(2)
+          })
+        })
+      })
     })
   })
 })

--- a/src/components/Popover/Popover.md
+++ b/src/components/Popover/Popover.md
@@ -25,8 +25,8 @@ within the viewport (`collisionPadding` controls the gap kept from the edge).
 ## Controlled open state
 
 Bind `v-model:open` to drive the panel from outside, or read it to react to open
-/ close. The component also exposes `open()` and `close()` methods via a
-template ref, and emits `open` / `close` events.
+/ close. A template ref exposes `open()`, `close()` and `contentEl`, the content
+element (`null` while closed). The component emits `open` / `close` events.
 
 <ComponentPreview name="Popover-Controlled" />
 
@@ -45,6 +45,13 @@ Handy for select-style menus where the panel should line up under a wide button.
 
 <ComponentPreview name="Popover-MatchTriggerWidth" />
 
+## Reference element
+
+By default the content is positioned against the trigger element. Pass
+`reference` to position it against another element. This is for a trigger that
+is a labelled field: pass the input row, and the panel sits under the input
+rather than under the description. It works in both trigger modes.
+
 ## Bare
 
 Set `bare` to drop the panel shell (background, border, shadow, rounding) so
@@ -59,6 +66,18 @@ Set `arrow` to render a small arrow that points back at the trigger. It's styled
 to match the panel surface.
 
 <ComponentPreview name="Popover-Arrow" />
+
+## Typing-driven panels
+
+Two props stop a panel from fighting the input that drives it.
+`trigger="manual"` turns off toggling: a click on the input only places the
+caret, and `v-model:open` alone opens and closes the panel.
+`:auto-focus="false"` keeps focus in the input when the panel opens.
+
+<ComponentPreview name="Popover-Typeahead" />
+
+`manual` also removes the `aria-expanded` and `aria-controls` wiring. Add the
+combobox pattern yourself, or use [`Combobox`](./combobox), which has it.
 
 ## Styling
 
@@ -94,7 +113,7 @@ opens, and `prefers-reduced-motion` is respected. No configuration is required.
 - Use `#trigger` + `#default` for the standard click popover. Both slots get
   `{ open, close }`.
 - Reach for `v-model:open` only when an external control needs to drive the
-  panel — clicking the trigger already toggles it.
+  panel. Clicking the trigger already toggles it, unless `trigger="manual"`.
 - For a panel that opens on hover (profile previews, link previews), use the
   dedicated [`HoverCard`](./hovercard) component instead of a popover.
 - Attributes on `<Popover>` are not inherited — the component renders no element

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -1,16 +1,25 @@
 <template>
   <PopoverRoot v-model:open="isOpen">
     <!--
-      #trigger renders through reka's PopoverTrigger as-child, so click,
-      keyboard and aria wiring come for free on whatever element the consumer
-      passes.
+      The content is positioned against the anchor: `reference` if given, else
+      the trigger element. In `click` mode reka's PopoverTrigger adds click,
+      keyboard and aria wiring to the trigger. In `manual` mode a bare Primitive
+      adds nothing.
     -->
-    <PopoverTrigger ref="triggerRef" as-child data-slot="trigger">
-      <slot name="trigger" v-bind="slotProps" />
-    </PopoverTrigger>
+    <PopoverAnchor :reference="reference" as-child>
+      <component
+        :is="trigger === 'manual' ? Primitive : PopoverTrigger"
+        ref="triggerRef"
+        as-child
+        data-slot="trigger"
+      >
+        <slot name="trigger" v-bind="slotProps" />
+      </component>
+    </PopoverAnchor>
 
     <PopoverPortal :to="portalTarget">
       <PopoverContent
+        ref="contentRef"
         data-slot="content"
         class="z-[100]"
         :side="side"
@@ -24,6 +33,7 @@
         }"
         @interact-outside="onInteractOutside"
         @escape-key-down="onEscapeKeyDown"
+        @open-auto-focus="onOpenAutoFocus"
       >
         <slot v-if="bare" v-bind="slotProps" />
         <PopoverPanel v-else>
@@ -42,11 +52,13 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import {
+  PopoverAnchor,
   PopoverArrow,
   PopoverContent,
   PopoverPortal,
   PopoverRoot,
   PopoverTrigger,
+  Primitive,
 } from 'reka-ui'
 import PopoverPanel from '../shared/popover/PopoverPanel.vue'
 import { usePortalTarget } from '../../composables/usePortalTarget'
@@ -63,6 +75,8 @@ const props = withDefaults(defineProps<PopoverProps>(), {
   offset: 4,
   collisionPadding: 10,
   dismissible: true,
+  autoFocus: true,
+  trigger: 'click',
   matchTriggerWidth: false,
   bare: false,
   arrow: false,
@@ -77,6 +91,7 @@ const controlled = computed(() => props.open !== undefined)
 const uncontrolledOpen = ref(false)
 // reka's PopoverTrigger, exposes the trigger DOM node via `$el`.
 const triggerRef = ref<{ $el: Element } | null>(null)
+const contentRef = ref<{ $el: Element } | null>(null)
 
 const isOpen = computed<boolean>({
   get: () => (controlled.value ? Boolean(props.open) : uncontrolledOpen.value),
@@ -99,6 +114,15 @@ const isOpen = computed<boolean>({
 // its old order, after `update:open`.
 watch(isOpen, (value) => (value ? emit('open') : emit('close')))
 
+// PopoverContent keeps its template ref while its DOM mounts and unmounts, so
+// the element is read on demand, not cached. `$el` is reka's positioning
+// wrapper; the content root is the `data-slot` element inside it.
+function getContentEl(): HTMLElement | null {
+  const wrapper = contentRef.value?.$el
+  if (!(wrapper instanceof HTMLElement)) return null
+  return wrapper.querySelector<HTMLElement>('[data-slot="content"]')
+}
+
 function open() {
   if (isOpen.value) return
   isOpen.value = true
@@ -116,7 +140,13 @@ function toggle(flag?: boolean | Event) {
   else close()
 }
 
-defineExpose({ open, close })
+defineExpose({
+  open,
+  close,
+  get contentEl() {
+    return getContentEl()
+  },
+})
 
 // `open` is the state, not a method — the same word the rest of the family's
 // trigger slots use (Dropdown, Select, MultiSelect, HoverCard, Sidebar). The
@@ -127,6 +157,12 @@ const slotProps = computed<PopoverSlotProps>(() => ({
   close,
   toggle,
 }))
+
+// reka focuses the content on open. A panel driven by typing must leave the
+// caret in the input, so `autoFocus: false` cancels that.
+function onOpenAutoFocus(event: Event) {
+  if (!props.autoFocus) event.preventDefault()
+}
 
 // `dismissible` covers both user-initiated dismiss channels, per CONTEXT.md —
 // outside click and Escape. Wiring only the first left `:dismissible="false"`

--- a/src/components/Popover/stories/Typeahead.vue
+++ b/src/components/Popover/stories/Typeahead.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Popover, TextInput } from 'frappe-ui'
+
+const fruits = [
+  'Apricot',
+  'Blackberry',
+  'Cherry',
+  'Date',
+  'Elderberry',
+  'Fig',
+  'Grape',
+]
+
+const query = ref('')
+const open = ref(false)
+
+const matches = computed(() =>
+  fruits.filter((f) => f.toLowerCase().includes(query.value.toLowerCase())),
+)
+
+function onInput(value: string) {
+  query.value = value
+  open.value = value.length > 0 && matches.value.length > 0
+}
+
+function pick(fruit: string) {
+  query.value = fruit
+  open.value = false
+}
+</script>
+
+<template>
+  <!--
+    manual: clicking the input places the caret instead of toggling the panel.
+    auto-focus false: the panel opens without taking focus off the input.
+  -->
+  <Popover
+    v-model:open="open"
+    trigger="manual"
+    :auto-focus="false"
+    match-trigger-width
+  >
+    <template #trigger>
+      <TextInput
+        :model-value="query"
+        placeholder="Search fruit"
+        class="w-56"
+        @update:model-value="onInput"
+      />
+    </template>
+    <template #default>
+      <div class="p-1">
+        <button
+          v-for="fruit in matches"
+          :key="fruit"
+          type="button"
+          class="block w-full rounded-4 px-2 py-1.5 text-left text-base text-ink-gray-8 hover:bg-surface-gray-2"
+          @click="pick(fruit)"
+        >
+          {{ fruit }}
+        </button>
+      </div>
+    </template>
+  </Popover>
+</template>

--- a/src/components/Popover/types.ts
+++ b/src/components/Popover/types.ts
@@ -24,6 +24,28 @@ export interface PopoverProps {
   /** Whether the popover closes on outside interaction (click/focus). */
   dismissible?: boolean
 
+  /**
+   * Whether the content takes focus when it opens. Set to `false` when typing
+   * in the trigger drives the panel, so the caret stays in the input.
+   * Default: `true`.
+   */
+  autoFocus?: boolean
+
+  /**
+   * What opens the popover. `click` toggles it from the trigger element.
+   * `manual` does nothing on click; only `v-model:open` opens and closes it.
+   * In `manual` mode the trigger gets no `aria-expanded` or `aria-controls`.
+   * Default: `click`.
+   */
+  trigger?: 'click' | 'manual'
+
+  /**
+   * Element to position the content against, instead of the trigger. Use it
+   * when the trigger is a labelled field, so the panel sits under the input row
+   * rather than under the description.
+   */
+  reference?: Element
+
   /** Whether the content's min-width matches the trigger width. */
   matchTriggerWidth?: boolean
 
@@ -59,10 +81,12 @@ export interface PopoverSlotProps {
   toggle: (flag?: boolean | Event) => void
 }
 
-/** Methods available on a `<Popover>` template ref. */
+/** What a `<Popover>` template ref exposes. */
 export interface PopoverExposed {
   /** Opens the popover. No-op when it is already open. */
   open: () => void
   /** Closes the popover. No-op when it is already closed. */
   close: () => void
+  /** The content element. `null` while the popover is closed. */
+  contentEl: HTMLElement | null
 }

--- a/src/components/shared/picker/PickerShell.vue
+++ b/src/components/shared/picker/PickerShell.vue
@@ -1,13 +1,21 @@
 <template>
-  <PopoverRoot v-model:open="open">
-    <PopoverAnchor :reference="anchorEl" as-child>
+  <Popover
+    ref="popoverRef"
+    v-model:open="open"
+    trigger="manual"
+    :auto-focus="false"
+    :side="side"
+    :align="align"
+    :offset="offset"
+    :reference="anchorEl"
+  >
+    <template #trigger>
       <div v-bind="$attrs" @keydown.down.prevent="onArrowDown">
         <slot name="trigger" v-bind="triggerSlotProps">
           <TextInput
             ref="textInputRef"
             v-model="inputValue"
             type="text"
-            :class="inputClass"
             :id="id"
             :label="label"
             :description="description"
@@ -37,84 +45,34 @@
           </TextInput>
         </slot>
       </div>
-    </PopoverAnchor>
-    <PopoverPortal :to="portalTarget">
-      <PopoverContent
-        data-slot="content"
-        class="z-[100]"
-        :side="side"
-        :align="align"
-        :side-offset="offset"
-        @open-auto-focus.prevent
-        @interact-outside="onInteractOutside"
-      >
-        <PopoverPanel ref="popoverPanelRef" :class="contentClass">
-          <slot :close="closePopover" />
-        </PopoverPanel>
-      </PopoverContent>
-    </PopoverPortal>
-  </PopoverRoot>
+    </template>
+
+    <slot :close="closePopover" />
+  </Popover>
 </template>
 
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
-import {
-  PopoverAnchor,
-  PopoverContent,
-  PopoverPortal,
-  PopoverRoot,
-} from 'reka-ui'
+import Popover from '../../Popover/Popover.vue'
 import { TextInput } from '../../TextInput'
 import LucideChevronDown from '~icons/lucide/chevron-down'
-import PopoverPanel from '../popover/PopoverPanel.vue'
-import { usePortalTarget } from '../../../composables/usePortalTarget'
 import { useReactiveSlots } from '../../../composables/useReactiveSlots'
-import type { InputSize, InputVariant } from '../../../composables/inputTypes'
-import type { FrappeUIError } from '../../../composables/useInputLabeling'
+import type { PopoverExposed } from '../../Popover/types'
+import type {
+  PickerShellExposed,
+  PickerShellProps,
+  PickerShellSlots,
+  PickerShellTriggerSlotProps,
+} from './types'
 
-interface Props {
-  // Positioning — already resolved by caller from side/align/placement.
-  side: 'top' | 'right' | 'bottom' | 'left'
-  align: 'start' | 'center' | 'end'
-  offset: number
-
-  // Behaviour
-  openOnFocus?: boolean
-  openOnClick?: boolean
-
-  // TextInput pass-through
-  id?: string
-  label?: string
-  description?: string
-  error?: string | FrappeUIError
-  required?: boolean
-  size?: InputSize
-  variant?: InputVariant
-  placeholder?: string
-  disabled?: boolean
-  readonly?: boolean
-  inputClass?: string | Array<string> | Record<string, boolean>
-
-  // Display label exposed via trigger slot props for caller-rendered triggers.
-  displayLabel?: string
-
-  // Extra Tailwind classes (layout/sizing such as `w-56`/`w-fit`) merged onto
-  // the `PopoverPanel` shell. The elevated shell itself (rounded/bg/shadow/ring)
-  // is owned by `PopoverPanel`, so callers no longer pass those here.
-  contentClass?: string
-}
-
-const props = withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<PickerShellProps>(), {
   openOnFocus: false,
   openOnClick: true,
   required: false,
   disabled: false,
   readonly: false,
   displayLabel: '',
-  contentClass: '',
 })
-
-const portalTarget = usePortalTarget()
 
 const emit = defineEmits<{
   (e: 'focus'): void
@@ -132,13 +90,8 @@ const emit = defineEmits<{
   (e: 'requestFocus'): void
 }>()
 
-const declaredSlots = defineSlots<{
-  trigger?: (props: TriggerSlotProps) => any
-  prefix?: (props: TriggerSlotProps) => any
-  suffix?: (props: TriggerSlotProps) => any
-  default?: (props: { close: () => void }) => any
-}>()
-const slots = useReactiveSlots<typeof declaredSlots>()
+defineSlots<PickerShellSlots>()
+const slots = useReactiveSlots<PickerShellSlots>()
 
 defineOptions({ inheritAttrs: false })
 
@@ -146,25 +99,11 @@ const open = defineModel<boolean>('open', { default: false })
 const inputValue = defineModel<string>('inputValue', { default: '' })
 const typing = defineModel<boolean>('typing', { default: false })
 
-interface TriggerSlotProps {
-  /** Flips the popover open state, or sets it when passed a boolean. */
-  toggle: (flag?: boolean | Event) => void
-  /** Whether the popover is currently open. */
-  open: boolean
-  displayLabel: string
-  inputValue: string
-}
-
-// Anchor the popover at the input element itself (not the labeling wrapper),
-// so it sits below the input rather than below the description text.
 const textInputRef = ref<InstanceType<typeof TextInput> | null>(null)
-const popoverPanelRef = ref<{ $el: HTMLElement } | null>(null)
+const popoverRef = ref<PopoverExposed | null>(null)
 
-// PopoverPanel renders a single root <div>, so its `$el` is the panel element
-// we test focus containment against (Esc / selection should restore trigger
-// focus; click-outside should not).
-const panelEl = computed(() => popoverPanelRef.value?.$el ?? null)
-
+// Anchor to the `<input>` itself. Anchoring to the whole labelled field would
+// put the panel below the description.
 const anchorEl = computed(() => {
   if (slots.trigger) return undefined
   return textInputRef.value?.inputElement ?? undefined
@@ -182,19 +121,6 @@ function closePopover() {
   open.value = false
 }
 
-// Reka treats anything outside `PopoverContent` as "outside" — including our
-// own trigger — so a click on the input fires interact-outside and closes
-// the popover, then the click handler reopens it. Suppress the close when
-// the pointerdown originated inside the input's row (which holds the input
-// and any suffix like the chevron); those elements have their own logic.
-function onInteractOutside(event: Event) {
-  const target = event.target as Node | null
-  const triggerRow = textInputRef.value?.inputElement?.parentElement
-  if (target && triggerRow?.contains(target)) {
-    event.preventDefault()
-  }
-}
-
 function onFocus() {
   typing.value = true
   if (props.openOnFocus && !open.value) open.value = true
@@ -207,10 +133,11 @@ function onClick(e: MouseEvent) {
   emit('click', e)
 }
 
+// Focus moving into the portalled panel fires blur on the input. The panel
+// belongs to the input, so that is not a blur.
 function onBlur(e: FocusEvent) {
-  // Clicks inside the popover panel re-focus options; treat those as still-focused.
   const next = e.relatedTarget as Node | null
-  if (next && panelEl.value?.contains(next)) return
+  if (next && popoverRef.value?.contentEl?.contains(next)) return
   emit('blur')
   typing.value = false
 }
@@ -225,7 +152,7 @@ function onArrowDown() {
   emit('requestFocus')
 }
 
-const triggerSlotProps = computed<TriggerSlotProps>(() => ({
+const triggerSlotProps = computed<PickerShellTriggerSlotProps>(() => ({
   toggle,
   open: open.value,
   displayLabel: props.displayLabel,
@@ -248,7 +175,9 @@ watch(open, (val, prev) => {
     // Restore focus to the trigger input if the popover content had focus
     // (Esc, date selection in auto-close mode). Click-outside leaves focus
     // on the clicked element, so we skip in that case.
-    const hadFocusInside = panelEl.value?.contains(document.activeElement)
+    const hadFocusInside = popoverRef.value?.contentEl?.contains(
+      document.activeElement,
+    )
     emit('close')
     if (hadFocusInside) {
       nextTick(() => textInputRef.value?.focus())
@@ -256,7 +185,7 @@ watch(open, (val, prev) => {
   }
 })
 
-defineExpose({
+defineExpose<PickerShellExposed>({
   open: () => {
     open.value = true
   },

--- a/src/components/shared/picker/types.ts
+++ b/src/components/shared/picker/types.ts
@@ -1,0 +1,81 @@
+import type { InputSize, InputVariant } from '../../../composables/inputTypes'
+import type { FrappeUIError } from '../../../composables/useInputLabeling'
+
+export interface PickerShellProps {
+  /** Side of the trigger to render the panel on. Already resolved by the caller. */
+  side: 'top' | 'right' | 'bottom' | 'left'
+
+  /** Alignment of the panel along the chosen side. */
+  align: 'start' | 'center' | 'end'
+
+  /** Distance in px between the input row and the panel. */
+  offset: number
+
+  /** Whether focusing the input opens the panel. */
+  openOnFocus?: boolean
+
+  /** Whether clicking the input opens the panel. */
+  openOnClick?: boolean
+
+  /** Id of the underlying input. */
+  id?: string
+
+  /** Label above the input. */
+  label?: string
+
+  /** Help text below the input. */
+  description?: string
+
+  /** Error message, as a string or `FrappeUIError`. */
+  error?: string | FrappeUIError
+
+  /** Whether the input is required. */
+  required?: boolean
+
+  /** Input size token. */
+  size?: InputSize
+
+  /** Input variant token. */
+  variant?: InputVariant
+
+  /** Placeholder for the input. */
+  placeholder?: string
+
+  /** Whether the input is disabled. */
+  disabled?: boolean
+
+  /** Whether the input is read-only. */
+  readonly?: boolean
+
+  /** Formatted value, passed to the trigger slots so a custom trigger can render it. */
+  displayLabel?: string
+}
+
+/** Slot props passed to the `#trigger`, `#prefix` and `#suffix` slots. */
+export interface PickerShellTriggerSlotProps {
+  /** Flips the open state, or sets it when passed a boolean. */
+  toggle: (flag?: boolean | Event) => void
+  /** Whether the panel is currently open. */
+  open: boolean
+  /** The formatted value. */
+  displayLabel: string
+  /** The raw text in the input. */
+  inputValue: string
+}
+
+export interface PickerShellSlots {
+  /** Replaces the whole `TextInput` trigger. */
+  trigger?: (props: PickerShellTriggerSlotProps) => any
+  /** Content before the input text. */
+  prefix?: (props: PickerShellTriggerSlotProps) => any
+  /** Content after the input text. Replaces the chevron. */
+  suffix?: (props: PickerShellTriggerSlotProps) => any
+  /** The panel body. */
+  default?: (props: { close: () => void }) => any
+}
+
+/** Methods available on a `<PickerShell>` template ref. */
+export interface PickerShellExposed {
+  /** Opens the panel. */
+  open: () => void
+}


### PR DESCRIPTION
Standalone `DateCalendar` and `DateRangeCalendar`, the three date pickers rebuilt on them, and `PickerShell` rebuilt on `Popover`.

Gaps hit while building a date picker on the primitives. Five commits, each standing alone.

- **Popover** gains `:auto-focus="false"`, `trigger="manual"`, `reference` and an exposed `contentEl`. A panel under an input no longer takes focus on open, closes on a caret click, or anchors under the field's description.
- **ChartContainer** centres `#actions` on the title line instead of making the header taller.
- **PickerShell** renders `<Popover>`, drops `inputClass` and `contentClass`, and is exported from `experimental` for apps building their own picker.
- **DateCalendar** holds one date as `v-model` and emits `select` and `today` on every click. `DatePicker` and `DateTimePicker` are rebuilt on it.
- **DateRangeCalendar** holds a `[from, to]` pair with hover preview and dual pane, and emits the same events. `DateRangePicker` is rebuilt on it.

Both calendars ship from `frappe-ui/experimental`. Setting a value from outside moves the view; a click inside the calendar does not. `CalendarPanel` stays internal. The three pickers' props, emits and slots are unchanged.

<!-- coverage-report:start -->
Coverage: 73.57% (+0.01% vs `main`)
<!-- coverage-report:end -->



